### PR TITLE
Add original werewolves to Innistrad Remastered

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7129,6 +7129,12 @@ Numbers computed at resolution time.
     beforeTriggeringSpell = true)`.
   - Pairs with the `YouCastSpellsThisTurn` **condition** (§ conditions) — that gates a yes/no
     threshold, this yields the count.
+- `SpellsCastLastTurn` (facade `DynamicAmounts.spellsCastLastTurn()`) — total spells cast during the
+  immediately preceding turn. Reads the active-player/shared-team snapshot captured at the turn
+  boundary before current-turn counters reset. Compose with `Conditions.CompareAmounts`: `== 0`
+  models the original Innistrad werewolf front-face trigger, while `>= 2` models its back-face
+  trigger. It is deliberately turn-global rather than controller-scoped, matching "no spells were
+  cast last turn" and "a player cast two or more spells last turn."
 - `CraftedMaterialsTotalPower` — total printed power of the cards exiled to craft the source
   permanent (CR 702.167c). Reads the source's `CraftedFromExiledComponent`. Used for the
   `*`-power CDA on Mastercraft Raptor (Saheeli's Lattice back face). Evaluates to 0 when the

--- a/manual-scenarios/mechanics/original-werewolf-transform.json
+++ b/manual-scenarios/mechanics/original-werewolf-transform.json
@@ -1,0 +1,32 @@
+{
+  "player1Name": "Werewolf Player",
+  "player2Name": "Opponent",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Lightning Bolt", "Lightning Bolt"],
+    "battlefield": [
+      {"name": "Village Messenger", "summoningSickness": false},
+      {"name": "Hinterland Logger", "summoningSickness": false},
+      {"name": "Villagers of Estwald", "summoningSickness": false},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": ["UPKEEP", "PRECOMBAT_MAIN"],
+  "player2StopAtSteps": ["UPKEEP"],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -536,6 +536,9 @@ object DynamicAmounts {
             player, filter, excludeSelf, fromZone, beforeTriggeringSpell = beforeTriggeringSpell
         )
 
+    /** The total number of spells cast during the immediately preceding turn. */
+    fun spellsCastLastTurn(): DynamicAmount = DynamicAmount.SpellsCastLastTurn
+
     /** The starting life total of a player (20 in standard, 40 in commander). */
     fun startingLifeTotal(player: Player = Player.You): DynamicAmount =
         DynamicAmount.StartingLifeTotal(player)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -1366,6 +1366,20 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     }
 
     /**
+     * The total number of spells cast during the immediately preceding turn.
+     *
+     * This reads the snapshot captured at the turn boundary before the current-turn spell
+     * counters are cleared. It deliberately totals the previous active player's shared-turn team,
+     * matching old Innistrad werewolf wording such as "if no spells were cast last turn" and
+     * "if a player cast two or more spells last turn."
+     */
+    @SerialName("SpellsCastLastTurn")
+    @Serializable
+    data object SpellsCastLastTurn : DynamicAmount {
+        override val description: String = "the number of spells cast last turn"
+    }
+
+    /**
      * Total printed power of the cards exiled to craft the source permanent (CR 702.167c).
      *
      * Reads the source's

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HinterlandLoggerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HinterlandLoggerReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val HinterlandLoggerReprint = Printing(
+    oracleId = "29b22d41-4c6e-46de-8553-983d05f12f0f",
+    name = "Hinterland Logger",
+    setCode = "INR",
+    collectorNumber = "203",
+    scryfallId = "34898af1-ebe6-4ede-81be-23fd62844480",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34898af1-ebe6-4ede-81be-23fd62844480.jpg?1783908102",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/3/4/34898af1-ebe6-4ede-81be-23fd62844480.jpg?1783908102",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/VillageMessengerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/VillageMessengerReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val VillageMessengerReprint = Printing(
+    oracleId = "f6634a84-a9ce-4bbd-bc2c-3f9179b7f16a",
+    name = "Village Messenger",
+    setCode = "INR",
+    collectorNumber = "179",
+    scryfallId = "8bdc98cd-d03a-4c24-8642-b9ffb1f144c6",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8bdc98cd-d03a-4c24-8642-b9ffb1f144c6.jpg?1783908117",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/8/b/8bdc98cd-d03a-4c24-8642-b9ffb1f144c6.jpg?1783908117",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/VillagersOfEstwaldReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/VillagersOfEstwaldReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val VillagersOfEstwaldReprint = Printing(
+    oracleId = "dcf692f6-baec-4b60-a6e3-2a8b731d7816",
+    name = "Villagers of Estwald",
+    setCode = "INR",
+    collectorNumber = "224",
+    scryfallId = "319b65f6-a6e6-45ea-9837-bc5831f54205",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/319b65f6-a6e6-45ea-9837-bc5831f54205.jpg?1783908089",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/3/1/319b65f6-a6e6-45ea-9837-bc5831f54205.jpg?1783908089",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/VillagersOfEstwald.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/VillagersOfEstwald.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val VillagersOfEstwaldFront = card("Villagers of Estwald") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Werewolf"
+    power = 2
+    toughness = 3
+    oracleText = "At the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.EQ, DynamicAmount.Fixed(0)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "209"
+        artist = "Kev Walker"
+        flavorText = "You can spot a werewolf-infested town by its lack of butcher shops."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg?1783940912"
+    }
+}
+
+private val HowlpackOfEstwald = card("Howlpack of Estwald") {
+    manaCost = ""
+    colorIdentity = "G"
+    colorIndicator = "G"
+    typeLine = "Creature — Werewolf"
+    power = 4
+    toughness = 6
+    oracleText = "At the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.GTE, DynamicAmount.Fixed(2)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "209"
+        artist = "Kev Walker"
+        flavorText = "Estwald's citizens don't dislike outsiders—they taste just fine."
+        imageUri = "https://cards.scryfall.io/normal/back/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg?1783940912"
+    }
+}
+
+val VillagersOfEstwald: CardDefinition = CardDefinition.doubleFacedCreature(VillagersOfEstwaldFront, HowlpackOfEstwald)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HinterlandLogger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HinterlandLogger.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val HinterlandLoggerFront = card("Hinterland Logger") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Werewolf"
+    power = 2
+    toughness = 1
+    oracleText = "At the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.EQ, DynamicAmount.Fixed(0)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Karl Kopinski"
+        flavorText = "\"There's a forester lives up in the highlands. Tried to sell her one of my finest axes at a bargain, but she wasn't interested.\"\n—Old Rutstein"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg?1783937734"
+    }
+}
+
+private val TimberShredder = card("Timber Shredder") {
+    manaCost = ""
+    colorIdentity = "G"
+    colorIndicator = "G"
+    typeLine = "Creature — Werewolf"
+    power = 4
+    toughness = 2
+    oracleText = "Trample\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature."
+
+    keywords(Keyword.TRAMPLE)
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.GTE, DynamicAmount.Fixed(2)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Karl Kopinski"
+        flavorText = "\"She even had the audacity to criticize my wares as inferior.\"\n—Old Rutstein"
+        imageUri = "https://cards.scryfall.io/normal/back/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg?1783937734"
+    }
+}
+
+val HinterlandLogger: CardDefinition = CardDefinition.doubleFacedCreature(HinterlandLoggerFront, TimberShredder)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VillageMessenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VillageMessenger.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val VillageMessengerFront = card("Village Messenger") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Werewolf"
+    power = 1
+    toughness = 1
+    oracleText = "Haste\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    keywords(Keyword.HASTE)
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.EQ, DynamicAmount.Fixed(0)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Daarken"
+        flavorText = "\"I'm afraid it's bad news.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg?1783937747"
+    }
+}
+
+private val MoonriseIntruder = card("Moonrise Intruder") {
+    manaCost = ""
+    colorIdentity = "R"
+    colorIndicator = "R"
+    typeLine = "Creature — Werewolf"
+    power = 2
+    toughness = 2
+    oracleText = "Menace\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature."
+
+    keywords(Keyword.MENACE)
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.GTE, DynamicAmount.Fixed(2)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Daarken"
+        imageUri = "https://cards.scryfall.io/normal/back/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg?1783937747"
+    }
+}
+
+val VillageMessenger: CardDefinition = CardDefinition.doubleFacedCreature(VillageMessengerFront, MoonriseIntruder)

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -5481,6 +5481,96 @@
     ]
 }
 
+// Villagers of Estwald
+{
+    "name": "Villagers of Estwald",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Human Werewolf",
+    "oracleText": "At the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Howlpack of Estwald",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "At the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 6
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "209",
+            "artist": "Kev Walker",
+            "flavorText": "Estwald's citizens don't dislike outsiders—they taste just fine.",
+            "imageUri": "https://cards.scryfall.io/normal/back/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg?1783940912"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ],
+        "colorIndicator": [
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "artist": "Kev Walker",
+        "flavorText": "You can spot a werewolf-infested town by its lack of butcher shops.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e42a0a3d-a987-4b24-b9d4-27380a12e093.jpg?1783940912"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Voiceless Spirit
 {
     "name": "Voiceless Spirit",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1208,6 +1208,99 @@
     "colorIdentityOverride": []
 }
 
+// Hinterland Logger
+{
+    "name": "Hinterland Logger",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Werewolf",
+    "oracleText": "At the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Timber Shredder",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "Trample\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 2
+        },
+        "keywords": [
+            "TRAMPLE"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "210",
+            "artist": "Karl Kopinski",
+            "flavorText": "\"She even had the audacity to criticize my wares as inferior.\"\n—Old Rutstein",
+            "imageUri": "https://cards.scryfall.io/normal/back/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg?1783937734"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ],
+        "colorIndicator": [
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"There's a forester lives up in the highlands. Tried to sell her one of my finest axes at a bargain, but she wasn't interested.\"\n—Old Rutstein",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14529bed-9632-4d58-8edc-c5a1359f6604.jpg?1783937734"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Howlpack Resurgence
 {
     "name": "Howlpack Resurgence",
@@ -3543,6 +3636,103 @@
         "artist": "Jason Kang",
         "flavorText": "\"It's right to fear those that you keep locked away.\"\n—Rahilda, Vildin-Pack alpha",
         "imageUri": "https://cards.scryfall.io/normal/front/4/0/40440487-5ff2-43da-aa06-c649bf972ef1.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Village Messenger
+{
+    "name": "Village Messenger",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Werewolf",
+    "oracleText": "Haste\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Moonrise Intruder",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "Menace\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 2,
+            "toughness": 2
+        },
+        "keywords": [
+            "MENACE"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "190",
+            "rarity": "UNCOMMON",
+            "artist": "Daarken",
+            "imageUri": "https://cards.scryfall.io/normal/back/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg?1783937747"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ],
+        "colorIndicator": [
+            "RED"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "\"I'm afraid it's bad news.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44deb8cf-b9d1-4a14-aeaf-e62cf3dc9ef2.jpg?1783937747"
     },
     "colorIdentityOverride": [
         "RED"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -620,6 +620,9 @@ class DynamicAmountEvaluator(
                 }
             }
 
+            DynamicAmount.SpellsCastLastTurn ->
+                state.previousTurnActiveTeamSpellCounts.values.sum()
+
             is DynamicAmount.CraftedMaterialsTotalPower -> {
                 val sourceId = context.sourceId
                 if (sourceId == null) 0 else {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HinterlandLoggerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HinterlandLoggerScenarioTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class HinterlandLoggerScenarioTest : ScenarioTestBase() {
+    init {
+        context("Hinterland Logger") {
+            fun advanceToNextUpkeep(game: TestGame) {
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+            }
+
+            test("transforms in both directions from the previous turn's spell count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hinterland Logger", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val permanent = game.findPermanent("Hinterland Logger")!!
+                val active = game.state.activePlayerId!!
+
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(active to 0))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Timber Shredder"
+
+                val nextActive = game.state.activePlayerId!!
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(nextActive to 2))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Hinterland Logger"
+
+                val thirdActive = game.state.activePlayerId!!
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(thirdActive to 1))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Hinterland Logger"
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VillageMessengerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VillageMessengerScenarioTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class VillageMessengerScenarioTest : ScenarioTestBase() {
+    init {
+        context("Village Messenger") {
+            fun advanceToNextUpkeep(game: TestGame) {
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+            }
+
+            test("transforms in both directions from the previous turn's spell count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Village Messenger", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val permanent = game.findPermanent("Village Messenger")!!
+                val active = game.state.activePlayerId!!
+
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(active to 0))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Moonrise Intruder"
+
+                val nextActive = game.state.activePlayerId!!
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(nextActive to 2))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Village Messenger"
+
+                val thirdActive = game.state.activePlayerId!!
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(thirdActive to 1))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Village Messenger"
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VillagersOfEstwaldScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VillagersOfEstwaldScenarioTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class VillagersOfEstwaldScenarioTest : ScenarioTestBase() {
+    init {
+        context("Villagers of Estwald") {
+            fun advanceToNextUpkeep(game: TestGame) {
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+            }
+
+            test("transforms in both directions from the previous turn's spell count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Villagers of Estwald", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val permanent = game.findPermanent("Villagers of Estwald")!!
+                val active = game.state.activePlayerId!!
+
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(active to 0))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Howlpack of Estwald"
+
+                val nextActive = game.state.activePlayerId!!
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(nextActive to 2))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Villagers of Estwald"
+
+                val thirdActive = game.state.activePlayerId!!
+                game.state = game.state.copy(playerSpellsCastThisTurn = mapOf(thirdActive to 1))
+                advanceToNextUpkeep(game)
+                game.state.getEntity(permanent)!!.get<CardComponent>()!!.name shouldBe "Villagers of Estwald"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- implement Village Messenger, Hinterland Logger, and Villagers of Estwald in their earliest canonical sets
- add Innistrad Remastered printing rows with front/back art metadata
- add reusable `SpellsCastLastTurn` SDK vocabulary backed by the existing turn-boundary snapshot
- cover zero-, one-, and two-spell cases plus both transform directions in one scenario file per card
- add a manual scenario for exercising the three original werewolves together

## Verification

- `just test`
- `just test-class VillageMessengerScenarioTest`
- `just test-class HinterlandLoggerScenarioTest`
- `just test-class VillagersOfEstwaldScenarioTest`
- `just check-card-printing "Village Messenger"`
- `just check-card-printing "Hinterland Logger"`
- `just check-card-printing "Villagers of Estwald"`
- `git diff --check`

Innistrad Remastered coverage increases from 247/290 to 250/290.