### PR TITLE
Fix Aetherdrift basic land coverage

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageServiceTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/coverage/SetCoverageServiceTest.kt
@@ -67,6 +67,17 @@ class SetCoverageServiceTest : FunSpec({
         blb.extraTotal shouldBe 13
     }
 
+    test("Aetherdrift basic lands count as implemented") {
+        val dft = coverage.find { it.code == "DFT" }.shouldNotBeNull()
+        dft.total shouldBe 276
+        dft.implemented shouldBe 276
+        dft.percent shouldBe 100.0
+
+        val detail = service.detail("DFT").shouldNotBeNull()
+        val basics = setOf("Plains", "Island", "Swamp", "Mountain", "Forest")
+        detail.draft.filter { it.name in basics }.all { it.implemented } shouldBe true
+    }
+
     test("a card counts as draft when *any* of its printings in the set is boosterable") {
         // Regression: the booster flag used to be read off a single arbitrary printing per name
         // (`unique=cards`), so a card Scryfall happened to serve as its non-booster printing was

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/AetherdriftSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/AetherdriftSet.kt
@@ -16,10 +16,13 @@ object AetherdriftSet : MtgSet {
     override val code = "DFT"
     override val displayName = "Aetherdrift"
     override val releaseDate = "2025-02-14"
-    override val incomplete = true
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
     }
 
     override val printings: List<Printing> by lazy {


### PR DESCRIPTION
## Summary
- expose Aetherdrift basic-land definitions through `MtgSet.basicLands`
- remove the stale incomplete-set flag now that DFT reports 276/276
- add a regression test covering all five basic-land names in set completion

## Verification
- `just build`