### PR TITLE
Add Mayor and Huntmaster to Innistrad Remastered

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/HuntmasterOfTheFells.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/HuntmasterOfTheFells.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val createHuntmasterWolf = Effects.CreateToken(
+    power = 2,
+    toughness = 2,
+    colors = setOf(Color.GREEN),
+    creatureTypes = setOf("Wolf"),
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89b89a55-3ea2-4186-b946-06831bc16169.jpg?1783907965",
+)
+
+private val huntmasterFrontTrigger = Effects.Composite(
+    createHuntmasterWolf,
+    Effects.GainLife(2),
+)
+
+private val HuntmasterOfTheFellsFront = card("Huntmaster of the Fells") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Human Werewolf"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature enters or transforms into Huntmaster of the Fells, create a 2/2 green Wolf creature token and you gain 2 life.\n" +
+        "At the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = huntmasterFrontTrigger
+    }
+    triggeredAbility {
+        trigger = Triggers.TransformsToFront
+        effect = huntmasterFrontTrigger
+    }
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(),
+            ComparisonOperator.EQ,
+            DynamicAmount.Fixed(0),
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "140"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg?1783940803"
+    }
+}
+
+private val RavagerOfTheFells = card("Ravager of the Fells") {
+    manaCost = ""
+    colorIdentity = "RG"
+    colorIndicator = "RG"
+    typeLine = "Creature — Werewolf"
+    power = 4
+    toughness = 4
+    oracleText = "Trample\n" +
+        "Whenever this creature transforms into Ravager of the Fells, it deals 2 damage to target opponent or planeswalker and 2 damage to up to one target creature that player or that planeswalker's controller controls.\n" +
+        "At the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature."
+
+    keywords(Keyword.TRAMPLE)
+    triggeredAbility {
+        trigger = Triggers.TransformsToBack
+        val playerOrPlaneswalker = target("target opponent or planeswalker", Targets.OpponentOrPlaneswalker)
+        val creature = target(
+            "target creature that player controls",
+            TargetCreature(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.targetPlayerControls(playerOrPlaneswalker),
+                ),
+            ),
+        )
+        effect = Effects.Composite(
+            Effects.DealDamage(2, playerOrPlaneswalker),
+            Effects.DealDamage(2, creature),
+        )
+    }
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2),
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "140"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/back/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg?1783940803"
+    }
+}
+
+val HuntmasterOfTheFells: CardDefinition =
+    CardDefinition.doubleFacedCreature(HuntmasterOfTheFellsFront, RavagerOfTheFells)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HuntmasterOfTheFellsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HuntmasterOfTheFellsReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val HuntmasterOfTheFellsReprint = Printing(
+    oracleId = "582328cd-660d-47a4-bb23-e91e80b9a907",
+    name = "Huntmaster of the Fells",
+    setCode = "INR",
+    collectorNumber = "241",
+    scryfallId = "b3819a11-2f3e-4304-a1b0-6abf893c89c5",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b3819a11-2f3e-4304-a1b0-6abf893c89c5.jpg?1783908083",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MayorOfAvabruckReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MayorOfAvabruckReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val MayorOfAvabruckReprint = Printing(
+    oracleId = "6e638587-30b3-4c4b-b463-fb415ea048f7",
+    name = "Mayor of Avabruck",
+    setCode = "INR",
+    collectorNumber = "207",
+    scryfallId = "ef84540b-a132-4169-b3c0-b0edeb395c9b",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef84540b-a132-4169-b3c0-b0edeb395c9b.jpg?1783908100",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/MayorOfAvabruck.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/MayorOfAvabruck.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+private val MayorOfAvabruckFront = card("Mayor of Avabruck") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Advisor Werewolf"
+    power = 1
+    toughness = 1
+    oracleText = "Other Human creatures you control get +1/+1.\n" +
+        "At the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.HUMAN).youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(),
+            ComparisonOperator.EQ,
+            DynamicAmount.Fixed(0),
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "193"
+        artist = "Svetlin Velinov"
+        flavorText = "He can deny his true nature for only so long."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg?1783940920"
+    }
+}
+
+private val HowlpackAlpha = card("Howlpack Alpha") {
+    manaCost = ""
+    colorIdentity = "G"
+    colorIndicator = "G"
+    typeLine = "Creature — Werewolf"
+    power = 3
+    toughness = 3
+    oracleText = "Each other creature you control that's a Werewolf or a Wolf gets +1/+1.\n" +
+        "At the beginning of your end step, create a 2/2 green Wolf creature token.\n" +
+        "At the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature
+                    .withAnyOfSubtypes(listOf(Subtype.WEREWOLF, Subtype.WOLF))
+                    .youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Wolf"),
+            imageUri = "https://cards.scryfall.io/normal/front/a/5/a53f8031-aaa8-424c-929a-5478538a8cc6.jpg?1783940880",
+        )
+    }
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2),
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "193"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/back/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg?1783940920"
+        ruling(
+            "2025-01-24",
+            "A creature that is both a Werewolf and a Wolf gets only +1/+1 from Howlpack Alpha's first ability.",
+        )
+    }
+}
+
+val MayorOfAvabruck: CardDefinition = CardDefinition.doubleFacedCreature(MayorOfAvabruckFront, HowlpackAlpha)

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -602,6 +602,223 @@
     "colorIdentityOverride": []
 }
 
+// Huntmaster of the Fells
+{
+    "name": "Huntmaster of the Fells",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Human Werewolf",
+    "oracleText": "Whenever this creature enters or transforms into Huntmaster of the Fells, create a 2/2 green Wolf creature token and you gain 2 life.\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "GREEN"
+                            ],
+                            "creatureTypes": [
+                                "Wolf"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/8/9/89b89a55-3ea2-4186-b946-06831bc16169.jpg?1783907965"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "TransformEvent",
+                    "intoBackFace": false
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "GREEN"
+                            ],
+                            "creatureTypes": [
+                                "Wolf"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/8/9/89b89a55-3ea2-4186-b946-06831bc16169.jpg?1783907965"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Ravager of the Fells",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "Trample\nWhenever this creature transforms into Ravager of the Fells, it deals 2 damage to target opponent or planeswalker and 2 damage to up to one target creature that player or that planeswalker's controller controls.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 4
+        },
+        "keywords": [
+            "TRAMPLE"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_4",
+                    "trigger": {
+                        "type": "TransformEvent",
+                        "intoBackFace": true
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target opponent or planeswalker"
+                                }
+                            },
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature that player controls"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirement": {
+                        "type": "TargetOpponentOrPlaneswalker",
+                        "id": "target opponent or planeswalker"
+                    },
+                    "additionalTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "controllerPredicate": {
+                                        "type": "ControlledByReferencedPlayer",
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target opponent or planeswalker"
+                                        }
+                                    }
+                                }
+                            },
+                            "id": "target creature that player controls"
+                        }
+                    ]
+                },
+                {
+                    "id": "ability_5",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "140",
+            "rarity": "MYTHIC",
+            "artist": "Chris Rahn",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg?1783940803"
+        },
+        "colorIdentityOverride": [
+            "RED",
+            "GREEN"
+        ],
+        "colorIndicator": [
+            "RED",
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "MYTHIC",
+        "artist": "Chris Rahn",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aae6fb12-b252-453b-bca7-1ea2a0d6c8dc.jpg?1783940803"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Lingering Souls
 {
     "name": "Lingering Souls",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -3387,6 +3387,157 @@
     ]
 }
 
+// Mayor of Avabruck
+{
+    "name": "Mayor of Avabruck",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Advisor Werewolf",
+    "oracleText": "Other Human creatures you control get +1/+1.\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Human ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Howlpack Alpha",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "Each other creature you control that's a Werewolf or a Wolf gets +1/+1.\nAt the beginning of your end step, create a 2/2 green Wolf creature token.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "END"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 2,
+                        "toughness": 2,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Wolf"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a53f8031-aaa8-424c-929a-5478538a8cc6.jpg?1783940880"
+                    }
+                },
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "HasAnyOfSubtypes",
+                                    "subtypes": [
+                                        "Werewolf",
+                                        "Wolf"
+                                    ]
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        },
+                        "excludeSelf": true
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "193",
+            "rarity": "RARE",
+            "artist": "Svetlin Velinov",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg?1783940920",
+            "rulings": [
+                {
+                    "date": "2025-01-24",
+                    "text": "A creature that is both a Werewolf and a Wolf gets only +1/+1 from Howlpack Alpha's first ability."
+                }
+            ]
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ],
+        "colorIndicator": [
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "He can deny his true nature for only so long.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd8ca448-f734-4cb9-b1d5-790eed9a4b2d.jpg?1783940920"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mentor of the Meek
 {
     "name": "Mentor of the Meek",


### PR DESCRIPTION
## Summary

- add canonical Mayor of Avabruck // Howlpack Alpha definition to Innistrad
- add canonical Huntmaster of the Fells // Ravager of the Fells definition to Dark Ascension
- add Innistrad Remastered printing rows for both cards
- update the ISD and DKA card snapshots

The batch is intentionally limited to two cards because the remaining INR gaps require larger mechanics such as madness, emerge, disturb, soulbond, splice, battles, or emblems.

## Verification

- just build
- just check-card-printing "Mayor of Avabruck"
- just check-card-printing "Huntmaster of the Fells"
- git diff --check
- all canonical front/back and INR printing image URLs return HTTP 200