### PR TITLE
Add Innistrad Remastered escalate spells

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7758,6 +7758,22 @@ mode-selection pause; choose-1 modal spells remain client-local `CastSpellMode` 
 change is needed to author a Spree card — it is a plain `ModalEffect` with per-mode
 `additionalManaCost` (see Trash the Town).
 
+**Escalate (CR 702.120a).** Set `additionalManaCostPerExtraMode` on `ModalEffect`, or pass it to the `modal(...)`
+builder, for “Pay this cost for each mode chosen beyond the first.” Unlike Spree's per-mode
+`additionalManaCost`, no printed mode carries the cost: selecting one mode adds nothing, selecting two
+adds the cost once, and selecting three adds it twice. The server includes the field in the modal legal
+action so the existing single-panel selector previews the combined additional and total mana costs.
+
+```kotlin
+spell {
+    modal(chooseCount = 3, minChooseCount = 1, additionalManaCostPerExtraMode = "{1}") {
+        mode("First mode") { effect = firstEffect }
+        mode("Second mode") { effect = secondEffect }
+        mode("Third mode") { effect = thirdEffect }
+    }
+}
+```
+
 **Tiered (CR 702.183) — `spell { tiered { } }`.** *"Tiered (Choose one additional cost.)"* is a
 choose-**one** modal spell where each tier carries its own additional mana cost, paid as you cast
 the spell (702.183a: *"Choose one. As an additional cost to cast this spell, pay the cost associated

--- a/manual-scenarios/cards/b/borrowed-hostility-escalate.json
+++ b/manual-scenarios/cards/b/borrowed-hostility-escalate.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Borrowed Hostility"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Grizzly Bears", "summoningSickness": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears", "summoningSickness": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/cards/s/savage-alliance-escalate.json
+++ b/manual-scenarios/cards/s/savage-alliance-escalate.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Savage Alliance"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Grizzly Bears", "summoningSickness": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Wind Drake", "summoningSickness": false}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1185,11 +1185,19 @@ class SpellBuilder {
         chooseCount: Int = 1,
         minChooseCount: Int = chooseCount,
         allowRepeat: Boolean = false,
+        additionalManaCostPerExtraMode: String? = null,
         chooseAllIfBlightPaid: Boolean = false,
         dynamicChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null,
         init: ModalBuilder.() -> Unit
     ) {
-        val builder = ModalBuilder(chooseCount, minChooseCount, allowRepeat, chooseAllIfBlightPaid, dynamicChooseCount)
+        val builder = ModalBuilder(
+            chooseCount,
+            minChooseCount,
+            allowRepeat,
+            additionalManaCostPerExtraMode,
+            chooseAllIfBlightPaid,
+            dynamicChooseCount
+        )
         builder.init()
         effect = builder.build()
     }
@@ -1244,6 +1252,7 @@ class ModalBuilder(
     private val chooseCount: Int,
     private val minChooseCount: Int = chooseCount,
     private val allowRepeat: Boolean = false,
+    private val additionalManaCostPerExtraMode: String? = null,
     private val chooseAllIfBlightPaid: Boolean = false,
     private val dynamicChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null
 ) {
@@ -1271,6 +1280,7 @@ class ModalBuilder(
             chooseCount = chooseCount,
             minChooseCount = minChooseCount,
             allowRepeat = allowRepeat,
+            additionalManaCostPerExtraMode = additionalManaCostPerExtraMode,
             chooseAllIfBlightPaid = chooseAllIfBlightPaid,
             dynamicChooseCount = dynamicChooseCount
         )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -127,6 +127,8 @@ data class Mode(
  *           (i.e. "choose exactly N"). Set lower for "choose one or both" / "choose one or more" (rules 700.2).
  * @property allowRepeat If true, the same mode index may be chosen more than once
  *           (rules 700.2d — Escalate/Spree-style).
+ * @property additionalManaCostPerExtraMode Additional cost paid for each chosen mode beyond the
+ *           first. Models escalate without assigning a cost to any particular printed mode.
  */
 @SerialName("Modal")
 @Serializable
@@ -135,6 +137,7 @@ data class ModalEffect(
     val chooseCount: Int = 1,
     val minChooseCount: Int = chooseCount,
     val allowRepeat: Boolean = false,
+    val additionalManaCostPerExtraMode: String? = null,
     /**
      * If true, when this spell's `AdditionalCost.BlightOrPay` cost was paid via the
      * blight path, the effective number of modes the player must choose becomes

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardSerializationRoundTripTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/serialization/CardSerializationRoundTripTest.kt
@@ -401,10 +401,12 @@ class CardSerializationRoundTripTest : DescribeSpec({
                     Mode.noTarget(DrawCardsEffect(DynamicAmount.Fixed(1), EffectTarget.Controller), "Draw a card"),
                     Mode.noTarget(GainLifeEffect(DynamicAmount.Fixed(2), EffectTarget.Controller), "Gain 2 life")
                 ),
-                chooseCount = 2
+                chooseCount = 2,
+                additionalManaCostPerExtraMode = "{3}"
             )
             directModal.minChooseCount shouldBe 2
             directModal.allowRepeat shouldBe false
+            directModal.additionalManaCostPerExtraMode shouldBe "{3}"
 
             // Produce a payload written by an older schema by round-tripping through
             // the current serializer and stripping the new fields.
@@ -415,6 +417,7 @@ class CardSerializationRoundTripTest : DescribeSpec({
             val legacyJson = fullJson
                 .replace(Regex(",\\s*\"minChooseCount\"\\s*:\\s*\\d+"), "")
                 .replace(Regex(",\\s*\"allowRepeat\"\\s*:\\s*(true|false)"), "")
+                .replace(Regex(",\\s*\"additionalManaCostPerExtraMode\"\\s*:\\s*\"[^\"]+\""), "")
             legacyJson shouldContain "\"chooseCount\""
             (legacyJson.contains("minChooseCount") || legacyJson.contains("allowRepeat")) shouldBe false
 
@@ -425,6 +428,7 @@ class CardSerializationRoundTripTest : DescribeSpec({
             parsed.chooseCount shouldBe 2
             parsed.minChooseCount shouldBe 2
             parsed.allowRepeat shouldBe false
+            parsed.additionalManaCostPerExtraMode shouldBe null
         }
 
         it("should round-trip a card built with the vividEtb DSL helper") {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BorrowedHostility.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BorrowedHostility.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/** Borrowed Hostility — Eldritch Moon #121. */
+val BorrowedHostility = card("Borrowed Hostility") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Escalate {3} (Pay this cost for each mode chosen beyond the first.)\n" +
+        "Choose one or both —\n" +
+        "• Target creature gets +3/+0 until end of turn.\n" +
+        "• Target creature gains first strike until end of turn."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1, additionalManaCostPerExtraMode = "{3}") {
+            mode("Target creature gets +3/+0 until end of turn.") {
+                val creature = target("power target", TargetCreature())
+                effect = Effects.ModifyStats(3, 0, creature)
+            }
+            mode("Target creature gains first strike until end of turn.") {
+                val creature = target("first strike target", TargetCreature())
+                effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Volkan Baǵa"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd91a194-6043-4c2d-afc8-427c38996ef4.jpg?1783937466"
+        ruling("2016-07-13", "If two chosen modes target a creature, you may choose the same creature for both targets or different creatures.")
+        ruling("2016-07-13", "If one target becomes illegal, the other target is still affected. If all targets become illegal, the spell doesn't resolve.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/SavageAlliance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/SavageAlliance.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/** Savage Alliance — Eldritch Moon #140. */
+val SavageAlliance = card("Savage Alliance") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\n" +
+        "Choose one or more —\n" +
+        "• Creatures target player controls gain trample until end of turn.\n" +
+        "• Savage Alliance deals 2 damage to target creature.\n" +
+        "• Savage Alliance deals 1 damage to each creature target opponent controls."
+
+    spell {
+        modal(chooseCount = 3, minChooseCount = 1, additionalManaCostPerExtraMode = "{1}") {
+            mode("Creatures target player controls gain trample until end of turn.") {
+                val player = target("trample player", TargetPlayer())
+                effect = Patterns.Group.grantKeywordToAll(
+                    keyword = Keyword.TRAMPLE,
+                    filter = GroupFilter(GameObjectFilter.Creature.targetPlayerControls(player))
+                )
+            }
+            mode("Savage Alliance deals 2 damage to target creature.") {
+                val creature = target("damage creature", TargetCreature())
+                effect = Effects.DealDamage(2, creature)
+            }
+            mode("Savage Alliance deals 1 damage to each creature target opponent controls.") {
+                val opponent = target("damage opponent", TargetOpponent())
+                effect = Patterns.Group.dealDamageToAll(
+                    amount = 1,
+                    filter = GroupFilter(GameObjectFilter.Creature.targetPlayerControls(opponent))
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "140"
+        artist = "Johann Bodin"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5255da8-8511-48a7-98e5-ba43ca6e8681.jpg?1783937456"
+        ruling("2016-07-13", "If the second and third modes affect the same creature, it is dealt 2 damage and 1 damage as separate events.")
+        ruling("2016-07-13", "If one target becomes illegal, the other targets are still affected. If all targets become illegal, the spell doesn't resolve.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BorrowedHostilityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BorrowedHostilityReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in EMN. */
+val BorrowedHostilityReprint = Printing(
+    oracleId = "b45fc33b-0658-4fe1-89da-54a07a12ebd4",
+    name = "Borrowed Hostility",
+    setCode = "INR",
+    collectorNumber = "146",
+    scryfallId = "64185203-9d47-4d67-b433-1c4b09816a35",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/64185203-9d47-4d67-b433-1c4b09816a35.jpg?1783908127",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SavageAllianceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/SavageAllianceReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in EMN. */
+val SavageAllianceReprint = Printing(
+    oracleId = "57da1d3f-7469-4efa-9b82-b2d915177d89",
+    name = "Savage Alliance",
+    setCode = "INR",
+    collectorNumber = "169",
+    scryfallId = "54bebcf4-7697-4b2d-9160-243cd447c1d4",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/5/4/54bebcf4-7697-4b2d-9160-243cd447c1d4.jpg?1783908113",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -140,6 +140,89 @@
     ]
 }
 
+// Borrowed Hostility
+{
+    "name": "Borrowed Hostility",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Escalate {3} (Pay this cost for each mode chosen beyond the first.)\nChoose one or both —\n• Target creature gets +3/+0 until end of turn.\n• Target creature gains first strike until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "power target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "power target"
+                        }
+                    ],
+                    "description": "Target creature gets +3/+0 until end of turn."
+                },
+                {
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "FIRST_STRIKE",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "first strike target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "first strike target"
+                        }
+                    ],
+                    "description": "Target creature gains first strike until end of turn."
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{3}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Volkan Baǵa",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd91a194-6043-4c2d-afc8-427c38996ef4.jpg?1783937466",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "If two chosen modes target a creature, you may choose the same creature for both targets or different creatures."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "If one target becomes illegal, the other target is still affected. If all targets become illegal, the spell doesn't resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Brisela, Voice of Nightmares
 {
     "name": "Brisela, Voice of Nightmares",
@@ -2363,6 +2446,137 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Savage Alliance
+{
+    "name": "Savage Alliance",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Creatures target player controls gain trample until end of turn.\n• Savage Alliance deals 2 damage to target creature.\n• Savage Alliance deals 1 damage to each creature target opponent controls.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "controllerPredicate": {
+                                        "type": "ControlledByReferencedPlayer",
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "trample player"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "body": {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": "Self"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "trample player"
+                        }
+                    ],
+                    "description": "Creatures target player controls gain trample until end of turn."
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "damage creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "damage creature"
+                        }
+                    ],
+                    "description": "Savage Alliance deals 2 damage to target creature."
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "controllerPredicate": {
+                                        "type": "ControlledByReferencedPlayer",
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "damage opponent"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponent",
+                            "id": "damage opponent"
+                        }
+                    ],
+                    "description": "Savage Alliance deals 1 damage to each creature target opponent controls."
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{1}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "UNCOMMON",
+        "artist": "Johann Bodin",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5255da8-8511-48a7-98e5-ba43ca6e8681.jpg?1783937456",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "If the second and third modes affect the same creature, it is dealt 2 damage and 1 damage as separate events."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "If one target becomes illegal, the other targets are still affected. If all targets become illegal, the spell doesn't resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -2237,6 +2237,12 @@ class CastSpellHandler(
                     val modeManaCost = modalEffect.modes.getOrNull(modeIndex)?.additionalManaCost ?: continue
                     effectiveCost = effectiveCost + ManaCost.parse(modeManaCost)
                 }
+                val perExtraMode = modalEffect.additionalManaCostPerExtraMode
+                if (perExtraMode != null) {
+                    repeat((action.chosenModes.size - 1).coerceAtLeast(0)) {
+                        effectiveCost = effectiveCost + ManaCost.parse(perExtraMode)
+                    }
+                }
             }
         }
 
@@ -3864,10 +3870,15 @@ class CastSpellHandler(
     private fun canPayModeSelection(
         state: GameState,
         action: CastSpell,
-        modes: List<com.wingedsheep.sdk.scripting.effects.Mode>,
+        modalEffect: ModalEffect,
         chosenIndices: List<Int>
     ): Boolean {
-        val extraCosts = chosenIndices.mapNotNull { modes.getOrNull(it)?.additionalManaCost }
+        val extraCosts = buildList {
+            addAll(chosenIndices.mapNotNull { modalEffect.modes.getOrNull(it)?.additionalManaCost })
+            modalEffect.additionalManaCostPerExtraMode?.let { perExtraMode ->
+                repeat((chosenIndices.size - 1).coerceAtLeast(0)) { add(perExtraMode) }
+            }
+        }
         // Nothing stacks — base-cost affordability was already validated on the cast action.
         if (extraCosts.isEmpty()) return true
         val cardComponent = state.getEntity(action.cardId)?.get<CardComponent>() ?: return true
@@ -3910,7 +3921,7 @@ class CastSpellHandler(
         // through mode + target selection and dead-ends at payment, where the pending
         // decision can never be answered legally (only cancelled).
         val offerIndices = candidateIndices.filter { candidate ->
-            canPayModeSelection(state, baseCastAction, modalEffect.modes, selectedModeIndices + candidate)
+            canPayModeSelection(state, baseCastAction, modalEffect, selectedModeIndices + candidate)
         }
         if (offerIndices.isEmpty() && selectedModeIndices.size < modalEffect.minChooseCount) {
             return ExecutionResult.error(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -193,6 +193,7 @@ data class ModalLegalEnumeration(
     val chooseCount: Int,
     val minChooseCount: Int,
     val allowRepeat: Boolean,
+    val additionalManaCostPerExtraMode: String? = null,
     val modes: List<ModalEnumerationMode>,
     val unavailableIndices: List<Int>
 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -1118,6 +1118,7 @@ class CastSpellEnumerator : ActionEnumerator {
                                 chooseCount = variantEffect.chooseCount,
                                 minChooseCount = variantEffect.minChooseCount,
                                 allowRepeat = variantEffect.allowRepeat,
+                                additionalManaCostPerExtraMode = variantEffect.additionalManaCostPerExtraMode,
                                 modes = enumerationModes,
                                 unavailableIndices = unavailableIndices
                             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -142,6 +142,7 @@ class LegalActionEnricher(
         chooseCount = chooseCount,
         minChooseCount = minChooseCount,
         allowRepeat = allowRepeat,
+        additionalManaCostPerExtraMode = additionalManaCostPerExtraMode,
         modes = modes.map { it.toDto() },
         unavailableIndices = unavailableIndices
     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -159,6 +159,7 @@ data class ModalLegalEnumerationInfo(
     val chooseCount: Int,
     val minChooseCount: Int,
     val allowRepeat: Boolean,
+    val additionalManaCostPerExtraMode: String? = null,
     val modes: List<ModalEnumerationModeInfo>,
     val unavailableIndices: List<Int>
 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalPerModeAdditionalCostTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalPerModeAdditionalCostTest.kt
@@ -103,9 +103,28 @@ class ModalPerModeAdditionalCostTest : FunSpec({
         )
     )
 
+    val EscalateModal = CardDefinition(
+        name = "Test Escalate Modal",
+        manaCost = ManaCost.parse("{R}"),
+        typeLine = TypeLine.sorcery(),
+        oracleText = "Escalate {2}\nChoose one or more —\n• Gain 1 life.\n• Draw a card.\n• You lose 1 life.",
+        script = CardScript.spell(
+            effect = ModalEffect(
+                modes = listOf(
+                    Mode.noTarget(GainLifeEffect(DynamicAmount.Fixed(1), EffectTarget.Controller), "Gain 1 life"),
+                    Mode.noTarget(DrawCardsEffect(DynamicAmount.Fixed(1), EffectTarget.Controller), "Draw a card"),
+                    Mode.noTarget(LoseLifeEffect(DynamicAmount.Fixed(1), EffectTarget.Controller), "Lose 1 life")
+                ),
+                chooseCount = 3,
+                minChooseCount = 1,
+                additionalManaCostPerExtraMode = "{2}"
+            )
+        )
+    )
+
     fun driver(): GameTestDriver {
         val d = GameTestDriver()
-        d.registerCards(TestCards.all + listOf(StackingCostsModal, SacrificeModal))
+        d.registerCards(TestCards.all + listOf(StackingCostsModal, SacrificeModal, EscalateModal))
         return d
     }
 
@@ -253,5 +272,67 @@ class ModalPerModeAdditionalCostTest : FunSpec({
             )
         )
         result.isSuccess shouldBe false
+    }
+
+    test("Escalate — the first chosen mode adds no mana cost") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveMana(p1, Color.RED, 1)
+        val lifeBefore = d.state.getEntity(p1)!!.get<LifeTotalComponent>()!!.life
+        val spell = d.putCardInHand(p1, "Test Escalate Modal")
+
+        d.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = spell,
+                chosenModes = listOf(0),
+                paymentStrategy = com.wingedsheep.engine.core.PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.state.getEntity(p1)!!.get<LifeTotalComponent>()!!.life shouldBe lifeBefore + 1
+    }
+
+    test("Escalate — its cost is paid once for each mode beyond the first") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 4)
+        val lifeBefore = d.state.getEntity(p1)!!.get<LifeTotalComponent>()!!.life
+        val spell = d.putCardInHand(p1, "Test Escalate Modal")
+
+        d.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = spell,
+                chosenModes = listOf(0, 1, 2),
+                paymentStrategy = com.wingedsheep.engine.core.PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.state.getEntity(p1)!!.get<LifeTotalComponent>()!!.life shouldBe lifeBefore
+    }
+
+    test("Escalate — a second mode is illegal when its one escalate payment is unaffordable") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 1)
+        val spell = d.putCardInHand(p1, "Test Escalate Modal")
+
+        d.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = spell,
+                chosenModes = listOf(0, 1),
+                paymentStrategy = com.wingedsheep.engine.core.PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe false
     }
 })

--- a/web-client/src/components/ui/ModalModeSelector.tsx
+++ b/web-client/src/components/ui/ModalModeSelector.tsx
@@ -56,7 +56,7 @@ function ModalModePanel({ state }: { state: ModalModeSelectionState }) {
   const responsive = useResponsive()
 
   const { enumeration, cardName, baseManaCost } = state
-  const { modes, minChooseCount, chooseCount, allowRepeat } = enumeration
+  const { modes, minChooseCount, chooseCount, allowRepeat, additionalManaCostPerExtraMode } = enumeration
 
   const [counts, setCounts] = useState<number[]>(() => new Array(modes.length).fill(0) as number[])
   const [minimized, setMinimized] = useState(false)
@@ -77,9 +77,13 @@ function ModalModePanel({ state }: { state: ModalModeSelectionState }) {
   const toggle = (i: number) => { if ((counts[i] ?? 0) > 0) remove(i); else add(i) }
 
   // Live cost preview from the currently-selected modes.
-  const additionalCost = combineManaCosts(
-    counts.flatMap((c, i) => Array.from({ length: c }, () => modes[i]?.additionalManaCost ?? ''))
-  )
+  const additionalCost = combineManaCosts([
+    ...counts.flatMap((c, i) => Array.from({ length: c }, () => modes[i]?.additionalManaCost ?? '')),
+    ...Array.from(
+      { length: Math.max(0, totalChosen - 1) },
+      () => additionalManaCostPerExtraMode ?? ''
+    ),
+  ])
   const totalCost = combineManaCosts([baseManaCost, additionalCost])
 
   const withinRange = totalChosen >= minChooseCount && totalChosen <= chooseCount
@@ -115,7 +119,9 @@ function ModalModePanel({ state }: { state: ModalModeSelectionState }) {
       )}
 
       <h2 className={decisionStyles.title}>{cardName}</h2>
-      <p className={decisionStyles.sourceLabel}>{rangeLabel} — pay for each chosen mode</p>
+      <p className={decisionStyles.sourceLabel}>
+        {rangeLabel}{additionalManaCostPerExtraMode ? ' — escalate for each mode beyond the first' : ' — pay for each chosen mode'}
+      </p>
 
       {/* Mode list */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8, width: '100%', maxWidth: 540 }}>

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -951,6 +951,8 @@ export interface ModalLegalEnumerationInfo {
   readonly minChooseCount: number
   /** When true, the same mode may be chosen more than once (Escalate-style repeat). */
   readonly allowRepeat: boolean
+  /** Additional mana paid for every selected mode beyond the first (Escalate). */
+  readonly additionalManaCostPerExtraMode?: string
   /** One entry per declared mode, in printed order. */
   readonly modes: readonly ModalEnumerationModeInfo[]
   /** Mode indices that cannot currently be chosen (no legal target / unaffordable). */


### PR DESCRIPTION
## Summary
- implement Borrowed Hostility and Savage Alliance in their canonical Eldritch Moon package
- add exact Innistrad Remastered printing rows and refreshed EMN card snapshots
- add reusable escalate cost support to modal spells, including server-authoritative payment, legal-action transport, and live web-client cost preview
- add focused engine coverage and manual client scenarios for both cards

I intentionally kept this batch to two cards: the remaining INR backlog is dominated by mechanics such as madness, emerge, transforming double-faced cards, and soulbond, while these two share one reusable capability.

## Verification
- just test
- just check
- npm run typecheck
- just check-card-printing "Borrowed Hostility"
- just check-card-printing "Savage Alliance"
- Scryfall image URLs return HTTP 200
- official Comprehensive Rules checked: escalate is CR 702.120a (June 19, 2026 rules)

## Player experience
Both spells use the existing single-panel cast-time modal selector. The panel now previews the escalate charge once per selected mode beyond the first, then the existing server-driven targeting flow collects each selected mode target.