### PR TITLE
Add all Aetherdrift basic land printings

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AetherdriftBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/AetherdriftBasicLands.kt
@@ -3,15 +3,51 @@ package com.wingedsheep.mtg.sets.definitions.dft.cards
 import com.wingedsheep.sdk.dsl.basicLand
 
 /**
- * Aetherdrift Basic Lands
+ * All Aetherdrift basic land printings.
  *
- * Aetherdrift contains one basic land of each type (cards 277, 280, 283, 286, and 289).
+ * The main set has cards 272-291, and the showcase treatments are cards 507-516.
  */
+
+val AetherdriftPlains272 = basicLand("Plains") {
+    collectorNumber = "272"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/2/d/2d2da8b9-797f-46e8-a15d-a86c7c56dc84.jpg?1783907836"
+}
 
 val AetherdriftPlains277 = basicLand("Plains") {
     collectorNumber = "277"
     artist = "Samuele Bandini"
     imageUri = "https://cards.scryfall.io/normal/front/4/6/464723b3-0723-45f2-a258-32d098c39039.jpg?1783907835"
+}
+
+val AetherdriftPlains278 = basicLand("Plains") {
+    collectorNumber = "278"
+    artist = "Titus Lunter"
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4b97d2f5-498c-42db-95d9-f9002d4dfcc5.jpg?1783907834"
+}
+
+val AetherdriftPlains279 = basicLand("Plains") {
+    collectorNumber = "279"
+    artist = "Leon Tukker"
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1cf2f81-3041-4349-9b37-f215c4e38c5b.jpg?1783907833"
+}
+
+val AetherdriftPlains507 = basicLand("Plains") {
+    collectorNumber = "507"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e196d67-1923-459d-98cf-646337914d3b.jpg?1783907767"
+}
+
+val AetherdriftPlains512 = basicLand("Plains") {
+    collectorNumber = "512"
+    artist = "Calder Moore"
+    imageUri = "https://cards.scryfall.io/normal/front/5/d/5dd76e71-df9b-4fd2-b534-d3f724a56a91.jpg?1783907766"
+}
+
+val AetherdriftIsland273 = basicLand("Island") {
+    collectorNumber = "273"
+    artist = "Maxime Minard"
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f53ed206-8ec4-46a6-8603-c819682e1433.jpg?1783907835"
 }
 
 val AetherdriftIsland280 = basicLand("Island") {
@@ -20,10 +56,70 @@ val AetherdriftIsland280 = basicLand("Island") {
     imageUri = "https://cards.scryfall.io/normal/front/5/a/5a8e9b9e-4947-4b6a-b21b-6fe009760fc5.jpg?1783907834"
 }
 
+val AetherdriftIsland281 = basicLand("Island") {
+    collectorNumber = "281"
+    artist = "Mark Poole"
+    imageUri = "https://cards.scryfall.io/normal/front/f/9/f9369d0a-87c0-4c29-b43c-cd45c007f8d6.jpg?1783907834"
+}
+
+val AetherdriftIsland282 = basicLand("Island") {
+    collectorNumber = "282"
+    artist = "Leon Tukker"
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a3c4a9d-48db-474f-aeb6-8b4fa08ce6fa.jpg?1783907833"
+}
+
+val AetherdriftIsland508 = basicLand("Island") {
+    collectorNumber = "508"
+    artist = "Maxime Minard"
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9b33841e-7006-41d4-98b0-313ab151c9ec.jpg?1783907767"
+}
+
+val AetherdriftIsland513 = basicLand("Island") {
+    collectorNumber = "513"
+    artist = "Calder Moore"
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d13bb767-1123-48d2-960f-b90b6db3f6ed.jpg?1783907765"
+}
+
+val AetherdriftSwamp274 = basicLand("Swamp") {
+    collectorNumber = "274"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e969e168-e74c-4608-9fa0-a5660bf7fa02.jpg?1783907835"
+}
+
 val AetherdriftSwamp283 = basicLand("Swamp") {
     collectorNumber = "283"
     artist = "Samuele Bandini"
     imageUri = "https://cards.scryfall.io/normal/front/0/4/040d064e-b023-4750-afeb-1f58e36bc4ab.jpg?1783907831"
+}
+
+val AetherdriftSwamp284 = basicLand("Swamp") {
+    collectorNumber = "284"
+    artist = "Ron Spencer"
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/73e124b6-3af7-41c0-b829-ff85aa0c3782.jpg?1783907832"
+}
+
+val AetherdriftSwamp285 = basicLand("Swamp") {
+    collectorNumber = "285"
+    artist = "Leon Tukker"
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/85288987-6f3f-4b7b-9ecc-9393dd37f115.jpg?1783907831"
+}
+
+val AetherdriftSwamp509 = basicLand("Swamp") {
+    collectorNumber = "509"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba042d60-b1e8-44ad-9103-f40588a0b29c.jpg?1783907768"
+}
+
+val AetherdriftSwamp514 = basicLand("Swamp") {
+    collectorNumber = "514"
+    artist = "Calder Moore"
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f4d198b3-2ff5-484a-905f-c272de7c139d.jpg?1783907764"
+}
+
+val AetherdriftMountain275 = basicLand("Mountain") {
+    collectorNumber = "275"
+    artist = "Chris Ostrowski"
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/50748a4c-43a0-4274-9a84-046d76027166.jpg?1783907834"
 }
 
 val AetherdriftMountain286 = basicLand("Mountain") {
@@ -32,16 +128,95 @@ val AetherdriftMountain286 = basicLand("Mountain") {
     imageUri = "https://cards.scryfall.io/normal/front/f/b/fb76cb6c-2f4d-4ca2-876f-d49ea529e59b.jpg?1783907832"
 }
 
+val AetherdriftMountain287 = basicLand("Mountain") {
+    collectorNumber = "287"
+    artist = "Florian de Gesincourt"
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c872e70c-626f-4d2c-b26b-d94f815fceea.jpg?1783907832"
+}
+
+val AetherdriftMountain288 = basicLand("Mountain") {
+    collectorNumber = "288"
+    artist = "Leon Tukker"
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/653e2393-30a7-4e0c-bd20-f05ca0ba3cb6.jpg?1783907830"
+}
+
+val AetherdriftMountain510 = basicLand("Mountain") {
+    collectorNumber = "510"
+    artist = "Chris Ostrowski"
+    imageUri = "https://cards.scryfall.io/normal/front/c/7/c7533cbb-ab73-4a0c-9ea0-baa97c4665b8.jpg?1783907767"
+}
+
+val AetherdriftMountain515 = basicLand("Mountain") {
+    collectorNumber = "515"
+    artist = "Calder Moore"
+    imageUri = "https://cards.scryfall.io/normal/front/5/e/5e4952a8-4e1f-4a74-8a06-c9d633b25dcd.jpg?1783907764"
+}
+
+val AetherdriftForest276 = basicLand("Forest") {
+    collectorNumber = "276"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/777e868d-cb88-4b8e-99d1-12ff67f5eae2.jpg?1783907835"
+}
+
 val AetherdriftForest289 = basicLand("Forest") {
     collectorNumber = "289"
     artist = "Samuele Bandini"
     imageUri = "https://cards.scryfall.io/normal/front/b/6/b69adddd-3626-45d6-8100-26cf1f314d00.jpg?1783907831"
 }
 
+val AetherdriftForest290 = basicLand("Forest") {
+    collectorNumber = "290"
+    artist = "Yeong-Hao Han"
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/6472e2a6-287f-4e7c-ad85-1454e40d4a46.jpg?1783907831"
+}
+
+val AetherdriftForest291 = basicLand("Forest") {
+    collectorNumber = "291"
+    artist = "Leon Tukker"
+    imageUri = "https://cards.scryfall.io/normal/front/5/6/562b16ae-8ae7-4b2d-9098-bf3ff1429f7b.jpg?1783907830"
+}
+
+val AetherdriftForest511 = basicLand("Forest") {
+    collectorNumber = "511"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/f/d/fd1b6c5c-4585-47c1-82eb-a324189f3ebd.jpg?1783907768"
+}
+
+val AetherdriftForest516 = basicLand("Forest") {
+    collectorNumber = "516"
+    artist = "Calder Moore"
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a7aba60-d300-4c33-9e1e-846d6167dc50.jpg?1783907764"
+}
+
 val AetherdriftBasicLands = listOf(
+    AetherdriftPlains272,
     AetherdriftPlains277,
+    AetherdriftPlains278,
+    AetherdriftPlains279,
+    AetherdriftPlains507,
+    AetherdriftPlains512,
+    AetherdriftIsland273,
     AetherdriftIsland280,
+    AetherdriftIsland281,
+    AetherdriftIsland282,
+    AetherdriftIsland508,
+    AetherdriftIsland513,
+    AetherdriftSwamp274,
     AetherdriftSwamp283,
+    AetherdriftSwamp284,
+    AetherdriftSwamp285,
+    AetherdriftSwamp509,
+    AetherdriftSwamp514,
+    AetherdriftMountain275,
     AetherdriftMountain286,
+    AetherdriftMountain287,
+    AetherdriftMountain288,
+    AetherdriftMountain510,
+    AetherdriftMountain515,
+    AetherdriftForest276,
     AetherdriftForest289,
+    AetherdriftForest290,
+    AetherdriftForest291,
+    AetherdriftForest511,
+    AetherdriftForest516,
 )


### PR DESCRIPTION
## Summary
- expand Aetherdrift basic lands from five representative cards to all 30 printings
- include collector numbers 272-291 and 507-516
- use exact Scryfall artist metadata and image URLs for every printing

## Verification
- `just build` — passed
- all 30 Scryfall image URLs return HTTP 200
- `git diff --check` — passed
- dedicated `BasicLandArtOrderTest` and card discovery/snapshot tests — passed

## Note
- `just check-card-printing` is not applicable to basic-land variants in the current repository model; it reports pre-existing canonical-placement drift for basic lands across hundreds of sets.