### PR TITLE
Show granted supertypes in the client type line

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1072,7 +1072,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ### Color & type
 
-- `AddCardType(type, target, duration)` — add a card type (e.g. become an artifact).
+- `AddCardType(type, target, duration)` — add a card type (e.g. become an artifact). Also takes a **supertype** — `AddCardType("LEGENDARY", …)` for "it becomes a legendary Spider Hero" (Origin of Spider-Man) — because the layer projection stores supertypes in the same type set; there is no separate `AddSupertype`.
 - `AddSubtype(subtype, target, duration)` — add a subtype temporarily.
 - `SetLandType(landType, target, duration, fromChosenValueKey)` — target land *becomes* the basic land type, **replacing** its existing land subtypes (Rule 305.7); pass `fromChosenValueKey` to read the type from a preceding `ChooseOption(OptionType.BASIC_LAND_TYPE)`. One-shot counterpart to the `SetEnchantedLandType` aura static ability. (Dream Thrush)
 - `ChooseColorForTarget(target)` — target picks a color; stored in context.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Supertype.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Supertype.kt
@@ -12,5 +12,17 @@ enum class Supertype(val displayName: String) {
     companion object {
         fun fromString(value: String): Supertype? =
             entries.find { it.displayName.equals(value, ignoreCase = true) }
+
+        /**
+         * The supertypes present in a *projected* type set — the engine's layer projection stores
+         * supertypes, card types and subtypes together in one `Set<String>` of uppercase enum names,
+         * so every reader has to isolate them by name. Deriving that from [entries] (rather than
+         * repeating a literal `setOf("BASIC", "LEGENDARY", …)`) keeps the readers correct when a
+         * supertype is added here.
+         *
+         * Returned in declaration order, which is printed order: "Basic Snow Land", "Legendary Snow Land".
+         */
+        fun fromProjectedTypes(types: Set<String>): List<Supertype> =
+            entries.filter { it.name in types }
     }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TypeAndColorEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TypeAndColorEffects.kt
@@ -221,7 +221,10 @@ data class SetLandTypeEffect(
  * Creates a floating effect on Layer.TYPE with AddType modification.
  * Unlike AnimateLandEffect, this does NOT set P/T — it only adds the type.
  *
- * @property cardType The card type to add (e.g., "ARTIFACT", "CREATURE")
+ * @property cardType The card type to add (e.g., "ARTIFACT", "CREATURE"). Also accepts a
+ *   *supertype* — "LEGENDARY" for Origin of Spider-Man's "it becomes a legendary Spider Hero" —
+ *   since the engine projects supertypes into the same type set; there is no separate
+ *   AddSupertypeEffect and none is needed.
  * @property target The permanent to modify
  * @property duration How long the type change lasts (default: Permanent)
  */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedState.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.mechanics.layers
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Supertype
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -171,7 +172,7 @@ class ProjectedState(
      * projected [types] set as card types, so they are isolated by name here for protection checks.
      */
     fun getSupertypes(entityId: EntityId): Set<String> =
-        getTypes(entityId).intersect(setOf("BASIC", "LEGENDARY", "SNOW", "WORLD"))
+        Supertype.fromProjectedTypes(getTypes(entityId)).mapTo(mutableSetOf()) { it.name }
 
     fun hasSubtype(entityId: EntityId, subtype: String): Boolean =
         getSubtypes(entityId).any { it.equals(subtype, ignoreCase = true) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -459,12 +459,27 @@ data class ClientCard(
     val copyOf: String? = null,
 
     /**
-     * True when this permanent's printed card has the Legendary supertype but its current
-     * type line does not — i.e. a copy effect explicitly stripped legendariness
-     * ("except it isn't legendary" / Impostor Syndrome). Lets the UI flag the difference
-     * between an original legendary creature and a non-legendary token copy of it.
+     * True when this permanent's printed card has the Legendary supertype but it is not legendary
+     * now — i.e. a copy effect explicitly stripped legendariness ("except it isn't legendary" /
+     * Impostor Syndrome). Lets the UI flag the difference between an original legendary creature
+     * and a non-legendary token copy of it. Mutually exclusive with [legendaryByEffect]: an effect
+     * that grants the supertype back wins, because the permanent then really is legendary.
      */
     val nonLegendaryCopy: Boolean = false,
+
+    /**
+     * The mirror of [nonLegendaryCopy]: this permanent's printed card is *not* legendary but a
+     * continuous effect has granted it the Legendary supertype — Origin of Spider-Man's "it becomes
+     * a legendary Spider Hero", the Ring emblem's "your Ring-bearer is legendary" (CR 701.54c). The
+     * printed art still shows a non-legendary frame, so the UI needs the flag to tell the player the
+     * legend rule now applies. [typeLine] carries the supertype too; this is the at-a-glance cue.
+     *
+     * Deliberately narrowed to Legendary rather than a general `grantedSupertypes` set: only the
+     * legend rule changes how a permanent must be played around, so only it earns a badge. A granted
+     * Snow or World supertype reaches the client through [typeLine] alone — widen this to a set
+     * rather than adding a second boolean if one of those ever needs its own cue.
+     */
+    val legendaryByEffect: Boolean = false,
 
     /** Damage distribution for DividedDamageEffect spells on the stack (target entity ID -> damage amount) */
     val damageDistribution: Map<EntityId, Int>? = null,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.mechanics.combat.rules.DefenderBypass
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Supertype
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -1141,9 +1142,20 @@ class ClientStateTransformer(
         } else {
             typeLine.cardTypes.toList()
         }
+        // Supertypes share the projected `types` set with card types and subtypes (see
+        // StateProjector.extractTypes), so a granted supertype — Origin of Spider-Man's "it becomes
+        // a legendary Spider Hero", the Ring emblem's "your Ring-bearer is legendary" (CR 701.54c) —
+        // only reaches the client if we read them from the projection too. Reading base
+        // `typeLine.supertypes` dropped them: they're not a CardType, so `displayCardTypes` filters
+        // them out as well and "Legendary" vanished from the rendered type line entirely.
+        val displaySupertypes = if (projectedTypes != null) {
+            Supertype.fromProjectedTypes(projectedTypes)
+        } else {
+            typeLine.supertypes.toList()
+        }
         val typeLineParts = mutableListOf<String>()
-        if (typeLine.supertypes.isNotEmpty()) {
-            typeLineParts.add(typeLine.supertypes.joinToString(" ") { it.displayName })
+        if (displaySupertypes.isNotEmpty()) {
+            typeLineParts.add(displaySupertypes.joinToString(" ") { it.displayName })
         }
         typeLineParts.add(displayCardTypes.joinToString(" ") { it.displayName })
         val typeLineString = if (typeLineSubtypes.isNotEmpty()) {
@@ -1322,10 +1334,18 @@ class ClientStateTransformer(
             copyOf = container.get<com.wingedsheep.engine.state.components.identity.CopyOfComponent>()?.let { copyComp ->
                 cardRegistry.getCard(copyComp.originalCardDefinitionId)?.name
             },
+            // The two legendary flags are complements, and the `!in displaySupertypes` clause is what
+            // makes them so: a non-legendary copy that an effect then makes legendary again (Impostor
+            // Syndrome's copy designated Ring-bearer) is simply legendary, so "not legendary" is a lie
+            // about it and the client would otherwise badge it both ways at once.
             nonLegendaryCopy = zoneKey.zoneType == Zone.BATTLEFIELD
                 && cardDef != null
-                && com.wingedsheep.sdk.core.Supertype.LEGENDARY in cardDef.typeLine.supertypes
-                && com.wingedsheep.sdk.core.Supertype.LEGENDARY !in cardComponent.typeLine.supertypes,
+                && Supertype.LEGENDARY in cardDef.typeLine.supertypes
+                && Supertype.LEGENDARY !in cardComponent.typeLine.supertypes
+                && Supertype.LEGENDARY !in displaySupertypes,
+            legendaryByEffect = zoneKey.zoneType == Zone.BATTLEFIELD
+                && Supertype.LEGENDARY in displaySupertypes
+                && Supertype.LEGENDARY !in cardComponent.typeLine.supertypes,
             damageDistribution = (spellOnStack?.damageDistribution ?: container.get<TriggeredAbilityOnStackComponent>()?.damageDistribution)?.takeIf { it.isNotEmpty() },
             sagaTotalChapters = cardDef?.finalChapter,
             classLevel = container.get<com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent>()?.currentLevel,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRingScenarioTest.kt
@@ -117,6 +117,13 @@ class TheRingScenarioTest : FunSpec({
             .transform(driver.state, viewingPlayerId = active)
         view.cards[bear]?.isRingBearer shouldBe true
         view.cards[ogre]?.isRingBearer shouldBe false
+
+        // CR 701.54c makes the bearer legendary, and the client type line has to say so — the
+        // emblem's supertype grant lives only in the projection, never on the base CardComponent.
+        view.cards[bear]?.typeLine shouldBe "Legendary Creature"
+        view.cards[bear]?.legendaryByEffect shouldBe true
+        view.cards[ogre]?.typeLine shouldBe "Creature"
+        view.cards[ogre]?.legendaryByEffect shouldBe false
     }
 
     test("CR 701.54a: another player gaining control ends the Ring-bearer designation permanently") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/GrantedSupertypeVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/GrantedSupertypeVisibilityTest.kt
@@ -1,0 +1,190 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Supertype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.AddCardTypeEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * A granted supertype (Origin of Spider-Man's "it becomes a legendary Spider Hero in addition to
+ * its other types", the Ring emblem's "your Ring-bearer is legendary") has to reach the client's
+ * rendered type line, not just the projection the engine reasons over.
+ *
+ * Supertypes share the projected `types` set with card types and subtypes
+ * ([StateProjector.extractTypes]), so [ClientStateTransformer] must read them from the projection.
+ * Reading base `CardComponent.typeLine.supertypes` instead dropped granted supertypes entirely —
+ * "LEGENDARY" isn't a [com.wingedsheep.sdk.core.CardType], so the projected-card-types filter
+ * discarded it too and the player saw a plain "Creature — Cat".
+ */
+class GrantedSupertypeVisibilityTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // {0} sorcery mirroring Origin of Spider-Man chapter II's type grant (minus the counter).
+    val legendMaker = card("Legend Maker") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Target creature becomes a legendary Spider Hero in addition to its other types."
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.Composite(
+                listOf(
+                    AddCardTypeEffect("LEGENDARY", creature, Duration.Permanent),
+                    Effects.AddCreatureType("Spider", creature, Duration.Permanent),
+                    Effects.AddCreatureType("Hero", creature, Duration.Permanent)
+                )
+            )
+        }
+    }
+
+    // {0} sorcery mirroring Impostor Syndrome's "a copy of it, except it isn't legendary".
+    val impostor = card("Impostor Maker") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Create a token that's a copy of target creature, except it isn't legendary."
+        spell {
+            val creature = target("creature", Targets.Creature)
+            effect = Effects.CreateTokenCopyOfTarget(
+                target = creature,
+                removedSupertypes = setOf(Supertype.LEGENDARY)
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + legendMaker + impostor)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castOn(playerId: EntityId, cardName: String, targetId: EntityId) {
+        submit(
+            CastSpell(
+                playerId = playerId,
+                cardId = putCardInHand(playerId, cardName),
+                targets = listOf(ChosenTarget.Permanent(targetId)),
+                paymentStrategy = PaymentStrategy.AutoPay
+            )
+        )
+        bothPass()
+    }
+
+    fun view(driver: GameTestDriver, playerId: EntityId) =
+        ClientStateTransformer(cardRegistry = driver.cardRegistry)
+            .transform(driver.state, viewingPlayerId = playerId)
+
+    test("a creature granted LEGENDARY renders 'Legendary' in the client type line") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val lion = driver.putCreatureOnBattlefield(player, "Savannah Lions")
+        view(driver, player).cards[lion].shouldNotBeNull().let {
+            it.typeLine shouldBe "Creature — Cat"
+            it.legendaryByEffect shouldBe false
+        }
+
+        driver.castOn(player, "Legend Maker", lion)
+
+        projector.project(driver.state).isLegendary(lion) shouldBe true
+        view(driver, player).cards[lion].shouldNotBeNull().let {
+            it.typeLine shouldBe "Legendary Creature — Cat Spider Hero"
+            // The printed frame is non-legendary, so the client needs the at-a-glance chip too.
+            it.legendaryByEffect shouldBe true
+        }
+    }
+
+    test("the granted supertype is visible to the opponent too") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val lion = driver.putCreatureOnBattlefield(player, "Savannah Lions")
+        driver.castOn(player, "Legend Maker", lion)
+
+        view(driver, opponent).cards[lion].shouldNotBeNull()
+            .typeLine shouldBe "Legendary Creature — Cat Spider Hero"
+    }
+
+    test("a printed legendary permanent still renders 'Legendary'") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val prospector = driver.putCreatureOnBattlefield(player, "Test Hasty Prospector")
+
+        view(driver, player).cards[prospector].shouldNotBeNull().let {
+            it.typeLine shouldBe "Legendary Creature — Monkey Pirate"
+            // Printed legendary — the "granted" chip is for effects only.
+            it.legendaryByEffect shouldBe false
+        }
+    }
+
+    // CR 708.2a: a face-down permanent is a 2/2 creature with no name, no subtypes — and no
+    // supertypes. Opponents get a hardcoded masked card, but the *controller* is shown the real
+    // name and so falls through the normal transform path; reading base supertypes there made
+    // their own face-down legendary creature read "Legendary Creature" while its card types and
+    // subtypes had already been masked down to "Creature" by the projection.
+    test("a face-down printed-legendary creature is not Legendary, even to its controller") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val prospector = driver.putCreatureOnBattlefield(player, "Test Hasty Prospector")
+        driver.replaceState(
+            driver.state.updateEntity(prospector) { it.with(FaceDownComponent) }
+        )
+
+        view(driver, player).cards[prospector].shouldNotBeNull().let {
+            it.typeLine shouldBe "Creature"
+            it.legendaryByEffect shouldBe false
+        }
+        // The opponent's masked view was never affected, but pin it so the two stay in step.
+        view(driver, opponent).cards[prospector].shouldNotBeNull().let {
+            it.typeLine shouldBe "Creature"
+            it.legendaryByEffect shouldBe false
+        }
+    }
+
+    // The two legend flags drive chips that render at the same spot and say opposite things, so
+    // a permanent that is *both* a de-legendarized copy and a grant target must set only one.
+    test("granting Legendary back to a non-legendary copy clears nonLegendaryCopy") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val prospector = driver.putCreatureOnBattlefield(player, "Test Hasty Prospector")
+        driver.castOn(player, "Impostor Maker", prospector)
+
+        val token = driver.getPermanents(player).first { it != prospector }
+        view(driver, player).cards[token].shouldNotBeNull().let {
+            it.typeLine shouldBe "Creature — Monkey Pirate"
+            it.nonLegendaryCopy shouldBe true
+            it.legendaryByEffect shouldBe false
+        }
+
+        driver.castOn(player, "Legend Maker", token)
+
+        projector.project(driver.state).isLegendary(token) shouldBe true
+        view(driver, player).cards[token].shouldNotBeNull().let {
+            it.typeLine shouldBe "Legendary Creature — Monkey Pirate Spider Hero"
+            // It really is legendary again, so "Not Legendary" would be a lie — only one chip.
+            it.nonLegendaryCopy shouldBe false
+            it.legendaryByEffect shouldBe true
+        }
+    }
+})

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -98,6 +98,98 @@ interface GameCardProps {
   enableDragToCast?: boolean
 }
 
+/** The three-point coronet shared by the commander crown and both legend chips. */
+const CROWN_PATH = 'M1.5 12 L1.5 9 L4.5 5 L8 8 L12 2 L16 8 L19.5 5 L22.5 9 L22.5 12 Z'
+
+/**
+ * Pill badge that floats over a battlefield card's top edge, carrying a crown glyph and a label.
+ * Used for the two legend chips, which say opposite things about the same supertype and so must
+ * look like one another's mirror — sharing the geometry here is what keeps them aligned as the
+ * card scales, and stops a third variant from being a third copy of ~50 lines of inline style.
+ */
+function LegendChip({
+  width,
+  bandTop,
+  label,
+  title,
+  gradient,
+  textColor,
+  crownFill,
+  struckThrough = false,
+}: {
+  width: number
+  bandTop: number
+  label: string
+  title: string
+  gradient: string
+  textColor: string
+  crownFill: string
+  struckThrough?: boolean
+}) {
+  const chipHeight = Math.max(10, Math.round(width * 0.12))
+  const crownW = Math.round(chipHeight * 0.95)
+  const crownH = Math.round(chipHeight * 0.55)
+  return (
+    <div
+      aria-label={label}
+      title={title}
+      style={{
+        position: 'absolute',
+        top: bandTop - Math.round(chipHeight * 0.55),
+        left: '50%',
+        transform: 'translateX(-50%)',
+        height: chipHeight,
+        padding: `0 ${Math.max(4, Math.round(chipHeight * 0.6))}px`,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 4,
+        background: gradient,
+        color: textColor,
+        fontSize: Math.max(8, Math.round(chipHeight * 0.62)),
+        fontWeight: 800,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        borderRadius: chipHeight,
+        border: '1px solid rgba(0, 0, 0, 0.55)',
+        boxShadow: '0 1px 2px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.18)',
+        pointerEvents: 'none',
+        zIndex: 6,
+        whiteSpace: 'nowrap',
+        lineHeight: 1,
+      }}
+    >
+      <span style={{ position: 'relative', width: crownW, height: crownH, display: 'inline-block' }} aria-hidden>
+        <svg
+          viewBox="0 0 24 13"
+          width={crownW}
+          height={crownH}
+          preserveAspectRatio="none"
+          fill={crownFill}
+          stroke="rgba(0, 0, 0, 0.6)"
+          strokeWidth="0.5"
+          strokeLinejoin="round"
+          style={{ position: 'absolute', inset: 0 }}
+        >
+          <path d={CROWN_PATH} />
+        </svg>
+        {struckThrough && (
+          /* Diagonal strike over the crown, so the chip reads "no crown" at a glance. */
+          <svg
+            viewBox="0 0 24 13"
+            width={crownW}
+            height={crownH}
+            preserveAspectRatio="none"
+            style={{ position: 'absolute', inset: 0 }}
+          >
+            <line x1="2" y1="11.5" x2="22" y2="1.5" stroke="#ff6464" strokeWidth="1.4" strokeLinecap="round" />
+          </svg>
+        )}
+      </span>
+      {label}
+    </div>
+  )
+}
+
 /**
  * Single card display.
  */
@@ -2713,7 +2805,7 @@ function GameCardImpl({
           strokeLinejoin="round"
         >
           {/* Three-point coronet on a thin band: outer points at the corners, taller centre point */}
-          <path d="M1.5 12 L1.5 9 L4.5 5 L8 8 L12 2 L16 8 L19.5 5 L22.5 9 L22.5 12 Z" />
+          <path d={CROWN_PATH} />
         </svg>
       </div>
     )
@@ -2725,69 +2817,36 @@ function GameCardImpl({
   // frame, so without this chip a player can't tell the token copy isn't subject to
   // the legend rule. The server sets `nonLegendaryCopy` after comparing the printed
   // CardDefinition's supertypes to the live CardComponent's supertypes.
-  const showNonLegendaryChip = battlefield && !faceDown && card.nonLegendaryCopy === true
-  const nonLegendaryChip = showNonLegendaryChip ? (() => {
-    const chipHeight = Math.max(10, Math.round(width * 0.12))
-    const crownW = Math.round(chipHeight * 0.95)
-    const crownH = Math.round(chipHeight * 0.55)
-    return (
-      <div
-        aria-label="Not legendary"
-        title={`Not legendary — copy effect stripped the Legendary supertype (${card.typeLine})`}
-        style={{
-          position: 'absolute',
-          top: bandTop - Math.round(chipHeight * 0.55),
-          left: '50%',
-          transform: 'translateX(-50%)',
-          height: chipHeight,
-          padding: `0 ${Math.max(4, Math.round(chipHeight * 0.6))}px`,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 4,
-          background: 'linear-gradient(135deg, #4a4a4a 0%, #6b6b6b 50%, #4a4a4a 100%)',
-          color: '#f0f0f0',
-          fontSize: Math.max(8, Math.round(chipHeight * 0.62)),
-          fontWeight: 800,
-          letterSpacing: '0.08em',
-          textTransform: 'uppercase',
-          borderRadius: chipHeight,
-          border: '1px solid rgba(0, 0, 0, 0.55)',
-          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.18)',
-          pointerEvents: 'none',
-          zIndex: 6,
-          whiteSpace: 'nowrap',
-          lineHeight: 1,
-        }}
-      >
-        {/* Crown silhouette with a diagonal strike-through to read "no crown". */}
-        <span style={{ position: 'relative', width: crownW, height: crownH, display: 'inline-block' }} aria-hidden>
-          <svg
-            viewBox="0 0 24 13"
-            width={crownW}
-            height={crownH}
-            preserveAspectRatio="none"
-            fill="rgba(220, 220, 220, 0.55)"
-            stroke="rgba(0, 0, 0, 0.6)"
-            strokeWidth="0.5"
-            strokeLinejoin="round"
-            style={{ position: 'absolute', inset: 0 }}
-          >
-            <path d="M1.5 12 L1.5 9 L4.5 5 L8 8 L12 2 L16 8 L19.5 5 L22.5 9 L22.5 12 Z" />
-          </svg>
-          <svg
-            viewBox="0 0 24 13"
-            width={crownW}
-            height={crownH}
-            preserveAspectRatio="none"
-            style={{ position: 'absolute', inset: 0 }}
-          >
-            <line x1="2" y1="11.5" x2="22" y2="1.5" stroke="#ff6464" strokeWidth="1.4" strokeLinecap="round" />
-          </svg>
-        </span>
-        Not Legendary
-      </div>
-    )
-  })() : null
+  const nonLegendaryChip = battlefield && !faceDown && card.nonLegendaryCopy === true ? (
+    <LegendChip
+      width={width}
+      bandTop={bandTop}
+      label="Not Legendary"
+      title={`Not legendary — copy effect stripped the Legendary supertype (${card.typeLine})`}
+      gradient="linear-gradient(135deg, #4a4a4a 0%, #6b6b6b 50%, #4a4a4a 100%)"
+      textColor="#f0f0f0"
+      crownFill="rgba(220, 220, 220, 0.55)"
+      struckThrough
+    />
+  ) : null
+
+  // "Legendary" chip — the mirror of the one above, pinned to a permanent whose printed card is
+  // NOT legendary but which a continuous effect has made legendary (Origin of Spider-Man's "it
+  // becomes a legendary Spider Hero", the Ring emblem's "your Ring-bearer is legendary"). The
+  // printed art still shows a non-legendary frame, so without this chip the player can't see that
+  // the legend rule now applies. The server keeps the two flags mutually exclusive (a granted
+  // supertype clears `nonLegendaryCopy`), so the identically-positioned chips can't collide.
+  const grantedLegendaryChip = battlefield && !faceDown && card.legendaryByEffect === true ? (
+    <LegendChip
+      width={width}
+      bandTop={bandTop}
+      label="Legendary"
+      title={`Legendary — granted by an effect (${card.typeLine})`}
+      gradient="linear-gradient(135deg, #6b5312 0%, #b8912c 50%, #6b5312 100%)"
+      textColor="#fff6da"
+      crownFill="#f2d071"
+    />
+  ) : null
 
   // Wrap in container for sideways battlefield cards (tapped permanents and Rooms) to
   // prevent overlap with neighbours.
@@ -2806,15 +2865,16 @@ function GameCardImpl({
       }}>
         {commanderCrown}
         {nonLegendaryChip}
+        {grantedLegendaryChip}
         {cardElement}
       </div>
       </RenderProfiler>
     )
   }
 
-  // Commander OR non-legendary-copy permanents need a relative-positioned wrapper so the chip
-  // can float above the card without being clipped by the card's `overflow: hidden`.
-  if (showCommanderCrown || nonLegendaryChip) {
+  // Commander, non-legendary-copy OR granted-legendary permanents need a relative-positioned
+  // wrapper so the chip can float above the card without being clipped by `overflow: hidden`.
+  if (showCommanderCrown || nonLegendaryChip || grantedLegendaryChip) {
     return (
       <RenderProfiler id={profilerId}>
         <div style={{
@@ -2825,6 +2885,7 @@ function GameCardImpl({
         }}>
           {commanderCrown}
           {nonLegendaryChip}
+          {grantedLegendaryChip}
           {cardElement}
         </div>
       </RenderProfiler>

--- a/web-client/src/store/cardGrouping.ts
+++ b/web-client/src/store/cardGrouping.ts
@@ -127,6 +127,7 @@ export function computeCardGroupKey(card: ClientCard): string {
   // Copy provenance is badged and shown in details, so a token copy doesn't merge with the original.
   if (card.copyOf) parts.push(`copy:${card.copyOf}`)
   if (card.nonLegendaryCopy) parts.push('nonleg')
+  if (card.legendaryByEffect) parts.push('grantedleg')
 
   // Granted/projected keywords, ability flags and protections differ when one copy is
   // pumped or granted an ability (without an attachment) but its twin isn't.

--- a/web-client/src/store/groupCards.test.ts
+++ b/web-client/src/store/groupCards.test.ts
@@ -37,6 +37,7 @@ function token({ id, ...over }: { id: string } & Record<string, unknown>): Clien
     isRingBearer: false,
     isCommander: false,
     nonLegendaryCopy: false,
+    legendaryByEffect: false,
     ...over,
   } as unknown as ClientCard
 }
@@ -63,6 +64,10 @@ describe('groupCards — token quantity aggregation (display layer)', () => {
     ['summoning sickness', { hasSummoningSickness: true }],
     ['a granted keyword', { keywords: ['FLYING'] }],
     ['transformed', { isTransformed: true }],
+    // Both legend badges change what the card looks like and whether the legend rule bites, so a
+    // badged permanent must never hide inside a stack of unbadged twins.
+    ['a stripped Legendary supertype', { nonLegendaryCopy: true }],
+    ['a granted Legendary supertype', { legendaryByEffect: true }],
   ])('splits a member that diverges by %s back into its own group', (_label, diff) => {
     const groups = groupCards([
       token({ id: 'plain1' }),

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -418,9 +418,19 @@ export interface ClientCard {
    * True when the printed card is legendary but this permanent's projected type line is not —
    * a copy effect explicitly stripped legendariness ("except it isn't legendary" /
    * Impostor Syndrome). The UI badges this so a non-legendary token copy of a legendary
-   * creature is visually distinguishable from the original.
+   * creature is visually distinguishable from the original. The server keeps this mutually
+   * exclusive with {@link legendaryByEffect} — an effect that grants the supertype back wins,
+   * because the permanent then really is legendary.
    */
   readonly nonLegendaryCopy?: boolean
+
+  /**
+   * The mirror of {@link nonLegendaryCopy}: the printed card is not legendary but a continuous
+   * effect has granted the Legendary supertype (Origin of Spider-Man, the Ring emblem's
+   * "your Ring-bearer is legendary"). The printed art shows a non-legendary frame, so the UI
+   * badges it to make the legend rule visible.
+   */
+  readonly legendaryByEffect?: boolean
 
   /** Damage distribution for DividedDamageEffect spells on the stack (target entity ID -> damage amount) */
   readonly damageDistribution?: Record<EntityId, number> | null


### PR DESCRIPTION

<img width="110" height="104" alt="image" src="https://github.com/user-attachments/assets/a8f84f17-8920-48e8-80a3-f15e68ad3c80" />


# Show granted supertypes in the client type line

A supertype granted by a continuous effect never reached the client. `ClientStateTransformer` built the rendered type line from the **base** `CardComponent`'s supertypes while taking card types and subtypes from the **layer projection** — and granted supertypes live in the projected `types` set alongside both (`StateProjector.extractTypes`). Since `"LEGENDARY"` isn't a `CardType`, the projected-card-types filter dropped it too, so it vanished from the type line entirely.

The engine had it right throughout: `isLegendary()`, `LegendRuleCheck`, and `BlockPhaseManager` all read the projection. Only the view was stale.

Visible as:

- **Origin of Spider-Man** chapter II — "It becomes a legendary Spider Hero in addition to its other types" rendered as `Creature — Cat`.
- **The Ring emblem** — "Your Ring-bearer is legendary" (CR 701.54c) rendered as plain `Creature`, so a player couldn't see that the legend rule had started applying to their bearer.

## What changed

**Engine / view layer**

- `ClientStateTransformer` reads supertypes from the projection for battlefield permanents, falling back to the base type line for the other zones (which have no projection entry).
- Three readers already knew that supertypes are stored by name inside the projected type set, one via a literal `setOf("BASIC", "LEGENDARY", "SNOW", "WORLD")` that a fifth `Supertype` would have silently outgrown. That isolation is now derived once from the enum — `Supertype.fromProjectedTypes` — and used from both `ProjectedState.getSupertypes` and the transformer. Declaration order is printed order, so `Dark Depths` renders "Legendary Snow Land" and `Snow-Covered Plains` renders "Basic Snow Land".
- New `ClientCard.legendaryByEffect`, the mirror of the existing `nonLegendaryCopy`: the printed frame is non-legendary but the permanent is legendary now, so the UI needs an at-a-glance cue that the legend rule applies.
- `nonLegendaryCopy` additionally requires that the permanent isn't *currently* legendary. Both flags previously fired on a de-legendarized copy that an effect made legendary again (an Impostor Syndrome token designated Ring-bearer), which would have badged one card "Legendary" and "Not Legendary" at the same coordinates.

**Client**

- Gold "Legendary" chip mirroring the existing grey "Not Legendary" one, plus a `cardGrouping` key so a granted-legendary permanent doesn't merge into a stack with an identical twin that isn't.
- Both chips now come from one `LegendChip` component. They are meant to read as mirrors of each other, which two copies of ~50 lines of inline style would not have stayed.

**Side effect, deliberate:** this also changes what a player sees looking at *their own* face-down permanent. Opponents already got a hardcoded masked card, but the controller is shown the real name and so falls through the normal transform path — where the base read made their face-down legendary creature render "Legendary Creature" even though its card types and subtypes had already been masked down to "Creature". A face-down permanent has no supertypes (CR 708.2a), and the type line now says so. Covered by a test.

## Tests

`GrantedSupertypeVisibilityTest` (new, `rules-engine`) — a granted `LEGENDARY` renders in the type line; it's visible to the opponent too; a printed legendary still renders; a face-down printed-legendary creature is not legendary even to its controller; granting Legendary back to a non-legendary copy clears `nonLegendaryCopy`. The test cards mirror the real shapes — `AddCardTypeEffect("LEGENDARY", …)` as in Origin of Spider-Man, `CreateTokenCopyOfTarget(removedSupertypes = setOf(LEGENDARY))` as in Impostor Syndrome — rather than pulling SPM into set scope.

`TheRingScenarioTest` gains type-line and flag assertions on the bearer and a non-bearer.

`groupCards.test.ts` gains both legend flags as divergence axes (`nonLegendaryCopy` had none either).

## Verification

- `just test-rules` — full `:rules-engine` suite green.
- `just test-class GrantedSupertypeVisibilityTest` — 5/5.
- `just test-class TheRingScenarioTest` — 9/9.
- `npm run typecheck` — no new errors. Five pre-existing `TS2307` module-not-found errors in `admin/` and `profile/` (`recharts`, `d3-geo`, `topojson-client`, `world-countries`) are unrelated to this change and unfixable in this sandbox, whose network is firewalled.
- `npx vitest run src/store/groupCards.test.ts` could **not** be run here: the `rolldown` native binding is missing from `node_modules` in this sandbox (`MODULE_NOT_FOUND`). The two added `it.each` rows are unexercised on my end and need a CI run.

No screenshot: the app stack couldn't be brought up in this firewalled sandbox. Happy to add one before merge if you'd like it.

## Rules citations

Verified against `MagicCompRules_20260619.txt`:

- **CR 701.54c** — The Ring has "Your Ring-bearer is legendary and can't be blocked by creatures with greater power."
- **CR 708.2a** — a face-down permanent is a 2/2 creature with no text, no name, no subtypes, and no mana cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
