### PR TITLE
Add Spider-Punk (Riot keyword + granted-riot synthesis) and enters-with replacements for
  token copies

### DIFF
--- a/backlog/sets/marvels-spider-man/cards.md
+++ b/backlog/sets/marvels-spider-man/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 188 booster cards (excluding basic lands and tokens)
 **Release Date:** September 26, 2025
-**Implemented:** 187 / 188
+**Implemented:** 188 / 188
 - [x] Agent Venom
 - [x] Alien Symbiosis
 - [x] Angry Rabble
@@ -139,7 +139,7 @@
 - [x] Spider-Man, Brooklyn Visionary
 - [x] Spider-Man, Web-Slinger
 - [x] Spider-Mobile
-- [ ] Spider-Punk
+- [x] Spider-Punk
 - [x] Spider-Rex, Daring Dino
 - [x] Spider-Sense
 - [x] Spider-Slayer, Hatred Honed

--- a/backlog/sets/marvels-spider-man/mechanics.md
+++ b/backlog/sets/marvels-spider-man/mechanics.md
@@ -143,7 +143,25 @@ Also enabled by the **discarded-this-turn tracking** half (now implemented) but 
   Then **draw a card for each card you've discarded this turn**" — now expressible via
   `DynamicAmounts.cardsDiscardedThisTurn()`; a follow-up card.
 
-## Riot (keyword — enters with your choice of a +1/+1 counter or haste)
+## Riot (keyword — enters with your choice of a +1/+1 counter or haste) — ✅ IMPLEMENTED
+
+**Done** (branch `spm-spider-punk`). New `Keyword.RIOT` + a `CardBuilder.riot()` DSL helper modeling
+printed Riot via the Khans-Siege `EntersWithChoice(ChoiceType.MODE, [counter, haste])` pattern +
+mode-gated `EntersWithCounters(condition = SourceChosenModeIs("counter"))` + mode-gated
+`ConditionalStaticAbility(GrantKeyword(HASTE), SourceChosenModeIs("haste"))`. **Granted riot** ("Other
+Spiders you control have riot") is handled by a new `RiotSynthesis` helper: for a Spider cast as a
+spell it scans battlefield `GrantKeyword(RIOT)` lords (excludeSelf, deduped vs printed) and ORs a
+synthesized `EntersWithChoice` into the entry; for token/land entries it detects granted RIOT via
+projected `hasKeyword`; the resumers apply the chosen +1/+1-counter or Duration.Permanent-floating-haste
+branch directly (a granted creature has no printed statics). Wired into StackResolver /
+PermanentEntryReplacements / TokenFromDefinition / PlayLandHandler + both continuation resumers.
+"Spells and abilities can't be countered" = `GrantCantBeCountered(Any, includesAbilities = true)` (the
+new `includesAbilities` flag fizzles Stifle-type ability counters). "Damage can't be prevented" =
+`DamageCantBePrevented`. Scenario tests cover printed Riot (counter/haste), granted riot (a cast Spider
+gets the choice), and can't-be-countered. Full regression green. (Granted-riot synthesis for
+blink/reanimation entry paths is not wired — a rare edge, flagged.)
+
+<details><summary>Original analysis (kept for reference)</summary>
 
 > Riot *(This creature enters with your choice of a +1/+1 counter or haste.)*
 
@@ -153,6 +171,8 @@ which requires Riot to exist as a grantable keyword. `add-feature` scope.
 
 Blocked cards:
 - **Spider-Punk** [92] — `{1}{R}` Riot; "Other Spiders you control have riot"; also "Spells and abilities can't be countered" + "Damage can't be prevented" (verify those two independently)
+
+</details>
 
 ## "Modified" state on a leaves-the-battlefield (last-known-information) trigger — ✅ IMPLEMENTED
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5987,6 +5987,20 @@ composite abilities).
   counter directly: `StateProjector` projects the `DECAYED` keyword + `cantBlock = true`, and `TriggerDetector`
   schedules the end-of-combat self-sacrifice when a decayed-countered creature is declared as an attacker — no
   per-card static/trigger needed for the counter form.
+- `Riot` — "Riot (This creature enters with your choice of a +1/+1 counter or haste.)" (CR 702.136). Display-only
+  keyword; wire it with the `card { riot() }` builder helper, which composes the Khans-Siege
+  `EntersWithChoice(ChoiceType.MODE, [counter, haste])` + a mode-gated `EntersWithCounters(count = 1, selfOnly = true,
+  condition = SourceChosenModeIs("counter"))` + a mode-gated `ConditionalStaticAbility(GrantKeyword(HASTE,
+  GroupFilter.source()), SourceChosenModeIs("haste"))`. **Grant-aware:** when Riot is *granted* to other permanents
+  (`GrantKeyword(Keyword.RIOT, <group>)`, e.g. Spider-Punk's "Other Spiders you control have riot"), the engine
+  synthesizes one enters-with choice per granting lord (`RiotSynthesis.grantedRiotInstanceCount`, honoring each lord's
+  `excludeSelf` and its *projected* controller — one instance per grant, CR 702.136b), wired into the spell-resolution
+  + token/land entry seams; the choice resumer applies each chosen counter/haste branch directly and re-pauses for the
+  next instance (a granted permanent has none of the printed replacement/static abilities to fall back on).
+  `GrantCantBeCountered` gained an `includesAbilities` flag (default false) so "spells **and abilities** can't be
+  countered" (Spider-Punk) also makes matching abilities uncounterable (e.g. Stifle fizzles); `DamageCantBePrevented`
+  is a global replacement — while one is on the battlefield (or the "damage can't be prevented this turn" one-shot is
+  active) `DamageUtils.applyDamagePreventionShields` applies no prevention shields (CR 615.12).
 - `Exploit` — "Exploit (When this creature enters, you may sacrifice a creature.)" (CR 702.110, Dragons of Tarkir;
   reprinted MH1/MH2/VOW/PIP/MH3). Display-only keyword; wire the behavior with the `card { exploit(onExploit, onExploitTargets) }`
   builder helper. It adds the keyword plus one `EntersBattlefield` triggered ability whose effect is a

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1257,6 +1257,19 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   entity IDs to the `CREATED_TOKENS` pipeline collection, so a sibling effect in a `CompositeEffect` can address
   the new copy — e.g. Applied Geometry's "Create a token that's a copy … Put six +1/+1 counters on it" composes
   `CreateTokenCopyOfTarget(...)` then `AddCountersToCollection(CREATED_TOKENS, "+1/+1", 6)`.
+  **Enters-with replacements (CR 707.2).** A copy has the copied card's abilities, so every token copy runs the
+  copied card's "as-enters" replacements as it enters — the same pipeline a minted token (`TokenFromDefinition`)
+  and a directly-entering permanent use. This spans all four copy effects (`CreateTokenCopyOfTarget` /
+  `-OfSource` / `-OfChosenPermanent` / `-OfEquippedCreature`): the copied card's own **and** global
+  `EntersWithCounters`/`EntersWithDynamicCounters` (a token copy of a creature that "enters with a +1/+1
+  counter", plus grants like Gev, Scaled Scorch — applied inline via `EntersWithReplacements.applyOnEntry`),
+  its printed `EntersWithChoice` (Alloy Golem color, the Siege `MODE`, printed Riot — CR 614.12), and any
+  **granted** Riot (Spider-Punk's "Other Spiders you control have riot" — one choice per lord, CR 702.136b).
+  The choice half pauses for a player decision; `TokenEntryReplacements.firstEntersWithChoice` selects the choice
+  and `PermanentEntryReplacements.pauseForEntersWithChoice` raises it, so the token's ETB triggers fire once
+  after the choice resolves. For a multi-token `CreateTokenCopyOfTarget`/`-OfSource` where a token needs a choice,
+  the batch resumes token-by-token through a `CreateTokenCopyRemainingContinuation` (each remaining token runs its
+  own as-enters pipeline). A token that pauses for a choice is not published to `CREATED_TOKENS`.
 - `CreateTokenCopyOfEquippedCreature(count?, tapped?)` — equipment-specific copy.
 - `CreateRandomCreatureTokenWithManaValue(manaValue)` — create a token that's a copy of a *randomly
   chosen* creature card whose mana value equals `manaValue` (the Momir Basic Vanguard avatar's payoff —

--- a/manual-scenarios/cards/s/spider-punk.json
+++ b/manual-scenarios/cards/s/spider-punk.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Spider-Punk", "Sun-Spider, Nimble Webber"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Forest", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Counterspell"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -82,6 +82,19 @@ enum class Keyword(val displayName: String) {
     AMPLIFY("Amplify"),
 
     /**
+     * Riot (CR 702.136). "This permanent enters the battlefield with your choice of a +1/+1 counter
+     * or haste." A display tag; the mechanic is composed in the DSL via
+     * [com.wingedsheep.sdk.dsl.riot], which pairs an
+     * [com.wingedsheep.sdk.scripting.EntersWithChoice] (ChoiceType.MODE, counter|haste) with a
+     * mode-gated [com.wingedsheep.sdk.scripting.EntersWithCounters] (counter branch) and a mode-gated
+     * haste grant. Unlike most composed keywords, RIOT is **grant-aware**: when a lord effect grants
+     * riot to other permanents ("Other Spiders you control have riot" — Spider-Punk), the engine
+     * synthesizes the same enters-with choice for any permanent that enters carrying the projected
+     * RIOT keyword.
+     */
+    RIOT("Riot"),
+
+    /**
      * Devour (CR 702.82). "Devour N" — "As this creature enters, you may sacrifice
      * any number of creatures. This creature enters with N times that many +1/+1
      * counters on it." Variants substitute the sacrificed permanent type: e.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/RiotDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/RiotDsl.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModeOption
+import com.wingedsheep.sdk.scripting.conditions.SourceChosenModeIs
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/** The two Riot mode ids, shared between the printed DSL and the engine's granted-riot synthesis. */
+const val RIOT_MODE_COUNTER = "counter"
+const val RIOT_MODE_HASTE = "haste"
+
+/** The card-defined Riot mode options (a +1/+1 counter, or haste). */
+val RIOT_MODE_OPTIONS: List<ModeOption> = listOf(
+    ModeOption(id = RIOT_MODE_COUNTER, label = "A +1/+1 counter", iconKey = "plusOneCounter"),
+    ModeOption(id = RIOT_MODE_HASTE, label = "Haste", iconKey = "haste"),
+)
+
+/**
+ * Add Riot (CR 702.136) — "This creature enters the battlefield with your choice of a +1/+1 counter
+ * or haste."
+ *
+ * The keyword is display-only; the mechanic is composed from existing primitives via the Khans-Siege
+ * [EntersWithChoice] `MODE` pattern (cf. Outpost Siege):
+ *  - an [EntersWithChoice] (`ChoiceType.MODE`, options `counter`/`haste`) records the choice on the
+ *    entering permanent's cast-choices bag as it enters (CR 614.12);
+ *  - a mode-gated [EntersWithCounters] (`selfOnly`, `condition = SourceChosenModeIs("counter")`)
+ *    adds the +1/+1 counter when the counter mode was chosen;
+ *  - a mode-gated [ConditionalStaticAbility] granting [Keyword.HASTE] to the source when the haste
+ *    mode was chosen.
+ *
+ * When Riot is *granted* to other permanents ("Other Spiders you control have riot"), the engine
+ * synthesizes the same [EntersWithChoice] and applies the chosen branch directly (see the
+ * granted-riot synthesis in the stack/permanent entry seams) — a granted creature has none of the
+ * printed replacement/static abilities above.
+ */
+fun CardBuilder.riot() {
+    keywordSet.add(Keyword.RIOT)
+    replacementEffect(
+        EntersWithChoice(
+            choiceType = ChoiceType.MODE,
+            modeOptions = RIOT_MODE_OPTIONS,
+        )
+    )
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 1,
+            selfOnly = true,
+            condition = SourceChosenModeIs(RIOT_MODE_COUNTER),
+        )
+    )
+    staticAbilities.add(
+        ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HASTE, GroupFilter.source()),
+            condition = SourceChosenModeIs(RIOT_MODE_HASTE),
+        )
+    )
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -48,13 +48,21 @@ data class GrantFlashToSpellType(
  * attempt fails.
  *
  * @property filter The filter that spells must match to be uncounterable
+ * @property includesAbilities When true, activated/triggered abilities matching [filter] also can't
+ *   be countered (Spider-Punk: "Spells **and abilities** can't be countered"). Default false — a
+ *   plain "spells can't be countered" grant leaves abilities counterable.
  */
 @SerialName("GrantCantBeCountered")
 @Serializable
 data class GrantCantBeCountered(
-    val filter: GameObjectFilter
+    val filter: GameObjectFilter,
+    val includesAbilities: Boolean = false
 ) : StaticAbility {
-    override val description: String = "${filter.description} spells can't be countered"
+    override val description: String = buildString {
+        append("${filter.description} spells")
+        if (includesAbilities) append(" and abilities")
+        append(" can't be countered")
+    }
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderPunk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderPunk.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.spm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.riot
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DamageCantBePrevented
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCantBeCountered
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Spider-Punk (Marvel's Spider-Man, #92)
+ * {1}{R}
+ * Legendary Creature — Spider Human Hero
+ * 2/1
+ *
+ * Riot (This creature enters with your choice of a +1/+1 counter or haste.)
+ * Other Spiders you control have riot.
+ * Spells and abilities can't be countered.
+ * Damage can't be prevented.
+ *
+ *  - **Riot** — the `riot()` DSL helper (Siege-style `EntersWithChoice(MODE)` + mode-gated counter /
+ *    haste).
+ *  - **Other Spiders you control have riot** — `GrantKeyword(Keyword.RIOT, other Spiders you
+ *    control)`. The engine synthesizes the enters-with choice for any Spider that enters carrying
+ *    the granted RIOT keyword (granted-riot synthesis at the entry seams).
+ *  - **Spells and abilities can't be countered** — a symmetric `GrantCantBeCountered(Any,
+ *    includesAbilities = true)`; every spell AND ability on the stack is uncounterable (e.g. Stifle
+ *    fizzles) while this is in play.
+ *  - **Damage can't be prevented** — a global `DamageCantBePrevented` replacement.
+ */
+val SpiderPunk = card("Spider-Punk") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Spider Human Hero"
+    power = 2
+    toughness = 1
+    oracleText = "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\n" +
+        "Other Spiders you control have riot.\n" +
+        "Spells and abilities can't be countered.\n" +
+        "Damage can't be prevented."
+
+    // Riot (printed).
+    riot()
+
+    // Other Spiders you control have riot.
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.RIOT,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Spider").youControl(), excludeSelf = true),
+        )
+    }
+
+    // Spells and abilities can't be countered.
+    staticAbility {
+        ability = GrantCantBeCountered(GameObjectFilter.Any, includesAbilities = true)
+    }
+
+    // Damage can't be prevented.
+    replacementEffect(DamageCantBePrevented())
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "92"
+        artist = "Forrest Imel"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0bd41879-fcd4-4211-9b98-47e7cdba5399.jpg?1783905333"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -10273,6 +10273,90 @@
     "colorIdentityOverride": []
 }
 
+// Spider-Punk
+{
+    "name": "Spider-Punk",
+    "manaCost": "{1}{R}",
+    "typeLine": "Legendary Creature — Spider Human Hero",
+    "oracleText": "Riot (This creature enters with your choice of a +1/+1 counter or haste.)\nOther Spiders you control have riot.\nSpells and abilities can't be countered.\nDamage can't be prevented.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "RIOT"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "haste"
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "RIOT",
+                "filter": {
+                    "baseFilter": "creature Spider ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "GrantCantBeCountered",
+                "filter": {},
+                "includesAbilities": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "counter",
+                        "label": "A +1/+1 counter",
+                        "iconKey": "plusOneCounter"
+                    },
+                    {
+                        "id": "haste",
+                        "label": "Haste",
+                        "iconKey": "haste"
+                    }
+                ]
+            },
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "counter"
+                }
+            },
+            "DamageCantBePrevented"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "RARE",
+        "artist": "Forrest Imel",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0bd41879-fcd4-4211-9b98-47e7cdba5399.jpg?1783905333"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Spider-Rex, Daring Dino
 {
     "name": "Spider-Rex, Daring Dino",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -305,7 +305,18 @@ data class EntersWithChoiceSpellContinuation(
      * this list to recover the name stored under
      * [com.wingedsheep.sdk.scripting.ChoiceSlot.CARD_NAME].
      */
-    val cardNames: List<String> = emptyList()
+    val cardNames: List<String> = emptyList(),
+    /**
+     * True when this MODE choice is a **synthesized Riot** choice granted to the entity (not printed
+     * on its card). The resumer then applies the chosen branch (a +1/+1 counter or a haste grant)
+     * directly, because a granted permanent has no printed `EntersWithCounters`/haste static.
+     */
+    val syntheticRiot: Boolean = false,
+    /**
+     * The number of *further* synthesized Riot choices to present after this one (CR 702.136b — each
+     * granted riot instance is a separate choice). The resumer re-pauses that many more times.
+     */
+    val syntheticRiotRemaining: Int = 0
 ) : ContinuationFrame
 
 /**
@@ -346,7 +357,11 @@ data class EntersWithChoiceOnBattlefieldContinuation(
     /** For [com.wingedsheep.sdk.scripting.ChoiceType.CARD_NAME] choices, the land card names
      *  presented (the resumer stores the chosen name by index). */
     val cardNames: List<String> = emptyList(),
-    val fromZone: Zone? = null
+    val fromZone: Zone? = null,
+    /** See [EntersWithChoiceSpellContinuation.syntheticRiot]. */
+    val syntheticRiot: Boolean = false,
+    /** See [EntersWithChoiceSpellContinuation.syntheticRiotRemaining]. */
+    val syntheticRiotRemaining: Int = 0
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalAndCloneContinuations.kt
@@ -535,6 +535,39 @@ data class CreateTokenCopyAuraHostContinuation(
 ) : ContinuationFrame
 
 /**
+ * Auto-resumed continuation that creates the **remaining** token copies of a multi-token
+ * create-token-copy effect after one token paused for an "as-enters" choice (a printed
+ * [com.wingedsheep.sdk.scripting.EntersWithChoice] or a synthesized granted-riot choice — CR 614.12 /
+ * 702.136).
+ *
+ * A create-token-copy effect makes N tokens in a loop; each token must resolve its own as-enters
+ * choice (CR 707.2 — the copy has the copied card's abilities). When a token pauses, this frame is
+ * pushed **below** the choice's
+ * [EntersWithChoiceOnBattlefieldContinuation] so that, once that token's choice (and every granted-riot
+ * instance / chained printed choice) has resolved and its ETB triggers fired, the batch resumes here
+ * and creates the next token — which may pause again, pushing a fresh frame with a smaller [remaining].
+ * The resolution-time twin of [ModalPreChosenContinuation] / [ModalChosenModeTailContinuation]'s
+ * "push a tail frame below the nested decision" pattern; the copy analogue of
+ * [CreateTokenCopyAuraHostContinuation]'s per-token re-entry.
+ *
+ * [effect] is the original create-token-copy effect (a
+ * [com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect] or
+ * [com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfSourceEffect]) and [context] the resolution
+ * context, both re-used so the copy's source/target still resolves on resume — mirroring
+ * [CreateTokenCopyAuraHostContinuation].
+ *
+ * @property remaining how many more token copies are owed (always > 0 while this frame is live).
+ */
+@Serializable
+data class CreateTokenCopyRemainingContinuation(
+    override val decisionId: String,
+    val effect: @Serializable Effect,
+    val context: com.wingedsheep.engine.handlers.EffectContext,
+    val controllerId: EntityId,
+    val remaining: Int,
+) : ContinuationFrame
+
+/**
  * Resume after a player chooses an action from a list of labeled options.
  *
  * Used by [ChooseActionEffect] — the player is presented with feasible options

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -314,6 +314,7 @@ val engineSerializersModule = SerializersModule {
         subclass(WardTapPermanentsSubCostContinuation::class)
         subclass(CreateTokenCopyOfChosenContinuation::class)
         subclass(CreateTokenCopyAuraHostContinuation::class)
+        subclass(CreateTokenCopyRemainingContinuation::class)
         subclass(DistributeDamageContinuation::class)
         subclass(EachPlayerDiscardsOrLoseLifeContinuation::class)
         subclass(ManaSourceSelectionContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -58,6 +58,8 @@ class PlayLandHandler(
 ) : ActionHandler<PlayLand> {
     override val actionType: KClass<PlayLand> = PlayLand::class
 
+    private val predicateEvaluator = com.wingedsheep.engine.handlers.PredicateEvaluator()
+
     override fun validate(state: GameState, action: PlayLand): String? {
         if (!state.isActiveTurnFor(action.playerId)) {
             // CR 805.4c — each player on the active team may play a land on the team's turn.
@@ -464,8 +466,15 @@ class PlayLandHandler(
         // Process first choice in priority order: COLOR → CREATURE_TYPE
         // Continuations handle chaining to subsequent choices.
         if (cardDef != null) {
-            val firstChoice = cardDef.script.replacementEffects
-                .filterIsInstance<EntersWithChoice>()
+            val printedChoices = cardDef.script.replacementEffects.filterIsInstance<EntersWithChoice>()
+            // Granted Riot (a land that is a Spider with riot granted — vanishingly rare, but wired
+            // for consistency with the token/spell entry seams; one choice per grant, CR 702.136b).
+            val grantedRiotCount = com.wingedsheep.engine.mechanics.RiotSynthesis
+                .grantedRiotInstanceCount(newState, action.cardId, cardRegistry, predicateEvaluator)
+            val syntheticRiotChoice = if (grantedRiotCount > 0) {
+                com.wingedsheep.engine.mechanics.RiotSynthesis.RIOT_CHOICE
+            } else null
+            val firstChoice = (printedChoices + listOfNotNull(syntheticRiotChoice))
                 .sortedBy { it.choiceType.ordinal }
                 .firstOrNull()
             if (firstChoice != null) {
@@ -500,6 +509,8 @@ class PlayLandHandler(
                         cardNameOptions = if (firstChoice.choiceType == ChoiceType.CARD_NAME) {
                             cardRegistry.cardNamesIn(firstChoice.cardNamePool).toList()
                         } else emptyList(),
+                        syntheticRiot = firstChoice === syntheticRiotChoice,
+                        syntheticRiotRemaining = if (firstChoice === syntheticRiotChoice) grantedRiotCount - 1 else 0,
                     )
                 if (result != null) return result
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
@@ -186,6 +186,32 @@ class CoreAutoResumerModule(
             )
         },
 
+        // A multi-token create-token-copy effect paused mid-batch because one token owed an
+        // as-enters choice (printed EntersWithChoice or granted riot). That token's choice, every
+        // granted-riot instance, and its ETB triggers have now resolved — create the remaining
+        // token copies, each of which runs its own as-enters pipeline and may pause again.
+        autoResumer(CreateTokenCopyRemainingContinuation::class, canResume = { it.remaining > 0 }) { state, continuation, events, checkForMore ->
+            val staticAbilityHandler = com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler(services.cardRegistry)
+            val result = when (val e = continuation.effect) {
+                is com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect ->
+                    com.wingedsheep.engine.handlers.effects.token.CreateTokenCopyOfTargetExecutor(
+                        staticAbilityHandler = staticAbilityHandler,
+                        cardRegistry = services.cardRegistry,
+                    ).createTokens(
+                        state, e, continuation.context, continuation.controllerId,
+                        continuation.remaining, auraHostId = null,
+                    )
+                is com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfSourceEffect ->
+                    com.wingedsheep.engine.handlers.effects.token.CreateTokenCopyOfSourceExecutor(
+                        services.cardRegistry, staticAbilityHandler,
+                    ).createTokens(
+                        state, e, continuation.context, continuation.controllerId, continuation.remaining,
+                    )
+                else -> com.wingedsheep.engine.core.EffectResult.success(state)
+            }
+            mergeAndContinue(result.toExecutionResult(), events, checkForMore)
+        },
+
         // CR 605.3a — the player activated a mana ability while the engine was asking them for a
         // mana payment, and that ability needed a decision of its own. Now that it has resolved,
         // put the payment window back up (refreshed: the source they just tapped is gone from the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -1438,7 +1438,7 @@ class ModalAndCloneContinuationResumer(
         val staticAbilityHandler = com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler(services.cardRegistry)
         val result = com.wingedsheep.engine.handlers.effects.token.CreateTokenCopyOfChosenPermanentExecutor.createTokenCopy(
             state, chosenId, continuation.controllerId,
-            staticAbilityHandler
+            staticAbilityHandler, services.cardRegistry
         ).toExecutionResult()
         if (result.isPaused) return result
         return checkForMore(result.state, result.events.toList())

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -660,6 +660,38 @@ class ModalAndCloneContinuationResumer(
             }
         }
 
+        // Granted-Riot synthesis: apply the chosen +1/+1-counter / haste branch now — a granted
+        // permanent has no printed EntersWithCounters/haste static — before it enters the battlefield.
+        val syntheticRiotEvents = mutableListOf<GameEvent>()
+        if (continuation.syntheticRiot && response is OptionChosenResponse) {
+            val modeId = continuation.modeOptionIds.getOrNull(response.optionIndex)
+            if (modeId != null) {
+                val nm = newState.getEntity(spellId)?.get<CardComponent>()?.name ?: "Unknown"
+                val (rs, re) = com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+                    .applyGrantedRiotBranch(newState, spellId, controllerId, modeId, nm)
+                newState = rs
+                syntheticRiotEvents.addAll(re)
+            }
+            // CR 702.136b — each granted riot instance is a separate choice; re-pause for the next
+            // one (a permanent granted riot by two lords chooses counter/haste twice).
+            if (continuation.syntheticRiotRemaining > 0) {
+                val cc = newState.getEntity(spellId)?.get<CardComponent>()
+                if (cc != null) {
+                    val repause = services.stackResolver.pauseForEntersWithChoice(
+                        newState, spellId, controllerId, ownerId, cc,
+                        com.wingedsheep.engine.mechanics.RiotSynthesis.RIOT_CHOICE,
+                        syntheticRiot = true,
+                        syntheticRiotRemaining = continuation.syntheticRiotRemaining - 1
+                    )
+                    if (repause != null && repause.isPaused) {
+                        return ExecutionResult.paused(
+                            repause.state, repause.pendingDecision!!, syntheticRiotEvents + repause.events
+                        )
+                    }
+                }
+            }
+        }
+
         // Check if the card has remaining choices to chain to
         val spellContainer = newState.getEntity(spellId)
             ?: return ExecutionResult.error(state, "Spell entity not found: $spellId")
@@ -689,6 +721,7 @@ class ModalAndCloneContinuationResumer(
         newState = enterState
 
         val events = mutableListOf<GameEvent>()
+        events.addAll(syntheticRiotEvents)
         events.addAll(enterEvents)
         events.add(ResolvedEvent(spellId, cardComponent.name))
         events.add(
@@ -795,6 +828,38 @@ class ModalAndCloneContinuationResumer(
             }
         }
 
+        // Granted-Riot synthesis: apply the chosen +1/+1-counter / haste branch to the (already
+        // on-battlefield) permanent — it has no printed EntersWithCounters/haste static — before ETB
+        // triggers fire.
+        val syntheticRiotEvents = mutableListOf<GameEvent>()
+        if (continuation.syntheticRiot && response is OptionChosenResponse) {
+            val modeId = continuation.modeOptionIds.getOrNull(response.optionIndex)
+            if (modeId != null) {
+                val nm = newState.getEntity(entityId)?.get<CardComponent>()?.name ?: "Unknown"
+                val (rs, re) = com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+                    .applyGrantedRiotBranch(newState, entityId, continuation.controllerId, modeId, nm)
+                newState = rs
+                syntheticRiotEvents.addAll(re)
+            }
+            // CR 702.136b — each granted riot instance is a separate choice; re-pause for the next
+            // one, carrying the events already applied so they aren't lost across the pause.
+            if (continuation.syntheticRiotRemaining > 0) {
+                val cc = newState.getEntity(entityId)?.get<CardComponent>()
+                if (cc != null) {
+                    val repause = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                        .pauseForEntersWithChoice(
+                            newState, entityId, continuation.controllerId, cc,
+                            com.wingedsheep.engine.mechanics.RiotSynthesis.RIOT_CHOICE,
+                            continuation.fromZone,
+                            carryEvents = syntheticRiotEvents,
+                            syntheticRiot = true,
+                            syntheticRiotRemaining = continuation.syntheticRiotRemaining - 1
+                        )
+                    if (repause != null) return repause
+                }
+            }
+        }
+
         // Check if the permanent has remaining choices to chain to (e.g. color + creature type).
         val entityContainer = newState.getEntity(entityId)
         val cardComponent = entityContainer?.get<CardComponent>()
@@ -832,13 +897,13 @@ class ModalAndCloneContinuationResumer(
                 return ExecutionResult.paused(
                     triggerResult.state,
                     triggerResult.pendingDecision!!,
-                    triggerResult.events
+                    syntheticRiotEvents + triggerResult.events
                 )
             }
-            return checkForMore(triggerResult.newState, triggerResult.events)
+            return checkForMore(triggerResult.newState, syntheticRiotEvents + triggerResult.events)
         }
 
-        return checkForMore(newState, emptyList())
+        return checkForMore(newState, syntheticRiotEvents)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -903,6 +903,11 @@ object DamageUtils {
         isCombatDamage: Boolean = false,
         sourceId: EntityId? = null
     ): Pair<GameState, Int> {
+        // CR 615.12 — when damage can't be prevented, prevention shields aren't reduced and prevent
+        // nothing. When any battlefield "damage can't be prevented" (Spider-Punk) or the "this turn"
+        // one-shot (Fear, Fire, Foes!) is active, no shield applies and the damage passes through in full.
+        if (isDamagePreventionDisabled(state)) return state to amount
+
         var remainingDamage = amount
         val updatedEffects = state.floatingEffects.toMutableList()
         val toRemove = mutableListOf<Int>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
@@ -45,6 +45,58 @@ object EntersWithReplacements {
     private val conditionEvaluator = com.wingedsheep.engine.handlers.ConditionEvaluator()
 
     /**
+     * Apply a **granted-Riot** chosen branch to [entityId] (controlled by [controllerId]): the
+     * `counter` mode adds one +1/+1 counter (honoring counter-placement replacements); the `haste`
+     * mode grants a [Duration.Permanent] floating HASTE.
+     *
+     * This is a **deliberate parallel apply path**, not a duplicate: the printed `riot()` DSL applies
+     * its branch via a mode-gated `EntersWithCounters` and a mode-gated `ConditionalStaticAbility`
+     * that both live on the *printed card* and are read from its [CardDefinition]. A permanent that
+     * merely has RIOT *granted* ("Other Spiders you control have riot") has none of those statics on
+     * its own definition, so the printed path ([applyFromDefinition] / the layer system) has nothing
+     * to fire. The chosen branch is therefore assembled here from the same primitives the printed
+     * path uses ([ReplacementEffectUtils.applyCounterPlacementModifiers] for the counter,
+     * `addFloatingEffect(GrantKeyword(HASTE))` for haste), so the two paths stay behaviorally aligned.
+     */
+    fun applyGrantedRiotBranch(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        modeId: String,
+        entityName: String,
+    ): Pair<GameState, List<GameEvent>> {
+        val context = EffectContext(sourceId = entityId, controllerId = controllerId)
+        val events = mutableListOf<GameEvent>()
+        return when (modeId) {
+            com.wingedsheep.sdk.dsl.RIOT_MODE_COUNTER -> {
+                val counterType = com.wingedsheep.sdk.core.CounterType.PLUS_ONE_PLUS_ONE
+                val count = ReplacementEffectUtils.applyCounterPlacementModifiers(
+                    state, entityId, counterType, 1, placerId = controllerId
+                )
+                if (count <= 0) return state to events
+                val current = state.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
+                var newState = state.updateEntity(entityId) { c -> c.with(current.withAdded(counterType, count)) }
+                val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
+                newState = afterMark
+                events.add(CountersAddedEvent(entityId, "+1/+1", count, entityName, firstThisTurn, placedBy = controllerId))
+                newState to events
+            }
+            com.wingedsheep.sdk.dsl.RIOT_MODE_HASTE -> {
+                val newState = state.addFloatingEffect(
+                    layer = Layer.ABILITY,
+                    modification = SerializableModification.GrantKeyword(com.wingedsheep.sdk.core.Keyword.HASTE.name),
+                    affectedEntities = setOf(entityId),
+                    duration = Duration.Permanent,
+                    context = context,
+                )
+                events.add(KeywordGrantedEvent(targetId = entityId, targetName = entityName, keyword = "haste", sourceName = entityName))
+                newState to events
+            }
+            else -> state to events
+        }
+    }
+
+    /**
      * Apply both the entering entity's own enters-with replacement effects (from its
      * [CardDefinition], looked up via [cardRegistry]) and any global ones sourced from other
      * battlefield permanents. Used by callers that put a permanent on the battlefield from a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryReplacements.kt
@@ -204,6 +204,8 @@ object PermanentEntryReplacements {
         fromZone: Zone?,
         carryEvents: List<GameEvent> = emptyList(),
         cardNameOptions: List<String> = emptyList(),
+        syntheticRiot: Boolean = false,
+        syntheticRiotRemaining: Int = 0,
     ): ExecutionResult? {
         val chooserId = when (choice.chooser) {
             Player.AnOpponent -> state.getOpponents(controllerId).firstOrNull() ?: controllerId
@@ -291,7 +293,10 @@ object PermanentEntryReplacements {
 
             ChoiceType.MODE -> {
                 if (choice.modeOptions.isEmpty()) return null
-                val id = "choose-mode-enters-${entityId.value}"
+                // A permanent granted multiple riot instances re-pauses on the same entity; suffix
+                // the id with the remaining count so each instance's decision is distinct (702.136b).
+                val id = "choose-mode-enters-${entityId.value}" +
+                    if (syntheticRiot) "-riot$syntheticRiotRemaining" else ""
                 pause(
                     ChooseOptionDecision(
                         id = id,
@@ -309,7 +314,9 @@ object PermanentEntryReplacements {
                         controllerId = controllerId,
                         choiceType = ChoiceType.MODE,
                         modeOptionIds = choice.modeOptions.map { it.id },
-                        fromZone = fromZone
+                        fromZone = fromZone,
+                        syntheticRiot = syntheticRiot,
+                        syntheticRiotRemaining = syntheticRiotRemaining
                     )
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
@@ -57,7 +57,7 @@ class CreateTokenCopyOfChosenPermanentExecutor(
 
         if (candidates.size == 1) {
             // Auto-select the only option
-            return createTokenCopy(state, candidates.first(), controllerId)
+            return createTokenCopy(state, candidates.first(), controllerId, staticAbilityHandler, cardRegistry)
         }
 
         // Present choice to the player
@@ -100,7 +100,8 @@ class CreateTokenCopyOfChosenPermanentExecutor(
             state: GameState,
             chosenId: EntityId,
             controllerId: EntityId,
-            staticAbilityHandler: StaticAbilityHandler? = null
+            staticAbilityHandler: StaticAbilityHandler? = null,
+            cardRegistry: CardRegistry? = null
         ): EffectResult {
             val chosenContainer = state.getEntity(chosenId)
                 ?: return EffectResult.success(state)
@@ -147,6 +148,40 @@ class CreateTokenCopyOfChosenPermanentExecutor(
             newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
                 .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
 
+            // As-enters "enters with counters" (CR 614.1c): the copied card's own EntersWithCounters
+            // (a copy of a creature that "enters with a +1/+1 counter") plus global grants from other
+            // permanents (Gev, Scaled Scorch). Fall back to the global-only path when no registry is
+            // available (the token's own definition can't be resolved without it).
+            val (stateWithCounters, counterEvents) = if (cardRegistry != null) {
+                EntersWithReplacements.applyOnEntry(newState, tokenId, controllerId, cardRegistry)
+            } else {
+                EntersWithReplacements.applyGlobal(newState, tokenId, controllerId)
+            }
+            newState = stateWithCounters
+
+            // As-enters "choose X as this enters" (CR 614.12) + granted riot (CR 702.136): pause for
+            // the player's decision. Exactly one token is created here, so there is no batch to
+            // resume; the entry ZoneChangeEvent is omitted on a pause (the choice resumer synthesizes
+            // it after the choice resolves so ETB triggers fire once). Counters ride along.
+            if (cardRegistry != null) {
+                val choicePlan = TokenEntryReplacements.firstEntersWithChoice(newState, tokenId, cardRegistry)
+                if (choicePlan != null) {
+                    val paused = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                        .pauseForEntersWithChoice(
+                            state = newState,
+                            entityId = tokenId,
+                            controllerId = controllerId,
+                            cardComponent = tokenCard,
+                            choice = choicePlan.choice,
+                            fromZone = null,
+                            carryEvents = counterEvents,
+                            syntheticRiot = choicePlan.syntheticRiot,
+                            syntheticRiotRemaining = choicePlan.syntheticRiotRemaining,
+                        )
+                    if (paused != null) return EffectResult.from(paused)
+                }
+            }
+
             val event = ZoneChangeEvent(
                 entityId = tokenId,
                 entityName = tokenCard.name,
@@ -155,17 +190,11 @@ class CreateTokenCopyOfChosenPermanentExecutor(
                 ownerId = controllerId
             )
 
-            // Apply "enters with counters" replacement effects from other battlefield permanents
-            // (e.g., Gev, Scaled Scorch granting +1/+1 counters to token copies).
-            val (stateWithCounters, counterEvents) = EntersWithReplacements.applyGlobal(
-                newState, tokenId, controllerId
-            )
-
             // CR 714.2b/714.3a: a token copy of a Saga enters as a Saga with its on-enter lore
             // counter. BattlefieldEntry.place skips enters-with-counters setup, so apply the shared
             // Saga-entry helper (as the standard moveToZone pipeline does). No-op for non-Sagas.
             val (sagaState, sagaEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
-                .applySagaEntryIfNeeded(stateWithCounters, tokenId)
+                .applySagaEntryIfNeeded(newState, tokenId)
 
             return EffectResult.success(sagaState, listOf(event) + counterEvents + sagaEvents)
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
@@ -118,7 +118,36 @@ class CreateTokenCopyOfEquippedCreatureExecutor(
         newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
             .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
 
-        val events = listOf(
+        // As-enters "enters with counters" (CR 614.1c): the copied creature's own EntersWithCounters
+        // (a copy of a creature that "enters with a +1/+1 counter") plus global grants from other
+        // permanents (Gev, Scaled Scorch). BattlefieldEntry.place skips this, so apply it here.
+        val (afterCounters, counterEvents) = com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+            .applyOnEntry(newState, tokenId, controllerId, cardRegistry)
+        newState = afterCounters
+
+        // As-enters "choose X as this enters" (CR 614.12) + granted riot (CR 702.136): pause for the
+        // player's decision. Exactly one token is created, so there is no batch to resume; the entry
+        // ZoneChangeEvent is omitted on a pause (the choice resumer synthesizes it after the choice
+        // resolves so ETB triggers fire once). Counters ride along as carryEvents.
+        val choicePlan = com.wingedsheep.engine.handlers.effects.token.TokenEntryReplacements
+            .firstEntersWithChoice(newState, tokenId, cardRegistry)
+        if (choicePlan != null) {
+            val paused = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                .pauseForEntersWithChoice(
+                    state = newState,
+                    entityId = tokenId,
+                    controllerId = controllerId,
+                    cardComponent = tokenCard,
+                    choice = choicePlan.choice,
+                    fromZone = null,
+                    carryEvents = counterEvents,
+                    syntheticRiot = choicePlan.syntheticRiot,
+                    syntheticRiotRemaining = choicePlan.syntheticRiotRemaining,
+                )
+            if (paused != null) return EffectResult.from(paused)
+        }
+
+        val events = counterEvents + listOf(
             ZoneChangeEvent(
                 entityId = tokenId,
                 entityName = tokenCard.name,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -1,11 +1,13 @@
 package com.wingedsheep.engine.handlers.effects.token
 
 import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.event.DelayedTriggeredAbility
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.Component
@@ -33,6 +35,13 @@ import kotlin.reflect.KClass
  *
  * The token copies the source's CardComponent (name, mana cost, types, stats, keywords, colors)
  * and uses the same cardDefinitionId so the engine picks up triggered/static abilities automatically.
+ *
+ * Because a copy has the copied card's abilities (CR 707.2), each token runs the copied card's
+ * "enters with counters" (self + global — CR 614.1c) and "as this enters, choose …" (CR 614.12)
+ * replacements, plus any granted riot (CR 702.136), via the shared [TokenEntryReplacements] /
+ * [PermanentEntryReplacements] pipeline. A token owing an as-enters choice pauses; the rest of the
+ * batch resumes through a
+ * [com.wingedsheep.engine.core.CreateTokenCopyRemainingContinuation].
  */
 class CreateTokenCopyOfSourceExecutor(
     private val cardRegistry: CardRegistry,
@@ -45,6 +54,19 @@ class CreateTokenCopyOfSourceExecutor(
         state: GameState,
         effect: CreateTokenCopyOfSourceEffect,
         context: EffectContext
+    ): EffectResult = createTokens(state, effect, context, context.controllerId, effect.count)
+
+    /**
+     * Create [count] token copies of the effect's source. Split out of [execute] so the
+     * enters-with-choice batch continuation can re-enter here to create the tokens still owed after
+     * one paused for a player decision.
+     */
+    fun createTokens(
+        state: GameState,
+        effect: CreateTokenCopyOfSourceEffect,
+        context: EffectContext,
+        controllerId: EntityId,
+        count: Int,
     ): EffectResult {
         val sourceId = context.sourceId
             ?: return EffectResult.success(state)
@@ -55,15 +77,14 @@ class CreateTokenCopyOfSourceExecutor(
         val sourceCard = sourceContainer.get<CardComponent>()
             ?: return EffectResult.success(state)
 
-        val controllerId = context.controllerId
-
         var newState = state
+        val events = mutableListOf<GameEvent>()
         val createdTokens = mutableListOf<EntityId>()
 
-        repeat(com.wingedsheep.engine.core.GameLimits.cappedTokenCount(effect.count, "source-copy tokens")) {
+        val cappedCount = com.wingedsheep.engine.core.GameLimits.cappedTokenCount(count, "source-copy tokens")
+        for (index in 0 until cappedCount) {
             val (tokenId, stateWithId) = newState.newEntity()
             newState = stateWithId
-            createdTokens.add(tokenId)
 
             // Copy the source's CardComponent, setting the token's owner to the controller
             // Apply P/T overrides if specified (e.g., Offspring creates 1/1 copies)
@@ -136,17 +157,50 @@ class CreateTokenCopyOfSourceExecutor(
             // Consuls / Dauntless Dismantler on an opponent's token copy).
             newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
                 .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
-        }
 
-        // Apply "enters with counters" replacement effects from other battlefield permanents
-        // (e.g., Gev, Scaled Scorch granting +1/+1 counters to Offspring token copies).
-        val counterEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
-        for (tokenId in createdTokens) {
-            val (nextState, events) = EntersWithReplacements.applyGlobal(
-                newState, tokenId, controllerId
+            // As-enters "enters with counters" (CR 614.1c): the copied card's own EntersWithCounters
+            // (a copy of a creature that "enters with a +1/+1 counter") plus global grants from other
+            // permanents (Gev, Scaled Scorch). BattlefieldEntry.place skips this, so apply it here.
+            val (afterCounters, counterEvents) = EntersWithReplacements.applyOnEntry(
+                newState, tokenId, controllerId, cardRegistry
             )
-            newState = nextState
-            counterEvents.addAll(events)
+            newState = afterCounters
+            events.addAll(counterEvents)
+
+            // As-enters "choose X as this enters" (CR 614.12) + granted riot (CR 702.136/702.136b):
+            // pause for the player's decision. The entry ZoneChangeEvent is deliberately omitted on a
+            // pause — the choice resumer synthesizes it after the choice resolves so ETB triggers fire
+            // once. Counters already added ride along as carryEvents; the rest of the batch resumes
+            // below the choice's continuation.
+            val choicePlan = TokenEntryReplacements.firstEntersWithChoice(newState, tokenId, cardRegistry)
+            if (choicePlan != null) {
+                val remaining = cappedCount - (index + 1)
+                var pausedState = newState
+                if (remaining > 0) {
+                    pausedState = pausedState.pushContinuation(
+                        com.wingedsheep.engine.core.CreateTokenCopyRemainingContinuation(
+                            decisionId = "create-token-copy-remaining-${UUID.randomUUID()}",
+                            effect = effect,
+                            context = context,
+                            controllerId = controllerId,
+                            remaining = remaining,
+                        )
+                    )
+                }
+                val paused = PermanentEntryReplacements.pauseForEntersWithChoice(
+                    state = pausedState,
+                    entityId = tokenId,
+                    controllerId = controllerId,
+                    cardComponent = tokenCard,
+                    choice = choicePlan.choice,
+                    fromZone = null,
+                    carryEvents = events,
+                    syntheticRiot = choicePlan.syntheticRiot,
+                    syntheticRiotRemaining = choicePlan.syntheticRiotRemaining,
+                )
+                if (paused != null) return EffectResult.from(paused)
+                // null → choice couldn't be presented; complete this token's entry normally.
+            }
 
             // CR 714.2b/714.3a: a token copy of a Saga enters as a Saga and gets its on-enter lore
             // counter. BattlefieldEntry.place skips enters-with-counters setup, so apply the shared
@@ -154,38 +208,36 @@ class CreateTokenCopyOfSourceExecutor(
             val (sagaState, sagaEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
                 .applySagaEntryIfNeeded(newState, tokenId)
             newState = sagaState
-            counterEvents.addAll(sagaEvents)
-        }
+            events.addAll(sagaEvents)
 
-        // If exileAtStep is set, create delayed triggers to exile each created token
-        val exileStep = effect.exileAtStep
-        if (exileStep != null) {
-            val sourceName = sourceCard.name
-            for (tokenId in createdTokens) {
-                val delayedTrigger = DelayedTriggeredAbility(
-                    id = UUID.randomUUID().toString(),
-                    effect = MoveToZoneEffect(EffectTarget.SpecificEntity(tokenId), Zone.EXILE),
-                    fireAtStep = exileStep,
-                    sourceId = sourceId,
-                    sourceName = sourceName,
-                    controllerId = controllerId
+            events.add(
+                ZoneChangeEvent(
+                    entityId = tokenId,
+                    entityName = tokenCard.name,
+                    fromZone = null,
+                    toZone = Zone.BATTLEFIELD,
+                    ownerId = controllerId
                 )
-                newState = newState.addDelayedTrigger(delayedTrigger)
+            )
+            createdTokens.add(tokenId)
+
+            // If exileAtStep is set, create a delayed trigger to exile this created token
+            // (Stormsplitter: "exile it at the beginning of the next end step").
+            val exileStep = effect.exileAtStep
+            if (exileStep != null) {
+                newState = newState.addDelayedTrigger(
+                    DelayedTriggeredAbility(
+                        id = UUID.randomUUID().toString(),
+                        effect = MoveToZoneEffect(EffectTarget.SpecificEntity(tokenId), Zone.EXILE),
+                        fireAtStep = exileStep,
+                        sourceId = sourceId,
+                        sourceName = sourceCard.name,
+                        controllerId = controllerId
+                    )
+                )
             }
         }
 
-        val events = createdTokens.map { tokenId ->
-            val entity = newState.getEntity(tokenId)!!
-            val card = entity.get<CardComponent>()!!
-            ZoneChangeEvent(
-                entityId = tokenId,
-                entityName = card.name,
-                fromZone = null,
-                toZone = Zone.BATTLEFIELD,
-                ownerId = controllerId
-            )
-        }
-
-        return EffectResult.success(newState, events + counterEvents)
+        return EffectResult.success(newState, events)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -139,7 +139,8 @@ class CreateTokenCopyOfTargetExecutor(
         val events = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
         val createdTokens = mutableListOf<EntityId>()
 
-        repeat(com.wingedsheep.engine.core.GameLimits.cappedTokenCount(count, "target-copy tokens")) {
+        val cappedCount = com.wingedsheep.engine.core.GameLimits.cappedTokenCount(count, "target-copy tokens")
+        for (index in 0 until cappedCount) {
             val (tokenId, stateWithId) = newState.newEntity()
             newState = stateWithId
             val op = effect.overridePower
@@ -246,7 +247,20 @@ class CreateTokenCopyOfTargetExecutor(
                     )
                 )
             }
-            createdTokens.add(tokenId)
+
+            // As-enters "enters with counters" (CR 614.1c): the copied card's own
+            // EntersWithCounters (a copy of a creature that "enters with a +1/+1 counter"), plus
+            // global grants from other permanents (Gev, Scaled Scorch). BattlefieldEntry.place skips
+            // this setup, so apply it here the way the standard entry pipeline does. Non-pausing.
+            val (afterCounters, counterEvents) = if (cardRegistry != null) {
+                com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+                    .applyOnEntry(newState, tokenId, controllerId, cardRegistry)
+            } else {
+                com.wingedsheep.engine.handlers.effects.EntersWithReplacements
+                    .applyGlobal(newState, tokenId, controllerId)
+            }
+            newState = afterCounters
+            events.addAll(counterEvents)
 
             for (ability in effect.triggeredAbilities) {
                 val grant = GrantedTriggeredAbility(
@@ -289,6 +303,48 @@ class CreateTokenCopyOfTargetExecutor(
                 )
             }
 
+            // As-enters "choose X as this enters" (CR 614.12) + granted riot (CR 702.136/702.136b).
+            // A token copy of a creature that "enters with your choice of …" — or a Spider entering
+            // while Spider-Punk grants it riot — pauses for a player decision. We deliberately do NOT
+            // emit this token's entry ZoneChangeEvent when we pause: the choice resumer synthesizes it
+            // after the choice resolves, so ETB triggers fire exactly once (mirroring
+            // TokenFromDefinition). Counters already added ride along as carryEvents.
+            val choicePlan = if (cardRegistry != null) {
+                TokenEntryReplacements.firstEntersWithChoice(newState, tokenId, cardRegistry)
+            } else null
+            if (choicePlan != null) {
+                val remaining = cappedCount - (index + 1)
+                var pausedState = newState
+                if (remaining > 0) {
+                    // The rest of the batch resumes below the choice's continuation once this token's
+                    // choice (and every granted-riot instance) has fully resolved.
+                    pausedState = pausedState.pushContinuation(
+                        com.wingedsheep.engine.core.CreateTokenCopyRemainingContinuation(
+                            decisionId = "create-token-copy-remaining-${UUID.randomUUID()}",
+                            effect = effect,
+                            context = context,
+                            controllerId = controllerId,
+                            remaining = remaining,
+                        )
+                    )
+                }
+                val paused = com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+                    .pauseForEntersWithChoice(
+                        state = pausedState,
+                        entityId = tokenId,
+                        controllerId = controllerId,
+                        cardComponent = tokenCard,
+                        choice = choicePlan.choice,
+                        fromZone = null,
+                        carryEvents = events,
+                        syntheticRiot = choicePlan.syntheticRiot,
+                        syntheticRiotRemaining = choicePlan.syntheticRiotRemaining,
+                    )
+                if (paused != null) return EffectResult.from(paused)
+                // A null pause means the choice couldn't actually be presented (e.g. no legal object) —
+                // fall through and complete this token's entry normally.
+            }
+
             events.add(
                 ZoneChangeEvent(
                     entityId = tokenId,
@@ -307,6 +363,7 @@ class CreateTokenCopyOfTargetExecutor(
                 .applySagaEntryIfNeeded(newState, tokenId)
             newState = sagaState
             events.addAll(sagaEvents)
+            createdTokens.add(tokenId)
         }
 
         // If sacrificeAtStep is set, create a delayed trigger to sacrifice each created token

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenEntryReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenEntryReplacements.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.handlers.effects.token
+
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.mechanics.RiotSynthesis
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+
+/**
+ * The "as-enters" replacement pipeline shared by every path that puts a **token** onto the
+ * battlefield — [TokenFromDefinition.mint] (a token minted from a bare card definition) and the four
+ * token-copy executors ([CreateTokenCopyOfTargetExecutor], [CreateTokenCopyOfSourceExecutor],
+ * [CreateTokenCopyOfChosenPermanentExecutor], [CreateTokenCopyOfEquippedCreatureExecutor]).
+ *
+ * Those executors place their tokens via the ad-hoc [com.wingedsheep.engine.handlers.effects.BattlefieldEntry.place]
+ * path, which deliberately skips all enters-with replacement setup. Per CR 707.2 a copy has the
+ * copied card's abilities, so a token copy must still run the copied card's "enters with counters"
+ * (CR 614.1c) and "as this enters, choose …" (CR 614.12) replacements, plus any **granted** riot
+ * (CR 702.136 / 702.136b — each granted instance is a separate choice) from a lord such as
+ * Spider-Punk.
+ *
+ * Counters are applied inline by the caller through
+ * [com.wingedsheep.engine.handlers.effects.EntersWithReplacements.applyOnEntry] (non-pausing). The
+ * choice half is what needs a player decision mid-loop, so this object centralizes computing **which**
+ * choice a just-placed token owes; the caller then pauses via
+ * [com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements.pauseForEntersWithChoice],
+ * whose existing [com.wingedsheep.engine.core.EntersWithChoiceOnBattlefieldContinuation] resumer
+ * records the value, applies the granted-riot branch, loops per riot instance, chains any further
+ * printed choice, and fires the token's ETB triggers.
+ */
+object TokenEntryReplacements {
+
+    private val predicateEvaluator = PredicateEvaluator()
+
+    /**
+     * The [EntersWithChoice] a just-placed token owes as it enters, together with the granted-riot
+     * bookkeeping the choice pause needs. `null` when the token owes no choice (the common case).
+     *
+     * @property choice the first choice to present (printed choices and a synthesized granted-riot
+     *   choice are pooled and ordered by [com.wingedsheep.sdk.scripting.ChoiceType.ordinal], matching
+     *   [TokenFromDefinition]).
+     * @property syntheticRiot true when [choice] is the synthesized granted-riot choice (the resumer
+     *   then applies the chosen +1/+1-counter / haste branch directly — a granted permanent has no
+     *   printed static to fall back on).
+     * @property syntheticRiotRemaining the number of *further* granted-riot choices still owed after
+     *   [choice] (CR 702.136b), 0 unless [syntheticRiot].
+     */
+    data class EntersWithChoicePlan(
+        val choice: EntersWithChoice,
+        val syntheticRiot: Boolean,
+        val syntheticRiotRemaining: Int,
+    )
+
+    /**
+     * Compute the first "as-enters" choice a token already on the battlefield owes, pooling the copied
+     * card's printed [EntersWithChoice]s (looked up by the token's `cardDefinitionId`) with a
+     * synthesized granted-riot choice. Returns `null` when there is nothing to choose.
+     *
+     * Kept identical in ordering to [TokenFromDefinition] so a minted token and a token copy resolve
+     * their as-enters choices the same way.
+     */
+    fun firstEntersWithChoice(
+        state: GameState,
+        tokenId: EntityId,
+        cardRegistry: CardRegistry,
+    ): EntersWithChoicePlan? {
+        val cardComponent = state.getEntity(tokenId)?.get<CardComponent>() ?: return null
+        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
+        val printedChoices = cardDef?.script?.replacementEffects
+            ?.filterIsInstance<EntersWithChoice>()
+            ?: emptyList()
+        val grantedRiotCount = RiotSynthesis.grantedRiotInstanceCount(
+            state, tokenId, cardRegistry, predicateEvaluator
+        )
+        val syntheticRiotChoice = if (grantedRiotCount > 0) RiotSynthesis.RIOT_CHOICE else null
+        val firstChoice = (printedChoices + listOfNotNull(syntheticRiotChoice))
+            .sortedBy { it.choiceType.ordinal }
+            .firstOrNull() ?: return null
+        val isSynthetic = firstChoice === syntheticRiotChoice
+        return EntersWithChoicePlan(
+            choice = firstChoice,
+            syntheticRiot = isSynthetic,
+            syntheticRiotRemaining = if (isSynthetic) grantedRiotCount - 1 else 0,
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -5,7 +5,6 @@ import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.BattlefieldEntry
 import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
 import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
@@ -23,7 +22,6 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.EntersTapped
-import com.wingedsheep.sdk.scripting.EntersWithChoice
 
 /**
  * Mints a token that is a copy of a bare [CardDefinition] — one not instantiated in any zone —
@@ -65,7 +63,6 @@ import com.wingedsheep.sdk.scripting.EntersWithChoice
 object TokenFromDefinition {
 
     private val conditionEvaluator = ConditionEvaluator()
-    private val predicateEvaluator = PredicateEvaluator()
 
     fun mint(
         state: GameState,
@@ -133,18 +130,12 @@ object TokenFromDefinition {
         // ZoneChangeEvent — so we deliberately do NOT emit the entry ZoneChangeEvent here when we
         // pause (the resolution path would otherwise detect those triggers now AND again in the
         // resumer, firing them twice). Counters already added ride along as carryEvents.
-        val printedChoices = cardDef.script.replacementEffects.filterIsInstance<EntersWithChoice>()
-        // Granted Riot: a token that is a Spider entering while a lord grants "Other Spiders you
-        // control have riot" (Spider-Punk) gets a synthesized enters-with choice per grant (702.136b).
-        val grantedRiotCount = com.wingedsheep.engine.mechanics.RiotSynthesis
-            .grantedRiotInstanceCount(newState, tokenId, cardRegistry, predicateEvaluator)
-        val syntheticRiotChoice = if (grantedRiotCount > 0) {
-            com.wingedsheep.engine.mechanics.RiotSynthesis.RIOT_CHOICE
-        } else null
-        val firstChoice = (printedChoices + listOfNotNull(syntheticRiotChoice))
-            .sortedBy { it.choiceType.ordinal }
-            .firstOrNull()
-        if (firstChoice != null) {
+        // Printed EntersWithChoice + a synthesized granted-riot choice (Spider-Punk: "Other Spiders
+        // you control have riot" — CR 702.136b, each granted instance is a separate choice). Computed
+        // by the shared helper so a minted token and a token copy resolve as-enters choices the same
+        // way.
+        val choicePlan = TokenEntryReplacements.firstEntersWithChoice(newState, tokenId, cardRegistry)
+        if (choicePlan != null) {
             val cardComponent = newState.getEntity(tokenId)?.get<CardComponent>()
             if (cardComponent != null) {
                 val paused = PermanentEntryReplacements.pauseForEntersWithChoice(
@@ -152,11 +143,11 @@ object TokenFromDefinition {
                     entityId = tokenId,
                     controllerId = controllerId,
                     cardComponent = cardComponent,
-                    choice = firstChoice,
+                    choice = choicePlan.choice,
                     fromZone = null,
                     carryEvents = counterEvents,
-                    syntheticRiot = firstChoice === syntheticRiotChoice,
-                    syntheticRiotRemaining = if (firstChoice === syntheticRiotChoice) grantedRiotCount - 1 else 0
+                    syntheticRiot = choicePlan.syntheticRiot,
+                    syntheticRiotRemaining = choicePlan.syntheticRiotRemaining,
                 )
                 if (paused != null) return EffectResult.from(paused)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.effects.BattlefieldEntry
 import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
 import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
@@ -64,6 +65,7 @@ import com.wingedsheep.sdk.scripting.EntersWithChoice
 object TokenFromDefinition {
 
     private val conditionEvaluator = ConditionEvaluator()
+    private val predicateEvaluator = PredicateEvaluator()
 
     fun mint(
         state: GameState,
@@ -131,8 +133,15 @@ object TokenFromDefinition {
         // ZoneChangeEvent — so we deliberately do NOT emit the entry ZoneChangeEvent here when we
         // pause (the resolution path would otherwise detect those triggers now AND again in the
         // resumer, firing them twice). Counters already added ride along as carryEvents.
-        val firstChoice = cardDef.script.replacementEffects
-            .filterIsInstance<EntersWithChoice>()
+        val printedChoices = cardDef.script.replacementEffects.filterIsInstance<EntersWithChoice>()
+        // Granted Riot: a token that is a Spider entering while a lord grants "Other Spiders you
+        // control have riot" (Spider-Punk) gets a synthesized enters-with choice per grant (702.136b).
+        val grantedRiotCount = com.wingedsheep.engine.mechanics.RiotSynthesis
+            .grantedRiotInstanceCount(newState, tokenId, cardRegistry, predicateEvaluator)
+        val syntheticRiotChoice = if (grantedRiotCount > 0) {
+            com.wingedsheep.engine.mechanics.RiotSynthesis.RIOT_CHOICE
+        } else null
+        val firstChoice = (printedChoices + listOfNotNull(syntheticRiotChoice))
             .sortedBy { it.choiceType.ordinal }
             .firstOrNull()
         if (firstChoice != null) {
@@ -145,7 +154,9 @@ object TokenFromDefinition {
                     cardComponent = cardComponent,
                     choice = firstChoice,
                     fromZone = null,
-                    carryEvents = counterEvents
+                    carryEvents = counterEvents,
+                    syntheticRiot = firstChoice === syntheticRiotChoice,
+                    syntheticRiotRemaining = if (firstChoice === syntheticRiotChoice) grantedRiotCount - 1 else 0
                 )
                 if (paused != null) return EffectResult.from(paused)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RiotSynthesis.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RiotSynthesis.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.RIOT_MODE_OPTIONS
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Granted-Riot synthesis. Riot (CR 702.136) is composed at authoring time into an
+ * [EntersWithChoice]`(MODE, [counter, haste])` + mode-gated counter / haste (see the `riot()` DSL).
+ * Those printed replacement/static abilities are only read from a card's own definition, so a
+ * permanent that merely has RIOT *granted* ("Other Spiders you control have riot" — Spider-Punk)
+ * gets no enters-with choice. This object counts the granted instances and synthesizes that choice
+ * for the entry seams (spell resolution, token/land entry); the choice resumer then applies the
+ * chosen branch directly (a granted permanent has no printed `EntersWithCounters`/haste static to
+ * fall back on).
+ *
+ * Per CR 702.136b each instance of riot works separately, so a permanent granted riot by multiple
+ * lords is offered one choice per lord ([grantedRiotInstanceCount]); the resumer loops over them.
+ */
+object RiotSynthesis {
+
+    /** The synthesized Riot MODE choice — identical to the one the `riot()` DSL prints. */
+    val RIOT_CHOICE = EntersWithChoice(choiceType = ChoiceType.MODE, modeOptions = RIOT_MODE_OPTIONS)
+
+    /**
+     * The number of **granted** Riot instances on [entityId] — one per battlefield
+     * `GrantKeyword(RIOT)` lord whose filter matches it (CR 702.136b: each instance works
+     * separately). Honors each lord's `excludeSelf` (a granter never grants riot to itself) and
+     * reads the lord's **projected** controller, so "Spiders you control" tracks control changes.
+     *
+     * Works uniformly for a spell still on the stack (its subtype/type live on its [CardComponent],
+     * so the lord's filter resolves) and for a permanent already on the battlefield (token / land).
+     * This scans printed `GrantKeyword(RIOT)` statics only — the sole granter shape in the card pool
+     * (Spider-Punk); a granted-riot source of some other shape would not be counted here.
+     */
+    fun grantedRiotInstanceCount(
+        state: GameState,
+        entityId: EntityId,
+        cardRegistry: CardRegistry,
+        predicateEvaluator: PredicateEvaluator,
+    ): Int {
+        var count = 0
+        for (sourceId in state.getBattlefield()) {
+            val srcCard = state.getEntity(sourceId)?.get<CardComponent>() ?: continue
+            val def = cardRegistry.getCard(srcCard.cardDefinitionId) ?: continue
+            val srcController = state.projectedState.getController(sourceId) ?: continue
+            for (ability in def.staticAbilities) {
+                if (ability !is GrantKeyword || ability.keyword != Keyword.RIOT.name) continue
+                if (ability.filter.excludeSelf && sourceId == entityId) continue
+                val context = PredicateContext(sourceId = sourceId, controllerId = srcController)
+                if (predicateEvaluator.matches(
+                        state, state.projectedState, entityId, ability.filter.baseFilter, context
+                    )
+                ) {
+                    count++
+                }
+            }
+        }
+        return count
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -955,12 +955,26 @@ class StackResolver(
             // Process in priority order: COLOR → CREATURE_TYPE → CREATURE_ON_BATTLEFIELD
             // When a card has multiple choices (e.g., Riptide Replicator: color + creature type),
             // the first one pauses; its continuation resumer chains to the next.
-            val entersWithChoices = cardDef.script.replacementEffects.filterIsInstance<EntersWithChoice>()
+            val printedChoices = cardDef.script.replacementEffects.filterIsInstance<EntersWithChoice>()
+            // Granted Riot ("Other Spiders you control have riot") is not printed on the entering
+            // spell, so synthesize its enters-with choice — one per granting lord (CR 702.136b) —
+            // when a battlefield lord grants RIOT to it.
+            val grantedRiotCount = com.wingedsheep.engine.mechanics.RiotSynthesis
+                .grantedRiotInstanceCount(state, spellId, cardRegistry, predicateEvaluator)
+            val syntheticRiotChoice = if (grantedRiotCount > 0) {
+                com.wingedsheep.engine.mechanics.RiotSynthesis.RIOT_CHOICE
+            } else null
+            val entersWithChoices = printedChoices + listOfNotNull(syntheticRiotChoice)
             val firstChoice = entersWithChoices
                 .sortedBy { it.choiceType.ordinal }
                 .firstOrNull()
             if (firstChoice != null) {
-                val result = pauseForEntersWithChoice(state, spellId, controllerId, ownerId, cardComponent, firstChoice)
+                val isSynthetic = firstChoice === syntheticRiotChoice
+                val result = pauseForEntersWithChoice(
+                    state, spellId, controllerId, ownerId, cardComponent, firstChoice,
+                    syntheticRiot = isSynthetic,
+                    syntheticRiotRemaining = if (isSynthetic) grantedRiotCount - 1 else 0
+                )
                 if (result != null) return result
                 // null means choice couldn't be presented (e.g., no creatures on battlefield) — fall through
             }
@@ -2978,6 +2992,13 @@ class StackResolver(
             ?: container.get<ActivatedAbilityOnStackComponent>()?.let { "${it.sourceName}'s ability" }
             ?: "Unknown ability"
 
+        // "Abilities can't be countered" (Spider-Punk): a battlefield GrantCantBeCountered with
+        // includesAbilities = true whose filter matches this ability makes the counter fizzle — the
+        // ability stays on the stack and resolves normally.
+        if (isAbilityGrantedCantBeCountered(state, abilityId)) {
+            return ExecutionResult.success(state)
+        }
+
         // Remove from stack — abilities don't go to any zone
         val newState = state.removeFromStack(abilityId)
 
@@ -3376,6 +3397,32 @@ class StackResolver(
         return false
     }
 
+    /**
+     * Whether an activated/triggered ability on the stack ([abilityId]) can't be countered because a
+     * battlefield [GrantCantBeCountered] with `includesAbilities = true` covers it (its filter matches
+     * the ability — an unrestricted `GameObjectFilter.Any` matches every ability). Spider-Punk's
+     * "Spells and abilities can't be countered."
+     */
+    private fun isAbilityGrantedCantBeCountered(state: GameState, abilityId: EntityId): Boolean {
+        for (playerId in state.turnOrder) {
+            for (entityId in state.getBattlefield(playerId)) {
+                val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+                val def = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+                val sourceControllerId =
+                    state.getEntity(entityId)?.get<ControllerComponent>()?.playerId ?: playerId
+                val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId)
+                for (ability in def.staticAbilities) {
+                    if (ability is GrantCantBeCountered && ability.includesAbilities) {
+                        if (predicateEvaluator.matches(state, state.projectedState, abilityId, ability.filter, context)) {
+                            return true
+                        }
+                    }
+                }
+            }
+        }
+        return false
+    }
+
     // =========================================================================
     // Valiant / "first time targeted" tracking
     // =========================================================================
@@ -3410,7 +3457,9 @@ class StackResolver(
         controllerId: EntityId,
         ownerId: EntityId,
         cardComponent: CardComponent,
-        choice: EntersWithChoice
+        choice: EntersWithChoice,
+        syntheticRiot: Boolean = false,
+        syntheticRiotRemaining: Int = 0
     ): ExecutionResult? {
         val chooserId = when (choice.chooser) {
             com.wingedsheep.sdk.scripting.references.Player.AnOpponent ->
@@ -3513,7 +3562,10 @@ class StackResolver(
                 if (choice.modeOptions.isEmpty()) {
                     return null
                 }
-                val decisionId = "choose-mode-enters-${spellId.value}"
+                // A permanent granted multiple riot instances re-pauses on the same spell; suffix the
+                // id with the remaining count so each instance's decision is distinct (CR 702.136b).
+                val decisionId = "choose-mode-enters-${spellId.value}" +
+                    if (syntheticRiot) "-riot$syntheticRiotRemaining" else ""
                 val decision = ChooseOptionDecision(
                     id = decisionId,
                     playerId = chooserId,
@@ -3534,7 +3586,9 @@ class StackResolver(
                     controllerId = controllerId,
                     ownerId = ownerId,
                     choiceType = ChoiceType.MODE,
-                    modeOptionIds = choice.modeOptions.map { it.id }
+                    modeOptionIds = choice.modeOptions.map { it.id },
+                    syntheticRiot = syntheticRiot,
+                    syntheticRiotRemaining = syntheticRiotRemaining
                 )
                 val pausedState = state
                     .pushContinuation(continuation)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -173,8 +173,8 @@ data class GameState(
     val spellWarpedThisTurn: Boolean = false,
 
     /**
-     * Whether damage can't be prevented for the rest of this turn (CR 615.6 — a prevention effect
-     * can't apply to damage that can't be prevented). Set by the
+     * Whether damage can't be prevented for the rest of this turn (CR 615.12 — prevention shields
+     * aren't reduced and prevent nothing). Set by the
      * [com.wingedsheep.sdk.scripting.effects.DamageCantBePreventedThisTurnEffect] one-shot (Fear,
      * Fire, Foes!) and read by [com.wingedsheep.engine.handlers.effects.DamageUtils.isDamagePreventionDisabled].
      * Reset to false at every turn boundary.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -10,6 +10,8 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.RIOT_MODE_COUNTER
+import com.wingedsheep.sdk.dsl.RIOT_MODE_HASTE
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.GrantChosenColor
@@ -1084,8 +1086,11 @@ class ClientStateTransformer(
         // Get chosen mode label for "as enters, choose X or Y" permanents (e.g., Outpost Siege).
         // Resolve the stored mode id back to the display label declared in the card's
         // EntersWithChoice(modeOptions = [...]) so the UI can show the human-friendly name.
+        // Riot's counter/haste mode is a one-time enters-with choice, not an ongoing mode — its
+        // effect is already visible as a +1/+1 counter or the haste keyword — so it gets no badge.
         val chosenMode = container
             .chosenModeId()
+            ?.takeUnless { it == RIOT_MODE_COUNTER || it == RIOT_MODE_HASTE }
             ?.let { modeId ->
                 val modeOptions = cardDef?.script?.replacementEffects
                     ?.filterIsInstance<com.wingedsheep.sdk.scripting.EntersWithChoice>()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderPunkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderPunkScenarioTest.kt
@@ -1,0 +1,230 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lea.cards.HealingSalve
+import com.wingedsheep.mtg.sets.definitions.spm.cards.SpiderPunk
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Spider-Punk (SPM) — Riot (printed + granted to other Spiders, one choice per grant per CR
+ * 702.136b), "Spells and abilities can't be countered," and "Damage can't be prevented."
+ */
+class SpiderPunkScenarioTest : FunSpec({
+
+    // A plain Spider creature spell, to exercise granted Riot.
+    val testSpider = card("Test Web-Spinner") {
+        manaCost = "{2}{G}"
+        colorIdentity = "G"
+        typeLine = "Creature — Spider"
+        power = 1
+        toughness = 1
+    }
+
+    // A second, non-legendary lord that also grants riot to Spiders — so a Spider can carry two
+    // granted riot instances (Spider-Punk is legendary; Spider-Verse / Impostor Syndrome can also
+    // put a second Spider-Punk in play).
+    val testRiotLord = card("Test Riot Lord") {
+        manaCost = "{2}{R}"
+        colorIdentity = "R"
+        typeLine = "Creature — Human"
+        power = 1
+        toughness = 1
+        staticAbility {
+            ability = GrantKeyword(
+                Keyword.RIOT,
+                GroupFilter(GameObjectFilter.Creature.withSubtype("Spider").youControl(), excludeSelf = true),
+            )
+        }
+    }
+
+    // A creature with an ETB "gain 3 life" trigger, to exercise "abilities can't be countered".
+    val lifeGainCreature = card("Test Lifegainer") {
+        manaCost = "{1}{G}"
+        colorIdentity = "G"
+        typeLine = "Creature — Beast"
+        power = 2
+        toughness = 2
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.GainLife(3)
+        }
+    }
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(SpiderPunk, testSpider, testRiotLord, lifeGainCreature, HealingSalve)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+        return Triple(driver, you, opponent)
+    }
+
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun plusOne(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Choose the Riot mode whose label contains [needle] on the pending decision. */
+    fun chooseRiotMode(driver: GameTestDriver, you: EntityId, needle: String) {
+        val pick = driver.pendingDecision as ChooseOptionDecision
+        val idx = pick.options.indexOfFirst { it.contains(needle, ignoreCase = true) }
+        driver.submitDecision(you, OptionChosenResponse(pick.id, idx))
+        settle(driver)
+    }
+
+    test("printed Riot: choosing the counter gives Spider-Punk a +1/+1 counter") {
+        val (driver, you, _) = newGame()
+        driver.giveMana(you, Color.RED, 1)
+        driver.giveColorlessMana(you, 1)
+        val sp = driver.putCardInHand(you, "Spider-Punk")
+        driver.castSpell(you, sp)
+        settle(driver)
+        chooseRiotMode(driver, you, "counter")
+
+        plusOne(driver, driver.findPermanent(you, "Spider-Punk")!!) shouldBe 1
+    }
+
+    test("printed Riot: choosing haste grants Spider-Punk haste") {
+        val (driver, you, _) = newGame()
+        driver.giveMana(you, Color.RED, 1)
+        driver.giveColorlessMana(you, 1)
+        val sp = driver.putCardInHand(you, "Spider-Punk")
+        driver.castSpell(you, sp)
+        settle(driver)
+        chooseRiotMode(driver, you, "haste")
+
+        val onBf = driver.findPermanent(you, "Spider-Punk")!!
+        driver.state.projectedState.hasKeyword(onBf, Keyword.HASTE) shouldBe true
+    }
+
+    test("granted Riot: a Spider you cast while Spider-Punk is in play gets the enters-with choice") {
+        val (driver, you, _) = newGame()
+        driver.putCreatureOnBattlefield(you, "Spider-Punk") // the granter
+
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveColorlessMana(you, 2)
+        val spider = driver.putCardInHand(you, "Test Web-Spinner")
+        driver.castSpell(you, spider)
+        settle(driver) // pauses on the SYNTHESIZED riot choice
+        chooseRiotMode(driver, you, "counter")
+
+        plusOne(driver, driver.findPermanent(you, "Test Web-Spinner")!!) shouldBe 1
+    }
+
+    test("granted Riot: two riot granters give a Spider two separate choices (CR 702.136b)") {
+        val (driver, you, _) = newGame()
+        driver.putCreatureOnBattlefield(you, "Spider-Punk")   // grants riot to other Spiders
+        driver.putCreatureOnBattlefield(you, "Test Riot Lord") // also grants riot to Spiders
+
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveColorlessMana(you, 2)
+        val spider = driver.putCardInHand(you, "Test Web-Spinner")
+        driver.castSpell(you, spider)
+        settle(driver)
+        chooseRiotMode(driver, you, "counter") // first instance
+        chooseRiotMode(driver, you, "counter") // second instance re-pauses separately
+
+        // Each instance works separately, so the counter branch fires twice → two +1/+1 counters.
+        plusOne(driver, driver.findPermanent(you, "Test Web-Spinner")!!) shouldBe 2
+    }
+
+    test("spells can't be countered: opponent's Counterspell can't counter your spell") {
+        val (driver, you, opp) = newGame()
+        driver.putCreatureOnBattlefield(you, "Spider-Punk")
+
+        driver.giveMana(you, Color.GREEN, 2)
+        val bears = driver.putCardInHand(you, "Grizzly Bears")
+        driver.castSpell(you, bears)
+        val bearsOnStack = driver.getTopOfStack()!!
+        driver.passPriority(you)
+
+        driver.giveMana(opp, Color.BLUE, 2)
+        val counter = driver.putCardInHand(opp, "Counterspell")
+        driver.submit(
+            CastSpell(
+                playerId = opp,
+                cardId = counter,
+                targets = listOf(ChosenTarget.Spell(bearsOnStack)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        settle(driver) // Counterspell resolves (fizzles), then Grizzly Bears resolves.
+
+        // Counterspell resolves but can't counter — Grizzly Bears enters the battlefield.
+        driver.findPermanent(you, "Grizzly Bears") shouldNotBe null
+    }
+
+    test("abilities can't be countered: Stifle can't counter your ETB trigger") {
+        val (driver, you, opp) = newGame()
+        driver.putCreatureOnBattlefield(you, "Spider-Punk")
+
+        driver.giveMana(you, Color.GREEN, 2)
+        val creature = driver.putCardInHand(you, "Test Lifegainer")
+        driver.castSpell(you, creature)
+        driver.bothPass() // creature resolves; its ETB "gain 3 life" trigger goes on the stack
+
+        val trigger = driver.getTopOfStack()!!
+        driver.passPriority(you)
+        driver.giveMana(opp, Color.BLUE, 1)
+        val stifle = driver.putCardInHand(opp, "Stifle")
+        driver.castSpellWithTargets(opp, stifle, listOf(ChosenTarget.Spell(trigger)))
+        settle(driver) // Stifle resolves (fizzles), then the ETB trigger resolves.
+
+        // Stifle resolves but can't counter the ability — the trigger resolves and you gain 3 life.
+        driver.getLifeTotal(you) shouldBe 23
+    }
+
+    test("damage can't be prevented: a prevention shield doesn't stop your damage") {
+        val (driver, you, opp) = newGame()
+        driver.putCreatureOnBattlefield(you, "Spider-Punk")
+
+        // Shield the opponent from the next 3 damage this turn (Healing Salve, mode 1).
+        driver.giveMana(you, Color.WHITE, 1)
+        val salve = driver.putCardInHand(you, "Healing Salve")
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = salve,
+                targets = listOf(ChosenTarget.Player(opp)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(opp))),
+            )
+        )
+        driver.bothPass()
+
+        // Lightning Bolt the opponent — with Spider-Punk out the shield can't prevent it.
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opp)))
+        driver.bothPass()
+
+        driver.getLifeTotal(opp) shouldBe 17
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TokenCopyEntersWithScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TokenCopyEntersWithScenarioTest.kt
@@ -1,0 +1,199 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.SpiderPunk
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine mechanic: **token copies run the copied card's "enters-with" replacements** (CR 707.2 — a
+ * copy has the copied card's abilities). Exercises the four token-copy executors' shared
+ * enters-with pipeline through [com.wingedsheep.engine.handlers.effects.token.CreateTokenCopyOfTargetExecutor]:
+ *
+ *  1. a token copy of a creature that "enters with a +1/+1 counter" (CR 614.1c) gets the counter;
+ *  2. a token copy of a Spider entering while Spider-Punk grants riot (CR 702.136) gets the
+ *     enters-with choice, and choosing the counter mode adds a +1/+1 counter;
+ *  3. two riot granters give the token two separate choices (CR 702.136b);
+ *  4. a multi-token copy where each token gets its own choice — proving the per-token pause loop.
+ */
+class TokenCopyEntersWithScenarioTest : FunSpec({
+
+    // A creature that enters with a +1/+1 counter (a printed self EntersWithCounters replacement).
+    val counterCreature = card("Test Counter Bearer") {
+        manaCost = "{2}{G}"
+        colorIdentity = "G"
+        typeLine = "Creature — Beast"
+        power = 1
+        toughness = 1
+        replacementEffect(
+            EntersWithCounters(
+                counterType = CounterTypeFilter.PlusOnePlusOne,
+                count = 1,
+                selfOnly = true,
+            )
+        )
+    }
+
+    // A plain Spider, to exercise granted riot on a token copy.
+    val testSpider = card("Test Web-Spinner") {
+        manaCost = "{2}{G}"
+        colorIdentity = "G"
+        typeLine = "Creature — Spider"
+        power = 1
+        toughness = 1
+    }
+
+    // A second, non-legendary lord granting riot to Spiders — a Spider can then carry two grants.
+    val testRiotLord = card("Test Riot Lord") {
+        manaCost = "{2}{R}"
+        colorIdentity = "R"
+        typeLine = "Creature — Human"
+        power = 1
+        toughness = 1
+        staticAbility {
+            ability = GrantKeyword(
+                Keyword.RIOT,
+                GroupFilter(GameObjectFilter.Creature.withSubtype("Spider").youControl(), excludeSelf = true),
+            )
+        }
+    }
+
+    // "Create a token that's a copy of target creature."
+    val duplicator = card("Test Duplicator") {
+        manaCost = "{1}{U}"
+        colorIdentity = "U"
+        typeLine = "Sorcery"
+        spell {
+            val t = target("target creature", TargetCreature(filter = TargetFilter.Creature))
+            effect = Effects.CreateTokenCopyOfTarget(t)
+        }
+    }
+
+    // "Create two tokens that are copies of target creature."
+    val doubleDuplicator = card("Test Double Duplicator") {
+        manaCost = "{1}{U}"
+        colorIdentity = "U"
+        typeLine = "Sorcery"
+        spell {
+            val t = target("target creature", TargetCreature(filter = TargetFilter.Creature))
+            effect = Effects.CreateTokenCopyOfTarget(t, count = 2)
+        }
+    }
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(SpiderPunk, counterCreature, testSpider, testRiotLord, duplicator, doubleDuplicator)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun plusOne(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Token copies of [name] you control (excludes the original nontoken permanent). */
+    fun tokenCopies(driver: GameTestDriver, you: EntityId, name: String): List<EntityId> =
+        driver.state.getBattlefield().filter { id ->
+            val e = driver.state.getEntity(id) ?: return@filter false
+            e.get<CardComponent>()?.name == name &&
+                e.get<TokenComponent>() != null &&
+                driver.state.projectedState.getController(id) == you
+        }
+
+    fun chooseRiotMode(driver: GameTestDriver, you: EntityId, needle: String) {
+        val pick = driver.pendingDecision as ChooseOptionDecision
+        val idx = pick.options.indexOfFirst { it.contains(needle, ignoreCase = true) }
+        driver.submitDecision(you, OptionChosenResponse(pick.id, idx))
+        settle(driver)
+    }
+
+    fun castCopy(driver: GameTestDriver, you: EntityId, spellName: String, targetId: EntityId) {
+        driver.giveMana(you, Color.BLUE, 1)
+        driver.giveColorlessMana(you, 1)
+        val spell = driver.putCardInHand(you, spellName)
+        driver.castSpellWithTargets(you, spell, listOf(ChosenTarget.Permanent(targetId)))
+        settle(driver)
+    }
+
+    test("token copy of a creature that enters with a +1/+1 counter gets the counter") {
+        val (driver, you) = newGame()
+        val original = driver.putCreatureOnBattlefield(you, "Test Counter Bearer")
+
+        castCopy(driver, you, "Test Duplicator", original)
+
+        val tokens = tokenCopies(driver, you, "Test Counter Bearer")
+        tokens.size shouldBe 1
+        plusOne(driver, tokens.first()) shouldBe 1
+    }
+
+    test("token copy of a Spider while Spider-Punk grants riot gets the enters-with choice") {
+        val (driver, you) = newGame()
+        driver.putCreatureOnBattlefield(you, "Spider-Punk") // grants riot to other Spiders
+        val spider = driver.putCreatureOnBattlefield(you, "Test Web-Spinner")
+
+        castCopy(driver, you, "Test Duplicator", spider) // pauses on the synthesized riot choice
+        chooseRiotMode(driver, you, "counter")
+
+        val tokens = tokenCopies(driver, you, "Test Web-Spinner")
+        tokens.size shouldBe 1
+        plusOne(driver, tokens.first()) shouldBe 1
+    }
+
+    test("two riot granters give a token copy two separate choices (CR 702.136b)") {
+        val (driver, you) = newGame()
+        driver.putCreatureOnBattlefield(you, "Spider-Punk")
+        driver.putCreatureOnBattlefield(you, "Test Riot Lord")
+        val spider = driver.putCreatureOnBattlefield(you, "Test Web-Spinner")
+
+        castCopy(driver, you, "Test Duplicator", spider)
+        chooseRiotMode(driver, you, "counter") // first granted instance
+        chooseRiotMode(driver, you, "counter") // second instance re-pauses separately
+
+        val tokens = tokenCopies(driver, you, "Test Web-Spinner")
+        tokens.size shouldBe 1
+        plusOne(driver, tokens.first()) shouldBe 2
+    }
+
+    test("multi-token copy: each token gets its own enters-with choice (per-token pause loop)") {
+        val (driver, you) = newGame()
+        driver.putCreatureOnBattlefield(you, "Spider-Punk")
+        val spider = driver.putCreatureOnBattlefield(you, "Test Web-Spinner")
+
+        castCopy(driver, you, "Test Double Duplicator", spider)
+        chooseRiotMode(driver, you, "counter") // first token
+        chooseRiotMode(driver, you, "counter") // second token, created only after the first resolved
+
+        val tokens = tokenCopies(driver, you, "Test Web-Spinner")
+        tokens.size shouldBe 2
+        tokens.forEach { plusOne(driver, it) shouldBe 1 }
+    }
+})

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -182,6 +182,7 @@ export enum Keyword {
   BANDING = 'BANDING',
   // ETB modification
   AMPLIFY = 'AMPLIFY',
+  RIOT = 'RIOT',
   // Defense
   DEFENDER = 'DEFENDER',
   INDESTRUCTIBLE = 'INDESTRUCTIBLE',
@@ -274,6 +275,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.FLANKING]: 'Flanking',
   [Keyword.BANDING]: 'Banding',
   [Keyword.AMPLIFY]: 'Amplify',
+  [Keyword.RIOT]: 'Riot',
   [Keyword.DEFENDER]: 'Defender',
   [Keyword.INDESTRUCTIBLE]: 'Indestructible',
   [Keyword.HEXPROOF]: 'Hexproof',


### PR DESCRIPTION
## Spider-Punk (Marvel's Spider-Man #92) — the last of the 188 SPM cards

`{1}{R}` Legendary Creature — Spider Human Hero, 2/1:

> Riot *(This creature enters with your choice of a +1/+1 counter or haste.)*
> Other Spiders you control have riot.
> Spells and abilities can't be countered.
> Damage can't be prevented.

## What's in this PR

Two commits on the branch:

### 1. Add Spider-Punk with the Riot keyword and granted-riot synthesis
- **Riot (CR 702.136, new keyword)** — `Keyword.RIOT` + a `riot()` DSL helper composing the Khans-Siege `EntersWithChoice(MODE, [counter, haste])` pattern (mode-gated `EntersWithCounters` + mode-gated `GrantKeyword(HASTE)`). Display-only keyword; no new executor.
- **"Other Spiders you control have riot"** — `GrantKeyword(RIOT, other Spiders)` plus `RiotSynthesis`, which synthesizes the enters-with choice for a permanent that carries *granted* riot (a granted creature has none of the printed statics). It counts battlefield `GrantKeyword(RIOT)` lords via each lord's **projected** controller and offers **one choice per grant** (CR 702.136b — each riot instance works separately); the resumers loop per instance. Wired through the spell-cast, token, and land entry seams.
- **"Spells and abilities can't be countered"** — `GrantCantBeCountered` gained an `includesAbilities` flag; `StackResolver.counterAbility` now fizzles ability counters (Stifle-type) while a matching grant is in play.
- **"Damage can't be prevented"** — `DamageCantBePrevented` replacement, plus a real bug fix: `DamageUtils.applyDamagePreventionShields` now honors `isDamagePreventionDisabled` (CR 615.12), so prevention shields no longer apply while a "damage can't be prevented" (or the "this turn" one-shot) is active. This also fixes a pre-existing gap for Fear, Fire, Foes!.
- **UI** — `ClientStateTransformer` no longer surfaces Riot's counter/haste as the persistent "chosen mode" badge (that badge is for ongoing modal characteristics like the Siege cycle; Riot's is a one-time enters-with choice already visible as a counter/keyword). `Keyword.RIOT` added to the web-client enums.

### 2. Run enters-with replacements for token copies
Follow-on from playtesting (two Spider-Punks + Impostor Syndrome): the token-copy executors (`CreateTokenCopyOfTarget/Source/ChosenPermanent/EquippedCreature`) placed tokens via the ad-hoc `BattlefieldEntry.place` path, which skipped **all** enters-with replacements — so a token copy of a riot creature (or any "enters with a +1/+1 counter" creature) got nothing (wrong per CR 707.2). They now run the copied card's enters-with counters, as-enters choices, and granted riot via a shared `TokenEntryReplacements` helper (reused by `TokenFromDefinition`) plus a `CreateTokenCopyRemainingContinuation` for the per-token pause loop (modeled on the existing Aura-host continuation).

## Tests
- `SpiderPunkScenarioTest` (7): printed Riot (counter/haste), granted Riot (single + two-instance/702.136b), spells & abilities can't be countered (Counterspell + Stifle), damage can't be prevented (Healing Salve shield).
- `TokenCopyEntersWithScenarioTest` (4): counter copy, granted-riot choice, two granters (702.136b), multi-token per-token pause loop.
- Full `:rules-engine:test` regression green.

## Docs
`docs/card-sdk-language-reference.md` updated for the Riot keyword, granted-riot synthesis, `GrantCantBeCountered.includesAbilities`, the damage-prevention rule, and token-copy enters-with behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
