### PR TITLE
Add five cards to The Hobbit

### DIFF
--- a/backlog/sets/the-hobbit/cards.md
+++ b/backlog/sets/the-hobbit/cards.md
@@ -2,10 +2,10 @@
 
 **Set Size:** 193 cards revealed as of 2026-08-04
 **Release Date:** August 14, 2026
-**Implemented:** 43 / 193
+**Implemented:** 48 / 193
 Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. This list covers only cards revealed as of that date.
 
-- [ ] 1. Long-Bodied Grey Dog
+- [x] 1. Long-Bodied Grey Dog
 - [x] 2. Old Thrush
 - [ ] 3. Troop of Ponies
 - [ ] 4. Belladonna Took
@@ -56,7 +56,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 49. Most Decrepit Old Bird
 - [ ] 50. Old Fat Spider Can't See Me
 - [ ] 51. Plunder the Trollshaws
-- [ ] 52. Ravenhill Flock
+- [x] 52. Ravenhill Flock
 - [ ] 53. Riddles in the Dark
 - [ ] 54. Roll-Roll-Roll-Roll
 - [ ] 55. Sound the Trumpets
@@ -77,7 +77,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 70. Gollum, Riddle Master
 - [ ] 71. Gollum, Silent Slinker
 - [ ] 72. Gollum the Abandoned
-- [ ] 73. Great Fierce Bee
+- [x] 73. Great Fierce Bee
 - [ ] 74. Great Ugly-Looking Goblin
 - [ ] 75. Head of the Hunt
 - [ ] 76. Inside Information
@@ -98,7 +98,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 91. Dáin Ironfoot
 - [ ] 92. Desert Were-Worm
 - [ ] 93. Desolation of Smaug
-- [ ] 94. Dori, Bearer of Friends
+- [x] 94. Dori, Bearer of Friends
 - [ ] 95. Dwarven Mauler
 - [ ] 96. Gandalf, Goblins' Bane
 - [ ] 97. Gandalf, Spark Starter
@@ -132,7 +132,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 125. Galion, Elvenking's Butler
 - [ ] 126. Gigantic Big Bear
 - [x] 127. Guardian of the Halls
-- [ ] 128. Little Bear
+- [x] 128. Little Bear
 - [x] 129. Mirkwood Pathmaker
 - [x] 130. Nasty Little Rabbit
 - [ ] 131. The Notary Hobbits

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/TheHobbitSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/TheHobbitSet.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
 import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.TokenPrinting
 
 /**
  * The Hobbit (2026)
@@ -29,6 +30,18 @@ object TheHobbitSet : MtgSet {
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
+
+    /**
+     * The set is too new to appear in the bulk `tokens.json` sync, so the tokens its cards actually
+     * mint are hand-authored here. Drop a row once `just token-art-sync` picks the same art up.
+     */
+    override val tokenArt: List<TokenPrinting> = listOf(
+        // thob #12 — the Treasure minted by Long-Bodied Grey Dog and Dori, Bearer of Friends.
+        TokenPrinting(
+            name = "Treasure",
+            imageUri = "https://cards.scryfall.io/art_crop/front/c/6/c6e096bb-ad9e-4a8b-8b42-26852fa32c1d.jpg?1783902770",
+        ),
+    )
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.hob.cards"
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DoriBearerOfFriends.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DoriBearerOfFriends.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dori, Bearer of Friends
+ * {2}{R}
+ * Legendary Creature — Dwarf Warrior
+ * 3/2
+ * Trample
+ * When Dori enters, create a Treasure token.
+ */
+val DoriBearerOfFriends = card("Dori, Bearer of Friends") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dwarf Warrior"
+    oracleText = "Trample\nWhen Dori enters, create a Treasure token. " +
+        "(It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+    power = 3
+    toughness = 2
+    keywords(Keyword.TRAMPLE)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure()
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Irvin Rodriguez"
+        flavorText = "\"I can't be always carrying burglars on my back, down tunnels and up trees! What do you think I am? A porter?\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2f60ad0-c887-4585-85f8-afcf72fb80d0.jpg?1785323237"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GreatFierceBee.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GreatFierceBee.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Great Fierce Bee
+ * {2}{B}
+ * Creature — Insect
+ * 2/2
+ * Flying
+ * Whenever one or more other creatures die, scry 1.
+ *
+ * The trigger is the *batched* death shape — a board wipe scries once, not once per creature
+ * (CR 603.3b). `anyController()` widens it past "you control" to every player's creatures, and
+ * `excludeSelf = true` carries the "other" in the oracle text.
+ */
+val GreatFierceBee = card("Great Fierce Bee") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    oracleText = "Flying\nWhenever one or more other creatures die, scry 1. " +
+        "(Look at the top card of your library. You may put that card on the bottom.)"
+    power = 2
+    toughness = 2
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.OneOrMoreCreaturesYouControlDie(
+            filter = GameObjectFilter.Creature.anyController(),
+            excludeSelf = true,
+        )
+        effect = Effects.Scry(1)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Leesha Hannigan"
+        flavorText = "\"If one were to sting me, I should swell up as big again as I am!\"\n—Bilbo"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d9ef88f-d208-4788-9553-cd672b3be1fe.jpg?1785497086"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LittleBear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LittleBear.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Little Bear
+ * {2}{G}
+ * Creature — Bear
+ * 3/2
+ * Flash
+ * When this creature enters, untap another target creature you control. If that creature is a
+ * Bear, put a +1/+1 counter on it.
+ *
+ * The Bear check reads the target at resolution (after the untap), so a creature that only became
+ * a Bear on the way in still gets the counter — and one that stopped being a Bear doesn't.
+ */
+val LittleBear = card("Little Bear") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    oracleText = "Flash\nWhen this creature enters, untap another target creature you control. " +
+        "If that creature is a Bear, put a +1/+1 counter on it."
+    power = 3
+    toughness = 2
+    keywords(Keyword.FLASH)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
+        effect = Effects.Composite(
+            Effects.Untap(t),
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(
+                    GameObjectFilter.Creature.withSubtype(Subtype.BEAR),
+                ),
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t),
+            ),
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Tomas Duchek"
+        flavorText = "Even the littlest bears joined in important bear meetings and moonlit dances."
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a50858a-33b5-4c45-9c31-5956ae5a33a6.jpg?1785323276"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LongBodiedGreyDog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LongBodiedGreyDog.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Long-Bodied Grey Dog
+ * {3}
+ * Creature — Dog
+ * 2/2
+ * Flash
+ * Reach
+ * When this creature enters, create a tapped Treasure token.
+ */
+val LongBodiedGreyDog = card("Long-Bodied Grey Dog") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Creature — Dog"
+    oracleText = "Flash\nReach\nWhen this creature enters, create a tapped Treasure token. " +
+        "(It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+    power = 2
+    toughness = 2
+    keywords(Keyword.FLASH, Keyword.REACH)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure(tapped = true)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Anna Podedworna"
+        flavorText = "Beorn's dogs took bowls and platters and knives and wooden spoons and quickly laid them on the trestle tables."
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1a1e520-1fe2-4529-8afb-c187bb80da3c.jpg?1785639260"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RavenhillFlock.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RavenhillFlock.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ravenhill Flock
+ * {3}{U}
+ * Creature — Bird
+ * 1/2
+ * Flying
+ * Whenever you draw a card, put a +1/+1 counter on this creature.
+ *
+ * `YouDraw` fires once per individual card drawn (CR 121.2), so "draw two cards" puts on two
+ * counters — which is what the card wants.
+ */
+val RavenhillFlock = card("Ravenhill Flock") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying\nWhenever you draw a card, put a +1/+1 counter on this creature."
+    power = 1
+    toughness = 2
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.YouDraw
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "52"
+        artist = "Irina Nordsol"
+        flavorText = "\"They live many a year, and their memories are long, and they hand on their wisdom to their children. I knew many among the ravens of the rocks when I was a Dwarf-lad.\"\n—Balin"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/acbb4d32-2771-469e-a6de-0df15155cc62.jpg?1784714603"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -307,6 +307,45 @@
     ]
 }
 
+// Dori, Bearer of Friends
+{
+    "name": "Dori, Bearer of Friends",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Dwarf Warrior",
+    "oracleText": "Trample\nWhen Dori enters, create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Irvin Rodriguez",
+        "flavorText": "\"I can't be always carrying burglars on my back, down tunnels and up trees! What do you think I am? A porter?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2f60ad0-c887-4585-85f8-afcf72fb80d0.jpg?1785323237"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Dwarven Provisioner
 {
     "name": "Dwarven Provisioner",
@@ -775,6 +814,47 @@
     ]
 }
 
+// Great Fierce Bee
+{
+    "name": "Great Fierce Bee",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flying\nWhenever one or more other creatures die, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CreaturesYouControlDiedEvent",
+                    "filter": "creature ctrl:any",
+                    "excludeSelf": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Leesha Hannigan",
+        "flavorText": "\"If one were to sting me, I should swell up as big again as I am!\"\n—Bilbo",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d9ef88f-d208-4788-9553-cd672b3be1fe.jpg?1785497086"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Guardian of the Halls
 {
     "name": "Guardian of the Halls",
@@ -926,6 +1006,124 @@
         "BLACK",
         "GREEN"
     ]
+}
+
+// Little Bear
+{
+    "name": "Little Bear",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Bear",
+    "oracleText": "Flash\nWhen this creature enters, untap another target creature you control. If that creature is a Bear, put a +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "tap": false
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "creature Bear"
+                                }
+                            },
+                            "then": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Tomas Duchek",
+        "flavorText": "Even the littlest bears joined in important bear meetings and moonlit dances.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a50858a-33b5-4c45-9c31-5956ae5a33a6.jpg?1785323276"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Long-Bodied Grey Dog
+{
+    "name": "Long-Bodied Grey Dog",
+    "manaCost": "{3}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Flash\nReach\nWhen this creature enters, create a tapped Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure",
+                    "tapped": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Anna Podedworna",
+        "flavorText": "Beorn's dogs took bowls and platters and knives and wooden spoons and quickly laid them on the trestle tables.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1a1e520-1fe2-4529-8afb-c187bb80da3c.jpg?1785639260"
+    },
+    "colorIdentityOverride": []
 }
 
 // Magnificent End
@@ -1489,6 +1687,46 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Ravenhill Flock
+{
+    "name": "Ravenhill Flock",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhenever you draw a card, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DrawEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "rarity": "UNCOMMON",
+        "artist": "Irina Nordsol",
+        "flavorText": "\"They live many a year, and their memories are long, and they hand on their wisdom to their children. I knew many among the ravens of the rocks when I was a Dwarf-lad.\"\n—Balin",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/acbb4d32-2771-469e-a6de-0df15155cc62.jpg?1784714603"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoriBearerOfFriendsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoriBearerOfFriendsScenarioTest.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dori, Bearer of Friends (HOB #94) — {2}{R} Legendary Creature — Dwarf Warrior 3/2.
+ *
+ * "Trample
+ *  When Dori enters, create a Treasure token."
+ *
+ * The counterpart to Long-Bodied Grey Dog's tapped Treasure — Dori's arrives untapped and is
+ * usable the same turn.
+ */
+class DoriBearerOfFriendsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dori, Bearer of Friends") {
+
+            test("it enters as a 3/2 trampler and makes an untapped Treasure") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dori, Bearer of Friends")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                g.castSpell(1, "Dori, Bearer of Friends").error shouldBe null
+                g.resolveStack()
+
+                val dori = g.findPermanent("Dori, Bearer of Friends")!!
+                withClue("printed characteristics") {
+                    g.state.projectedState.getPower(dori) shouldBe 3
+                    g.state.projectedState.getToughness(dori) shouldBe 2
+                    g.state.projectedState.hasKeyword(dori, Keyword.TRAMPLE) shouldBe true
+                }
+
+                val treasure = g.findPermanent("Treasure")
+                    ?: error("no Treasure token was created")
+                withClue("Dori's Treasure is not tapped") {
+                    g.state.getEntity(treasure)?.get<TappedComponent>() shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GreatFierceBeeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GreatFierceBeeScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Great Fierce Bee (HOB #73) — {2}{B} Creature — Insect 2/2.
+ *
+ * "Flying
+ *  Whenever one or more other creatures die, scry 1."
+ *
+ * The trigger is the *batched* death shape, so what these tests pin down is how often it fires:
+ * once per death batch (not once per creature), for any player's creatures, and never for the
+ * Bee's own death alone.
+ */
+class GreatFierceBeeScenarioTest : ScenarioTestBase() {
+
+    /** Resolves the stack, answering any scry prompts, and returns how many scrys happened. */
+    private fun resolveCountingScrys(g: TestGame): Int {
+        var scrys = 0
+        var guard = 0
+        g.resolveStack()
+        while (g.getPendingDecision() != null && guard++ < 12) {
+            when (g.getPendingDecision()) {
+                is SelectCardsDecision -> {
+                    scrys++
+                    g.skipSelection() // scry: keep the card on top
+                }
+                is ReorderLibraryDecision -> g.keepLibraryOrder()
+                else -> break
+            }
+            g.resolveStack()
+        }
+        return scrys
+    }
+
+    init {
+        context("Great Fierce Bee") {
+
+            test("a single other creature dying scrys once") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Great Fierce Bee")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = g.findPermanent("Grizzly Bears")!!
+                g.castSpell(1, "Lightning Bolt", bears).error shouldBe null
+
+                withClue("an opponent's creature dying still counts — the trigger is unscoped") {
+                    resolveCountingScrys(g) shouldBe 1
+                }
+                g.isOnBattlefield("Grizzly Bears") shouldBe false
+            }
+
+            test("a board wipe killing several creatures — including the Bee — scrys exactly once") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Great Fierce Bee")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Wrath of God")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                g.castSpell(1, "Wrath of God").error shouldBe null
+
+                withClue("batched trigger: one scry for the whole death batch, not one per creature") {
+                    resolveCountingScrys(g) shouldBe 1
+                }
+                withClue("CR 603.10 — the Bee died in the same batch and still saw the other deaths") {
+                    g.isOnBattlefield("Great Fierce Bee") shouldBe false
+                }
+            }
+
+            test("the Bee dying on its own does not scry") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Great Fierce Bee")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bee = g.findPermanent("Great Fierce Bee")!!
+                g.castSpell(2, "Lightning Bolt", bee).error shouldBe null
+
+                withClue("\"other creatures\" excludes the source itself") {
+                    resolveCountingScrys(g) shouldBe 0
+                }
+                g.isOnBattlefield("Great Fierce Bee") shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LittleBearScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LittleBearScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Little Bear (HOB #128) — {2}{G} Creature — Bear 3/2.
+ *
+ * "Flash
+ *  When this creature enters, untap another target creature you control. If that creature is a
+ *  Bear, put a +1/+1 counter on it."
+ *
+ * Covers the untap, the Bear-only counter rider, and that the target requirement excludes
+ * Little Bear itself.
+ */
+class LittleBearScenarioTest : ScenarioTestBase() {
+
+    private fun isTapped(game: TestGame, id: EntityId): Boolean =
+        game.state.getEntity(id)?.get<TappedComponent>() != null
+
+    private fun game(otherCreature: String) = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Little Bear")
+        .withCardOnBattlefield(1, otherCreature, tapped = true)
+        .withLandsOnBattlefield(1, "Forest", 3)
+        .withActivePlayer(1)
+        .withPriorityPlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        context("Little Bear") {
+
+            test("a tapped Bear is untapped and gets a +1/+1 counter") {
+                val g = game("Grizzly Bears")
+                val bears = g.findPermanent("Grizzly Bears")!!
+                isTapped(g, bears) shouldBe true
+
+                g.castSpell(1, "Little Bear").error shouldBe null
+                g.resolveStack()
+                g.selectTargets(listOf(bears)).error shouldBe null
+                g.resolveStack()
+
+                withClue("the target was untapped") {
+                    isTapped(g, bears) shouldBe false
+                }
+                withClue("Grizzly Bears is a Bear, so it also grew to 3/3") {
+                    g.state.projectedState.getPower(bears) shouldBe 3
+                    g.state.projectedState.getToughness(bears) shouldBe 3
+                }
+            }
+
+            test("a tapped non-Bear is untapped but gets no counter") {
+                val g = game("Old Thrush")
+                val thrush = g.findPermanent("Old Thrush")!!
+                isTapped(g, thrush) shouldBe true
+
+                g.castSpell(1, "Little Bear").error shouldBe null
+                g.resolveStack()
+                g.selectTargets(listOf(thrush)).error shouldBe null
+                g.resolveStack()
+
+                withClue("the target was untapped regardless of its type") {
+                    isTapped(g, thrush) shouldBe false
+                }
+                withClue("a Bird is not a Bear, so its printed 1/2 is unchanged") {
+                    g.state.projectedState.getPower(thrush) shouldBe 1
+                    g.state.projectedState.getToughness(thrush) shouldBe 2
+                }
+            }
+
+            test("Little Bear cannot target itself") {
+                val g = game("Grizzly Bears")
+
+                g.castSpell(1, "Little Bear").error shouldBe null
+                g.resolveStack()
+
+                val decision = g.getPendingDecision()
+                val legal = when (decision) {
+                    is ChooseTargetsDecision -> decision.legalTargets.values.flatten()
+                    else -> error("expected a target choice, got $decision")
+                }
+                withClue("\"another target creature you control\" excludes the source") {
+                    legal shouldNotContain g.findPermanent("Little Bear")!!
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LongBodiedGreyDogScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LongBodiedGreyDogScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Long-Bodied Grey Dog (HOB #1) — {3} Creature — Dog 2/2.
+ *
+ * "Flash
+ *  Reach
+ *  When this creature enters, create a tapped Treasure token."
+ *
+ * Covers the printed keywords, the flash timing (castable on the opponent's turn), and that the
+ * Treasure arrives *tapped*.
+ */
+class LongBodiedGreyDogScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Long-Bodied Grey Dog") {
+
+            test("it enters as a 2/2 with reach and makes a tapped Treasure") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Long-Bodied Grey Dog")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                g.castSpell(1, "Long-Bodied Grey Dog").error shouldBe null
+                g.resolveStack()
+
+                val dog = g.findPermanent("Long-Bodied Grey Dog")!!
+                withClue("printed characteristics") {
+                    g.state.projectedState.getPower(dog) shouldBe 2
+                    g.state.projectedState.getToughness(dog) shouldBe 2
+                    g.state.projectedState.hasKeyword(dog, Keyword.REACH) shouldBe true
+                }
+
+                val treasure = g.findPermanent("Treasure")
+                    ?: error("no Treasure token was created")
+                withClue("the Treasure enters tapped") {
+                    g.state.getEntity(treasure)?.get<TappedComponent>() shouldBe TappedComponent
+                }
+            }
+
+            test("flash lets it be cast on the opponent's turn") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Long-Bodied Grey Dog")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                g.castSpell(1, "Long-Bodied Grey Dog").error shouldBe null
+                g.resolveStack()
+
+                g.isOnBattlefield("Long-Bodied Grey Dog") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RavenhillFlockScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RavenhillFlockScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ravenhill Flock (HOB #52) — {3}{U} Creature — Bird 1/2.
+ *
+ * "Flying
+ *  Whenever you draw a card, put a +1/+1 counter on this creature."
+ *
+ * The trigger fires per individual card drawn (CR 121.2), so a "draw two" puts on two counters;
+ * an opponent's draw puts on none.
+ */
+class RavenhillFlockScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Ravenhill Flock") {
+
+            test("it is a 1/2 flier") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ravenhill Flock")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val flock = g.findPermanent("Ravenhill Flock")!!
+                g.state.projectedState.getPower(flock) shouldBe 1
+                g.state.projectedState.getToughness(flock) shouldBe 2
+                g.state.projectedState.hasKeyword(flock, Keyword.FLYING) shouldBe true
+            }
+
+            test("drawing two cards puts on two counters") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ravenhill Flock")
+                    .withCardInHand(1, "Divination")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val flock = g.findPermanent("Ravenhill Flock")!!
+                g.castSpell(1, "Divination").error shouldBe null
+                g.resolveStack()
+
+                withClue("the trigger fires once per card drawn, not once per draw effect") {
+                    plusOneCounters(g, flock) shouldBe 2
+                    g.state.projectedState.getPower(flock) shouldBe 3
+                    g.state.projectedState.getToughness(flock) shouldBe 4
+                }
+            }
+
+            test("an opponent drawing puts on nothing") {
+                val g = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ravenhill Flock")
+                    .withCardInHand(2, "Divination")
+                    .withLandsOnBattlefield(2, "Island", 3)
+                    .withCardInLibrary(2, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val flock = g.findPermanent("Ravenhill Flock")!!
+                g.castSpell(2, "Divination").error shouldBe null
+                g.resolveStack()
+
+                withClue("\"whenever you draw\" is scoped to the Flock's controller") {
+                    plusOneCounters(g, flock) shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements five of The Hobbit's simpler cards. All five are HOB-only printings on Scryfall, so each canonical `CardDefinition` lives in `definitions/hob/cards/` — `just check-card-printing` is clean for all of them.

| Card | Cost | Text |
|---|---|---|
| Long-Bodied Grey Dog | `{3}` | Flash, reach; ETB create a **tapped** Treasure |
| Great Fierce Bee | `{2}{B}` | Flying; whenever one or more **other** creatures die, scry 1 |
| Ravenhill Flock | `{3}{U}` | Flying; whenever you draw a card, +1/+1 counter on it |
| Dori, Bearer of Friends | `{2}{R}` | Trample; ETB create a Treasure |
| Little Bear | `{2}{G}` | Flash; ETB untap another target creature you control — if it's a Bear, +1/+1 counter on it |

No new SDK vocabulary — everything composes existing primitives.

### Two modelling notes

**Great Fierce Bee** uses the *batched* death trigger, `OneOrMoreCreaturesYouControlDie(filter = Creature.anyController(), excludeSelf = true)`. The per-creature `AnyCreatureDies` shape would over-scry on mass removal; the batched shape fires once per death batch (CR 603.3b), and `anyController()` widens it past "you control" to match the unscoped oracle text. The test pins all three axes: one death → one scry, a `Wrath of God` killing three (the Bee included) → still exactly one scry, and the Bee dying alone → none.

**Little Bear**'s "if that creature is a Bear" rider is a `ConditionalEffect` over `Conditions.TargetMatchesFilter(Creature.withSubtype(BEAR))` on the untap target, so the untap always happens and only the counter is gated.

### Token art

The Hobbit is too new to appear in the bulk `tokens.json` sync, so the set now declares a hand-authored `TokenPrinting` for its Treasure (`thob` #12) — the token both Long-Bodied Grey Dog and Dori mint. It can be dropped whenever `just token-art-sync` picks the same art up.

### Verification

- `just build` — green (full compile + all module tests).
- `just check` — green.
- 12 new scenario tests, one file per card, all passing.
- `just check-card-printing` — clean for all five.
- Card fields re-verified field-by-field against Scryfall (`hob` printing); every `imageUri` returns HTTP 200.
- Backlog ticked and `just fix-backlog` resynced the header (43 → 48 / 193).

🤖 Generated with [Claude Code](https://claude.com/claude-code)