### PR TITLE
Add Collective Defiance to Innistrad Remastered

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/CollectiveDefiance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/CollectiveDefiance.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOpponentOrPlaneswalker
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Collective Defiance — Eldritch Moon #123. */
+val CollectiveDefiance = card("Collective Defiance") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\n" +
+        "Choose one or more —\n" +
+        "• Target player discards all the cards in their hand, then draws that many cards.\n" +
+        "• Collective Defiance deals 4 damage to target creature.\n" +
+        "• Collective Defiance deals 3 damage to target opponent or planeswalker."
+
+    spell {
+        modal(chooseCount = 3, minChooseCount = 1, additionalManaCostPerExtraMode = "{1}") {
+            mode("Target player discards their hand, then draws that many cards.") {
+                val player = target("wheel player", TargetPlayer())
+                effect = Effects.Composite(
+                    Patterns.Hand.discardHand(player),
+                    Effects.DrawCards(DynamicAmount.VariableReference("discardedHand_count"), player),
+                )
+            }
+            mode("Collective Defiance deals 4 damage to target creature.") {
+                val creature = target("damage creature", TargetCreature())
+                effect = Effects.DealDamage(4, creature)
+            }
+            mode("Collective Defiance deals 3 damage to target opponent or planeswalker.") {
+                val opponentOrPlaneswalker = target(
+                    "damage opponent or planeswalker",
+                    TargetOpponentOrPlaneswalker(),
+                )
+                effect = Effects.DealDamage(3, opponentOrPlaneswalker)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "123"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8960883f-3813-412b-9a5b-f8cf8d566fac.jpg?1783937466"
+        ruling("2016-07-13", "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes.")
+        ruling("2016-07-13", "If one target of an escalate spell becomes illegal, the other targets will still be affected. If all of the targets become illegal, the spell won't resolve.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CollectiveDefianceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CollectiveDefianceReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Collective Defiance reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val CollectiveDefianceReprint = Printing(
+    oracleId = "43ddc3e8-936b-4be0-9e64-484bbbd69016",
+    name = "Collective Defiance",
+    setCode = "INR",
+    collectorNumber = "149",
+    scryfallId = "17d512c0-fc02-419f-90f2-a6acc7815bd4",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17d512c0-fc02-419f-90f2-a6acc7815bd4.jpg?1783908123",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -525,6 +525,141 @@
     ]
 }
 
+// Collective Defiance
+{
+    "name": "Collective Defiance",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Escalate {1} (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Target player discards all the cards in their hand, then draws that many cards.\n• Collective Defiance deals 4 damage to target creature.\n• Collective Defiance deals 3 damage to target opponent or planeswalker.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        },
+                                        "storeAs": "discardedHand"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discardedHand",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "VariableReference",
+                                    "variableName": "discardedHand_count"
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "wheel player"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "wheel player"
+                        }
+                    ],
+                    "description": "Target player discards their hand, then draws that many cards."
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "damage creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "damage creature"
+                        }
+                    ],
+                    "description": "Collective Defiance deals 4 damage to target creature."
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "damage opponent or planeswalker"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponentOrPlaneswalker",
+                            "id": "damage opponent or planeswalker"
+                        }
+                    ],
+                    "description": "Collective Defiance deals 3 damage to target opponent or planeswalker."
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1,
+            "additionalManaCostPerExtraMode": "{1}"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "RARE",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/8960883f-3813-412b-9a5b-f8cf8d566fac.jpg?1783937466",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "If one target of an escalate spell becomes illegal, the other targets will still be affected. If all of the targets become illegal, the spell won't resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Conduit of Storms
 {
     "name": "Conduit of Storms",


### PR DESCRIPTION
## Summary
- add the canonical Collective Defiance definition to Eldritch Moon
- model all three independently targeted modes with the existing Escalate per-extra-mode mana cost
- add the Innistrad Remastered printing and refresh the EMN card snapshot

The remaining unimplemented INR cards require broader mechanics such as Madness, Emerge, Soulbond, Splice, Disturb, or non-mana Escalate costs, so this batch intentionally contains one faithful card rather than approximating several complex ones.

## Verification
- `just check-card-printing "Collective Defiance"`
- Scryfall original and INR image URLs return HTTP 200
- `just rebless-cards` (only Collective Defiance added to EMN snapshot)
- `just build`