### PR TITLE
Add Arlinn Kord to Innistrad Remastered

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1371,7 +1371,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   Aetherdrift's "3/2 colorless Vehicle artifact token with crew 1" (Mu Yanling, Wind Rider). A *noncreature*
   artifact carrying printed P/T and the ordinary `crew 1` keyword, defined on the predefined `Vehicle`
   `CardDefinition`, so it can't attack or block until something crews it and it crews through the normal path.
-- `CreatePermanentEmblem(name, abilities)` — planeswalker emblem with static abilities.
+- `CreatePermanentEmblem(groupFilter, powerBonus?, toughnessBonus?, grantedKeywords?, grantedActivatedAbilities?, emblemDescription)` — permanent planeswalker emblem whose dynamically evaluated group receives the listed stats, keywords, and activated abilities. Unlike a one-shot group grant, the emblem also affects matching permanents that enter later. The activated-ability form powers Arlinn Kord's emblem.
 
 ### Ability granting
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1066,12 +1066,14 @@ object Effects {
         powerBonus: Int = 0,
         toughnessBonus: Int = 0,
         grantedKeywords: List<String> = emptyList(),
+        grantedActivatedAbilities: List<com.wingedsheep.sdk.scripting.ActivatedAbility> = emptyList(),
         emblemDescription: String
     ): Effect = com.wingedsheep.sdk.scripting.effects.CreatePermanentEmblemEffect(
         groupFilter = groupFilter,
         powerBonus = powerBonus,
         toughnessBonus = toughnessBonus,
         grantedKeywords = grantedKeywords,
+        grantedActivatedAbilities = grantedActivatedAbilities,
         emblemDescription = emblemDescription
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -702,6 +702,7 @@ data class CreatePermanentEmblemEffect(
     val powerBonus: Int = 0,
     val toughnessBonus: Int = 0,
     val grantedKeywords: List<String> = emptyList(),
+    val grantedActivatedAbilities: List<com.wingedsheep.sdk.scripting.ActivatedAbility> = emptyList(),
     val emblemDescription: String
 ) : Effect {
     override val description: String = "You get an emblem with \"$emblemDescription\""

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ArlinnKordReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ArlinnKordReprint.kt
@@ -1,0 +1,15 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val ArlinnKordReprint = Printing(
+    oracleId = "6bb7d0df-7a9f-4e17-8c31-7628c4b12356",
+    name = "Arlinn Kord",
+    setCode = "INR",
+    collectorNumber = "230",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/e/7/e72d7c11-2165-4c72-80f3-3c1a7b4b5572.jpg?1783908089",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ArlinnKord.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ArlinnKord.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+private const val ARLINN_EMBLEM = "Creatures you control have haste and '{T}: This creature deals damage equal to its power to any target.'"
+
+private val arlinnEmblemAbility = ActivatedAbility(
+    id = AbilityId.generate(),
+    cost = Costs.Tap,
+    targetRequirements = listOf(AnyTarget()),
+    effect = Effects.DealDamage(DynamicAmounts.sourcePower(), EffectTarget.ContextTarget(0)),
+    descriptionOverride = "{T}: This creature deals damage equal to its power to any target.",
+)
+
+private val ArlinnEmbracedByTheMoon = card("Arlinn, Embraced by the Moon") {
+    manaCost = ""
+    colorIdentity = "RG"
+    typeLine = "Legendary Planeswalker — Arlinn"
+    oracleText = "+1: Creatures you control get +1/+1 and gain trample until end of turn.\n" +
+        "−1: Arlinn deals 3 damage to any target. Transform Arlinn.\n" +
+        "−6: You get an emblem with \"$ARLINN_EMBLEM\""
+
+    loyaltyAbility(+1) {
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreaturesYouControl,
+            Effects.ModifyStats(1, 1, EffectTarget.Self) then
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self, Duration.EndOfTurn),
+        )
+    }
+    loyaltyAbility(-1) {
+        val target = target("target", AnyTarget())
+        effect = Effects.DealDamage(3, target) then TransformEffect(EffectTarget.Self)
+    }
+    loyaltyAbility(-6) {
+        effect = Effects.CreatePermanentEmblem(
+            groupFilter = GroupFilter.AllCreaturesYouControl,
+            grantedKeywords = listOf(Keyword.HASTE.name),
+            grantedActivatedAbilities = listOf(arlinnEmblemAbility),
+            emblemDescription = ARLINN_EMBLEM,
+        )
+    }
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "243"
+        artist = "Winona Nelson"
+        imageUri = "https://cards.scryfall.io/normal/back/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg?1783937719"
+    }
+}
+
+private val ArlinnKordFront = card("Arlinn Kord") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Planeswalker — Arlinn"
+    startingLoyalty = 3
+    oracleText = "+1: Until end of turn, up to one target creature gets +2/+2 and gains vigilance and haste.\n" +
+        "0: Create a 2/2 green Wolf creature token. Transform Arlinn Kord."
+
+    loyaltyAbility(+1) {
+        val creature = target("creature", TargetCreature(optional = true))
+        effect = Effects.ModifyStats(2, 2, creature) then
+            Effects.GrantKeyword(Keyword.VIGILANCE, creature, Duration.EndOfTurn) then
+            Effects.GrantKeyword(Keyword.HASTE, creature, Duration.EndOfTurn)
+    }
+    loyaltyAbility(0) {
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Wolf"),
+        ) then TransformEffect(EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "243"
+        artist = "Winona Nelson"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg?1783937719"
+    }
+}
+
+val ArlinnKord: CardDefinition = ArlinnKordFront.copy(backFace = ArlinnEmbracedByTheMoon)

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -505,6 +505,244 @@
     ]
 }
 
+// Arlinn Kord
+{
+    "name": "Arlinn Kord",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Legendary Planeswalker — Arlinn",
+    "oracleText": "+1: Until end of turn, up to one target creature gets +2/+2 and gains vigilance and haste.\n0: Create a 2/2 green Wolf creature token. Transform Arlinn Kord.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 0
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "GREEN"
+                            ],
+                            "creatureTypes": [
+                                "Wolf"
+                            ]
+                        },
+                        "Transform"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Arlinn, Embraced by the Moon",
+        "manaCost": "",
+        "typeLine": "Legendary Planeswalker — Arlinn",
+        "oracleText": "+1: Creatures you control get +1/+1 and gain trample until end of turn.\n−1: Arlinn deals 3 damage to any target. Transform Arlinn.\n−6: You get an emblem with \"Creatures you control have haste and '{T}: This creature deals damage equal to its power to any target.'\"",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostLoyalty",
+                        "change": 1
+                    },
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "TRAMPLE",
+                                    "target": "Self"
+                                }
+                            ]
+                        }
+                    },
+                    "timing": "SorcerySpeed",
+                    "isPlaneswalkerAbility": true
+                },
+                {
+                    "id": "ability_4",
+                    "cost": {
+                        "type": "CostLoyalty",
+                        "change": -1
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            "Transform"
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "AnyTarget",
+                            "id": "target"
+                        }
+                    ],
+                    "timing": "SorcerySpeed",
+                    "isPlaneswalkerAbility": true
+                },
+                {
+                    "id": "ability_5",
+                    "cost": {
+                        "type": "CostLoyalty",
+                        "change": -6
+                    },
+                    "effect": {
+                        "type": "CreatePermanentEmblem",
+                        "groupFilter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "grantedKeywords": [
+                            "HASTE"
+                        ],
+                        "grantedActivatedAbilities": [
+                            {
+                                "id": "ability_6",
+                                "cost": "CostTap",
+                                "effect": {
+                                    "type": "DealDamage",
+                                    "amount": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": "Power"
+                                    },
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                },
+                                "targetRequirements": [
+                                    "AnyTarget"
+                                ],
+                                "descriptionOverride": "{T}: This creature deals damage equal to its power to any target."
+                            }
+                        ],
+                        "emblemDescription": "Creatures you control have haste and '{T}: This creature deals damage equal to its power to any target.'"
+                    },
+                    "timing": "SorcerySpeed",
+                    "isPlaneswalkerAbility": true
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "243",
+            "rarity": "MYTHIC",
+            "artist": "Winona Nelson",
+            "imageUri": "https://cards.scryfall.io/normal/back/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg?1783937719"
+        },
+        "colorIdentityOverride": [
+            "RED",
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "rarity": "MYTHIC",
+        "artist": "Winona Nelson",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b37aa12c-a6b3-4cf8-b5a4-0a999ff12d02.jpg?1783937719"
+    },
+    "startingLoyalty": 3,
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Bound by Moonsilver
 {
     "name": "Bound by Moonsilver",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -383,6 +383,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CantBeCopiedComponent::class)
         subclass(PutIntoGraveyardThisTurnComponent::class)
         subclass(EmblemSourceComponent::class)
+        subclass(EmblemActivatedAbilityComponent::class)
         subclass(CommanderComponent::class)
         subclass(RingBearerComponent::class)
         subclass(TheRingComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CreatePermanentEmblemExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CreatePermanentEmblemExecutor.kt
@@ -14,6 +14,7 @@ import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.state.components.battlefield.withCastChoice
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.EmblemSourceComponent
+import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityComponent
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.CreatePermanentEmblemEffect
@@ -69,6 +70,11 @@ class CreatePermanentEmblemExecutor : EffectExecutor<CreatePermanentEmblemEffect
         if (chosenType != null) {
             emblemContainer = emblemContainer.withCastChoice(
                 ChoiceSlot.CREATURE_TYPE, ChoiceValue.TextChoice(chosenType)
+            )
+        }
+        if (effect.grantedActivatedAbilities.isNotEmpty()) {
+            emblemContainer = emblemContainer.with(
+                EmblemActivatedAbilityComponent(effect.groupFilter, effect.grantedActivatedAbilities)
             )
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -9,6 +9,9 @@ import com.wingedsheep.engine.state.components.battlefield.*
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityComponent
+import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
@@ -67,10 +70,22 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 .map { it.ability }
             val staticGrants = context.castPermissionUtils.getStaticGrantedAbilitiesWithGranter(entityId, state)
             val staticAbilities = staticGrants.map { it.ability }
+            val emblemAbilities = state.entities.mapNotNull { (emblemId, emblemContainer) ->
+                val grant = emblemContainer.get<EmblemActivatedAbilityComponent>() ?: return@mapNotNull null
+                val controllerId = emblemContainer.get<ControllerComponent>()?.playerId ?: return@mapNotNull null
+                val matches = context.predicateEvaluator.matches(
+                    state,
+                    projected,
+                    entityId,
+                    grant.filter.baseFilter,
+                    PredicateContext(controllerId = controllerId, sourceId = emblemId),
+                ) && (!grant.filter.excludeSelf || entityId != emblemId)
+                grant.takeIf { matches }?.abilities
+            }.flatten()
             // Which permanent granted each statically-granted ability, so a cost that names the
             // granter (AbilityCost.TapGrantingPermanent) can be gated on *its* state, not the host's.
             val granterByAbilityId = staticGrants.associate { it.ability.id to it.granterId }
-            val allAbilities = grantedAbilities + staticAbilities
+            val allAbilities = grantedAbilities + staticAbilities + emblemAbilities
 
             // If no card definition (e.g., tokens) and no granted/static abilities, skip
             if (cardDef == null && allAbilities.isEmpty()) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/EmblemAbilityComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/EmblemAbilityComponent.kt
@@ -1,0 +1,13 @@
+package com.wingedsheep.engine.state.components.identity
+
+import com.wingedsheep.engine.state.Component
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import kotlinx.serialization.Serializable
+
+/** Activated abilities granted dynamically by a permanent emblem. */
+@Serializable
+data class EmblemActivatedAbilityComponent(
+    val filter: GroupFilter,
+    val abilities: List<ActivatedAbility>,
+) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArlinnKordScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArlinnKordScenarioTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldNotBe
+
+class ArlinnKordScenarioTest : ScenarioTestBase() {
+
+    private fun seedLoyalty(game: TestGame, id: EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { container ->
+            container
+                .with(CountersComponent().withAdded(CounterType.LOYALTY, amount))
+                .without<AbilityActivatedThisTurnComponent>()
+        }
+    }
+
+    init {
+        test("emblem grants its tap ability to creatures you control") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Arlinn Kord")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val arlinn = game.findPermanent("Arlinn Kord")!!
+            val frontTransform = cardRegistry.getCard("Arlinn Kord")!!.script.activatedAbilities[1]
+            game.execute(ActivateAbility(game.player1Id, arlinn, frontTransform.id))
+            game.resolveStack()
+
+            seedLoyalty(game, arlinn, 6)
+            val ultimate = cardRegistry.getCard("Arlinn Kord")!!.backFace!!.script.activatedAbilities[2]
+            game.execute(ActivateAbility(game.player1Id, arlinn, ultimate.id))
+            game.resolveStack()
+
+            val bear = game.findPermanent("Grizzly Bears")!!
+            val granted = game.getLegalActions(1).firstOrNull { legal ->
+                (legal.action as? ActivateAbility)?.sourceId == bear &&
+                    legal.description.contains("damage equal to its power")
+            }
+            withClue("Arlinn's emblem should make the Bear's damage ability activatable") {
+                granted shouldNotBe null
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement both faces of Arlinn Kord in her canonical Shadows over Innistrad printing
- register the Innistrad Remastered printing
- add reusable support for activated abilities granted by permanent emblems
- document the expanded emblem SDK and add a focused scenario test

The remaining INR backlog is a complex tail requiring distinct unsupported mechanics, so this PR intentionally contains one fully implemented card.

## Verification
- `just test-class ArlinnKordScenarioTest`
- `just test-class SerializationPolymorphicRegistrationTest`
- `just check-card-printing "Arlinn Kord"`
- `just check-backlog`
- `just build` (9,324 engine tests; passed)
- Scryfall front, back, and INR image URLs return HTTP 200