### PR TITLE
Add Duskwatch Recruiter and Geier Reach Bandit to Innistrad Remastered

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DuskwatchRecruiterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DuskwatchRecruiterReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in SOI. */
+val DuskwatchRecruiterReprint = Printing(
+    oracleId = "87c43776-dd98-4e12-9b95-82d2b8f4f1ab",
+    name = "Duskwatch Recruiter",
+    setCode = "INR",
+    collectorNumber = "193",
+    scryfallId = "4ef68479-ab2e-4a60-886c-ad007b64f185",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4ef68479-ab2e-4a60-886c-ad007b64f185.jpg?1783908108",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/4/e/4ef68479-ab2e-4a60-886c-ad007b64f185.jpg?1783908108",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GeierReachBanditReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GeierReachBanditReprint.kt
@@ -1,0 +1,18 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in SOI. */
+val GeierReachBanditReprint = Printing(
+    oracleId = "64720167-b88b-47f7-bfc1-d5e005c9fd68",
+    name = "Geier Reach Bandit",
+    setCode = "INR",
+    collectorNumber = "156",
+    scryfallId = "f0af234d-ce14-49ac-b877-00b0dd1f11e2",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f0af234d-ce14-49ac-b877-00b0dd1f11e2.jpg?1783908128",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/f/0/f0af234d-ce14-49ac-b877-00b0dd1f11e2.jpg?1783908128",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DuskwatchRecruiter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DuskwatchRecruiter.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Duskwatch Recruiter // Krallenhorde Howler (Shadows over Innistrad — the card's earliest
+ * printing; also reprinted in Shadows over Innistrad Remastered and Innistrad Remastered)
+ *
+ * Front — Duskwatch Recruiter ({1}{G}, Creature — Human Warrior Werewolf, 2/2)
+ *   {2}{G}: Look at the top three cards of your library. You may reveal a creature card from
+ *   among them and put it into your hand. Put the rest on the bottom of your library in any order.
+ *   At the beginning of each upkeep, if no spells were cast last turn, transform this creature.
+ *
+ * Back — Krallenhorde Howler (Creature — Werewolf, 3/3)
+ *   Creature spells you cast cost {1} less to cast.
+ *   At the beginning of each upkeep, if a player cast two or more spells last turn, transform
+ *   this creature.
+ *
+ * Implementation:
+ *  - The dig is [Patterns.Library.lookAtTopRevealMatchingToHand] (count 3, creature filter, the
+ *    reveal-to-hand is `ChooseUpTo(1)` so declining is legal), rest to the bottom. Current Oracle
+ *    reads "in any order" — the printed SOI wording was "in a random order" — so the remainder
+ *    uses [CardOrder.ControllerChooses].
+ *  - Both upkeep flips are the standard Werewolf pair: [Triggers.EachUpkeep] with an
+ *    intervening-if on [DynamicAmounts.spellsCastLastTurn] (== 0 front, >= 2 back).
+ *  - The back's cost reduction is [ModifySpellCost] over [SpellCostTarget.YouCast]; it applies to
+ *    every creature spell its controller casts, not just Werewolves.
+ */
+
+private val DuskwatchRecruiterFront = card("Duskwatch Recruiter") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Warrior Werewolf"
+    power = 2
+    toughness = 2
+    oracleText = "{2}{G}: Look at the top three cards of your library. You may reveal a creature " +
+        "card from among them and put it into your hand. Put the rest on the bottom of your " +
+        "library in any order.\n" +
+        "At the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(3),
+            filter = GameObjectFilter.Creature,
+            prompt = "You may reveal a creature card and put it into your hand",
+            restOrder = CardOrder.ControllerChooses,
+        )
+        description = "{2}{G}: Look at the top three cards of your library. You may reveal a " +
+            "creature card from among them and put it into your hand. Put the rest on the " +
+            "bottom of your library in any order."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.EQ, DynamicAmount.Fixed(0)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Craig J Spearing"
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg?1783937740"
+    }
+}
+
+private val KrallenhordeHowler = card("Krallenhorde Howler") {
+    manaCost = ""
+    colorIdentity = "G"
+    colorIndicator = "G"
+    typeLine = "Creature — Werewolf"
+    power = 3
+    toughness = 3
+    oracleText = "Creature spells you cast cost {1} less to cast.\n" +
+        "At the beginning of each upkeep, if a player cast two or more spells last turn, " +
+        "transform this creature."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.GTE, DynamicAmount.Fixed(2)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Craig J Spearing"
+        imageUri = "https://cards.scryfall.io/normal/back/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg?1783937740"
+    }
+}
+
+val DuskwatchRecruiter: CardDefinition =
+    CardDefinition.doubleFacedCreature(DuskwatchRecruiterFront, KrallenhordeHowler)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/GeierReachBandit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/GeierReachBandit.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Geier Reach Bandit // Vildin-Pack Alpha (Shadows over Innistrad — the card's earliest
+ * printing; also reprinted in Shadows over Innistrad Remastered and Innistrad Remastered)
+ *
+ * Front — Geier Reach Bandit ({2}{R}, Creature — Human Rogue Werewolf, 3/2)
+ *   Haste
+ *   At the beginning of each upkeep, if no spells were cast last turn, transform this creature.
+ *
+ * Back — Vildin-Pack Alpha (Creature — Werewolf, 4/3)
+ *   Whenever a Werewolf you control enters, you may transform it.
+ *   At the beginning of each upkeep, if a player cast two or more spells last turn, transform
+ *   this creature.
+ *
+ * Implementation:
+ *  - Both upkeep flips are the standard Werewolf pair: [Triggers.EachUpkeep] with an
+ *    intervening-if on [DynamicAmounts.spellsCastLastTurn] (== 0 front, >= 2 back).
+ *  - The back's ETB watcher is [Triggers.entersBattlefield] with [TriggerBinding.ANY] over
+ *    "Werewolf you control" — Oracle says *a* Werewolf, not *another*, so Vildin-Pack Alpha
+ *    entering (e.g. put onto the battlefield transformed) triggers it on itself too. The
+ *    optional flip is [MayEffect] over a [TransformEffect] aimed at
+ *    [EffectTarget.TriggeringEntity], so it flips the permanent that entered rather than the
+ *    Alpha.
+ */
+
+private val GeierReachBanditFront = card("Geier Reach Bandit") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue Werewolf"
+    power = 3
+    toughness = 2
+    oracleText = "Haste\n" +
+        "At the beginning of each upkeep, if no spells were cast last turn, transform this creature."
+
+    keywords(Keyword.HASTE)
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.EQ, DynamicAmount.Fixed(0)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "159"
+        artist = "Slawomir Maniak"
+        flavorText = "The cathars realized they had not tracked her—she had led them here."
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg?1783937760"
+    }
+}
+
+private val VildinPackAlpha = card("Vildin-Pack Alpha") {
+    manaCost = ""
+    colorIdentity = "R"
+    colorIndicator = "R"
+    typeLine = "Creature — Werewolf"
+    power = 4
+    toughness = 3
+    oracleText = "Whenever a Werewolf you control enters, you may transform it.\n" +
+        "At the beginning of each upkeep, if a player cast two or more spells last turn, " +
+        "transform this creature."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype("Werewolf").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = MayEffect(effect = TransformEffect(EffectTarget.TriggeringEntity))
+        description = "Whenever a Werewolf you control enters, you may transform it."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmounts.spellsCastLastTurn(), ComparisonOperator.GTE, DynamicAmount.Fixed(2)
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "159"
+        artist = "Slawomir Maniak"
+        imageUri = "https://cards.scryfall.io/normal/back/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg?1783937760"
+    }
+}
+
+val GeierReachBandit: CardDefinition =
+    CardDefinition.doubleFacedCreature(GeierReachBanditFront, VildinPackAlpha)

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1080,6 +1080,173 @@
     ]
 }
 
+// Duskwatch Recruiter
+{
+    "name": "Duskwatch Recruiter",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Warrior Werewolf",
+    "oracleText": "{2}{G}: Look at the top three cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature card and put it into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "ControllerChooses"
+                        }
+                    ]
+                },
+                "descriptionOverride": "{2}{G}: Look at the top three cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Krallenhorde Howler",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "Creature spells you cast cost {1} less to cast.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifySpellCost",
+                    "target": {
+                        "type": "YouCast",
+                        "filter": "creature"
+                    },
+                    "modification": {
+                        "type": "ReduceGeneric",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "203",
+            "rarity": "UNCOMMON",
+            "artist": "Craig J Spearing",
+            "imageUri": "https://cards.scryfall.io/normal/back/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg?1783937740"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ],
+        "colorIndicator": [
+            "GREEN"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "Craig J Spearing",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1915d93-c7dd-4bb7-bd5c-63a359a02b97.jpg?1783937740"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Epitaph Golem
 {
     "name": "Epitaph Golem",
@@ -1276,6 +1443,118 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Geier Reach Bandit
+{
+    "name": "Geier Reach Bandit",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Rogue Werewolf",
+    "oracleText": "Haste\nAt the beginning of each upkeep, if no spells were cast last turn, transform this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": "SpellsCastLastTurn",
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Vildin-Pack Alpha",
+        "manaCost": "",
+        "typeLine": "Creature — Werewolf",
+        "oracleText": "Whenever a Werewolf you control enters, you may transform it.\nAt the beginning of each upkeep, if a player cast two or more spells last turn, transform this creature.",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 3
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "filter": "creature Werewolf ctrl:you",
+                        "to": "Battlefield"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "Transform",
+                            "target": "TriggeringEntity"
+                        }
+                    },
+                    "descriptionOverride": "Whenever a Werewolf you control enters, you may transform it."
+                },
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP",
+                        "player": "Each"
+                    },
+                    "binding": "ANY",
+                    "effect": "Transform",
+                    "triggerCondition": {
+                        "type": "Compare",
+                        "left": "SpellsCastLastTurn",
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "159",
+            "rarity": "RARE",
+            "artist": "Slawomir Maniak",
+            "imageUri": "https://cards.scryfall.io/normal/back/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg?1783937760"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ],
+        "colorIndicator": [
+            "RED"
+        ],
+        "hasNoManaCost": true
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "RARE",
+        "artist": "Slawomir Maniak",
+        "flavorText": "The cathars realized they had not tracked her—she had led them here.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/4570117d-c04b-4bdc-b804-21d49154721b.jpg?1783937760"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeierReachBanditScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeierReachBanditScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Geier Reach Bandit // Vildin-Pack Alpha (SOI #159).
+ *
+ *   Front (3/2, haste) — "At the beginning of each upkeep, if no spells were cast last turn,
+ *                         transform this creature."
+ *   Back  (4/3)        — "Whenever a Werewolf you control enters, you may transform it."
+ *                        "At the beginning of each upkeep, if a player cast two or more spells
+ *                         last turn, transform this creature."
+ *
+ * The back face is the first `TransformEffect` in the codebase aimed at something other than
+ * `EffectTarget.Self`, so these tests pin that it flips the Werewolf that *entered* — not the
+ * Alpha — and that declining the "may" leaves the newcomer on its front face.
+ */
+class GeierReachBanditScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Vildin-Pack Alpha") {
+
+            test("accepting the may-transform flips the Werewolf that entered, not the Alpha") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Vildin-Pack Alpha", summoningSickness = false)
+                    .withCardInHand(1, "Hinterland Logger")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val alpha = game.findPermanent("Vildin-Pack Alpha")!!
+
+                game.castSpell(1, "Hinterland Logger").error shouldBe null
+                game.resolveStack()
+
+                withClue("the enters trigger asks whether to transform the newcomer") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe true
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Hinterland Logger flipped to its back face, Timber Shredder") {
+                    game.isOnBattlefield("Timber Shredder") shouldBe true
+                    game.isOnBattlefield("Hinterland Logger") shouldBe false
+                }
+                withClue("the Alpha itself is untouched — the effect targets the triggering entity") {
+                    game.state.getEntity(alpha)!!.get<CardComponent>()!!.name shouldBe "Vildin-Pack Alpha"
+                }
+            }
+
+            test("declining the may-transform leaves the newcomer on its front face") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Vildin-Pack Alpha", summoningSickness = false)
+                    .withCardInHand(1, "Hinterland Logger")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Hinterland Logger").error shouldBe null
+                game.resolveStack()
+
+                (game.getPendingDecision() is YesNoDecision) shouldBe true
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("declined — still Hinterland Logger") {
+                    game.isOnBattlefield("Hinterland Logger") shouldBe true
+                    game.isOnBattlefield("Timber Shredder") shouldBe false
+                }
+            }
+
+            test("a non-Werewolf entering does not trigger the Alpha") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Vildin-Pack Alpha", summoningSickness = false)
+                    .withCardInHand(1, "Thraben Inspector")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Thraben Inspector").error shouldBe null
+                game.resolveStack()
+
+                withClue("a Human Soldier entering never asks the Werewolf question") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe false
+                }
+                game.isOnBattlefield("Thraben Inspector") shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two Werewolf transforming DFCs off the Innistrad Remastered missing list. Both canonical `CardDefinition`s land in **SOI** (each card's earliest real printing); INR gets a `Printing` row apiece.

## Cards

**Duskwatch Recruiter // Krallenhorde Howler** ({1}{G}, 2/2 // 3/3)
- The dig is `Patterns.Library.lookAtTopRevealMatchingToHand` — the reveal is `ChooseUpTo(1)`, so declining stays legal. The remainder goes to the bottom in the controller's chosen order: current Oracle reads *"in any order"*, though the printed SOI wording was *"in a random order"*.
- The back's discount is a `ModifySpellCost` over `SpellCostTarget.YouCast(Creature)` — every creature spell its controller casts, not just Werewolves.
- The activated ability carries an explicit `description` so the action-menu button reads like the card rather than the generated Gather/Select composite string.

**Geier Reach Bandit // Vildin-Pack Alpha** ({2}{R}, 3/2 haste // 4/3)
- Vildin-Pack Alpha's *"whenever a Werewolf you control enters, you may transform it"* is the **first `TransformEffect` in the codebase aimed at anything other than `EffectTarget.Self`**. It uses `EffectTarget.TriggeringEntity`, so the permanent that entered flips — not the Alpha.
- Oracle says *a* Werewolf, not *another*, so the trigger binds `ANY` and can see the Alpha itself.

Both upkeep flips are the standard Werewolf pair: `Triggers.EachUpkeep` with an intervening-if on `spellsCastLastTurn` (`== 0` front, `>= 2` back).

## Why only two cards

31 of the 33 remaining INR cards need engine mechanics we don't have yet, so they're `add-feature` work rather than `add-card`:

| Blocker | Count | Examples |
|---|---|---|
| Madness | 9 | Fiery Temper, Asylum Visitor, Gisa's Bidding |
| Emerge | 6 | Elder Deep-Fiend, Decimator of the Provinces |
| Disturb | 4 | Lunarch Veteran, Twinblade Geist |
| Soulbond | 2 | Deadeye Navigator, Lightning Mauler |
| Escalate / Battle / Eminence | 3 | Collective Brutality, Invasion of Innistrad, Edgar Markov |
| Other | 7 | Emrakul, Mirrorwing Dragon (per-creature retargeted spell copies), Garruk Relentless + Tamiyo (planeswalkers), Falkenrath Gorger (grants madness), Edgar's Awakening (self-discard trigger from graveyard) |

Through the Breach was scoped in initially and dropped: it has **Splice onto Arcane**, which also isn't supported.

## Testing

- `GeierReachBanditScenarioTest` covers the new non-`Self` transform path — accepting the "may" flips the newcomer and leaves the Alpha alone, declining leaves it on its front face, and a non-Werewolf entering never asks. All 3 pass.
- `just build` green.
- `just check-card-printing` clean for both cards (canonical in SOI, all scaffolded reprints have rows).
- SOI golden re-blessed; only these two cards move (279 insertions, 0 deletions).
- INR card-status: 257 → 259 implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)