### PR TITLE
Add The Aetherspark to Aetherdrift

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4721,6 +4721,10 @@ staticAbility {
   which attackers are restricted (evaluated with the source permanent as predicate source, so
   chosen-color/subtype predicates resolve against it) — e.g. Teferi's Moat:
   `CantBeAttackedWithout(Keyword.FLYING, GameObjectFilter.Creature.sharingChosenColorWithSource())`.
+- `CantBeAttackedWhileAttached` — the source permanent can't be chosen as an attack defender while
+  it has an `AttachedToComponent`. The restriction is checked only as attackers are declared, so
+  attaching the source after it is already being attacked doesn't remove it from combat. Used by
+  The Aetherspark.
 - `CantAttackUnlessCoAttacker(coAttackerFilter, filter = source)` — "This creature can't attack
   unless [a creature matching coAttackerFilter] also attacks" (Scarred Puma). Unlike
   `CantAttackUnless` (which is defender-relative), this depends on the whole proposed attacker

--- a/manual-scenarios/cards/t/the-aetherspark.json
+++ b/manual-scenarios/cards/t/the-aetherspark.json
@@ -1,0 +1,54 @@
+{
+  "player1Name": "Aetherspark Pilot",
+  "player2Name": "Challenger",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {
+        "name": "The Aetherspark",
+        "counters": {
+          "LOYALTY": 10
+        }
+      },
+      {
+        "name": "Grizzly Bears",
+        "summoningSickness": false
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Hill Giant",
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {
+        "name": "Hill Giant",
+        "summoningSickness": false
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Grizzly Bears",
+      "Hill Giant"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "DECLARE_ATTACKERS",
+    "COMBAT_DAMAGE"
+  ],
+  "player2StopAtSteps": [
+    "DECLARE_ATTACKERS"
+  ],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -417,6 +417,17 @@ data class CantBeAttackedWithout(
 }
 
 /**
+ * The source permanent can't be chosen as an attack defender while it is attached to another
+ * permanent. This is checked only when attackers are declared; becoming attached after attackers
+ * have already been declared does not remove the source from combat.
+ */
+@SerialName("CantBeAttackedWhileAttached")
+@Serializable
+data object CantBeAttackedWhileAttached : StaticAbility {
+    override val description: String = "This permanent can't be attacked while it's attached"
+}
+
+/**
  * Global cap on how many creatures may attack in a single combat (Dueling Grounds —
  * "No more than one creature can attack each combat").
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/TheAetherspark.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/TheAetherspark.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeAttackedWhileAttached
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Aetherspark — Aetherdrift #231
+ * {4} · Legendary Artifact Planeswalker — Equipment · Loyalty 4
+ */
+val TheAetherspark = card("The Aetherspark") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact Planeswalker — Equipment"
+    startingLoyalty = 4
+    oracleText = "As long as The Aetherspark is attached to a creature, The Aetherspark can't be " +
+        "attacked and has \"Whenever equipped creature deals combat damage during your turn, put " +
+        "that many loyalty counters on The Aetherspark.\"\n" +
+        "+1: Attach The Aetherspark to up to one target creature you control. Put a +1/+1 counter " +
+        "on that creature.\n" +
+        "−5: Draw two cards.\n" +
+        "−10: Add ten mana of any one color."
+
+    staticAbility {
+        ability = CantBeAttackedWhileAttached
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.Any,
+            binding = TriggerBinding.ATTACHED,
+        )
+        triggerCondition = Conditions.IsYourTurn
+        effect = Effects.AddDynamicCounters(
+            Counters.LOYALTY,
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            EffectTarget.Self,
+        )
+        description = "Whenever equipped creature deals combat damage during your turn, put that " +
+            "many loyalty counters on The Aetherspark."
+    }
+
+    loyaltyAbility(+1) {
+        val creature = target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl),
+        )
+        effect = Effects.AttachEquipment(creature) then
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+    }
+
+    loyaltyAbility(-5) {
+        effect = Effects.DrawCards(2)
+    }
+
+    loyaltyAbility(-10) {
+        effect = Effects.AddManaOfChoice(amount = 10)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "231"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/05690d52-06c4-40b1-8360-380418a83250.jpg?1783907850"
+
+        ruling(
+            "2025-02-07",
+            "If an effect causes The Aetherspark to become attached to a creature while it is being " +
+                "attacked, it will continue to be attacked."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -16605,6 +16605,128 @@
     ]
 }
 
+// The Aetherspark
+{
+    "name": "The Aetherspark",
+    "manaCost": "{4}",
+    "typeLine": "Legendary Artifact Planeswalker — Equipment",
+    "oracleText": "As long as The Aetherspark is attached to a creature, The Aetherspark can't be attacked and has \"Whenever equipped creature deals combat damage during your turn, put that many loyalty counters on The Aetherspark.\"\n+1: Attach The Aetherspark to up to one target creature you control. Put a +1/+1 counter on that creature.\n−5: Draw two cards.\n−10: Add ten mana of any one color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "loyalty",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "target": "Self"
+                },
+                "triggerCondition": "IsYourTurn",
+                "descriptionOverride": "Whenever equipped creature deals combat damage during your turn, put that many loyalty counters on The Aetherspark."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature you control"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "up to one target creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -5
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -10
+                },
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 10
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ],
+        "staticAbilities": [
+            "CantBeAttackedWhileAttached"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "MYTHIC",
+        "artist": "Donato Giancola",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/05690d52-06c4-40b1-8360-380418a83250.jpg?1783907850",
+        "rulings": [
+            {
+                "date": "2025-02-07",
+                "text": "If an effect causes The Aetherspark to become attached to a creature while it is being attacked, it will continue to be attacked."
+            }
+        ]
+    },
+    "startingLoyalty": 4,
+    "colorIdentityOverride": []
+}
+
 // The Last Ride
 {
     "name": "The Last Ride",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.CantAttackUnless
 import com.wingedsheep.sdk.scripting.CantBeAttackedWithout
+import com.wingedsheep.sdk.scripting.CantBeAttackedWhileAttached
 
 // =========================================================================
 // Per-creature attack restrictions (AttackRestrictionRule)
@@ -249,6 +250,20 @@ class CantBeAttackedWithoutDefenderRule : AttackDefenderRule {
     }
 }
 
+/** Prevents an attached permanent with [CantBeAttackedWhileAttached] from being attacked. */
+class CantBeAttackedWhileAttachedDefenderRule : AttackDefenderRule {
+    override fun check(ctx: AttackCheckContext, defenderId: EntityId): String? {
+        val defender = ctx.state.getEntity(defenderId) ?: return null
+        if (defender.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>() == null) {
+            return null
+        }
+        val card = defender.get<CardComponent>() ?: return null
+        val cardDef = ctx.cardRegistry.getCard(card.cardDefinitionId) ?: return null
+        if (cardDef.staticAbilities.none { it is CantBeAttackedWhileAttached }) return null
+        return "${card.name} can't be attacked while it's attached"
+    }
+}
+
 /**
  * AttackMode (CR 802 / 803): when the game uses attack-left or attack-right, a creature may only
  * attack the opponent in the adjacent seat (or a planeswalker/battle that opponent controls). The
@@ -302,5 +317,6 @@ fun defaultAttackRestrictionRules(): List<AttackRestrictionRule> = listOf(
 fun defaultAttackDefenderRules(): List<AttackDefenderRule> = listOf(
     CantAttackUnlessDefenderRule(),
     CantBeAttackedWithoutDefenderRule(),
+    CantBeAttackedWhileAttachedDefenderRule(),
     AttackModeDefenderRule()
 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -95,6 +95,7 @@ import com.wingedsheep.sdk.scripting.CanBlockAnyNumber
 import com.wingedsheep.sdk.scripting.CantAttackUnless
 import com.wingedsheep.sdk.scripting.CantAttackUnlessCoAttacker
 import com.wingedsheep.sdk.scripting.CantBeAttackedWithout
+import com.wingedsheep.sdk.scripting.CantBeAttackedWhileAttached
 import com.wingedsheep.sdk.scripting.CantBeBlockedBy
 import com.wingedsheep.sdk.scripting.CantBeBlockedByCreaturesWithLessPower
 import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
@@ -853,6 +854,7 @@ class StaticAbilityHandler(
             is CantAttackUnless,
             is CantAttackUnlessCoAttacker,
             is CantBeAttackedWithout,
+            is CantBeAttackedWhileAttached,
             is CantBeBlockedBy,
             is CantBeBlockedByCreaturesWithLessPower,
             is CantBeBlockedByMoreThan,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheAethersparkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheAethersparkScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/** Scenario coverage for The Aetherspark's attachment, defender restriction, and granted trigger. */
+class TheAethersparkScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Aetherspark") {
+
+            test("+1 attaches it and puts a +1/+1 counter on the chosen creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Aetherspark")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spark = game.findPermanent("The Aetherspark")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                setLoyalty(game, spark, 4)
+
+                val plusOne = cardRegistry.getCard("The Aetherspark")!!.script.activatedAbilities[0]
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = spark,
+                        abilityId = plusOne.id,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("The Aetherspark is attached to the chosen creature") {
+                    game.state.getEntity(spark)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                }
+                withClue("the creature receives the +1/+1 counter and the loyalty cost is paid") {
+                    counters(game, bears, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                    counters(game, spark, CounterType.LOYALTY) shouldBe 5
+                }
+            }
+
+            test("an attached Aetherspark can't be attacked") {
+                val game = scenario()
+                    .withPlayers("Defender", "Attacker")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "The Aetherspark", "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val spark = game.findPermanent("The Aetherspark")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val result = game.execute(
+                    DeclareAttackers(game.player2Id, mapOf(giant to spark))
+                )
+
+                result.error shouldNotBe null
+            }
+
+            test("an unattached Aetherspark can be attacked") {
+                val game = scenario()
+                    .withPlayers("Defender", "Attacker")
+                    .withCardOnBattlefield(1, "The Aetherspark")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val spark = game.findPermanent("The Aetherspark")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                game.execute(
+                    DeclareAttackers(game.player2Id, mapOf(giant to spark))
+                ).error shouldBe null
+            }
+
+            test("equipped creature combat damage during your turn adds that much loyalty") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "The Aetherspark", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val spark = game.findPermanent("The Aetherspark")!!
+                setLoyalty(game, spark, 4)
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+
+                withClue("Grizzly Bears dealt 2 combat damage, so The Aetherspark gains 2 loyalty") {
+                    counters(game, spark, CounterType.LOYALTY) shouldBe 6
+                }
+            }
+        }
+    }
+
+    private fun setLoyalty(game: TestGame, id: EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { container ->
+            container.with(CountersComponent().withAdded(CounterType.LOYALTY, amount))
+        }
+    }
+
+    private fun counters(game: TestGame, id: EntityId, type: CounterType): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(type) ?: 0
+}


### PR DESCRIPTION
## Summary

- implement The Aetherspark with its loyalty abilities and equipped-creature combat-damage trigger
- add reusable `CantBeAttackedWhileAttached` SDK/engine support
- add focused scenario coverage, the DFT card snapshot, SDK reference documentation, and a manual-play scenario

Aetherdrift was already complete on current `main` except for The Aetherspark and Mimeoplasm, Revered One (besides basic lands represented by the aggregate definition). Both remaining cards are complex, so this PR intentionally implements the smaller faithful unit rather than approximating or batching them.

## Verification

- `just test-class TheAethersparkScenarioTest`
- `just rebless-cards` (only The Aetherspark added to `DFT.json`; round-trip passed)
- `just check-card-printing "The Aetherspark"`
- exact Scryfall image URL returns HTTP 200
- `just test`
- `git diff --check`