### PR TITLE
Apply a planeswalker's starting loyalty on every battlefield entry

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -80,7 +80,10 @@ section; do not let SDK additions land without a corresponding doc update.
 - `dynamicStats(source, powerOffset?, toughnessOffset?)` — the `*`/`*` cycle: composes
   `dynamicPower` + `dynamicToughness` over one shared source, with optional `±` deltas
   (Tarmogoyf's `toughnessOffset = 1`).
-- `startingLoyalty: Int?` — starting loyalty for planeswalkers.
+- `startingLoyalty: Int?` — starting loyalty for planeswalkers. Placed as loyalty counters by the
+  engine's intrinsic enters-with replacement (CR 306.5b) on *every* battlefield entry — resolving from
+  the stack, reanimation, an "exile until this leaves" return, or any other put-onto-the-battlefield
+  effect. Card definitions never place them.
 - `colorIdentity: String?` — override (normally auto-detected). Treated as authoritative in this repo.
 - `colorIndicator: String?` — explicit color indicator (CR 204), e.g. `"B"`. `null` (default) = no
   indicator; the card's color is its mana-cost colors alone. Set it on a face printed with a color

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -82,8 +82,8 @@ section; do not let SDK additions land without a corresponding doc update.
   (Tarmogoyf's `toughnessOffset = 1`).
 - `startingLoyalty: Int?` — starting loyalty for planeswalkers. Placed as loyalty counters by the
   engine's intrinsic enters-with replacement (CR 306.5b) on *every* battlefield entry — resolving from
-  the stack, reanimation, an "exile until this leaves" return, or any other put-onto-the-battlefield
-  effect. Card definitions never place them.
+  the stack, reanimation, an "exile until this leaves" return, any other put-onto-the-battlefield
+  effect, and token copies (loyalty is a copiable value, CR 707.2). Card definitions never place them.
 - `colorIdentity: String?` — override (normally auto-detected). Treated as authoritative in this repo.
 - `colorIndicator: String?` — explicit color indicator (CR 204), e.g. `"B"`. `null` (default) = no
   indicator; the card's color is its mana-cost colors alone. Set it on a face printed with a color

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.core.PermanentsSacrificedEvent
 import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.ComponentContainer
@@ -59,6 +60,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.RedirectZoneChange
 import com.wingedsheep.sdk.scripting.RedirectZoneChangeWithEffect
 import com.wingedsheep.sdk.scripting.ZoneChangeCause
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
 import com.wingedsheep.sdk.scripting.predicates.evaluateWith
@@ -134,6 +136,50 @@ object ZoneMovementUtils {
                 .with(current.withAdded(CounterType.LORE, 1))
         }
         return newState to listOf(CountersAddedEvent(entityId, "LORE", 1, cardComponent.name))
+    }
+
+    /**
+     * Apply planeswalker entry setup to an entity entering the battlefield (CR 306.5b): a
+     * planeswalker has the intrinsic ability "This permanent enters with a number of loyalty
+     * counters on it equal to its printed loyalty number," which is a replacement effect
+     * (CR 614.1c) and therefore applies to *every* way it enters — not just a resolving spell.
+     * Without this, a planeswalker put onto the battlefield from any non-stack zone (returned by
+     * an O-Ring style "until this leaves" exile, reanimated, tutored straight into play) would
+     * enter with 0 loyalty and be put into its owner's graveyard by state-based actions
+     * (CR 704.5i) the moment it arrived.
+     *
+     * The cast pipeline owns its own copy of this step (see
+     * [com.wingedsheep.engine.mechanics.stack.StackResolver], which places permanents via
+     * `addToZone` rather than [ZoneTransitionService.moveToZone]) — the same split that exists
+     * for Saga entry, so the two never double-apply.
+     *
+     * The loyalty number is read from the *current* [CardComponent]'s definition, so a
+     * double-faced card returning transformed onto its planeswalker back face gets the back
+     * face's printed loyalty (its `cardDefinitionId` has already been flipped by then).
+     *
+     * Routed through [EntersWithReplacements.placeEntryCounters] so counter-placement modifiers
+     * (Vorinclex, Pir) and the "a counter was placed this turn" tracker behave exactly as they do
+     * for a printed "enters with counters".
+     *
+     * @return Pair of (updated state, events to emit) — empty events if not a planeswalker
+     */
+    fun applyPlaneswalkerEntryIfNeeded(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        cardRegistry: CardRegistry
+    ): Pair<GameState, List<EngineGameEvent>> {
+        val container = state.getEntity(entityId) ?: return state to emptyList()
+        val cardComponent = container.get<CardComponent>() ?: return state to emptyList()
+        if (!cardComponent.isPlaneswalker) return state to emptyList()
+
+        val startingLoyalty = cardRegistry.getCard(cardComponent.cardDefinitionId)?.startingLoyalty
+            ?: return state to emptyList()
+
+        return EntersWithReplacements.placeEntryCounters(
+            state, entityId, CounterTypeFilter.Loyalty, startingLoyalty, controllerId,
+            cardComponent.name
+        )
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -148,18 +148,25 @@ object ZoneMovementUtils {
      * enter with 0 loyalty and be put into its owner's graveyard by state-based actions
      * (CR 704.5i) the moment it arrived.
      *
-     * The cast pipeline owns its own copy of this step (see
-     * [com.wingedsheep.engine.mechanics.stack.StackResolver], which places permanents via
-     * `addToZone` rather than [ZoneTransitionService.moveToZone]) — the same split that exists
-     * for Saga entry, so the two never double-apply.
+     * Called from both battlefield-entry pipelines, exactly like [applySagaEntryIfNeeded]:
+     * [ZoneTransitionService.moveToZone] for every zone-change entry, and the ad-hoc
+     * [BattlefieldEntry.place] token-minting paths for a token copy of a planeswalker (loyalty is a
+     * copiable value per CR 707.2, so the token has one to place). The cast pipeline reaches the
+     * same counters through [EntersWithReplacements.placeEntryCounters] while the permanent is
+     * still on the stack (see [com.wingedsheep.engine.mechanics.stack.StackResolver]), so no entry
+     * gets them twice.
      *
      * The loyalty number is read from the *current* [CardComponent]'s definition, so a
      * double-faced card returning transformed onto its planeswalker back face gets the back
      * face's printed loyalty (its `cardDefinitionId` has already been flipped by then).
      *
+     * Face-down entries are skipped: a face-down permanent is a nameless 2/2 creature with no
+     * printed loyalty (CR 708.2a). The check lives here rather than at the call sites so every
+     * caller inherits it.
+     *
      * Routed through [EntersWithReplacements.placeEntryCounters] so counter-placement modifiers
-     * (Vorinclex, Pir) and the "a counter was placed this turn" tracker behave exactly as they do
-     * for a printed "enters with counters".
+     * (Doubling Season, Vorinclex, Pir) and the "a counter was placed this turn" tracker behave
+     * exactly as they do for a printed "enters with counters".
      *
      * @return Pair of (updated state, events to emit) — empty events if not a planeswalker
      */
@@ -170,6 +177,7 @@ object ZoneMovementUtils {
         cardRegistry: CardRegistry
     ): Pair<GameState, List<EngineGameEvent>> {
         val container = state.getEntity(entityId) ?: return state to emptyList()
+        if (container.has<FaceDownComponent>()) return state to emptyList()
         val cardComponent = container.get<CardComponent>() ?: return state to emptyList()
         if (!cardComponent.isPlaneswalker) return state to emptyList()
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -505,6 +505,16 @@ object ZoneTransitionService {
                 val (sagaState, sagaEvents) = applySagaEntryIfNeeded(newState, entityId)
                 newState = sagaState
                 events.addAll(sagaEvents)
+                // Handle a planeswalker entering the battlefield (CR 306.5b). Face-down entries
+                // are excluded: a face-down permanent is a nameless 2/2 creature with no printed
+                // loyalty (CR 708.2), so there is nothing to place.
+                if (!options.faceDown && ::cardRegistry.isInitialized) {
+                    val (loyaltyState, loyaltyEvents) = applyPlaneswalkerEntryIfNeeded(
+                        newState, entityId, destControllerId, cardRegistry
+                    )
+                    newState = loyaltyState
+                    events.addAll(loyaltyEvents)
+                }
             }
             Zone.LIBRARY -> {
                 if (effectiveLibraryPlacement is LibraryPlacement.Shuffled) {
@@ -1142,6 +1152,18 @@ object ZoneTransitionService {
         entityId: EntityId
     ): Pair<GameState, List<EngineGameEvent>> {
         return ZoneMovementUtils.applySagaEntryIfNeeded(state, entityId)
+    }
+
+    /**
+     * Place a planeswalker's printed loyalty counters as it enters the battlefield (CR 306.5b).
+     */
+    private fun applyPlaneswalkerEntryIfNeeded(
+        state: GameState,
+        entityId: EntityId,
+        controllerId: EntityId,
+        registry: CardRegistry
+    ): Pair<GameState, List<EngineGameEvent>> {
+        return ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded(state, entityId, controllerId, registry)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -505,10 +505,10 @@ object ZoneTransitionService {
                 val (sagaState, sagaEvents) = applySagaEntryIfNeeded(newState, entityId)
                 newState = sagaState
                 events.addAll(sagaEvents)
-                // Handle a planeswalker entering the battlefield (CR 306.5b). Face-down entries
-                // are excluded: a face-down permanent is a nameless 2/2 creature with no printed
-                // loyalty (CR 708.2), so there is nothing to place.
-                if (!options.faceDown && ::cardRegistry.isInitialized) {
+                // Handle a planeswalker entering the battlefield (CR 306.5b). The helper skips
+                // face-down entries itself — a face-down permanent is a nameless 2/2 creature with
+                // no printed loyalty (CR 708.2a).
+                if (::cardRegistry.isInitialized) {
                     val (loyaltyState, loyaltyEvents) = applyPlaneswalkerEntryIfNeeded(
                         newState, entityId, destControllerId, cardRegistry
                     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
@@ -196,7 +196,17 @@ class CreateTokenCopyOfChosenPermanentExecutor(
             val (sagaState, sagaEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
                 .applySagaEntryIfNeeded(newState, tokenId)
 
-            return EffectResult.success(sagaState, listOf(event) + counterEvents + sagaEvents)
+            // CR 306.5b: likewise a token copy of a planeswalker enters with the copied printed
+            // loyalty (a copiable value, CR 707.2), or state-based actions (CR 704.5i) bin it on
+            // arrival. No-op for non-planeswalkers.
+            val (loyaltyState, loyaltyEvents) = cardRegistry?.let { registry ->
+                com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                    .applyPlaneswalkerEntryIfNeeded(sagaState, tokenId, controllerId, registry)
+            } ?: (sagaState to emptyList())
+
+            return EffectResult.success(
+                loyaltyState, listOf(event) + counterEvents + sagaEvents + loyaltyEvents
+            )
         }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
@@ -163,6 +163,13 @@ class CreateTokenCopyOfEquippedCreatureExecutor(
         val (sagaState, sagaEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
             .applySagaEntryIfNeeded(newState, tokenId)
 
-        return EffectResult.success(sagaState, events + sagaEvents)
+        // CR 306.5b: the equipped creature can be a planeswalker card animated by its own ability
+        // (Gideon Blackblade) — the copy keeps the printed planeswalker types and loyalty (copiable
+        // values, CR 707.2) but not the animation, so it needs its loyalty counters or state-based
+        // actions (CR 704.5i) bin it on arrival. No-op for non-planeswalkers.
+        val (loyaltyState, loyaltyEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+            .applyPlaneswalkerEntryIfNeeded(sagaState, tokenId, controllerId, cardRegistry)
+
+        return EffectResult.success(loyaltyState, events + sagaEvents + loyaltyEvents)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -210,6 +210,14 @@ class CreateTokenCopyOfSourceExecutor(
             newState = sagaState
             events.addAll(sagaEvents)
 
+            // CR 306.5b: likewise a token copy of a planeswalker enters with the copied printed
+            // loyalty (a copiable value, CR 707.2), or state-based actions (CR 704.5i) bin it on
+            // arrival. No-op for non-planeswalkers.
+            val (loyaltyState, loyaltyEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .applyPlaneswalkerEntryIfNeeded(newState, tokenId, controllerId, cardRegistry)
+            newState = loyaltyState
+            events.addAll(loyaltyEvents)
+
             events.add(
                 ZoneChangeEvent(
                     entityId = tokenId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -363,6 +363,17 @@ class CreateTokenCopyOfTargetExecutor(
                 .applySagaEntryIfNeeded(newState, tokenId)
             newState = sagaState
             events.addAll(sagaEvents)
+
+            // CR 306.5b: likewise a token copy of a planeswalker enters with the copied printed
+            // loyalty (a copiable value, CR 707.2). Without it state-based actions (CR 704.5i)
+            // bin the token the instant it enters. No-op for non-planeswalkers.
+            cardRegistry?.let { registry ->
+                val (loyaltyState, loyaltyEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                    .applyPlaneswalkerEntryIfNeeded(newState, tokenId, controllerId, registry)
+                newState = loyaltyState
+                events.addAll(loyaltyEvents)
+            }
+
             createdTokens.add(tokenId)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -405,6 +405,16 @@ object TokenCreationReplacementHelper {
                 )
                 newState = afterCounters
                 events.addAll(counterEvents)
+
+                // CR 306.5b: an Aura can enchant a planeswalker, so a copy of the attached
+                // permanent may be one — it enters with the copied printed loyalty (a copiable
+                // value, CR 707.2) or state-based actions (CR 704.5i) bin it on arrival.
+                val (afterLoyalty, loyaltyEvents) = com.wingedsheep.engine.handlers.effects
+                    .ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded(
+                        newState, tokenId, controllerId, cardRegistry
+                    )
+                newState = afterLoyalty
+                events.addAll(loyaltyEvents)
             }
 
             events.add(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -159,6 +159,13 @@ object TokenFromDefinition {
         val (sagaState, sagaEvents) = ZoneMovementUtils.applySagaEntryIfNeeded(newState, tokenId)
         newState = sagaState
 
+        // CR 306.5b: same for a minted planeswalker — it enters with its printed loyalty counters,
+        // or state-based actions (CR 704.5i) bin it on arrival. No-op for non-planeswalkers.
+        val (loyaltyState, loyaltyEvents) = ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded(
+            newState, tokenId, controllerId, cardRegistry
+        )
+        newState = loyaltyState
+
         val event = ZoneChangeEvent(
             entityId = tokenId,
             entityName = cardDef.name,
@@ -167,6 +174,8 @@ object TokenFromDefinition {
             ownerId = controllerId
         )
 
-        return EffectResult.success(newState, listOf(event) + counterEvents + sagaEvents)
+        return EffectResult.success(
+            newState, listOf(event) + counterEvents + sagaEvents + loyaltyEvents
+        )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1545,7 +1545,11 @@ class StackResolver(
             counterEvents.addAll(riderEvents)
         }
 
-        // Handle planeswalker starting loyalty (Rule 306.5b)
+        // Handle planeswalker starting loyalty (Rule 306.5b). This is the cast pipeline's copy of
+        // the intrinsic entry replacement; every non-stack entry (reanimation, an O-Ring style
+        // return, a tutor straight into play) gets it from
+        // ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded instead. Keep the two in sync — the
+        // same split exists for Saga entry below.
         if (cardDef != null && !spellComponent.castFaceDown && cardDef.startingLoyalty != null) {
             val loyaltyCount = cardDef.startingLoyalty!!
             val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -56,7 +56,7 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.EntersAsCopy
 import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.handlers.effects.permanent.types.returnDfcFace
-import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.EntersWithChoice
 import com.wingedsheep.sdk.scripting.ChoiceSlot
@@ -1545,20 +1545,18 @@ class StackResolver(
             counterEvents.addAll(riderEvents)
         }
 
-        // Handle planeswalker starting loyalty (Rule 306.5b). This is the cast pipeline's copy of
-        // the intrinsic entry replacement; every non-stack entry (reanimation, an O-Ring style
-        // return, a tutor straight into play) gets it from
-        // ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded instead. Keep the two in sync — the
-        // same split exists for Saga entry below.
+        // Handle planeswalker starting loyalty (Rule 306.5b). This is the cast pipeline's entry
+        // point for the intrinsic entry replacement — it runs here, while the permanent is still
+        // on the stack, because resolution places permanents via addToZone rather than
+        // ZoneTransitionService.moveToZone. Every other entry reaches the same shared
+        // placeEntryCounters call through ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded.
         if (cardDef != null && !spellComponent.castFaceDown && cardDef.startingLoyalty != null) {
-            val loyaltyCount = cardDef.startingLoyalty!!
-            val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
-                newState, spellId, CounterType.LOYALTY, loyaltyCount, placerId = controllerId
+            val (loyaltyState, loyaltyEvents) = EntersWithReplacements.placeEntryCounters(
+                newState, spellId, CounterTypeFilter.Loyalty, cardDef.startingLoyalty!!,
+                controllerId, cardComponent?.name ?: ""
             )
-            val current = newState.getEntity(spellId)?.get<CountersComponent>() ?: CountersComponent()
-            newState = newState.updateEntity(spellId) { c ->
-                c.with(current.withAdded(CounterType.LOYALTY, modifiedCount))
-            }
+            newState = loyaltyState
+            counterEvents.addAll(loyaltyEvents)
         }
 
         // Handle Class entering the battlefield (Rule 716)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlaneswalkerEntryLoyaltyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlaneswalkerEntryLoyaltyScenarioTest.kt
@@ -11,7 +11,12 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 
@@ -28,15 +33,52 @@ import io.kotest.matchers.shouldBe
  * The engine places these counters in two spots, matching the split that already exists for Saga
  * lore counters: the cast pipeline does it in `StackResolver` (it adds permanents to the
  * battlefield zone directly), and every other entry gets it from
- * `ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded` via `ZoneTransitionService.moveToZone`. These
- * tests pin down both, plus the face-down exclusion.
+ * `ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded` via `ZoneTransitionService.moveToZone`. Both
+ * end up in the same `EntersWithReplacements.placeEntryCounters` call, so counter-placement
+ * modifiers apply identically either way. These tests pin down both, the face-down exclusion, and
+ * that parity. Token copies are covered by [TokenCopyOfPlaneswalkerEntryScenarioTest].
  */
 class PlaneswalkerEntryLoyaltyScenarioTest : ScenarioTestBase() {
 
     private fun loyaltyOf(entityId: EntityId, state: com.wingedsheep.engine.state.GameState): Int =
         state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
 
+    /** A creature that flips onto a planeswalker back face — the "returns transformed" entry. */
+    private val squire: CardDefinition = CardDefinition.doubleFacedPermanent(
+        frontFace = card("Test Squire") {
+            manaCost = "{W}"
+            colorIdentity = "W"
+            typeLine = "Creature — Human Soldier"
+            power = 1
+            toughness = 1
+            oracleText = ""
+        },
+        backFace = card("Test Squire Ascended") {
+            manaCost = ""
+            colorIndicator = "W"
+            typeLine = "Legendary Planeswalker — Squire"
+            startingLoyalty = 3
+            oracleText = "+1: You gain 1 life."
+            loyaltyAbility(+1) { effect = Effects.GainLife(1) }
+        },
+    )
+
+    /** "Exile target creature, then return it to the battlefield transformed." */
+    private val ascension = card("Test Ascension") {
+        manaCost = "{W}"
+        colorIdentity = "W"
+        typeLine = "Instant"
+        oracleText = "Exile target creature, then return it to the battlefield transformed."
+        spell {
+            target = Targets.Creature
+            effect = Effects.ExileAndReturnTransformed(EffectTarget.ContextTarget(0))
+        }
+    }
+
     init {
+        cardRegistry.register(squire)
+        cardRegistry.register(ascension)
+
         context("CR 306.5b — a planeswalker enters with its printed loyalty however it enters") {
 
             test("a planeswalker returned by an 'exile until this leaves' aura comes back with its printed loyalty") {
@@ -210,6 +252,87 @@ class PlaneswalkerEntryLoyaltyScenarioTest : ScenarioTestBase() {
                     ZoneEntryOptions(controllerId = game.player1Id)
                 )
                 loyaltyOf(bears, result.state) shouldBe 0
+            }
+
+            test("a double-faced card returning transformed enters with its back face's loyalty") {
+                // The back face's printed loyalty, not the front face's (a creature has none):
+                // returnDfcFace flips the CardComponent before handing the entity to moveToZone,
+                // so the entry step reads the planeswalker face's definition.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Test Squire")
+                    .withCardInHand(1, "Test Ascension")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val squirePermanent = game.findPermanent("Test Squire")!!
+                val cast = game.castSpell(1, "Test Ascension", squirePermanent)
+                withClue("casting the transform instant should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val ascended = game.findPermanent("Test Squire Ascended")
+                    ?: error("the transformed planeswalker is not on the battlefield")
+                withClue("it entered on its planeswalker face with that face's printed loyalty") {
+                    loyaltyOf(ascended, game.state) shouldBe 3
+                }
+            }
+        }
+
+        context("CR 306.5b entry counters honour counter-placement modifiers (CR 614)") {
+
+            // Doubling Season: "If an effect would put one or more counters on a permanent you
+            // control, it puts twice that many of those counters on that permanent instead." The
+            // entry loyalty counters are placed by a replacement effect like any other, so they
+            // double — the printed ruling, and the reason both entry paths route through
+            // EntersWithReplacements.placeEntryCounters instead of writing counters directly.
+
+            test("Doubling Season doubles the entry loyalty of a cast planeswalker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Ajani, Outland Chaperone")
+                    .withCardOnBattlefield(1, "Doubling Season")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Ajani, Outland Chaperone")
+                withClue("casting the planeswalker should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val ajani = game.findPermanent("Ajani, Outland Chaperone")!!
+                loyaltyOf(ajani, game.state) shouldBe 6
+            }
+
+            test("Doubling Season doubles the entry loyalty of a reanimated planeswalker") {
+                // The non-cast path has to reach the same modifiers, or the two pipelines disagree
+                // about the same card.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Perennation")
+                    .withCardInGraveyard(1, "Ajani, Outland Chaperone")
+                    .withCardOnBattlefield(1, "Doubling Season")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingGraveyardCard(
+                    1, "Perennation", 1, "Ajani, Outland Chaperone"
+                )
+                withClue("casting Perennation should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val ajani = game.findPermanent("Ajani, Outland Chaperone")!!
+                loyaltyOf(ajani, game.state) shouldBe 6
             }
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlaneswalkerEntryLoyaltyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlaneswalkerEntryLoyaltyScenarioTest.kt
@@ -1,0 +1,216 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 306.5b — "A planeswalker has the intrinsic ability 'This permanent enters with a number of
+ * loyalty counters on it equal to its printed loyalty number.' This ability creates a replacement
+ * effect (see rule 614.1c)."
+ *
+ * Because it is a replacement effect on *entering*, it applies however the planeswalker gets onto
+ * the battlefield — not only when a planeswalker spell resolves. A planeswalker that entered with
+ * no loyalty counters would immediately be put into its owner's graveyard by state-based actions
+ * (CR 704.5i, "If a planeswalker has loyalty 0, it's put into its owner's graveyard").
+ *
+ * The engine places these counters in two spots, matching the split that already exists for Saga
+ * lore counters: the cast pipeline does it in `StackResolver` (it adds permanents to the
+ * battlefield zone directly), and every other entry gets it from
+ * `ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded` via `ZoneTransitionService.moveToZone`. These
+ * tests pin down both, plus the face-down exclusion.
+ */
+class PlaneswalkerEntryLoyaltyScenarioTest : ScenarioTestBase() {
+
+    private fun loyaltyOf(entityId: EntityId, state: com.wingedsheep.engine.state.GameState): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    init {
+        context("CR 306.5b — a planeswalker enters with its printed loyalty however it enters") {
+
+            test("a planeswalker returned by an 'exile until this leaves' aura comes back with its printed loyalty") {
+                // The reported repro: Sheltered by Ghosts (DSK) exiles the opponent's planeswalker,
+                // then hands it back when the Aura is destroyed. The returning object is a new
+                // permanent entering the battlefield, so CR 306.5b applies to it — it must not
+                // arrive on 0 loyalty and die to CR 704.5i on the spot.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sheltered by Ghosts")
+                    .withCardInHand(1, "Disenchant")
+                    // {1}{W} for the Aura, {1}{W} for the Disenchant.
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    // Something for the Aura to enchant (it enchants a creature you control).
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // The opponent's planeswalker the ETB will exile.
+                    .withCardOnBattlefield(2, "Ajani, Outland Chaperone")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val ajani = game.findPermanent("Ajani, Outland Chaperone")!!
+
+                val cast = game.castSpell(1, "Sheltered by Ghosts", bears)
+                withClue("casting the Aura should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                // Resolve the Aura; its enters trigger asks for the nonland permanent to exile.
+                var guard = 0
+                while (game.state.pendingDecision !is ChooseTargetsDecision && guard < 20) {
+                    game.resolveStack(); guard++
+                }
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the exile trigger; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(ajani))))
+                game.resolveStack()
+
+                withClue("the planeswalker is exiled by the Aura's enters trigger") {
+                    game.isOnBattlefield("Ajani, Outland Chaperone") shouldBe false
+                    game.isInGraveyard(2, "Ajani, Outland Chaperone") shouldBe false
+                }
+
+                // Destroy the Aura — its leaves trigger returns the exiled card to the battlefield.
+                val disenchant = game.castSpell(1, "Disenchant", game.findPermanent("Sheltered by Ghosts")!!)
+                withClue("casting Disenchant should succeed: ${disenchant.error}") {
+                    disenchant.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the planeswalker is back on the battlefield, not in the graveyard") {
+                    game.isOnBattlefield("Ajani, Outland Chaperone") shouldBe true
+                    game.isInGraveyard(2, "Ajani, Outland Chaperone") shouldBe false
+                }
+                val returned = game.findPermanent("Ajani, Outland Chaperone")
+                    ?: error("the returned planeswalker is not on the battlefield")
+
+                withClue("it entered with its printed loyalty (CR 306.5b), so SBAs leave it alone") {
+                    loyaltyOf(returned, game.state) shouldBe 3
+                }
+                withClue("it returns under its owner's control") {
+                    game.state.getZone(game.player2Id, Zone.BATTLEFIELD).contains(returned) shouldBe true
+                }
+            }
+
+            test("a planeswalker reanimated from a graveyard enters with its printed loyalty") {
+                // A second, unrelated entry path: Perennation's PutOntoBattlefield (a targeted
+                // graveyard → battlefield move) rather than the linked-exile return pipeline.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Perennation")
+                    .withCardInGraveyard(1, "Ajani, Outland Chaperone")
+                    // {3}{W}{B}{G}
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingGraveyardCard(
+                    1, "Perennation", 1, "Ajani, Outland Chaperone"
+                )
+                withClue("casting Perennation should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val ajani = game.findPermanent("Ajani, Outland Chaperone")
+                    ?: error("the reanimated planeswalker is not on the battlefield")
+
+                withClue("it entered with its printed loyalty rather than 0") {
+                    loyaltyOf(ajani, game.state) shouldBe 3
+                }
+                withClue("Perennation's own keyword counters land on the same object") {
+                    val counters = game.state.getEntity(ajani)?.get<CountersComponent>()
+                    counters?.getCount(CounterType.HEXPROOF) shouldBe 1
+                    counters?.getCount(CounterType.INDESTRUCTIBLE) shouldBe 1
+                }
+            }
+
+            test("casting a planeswalker still places its printed loyalty exactly once") {
+                // Guards the cast pipeline against double-applying: it owns its own copy of the
+                // CR 306.5b step because it adds permanents to the battlefield zone directly
+                // instead of going through ZoneTransitionService.moveToZone.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Ajani, Outland Chaperone")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Ajani, Outland Chaperone")
+                withClue("casting the planeswalker should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val ajani = game.findPermanent("Ajani, Outland Chaperone")
+                    ?: error("the cast planeswalker is not on the battlefield")
+                withClue("exactly the printed loyalty — not doubled by a second entry pass") {
+                    loyaltyOf(ajani, game.state) shouldBe 3
+                }
+            }
+
+            test("a planeswalker put onto the battlefield face down gets no loyalty counters") {
+                // A face-down permanent is a nameless 2/2 creature with no card types beyond
+                // creature (CR 708.2), so there is no printed loyalty number to place. Driven
+                // through ZoneTransitionService directly: manifesting a planeswalker is legal but
+                // needs a whole manifest-dread pipeline to reach through a card.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Ajani, Outland Chaperone")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ajani = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Ajani, Outland Chaperone"
+                }
+
+                val faceUp = ZoneTransitionService.moveToZone(
+                    game.state, ajani, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+                withClue("sanity: the same move face up does place the loyalty counters") {
+                    loyaltyOf(ajani, faceUp.state) shouldBe 3
+                }
+
+                val faceDown = ZoneTransitionService.moveToZone(
+                    game.state, ajani, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id, faceDown = true, manifested = true)
+                )
+                withClue("a face-down entry has no printed loyalty to place") {
+                    loyaltyOf(ajani, faceDown.state) shouldBe 0
+                }
+            }
+
+            test("a non-planeswalker entering the battlefield gets no loyalty counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+
+                val result = ZoneTransitionService.moveToZone(
+                    game.state, bears, Zone.BATTLEFIELD,
+                    ZoneEntryOptions(controllerId = game.player1Id)
+                )
+                loyaltyOf(bears, result.state) shouldBe 0
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TokenCopyOfPlaneswalkerEntryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TokenCopyOfPlaneswalkerEntryScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 306.5b for token copies: a token that's a copy of a planeswalker enters with that
+ * planeswalker's printed loyalty. Loyalty is a copiable value (CR 707.2), so the token has a
+ * printed loyalty number of its own to place; without those counters state-based actions
+ * (CR 704.5i) put it into the graveyard the instant it enters — and a token that hits the
+ * graveyard simply ceases to exist.
+ *
+ * Token minting uses the ad-hoc `BattlefieldEntry.place` insertion path, which deliberately skips
+ * the enters-with setup that `ZoneTransitionService.moveToZone` runs, so the token executors call
+ * the shared entry hooks themselves — exactly as they already do for Saga lore counters (see
+ * [TokenCopyOfSagaEntryScenarioTest]). This test proves the planeswalker hook generally, driven by
+ * a plain "create a token that's a copy of target planeswalker" instant rather than any one card.
+ */
+class TokenCopyOfPlaneswalkerEntryScenarioTest : ScenarioTestBase() {
+
+    private val echo = card("Test Walker Echo") {
+        manaCost = "{2}{U}"
+        colorIdentity = "U"
+        typeLine = "Instant"
+        oracleText = "Create a token that's a copy of target planeswalker."
+        spell {
+            target = Targets.Planeswalker
+            effect = Effects.CreateTokenCopyOfTarget(EffectTarget.ContextTarget(0))
+        }
+    }
+
+    private fun loyaltyOf(entityId: EntityId, state: com.wingedsheep.engine.state.GameState): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    init {
+        cardRegistry.register(echo)
+
+        test("a token copy of a planeswalker enters with the copied printed loyalty and survives") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Test Walker Echo")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withCardOnBattlefield(1, "Ajani, Caller of the Pride")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val original = game.findPermanent("Ajani, Caller of the Pride")!!
+            val cast = game.castSpell(1, "Test Walker Echo", original)
+            withClue("casting the copy spell should succeed: ${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+
+            val copies = game.state.getZone(game.player1Id, Zone.BATTLEFIELD).filter { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Ajani, Caller of the Pride"
+            }
+            withClue("the token is still on the battlefield — 0 loyalty would have binned it") {
+                copies.size shouldBe 2
+            }
+
+            val token = copies.first { game.state.getEntity(it)?.get<TokenComponent>() != null }
+            withClue("the token copied Ajani's printed loyalty 4") {
+                loyaltyOf(token, game.state) shouldBe 4
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A planeswalker only got its loyalty counters when a planeswalker *spell resolved*. CR 306.5b makes
"this permanent enters with a number of loyalty counters on it equal to its printed loyalty number"
an **intrinsic replacement effect** (CR 614.1c), so it applies however the planeswalker enters. Every
other entry — an "exile until this leaves" return (Sheltered by Ghosts), reanimation, a tutor
straight into play, a DFC returning transformed onto a planeswalker back face, a token copy — arrived
at 0 loyalty and was put into its owner's graveyard by state-based actions (CR 704.5i) the instant it
entered. A token that hits the graveyard simply ceases to exist.

## What changed

**`ZoneMovementUtils.applyPlaneswalkerEntryIfNeeded`** is the single entry hook, mirroring the Saga
lore-counter split that already exists. It is called from every battlefield-entry pipeline:

| Pipeline | Call site |
|---|---|
| Zone-change entries (reanimation, linked-exile return, put-onto-battlefield, transform-and-return) | `ZoneTransitionService.moveToZone` battlefield branch |
| Ad-hoc token minting (`BattlefieldEntry.place`, which deliberately skips enters-with setup) | `TokenFromDefinition` + the four `CreateTokenCopyOf*Executor`s + `TokenCreationReplacementHelper.createAttachedPermanentCopies` |
| Cast / resolve | `StackResolver`, while the permanent is still on the stack |

All of them land in the same `EntersWithReplacements.placeEntryCounters` call, so counter-placement
modifiers (Doubling Season, Vorinclex, Pir), the "a counter was placed this turn" tracker, and the
emitted `CountersAddedEvent` behave exactly as they do for a printed "enters with counters" — and no
entry can get the counters twice.

Details worth calling out:

- **Token copies** need this because loyalty is a copiable value (CR 707.2), so the copy has a
  printed loyalty number of its own. Reachable today through Extravagant Replication ("a copy of
  another target nonland permanent you control").
- **The cast path no longer hand-rolls the placement.** It previously applied the counter modifiers
  but emitted no `CountersAddedEvent` and never recorded the placement, so counter watchers and the
  per-turn tracker saw a reanimated planeswalker but not a cast one. Both paths now share one helper.
- **Face-down entries are skipped inside the helper** (a face-down permanent is a nameless 2/2
  creature with no printed loyalty, CR 708.2a), so every caller inherits the check rather than
  repeating it.
- **DFC back faces work** because `returnDfcFace` flips the `CardComponent` before handing the entity
  to `moveToZone`, so the entry step reads the planeswalker face's printed loyalty.

`docs/card-sdk-language-reference.md` is updated in the same change: `startingLoyalty` is placed by
the engine on every entry, and card definitions never place it themselves.

No new SDK types — this is engine wiring over existing primitives.

## Tests

`PlaneswalkerEntryLoyaltyScenarioTest` (8 cases) and `TokenCopyOfPlaneswalkerEntryScenarioTest`:

- returned by an "exile until this leaves" Aura (the reported repro) — comes back at printed loyalty,
  under its owner's control, not in the graveyard
- reanimated from a graveyard (Perennation), with its own keyword counters landing on the same object
- cast — placed **exactly once**, guarding against the two pipelines double-applying
- a DFC returning transformed onto its planeswalker back face — the back face's loyalty, not the
  front's
- a token copy of a planeswalker — copied printed loyalty, and it survives the SBA check
- Doubling Season doubling the entry loyalty on **both** the cast and the reanimation path — the
  modifier parity the shared helper exists for
- negative cases: a face-down entry and a non-planeswalker get no loyalty counters

## Verification

`just test-rules` — **9333 tests passed, 0 failures** across 2952 test classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145yakyrz13zRy5cATmB5NT
