### PR TITLE
Add three Innistrad Remastered Werewolves

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/ScornedVillager.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/ScornedVillager.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val ScornedVillagerFront = card("Scorned Villager") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Werewolf"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Add {G}.\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+    }
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.EQ, DynamicAmount.Fixed(0)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Cynthia Sheppard"
+        flavorText = "\"My village's fear drove me into the wild . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1783940808"
+    }
+}
+
+private val MoonscarredWerewolf = card("Moonscarred Werewolf") {
+    manaCost = ""
+    colorIdentity = "G"
+    colorIndicator = "G"
+    typeLine = "Creature — Werewolf"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance\n{T}: Add {G}{G}.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature."
+
+    keywords(Keyword.VIGILANCE)
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN, 2)
+        manaAbility = true
+    }
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.GTE, DynamicAmount.Fixed(2)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Cynthia Sheppard"
+        flavorText = "\". . . and I will bring the fury of the wild back to my village.\""
+        imageUri = "https://cards.scryfall.io/normal/back/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1783940808"
+    }
+}
+
+val ScornedVillager: CardDefinition = CardDefinition.doubleFacedCreature(ScornedVillagerFront, MoonscarredWerewolf)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HanweirWatchkeepReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HanweirWatchkeepReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val HanweirWatchkeepReprint = Printing(
+    oracleId = "8bdf986e-a47e-47b6-8cdb-576c86c4041b",
+    name = "Hanweir Watchkeep",
+    setCode = "INR",
+    collectorNumber = "158",
+    scryfallId = "d067706b-e2cc-4ad5-b992-28222a8af4ad",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d067706b-e2cc-4ad5-b992-28222a8af4ad.jpg?1783908125",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/KruinOutlawReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/KruinOutlawReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val KruinOutlawReprint = Printing(
+    oracleId = "cf518f59-f083-42a0-9953-fac2757bf804",
+    name = "Kruin Outlaw",
+    setCode = "INR",
+    collectorNumber = "161",
+    scryfallId = "3c6ee666-9b5b-428a-9ddb-37c36a6272cb",
+    artist = "David Rapoza",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c6ee666-9b5b-428a-9ddb-37c36a6272cb.jpg?1783908121",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ScornedVillagerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ScornedVillagerReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val ScornedVillagerReprint = Printing(
+    oracleId = "52855f90-19c1-46c9-8eed-88b3c1722bb0",
+    name = "Scorned Villager",
+    setCode = "INR",
+    collectorNumber = "212",
+    scryfallId = "ee539a5e-2d10-4666-9b52-5064562dd233",
+    artist = "Cynthia Sheppard",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee539a5e-2d10-4666-9b52-5064562dd233.jpg?1783908096",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/HanweirWatchkeep.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/HanweirWatchkeep.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.MustAttack
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val HanweirWatchkeepFront = card("Hanweir Watchkeep") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior Werewolf"
+    power = 1
+    toughness = 5
+    oracleText = "Defender\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    keywords(Keyword.DEFENDER)
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.EQ, DynamicAmount.Fixed(0)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Wayne Reynolds"
+        flavorText = "He scans for wolves, knowing there's one he can never anticipate."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg?1783940944"
+    }
+}
+
+private val BaneOfHanweir = card("Bane of Hanweir") {
+    manaCost = ""
+    colorIdentity = "R"
+    colorIndicator = "R"
+    typeLine = "Creature — Werewolf"
+    power = 5
+    toughness = 5
+    oracleText = "This creature attacks each combat if able.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature."
+
+    staticAbility { ability = MustAttack() }
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.GTE, DynamicAmount.Fixed(2)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Wayne Reynolds"
+        flavorText = "Technically he never left his post. He looks after the wolf wherever it goes."
+        imageUri = "https://cards.scryfall.io/normal/back/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg?1783940944"
+    }
+}
+
+val HanweirWatchkeep: CardDefinition = CardDefinition.doubleFacedCreature(HanweirWatchkeepFront, BaneOfHanweir)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/KruinOutlaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/KruinOutlaw.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val KruinOutlawFront = card("Kruin Outlaw") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue Werewolf"
+    power = 2
+    toughness = 2
+    oracleText = "First strike\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    keywords(Keyword.FIRST_STRIKE)
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.EQ, DynamicAmount.Fixed(0)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "152"
+        artist = "David Rapoza"
+        flavorText = "\"Hold tight. I've got a surprise for them.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg?1783940938"
+        ruling(
+            "2011-09-22",
+            "If Kruin Outlaw somehow transforms after blockers have been declared but before combat ends, " +
+                "any Werewolves you control that are blocked by a single creature will remain blocked."
+        )
+    }
+}
+
+private val TerrorOfKruinPass = card("Terror of Kruin Pass") {
+    manaCost = ""
+    colorIdentity = "R"
+    colorIndicator = "R"
+    typeLine = "Creature — Werewolf"
+    power = 3
+    toughness = 3
+    oracleText = "Double strike\nWerewolves you control have menace. (A creature with menace can't be blocked except by two or more creatures.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature."
+
+    keywords(Keyword.DOUBLE_STRIKE)
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.MENACE,
+            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.WEREWOLF).youControl())
+        )
+    }
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.GTE, DynamicAmount.Fixed(2)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "152"
+        artist = "David Rapoza"
+        imageUri = "https://cards.scryfall.io/normal/back/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg?1783940938"
+    }
+}
+
+val KruinOutlaw: CardDefinition = CardDefinition.doubleFacedCreature(KruinOutlawFront, TerrorOfKruinPass)

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -799,6 +799,125 @@
     ]
 }
 
+// Scorned Villager
+{
+    "name": "Scorned Villager",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Werewolf",
+    "oracleText": "{T}: Add {G}.\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "isManaAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Moonscarred Werewolf",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "Vigilance\n{T}: Add {G}{G}.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 2,
+            "toughness": 2
+        },
+        "keywords": [
+            "VIGILANCE"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ],
+            "activatedAbilities": [
+                {
+                    "id": "ability_4",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "GREEN",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "isManaAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "125",
+            "artist": "Cynthia Sheppard",
+            "flavorText": "\". . . and I will bring the fury of the wild back to my village.\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1783940808"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ],
+        "colorIndicator": [
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Cynthia Sheppard",
+        "flavorText": "\"My village's fear drove me into the wild . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f35e364-81d9-4888-993b-acc7a53d963c.jpg?1783940808"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Thalia, Guardian of Thraben
 {
     "name": "Thalia, Guardian of Thraben",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -2255,6 +2255,104 @@
     ]
 }
 
+// Hanweir Watchkeep
+{
+    "name": "Hanweir Watchkeep",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Warrior Werewolf",
+    "oracleText": "Defender\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Bane of Hanweir",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "This creature attacks each combat if able.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 5
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ],
+            "staticAbilities": [
+                "MustAttack"
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "145",
+            "rarity": "UNCOMMON",
+            "artist": "Wayne Reynolds",
+            "flavorText": "Technically he never left his post. He looks after the wolf wherever it goes.",
+            "imageUri": "https://cards.scryfall.io/normal/back/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg?1783940944"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ],
+        "colorIndicator": [
+            "RED"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "flavorText": "He scans for wolves, knowing there's one he can never anticipate.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b14ed17-1a35-4c49-ac46-3cad42d46c14.jpg?1783940944"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Heartless Summoning
 {
     "name": "Heartless Summoning",
@@ -2555,6 +2653,118 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Kruin Outlaw
+{
+    "name": "Kruin Outlaw",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Human Rogue Werewolf",
+    "oracleText": "First strike\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Terror of Kruin Pass",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "Double strike\nWerewolves you control have menace. (A creature with menace can't be blocked except by two or more creatures.)\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "keywords": [
+            "DOUBLE_STRIKE"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "MENACE",
+                    "filter": {
+                        "baseFilter": "creature Werewolf ctrl:you"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "152",
+            "rarity": "RARE",
+            "artist": "David Rapoza",
+            "imageUri": "https://cards.scryfall.io/normal/back/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg?1783940938"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ],
+        "colorIndicator": [
+            "RED"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "RARE",
+        "artist": "David Rapoza",
+        "flavorText": "\"Hold tight. I've got a surprise for them.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec00d2d2-6597-474a-9353-345bbedfe57e.jpg?1783940938",
+        "rulings": [
+            {
+                "date": "2011-09-22",
+                "text": "If Kruin Outlaw somehow transforms after blockers have been declared but before combat ends, any Werewolves you control that are blocked by a single creature will remain blocked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
## Summary
- add canonical double-faced definitions for Hanweir Watchkeep, Scorned Villager, and Kruin Outlaw in their earliest printing sets
- add Innistrad Remastered printing metadata for all three cards
- update ISD and DKA card snapshots

## Verification
- `just check-card-printing` for all three cards
- `just rebless-cards`
- `just build`
- all six Scryfall face image URLs return HTTP 200