### PR TITLE
Collapse the *OrPay additional-cost family into one AdditionalCost.OrPay

### DIFF
--- a/backlog/sdk-reusability-consolidation.md
+++ b/backlog/sdk-reusability-consolidation.md
@@ -339,8 +339,12 @@ ZoneChange/SpellCast/Attack/DealsDamage variants:
 
 ### Costs (`scripting/AdditionalCost.kt`, `scripting/costs/PayCost.kt`)
 
-- **`AdditionalCost.BlightOrPay`** / **`BeholdOrPay`** → wrap any cost with
-  `OrPayMana(inner: AdditionalCost, manaCost: String)`.
+- ~~**`AdditionalCost.BeholdOrPay`** → wrap any cost with
+  `OrPayMana(inner: AdditionalCost, manaCost: String)`.~~ **Done** — landed as
+  `AdditionalCost.OrPay(cost: AdditionalCost, alternativeManaCost: String)`, which also
+  absorbed the `SacrificeOrPay` / `DiscardOrPay` / `ExileFromGraveyardOrPay` types.
+  `BlightOrPay` is the one holdout: there is no standalone blight `AdditionalCost` for
+  `OrPay` to wrap, so collapsing it means introducing one first.
 - **Strategic:** `AdditionalCost` (cast-time) and `PayCost` (activation-time) share
   concepts but neither references the other. Eventually unify under a single `Cost`
   sealed interface — flag, not an immediate change.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -463,34 +463,41 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   mana cost is waived — `GrantMayCastFromLinkedExile(withoutPayingManaCost = true, additionalCost =
   Costs.additional.PayLifeEqualToManaValueOfSpell)` — so the only cost paid is the life. The amount is
   read from the cast card's mana value, checked at cast time (CR 119.4 — must have at least that much life).
-- `Costs.additional.CostOrPay(atom, alternativeManaCost)` — **cost-vs-mana**: "as an additional cost
-  to cast this spell, \<pay this cost\> **or** pay {mana}". One `AdditionalCost.CostOrPay` covers the
-  whole "do X or pay {N}" family over the shared `CostAtom` vocabulary; the named shapes below are
-  its printed wordings and are one-line facades over it. The enumerator offers up to two cast paths:
-  the **atom path** (base cost + the atom's ordinary selection prompt — the same `costType` a plain
-  atom cost of that kind emits, so no new client UI) and the **pay path** (base cost +
-  `alternativeManaCost` folded in). The atom path is offered only when the board affords the atom's
-  selection, so with nothing to pay it only the pay path is castable — but the cost as a whole is
-  always payable. Which leg was taken is recovered at payment time from **which
-  `additionalCostPayment` field the client populated**, so `atom` must be a selection-carrying atom
-  (`Sacrifice` / `Discard` / `ExileFrom` / `TapPermanents` / `ReturnToHand`) and must not share its
-  field with another additional cost on the same card. `CastSpellHandler.reduceCostAlternatives`
-  then rewrites the cost to a plain `AdditionalCost.Atom` (leg paid) or drops it (pay path), so
-  validation, payment, LKI snapshots and discard tracking (CR 701.8) reuse the atom paths verbatim.
-  `BlightOrPay` / `BeholdOrPay` stay separate types because blight and behold aren't `CostAtom`s.
+- `Costs.additional.OrPay(cost, alternativeManaCost)` — **cost-vs-mana**: "as an additional cost
+  to cast this spell, \<pay this cost\> **or** pay {mana}". One `AdditionalCost.OrPay` covers the
+  whole "do X or pay {N}" family, parameterized by the `AdditionalCost` on the non-mana leg; the
+  named shapes below are its printed wordings and are one-line facades over it. The enumerator
+  offers up to two cast paths: the **leg path** (base cost + the leg cost's ordinary selection
+  prompt — the same `costType` that cost emits standing alone, so no new client UI) and the **pay
+  path** (base cost + `alternativeManaCost` folded in). The leg path is offered only when the board
+  affords the leg's selection, so with nothing to pay it only the pay path is castable — but the
+  cost as a whole is always payable. Which leg was taken is recovered at payment time from **which
+  `additionalCostPayment` field the client populated**, so `cost` must be a selection-carrying cost
+  — a `Behold`, or an atom cost over `Sacrifice` / `Discard` / `ExileFrom` / `TapPermanents` /
+  `ReturnToHand` — and must not share its field with another additional cost on the same card.
+  `CastSpellHandler.reduceCostAlternatives` then rewrites the whole cost to that plain leg cost (leg
+  paid) or drops it (pay path), so validation, payment, LKI snapshots, behold's pipeline storage and
+  discard tracking (CR 701.8) reuse the leg's own paths verbatim. `BlightOrPay` stays a separate
+  type only because there is no standalone blight `AdditionalCost` for `OrPay` to wrap.
+- `Costs.additional.BeholdOrPay(filter = Filters.Any, alternativeManaCost, storeAs = "beheld")` —
+  "behold a [filter] or pay {mana}" (Lys Alana Dignitary). `OrPay(AdditionalCost.Behold(filter,
+  storeAs = storeAs), …)`; the behold path surfaces as a `costType = "Behold"` cost over one
+  candidate pool spanning battlefield *and* hand, and stores the chosen cards under `storeAs` for
+  downstream costs/effects exactly as a plain `Behold` does.
 - `Costs.additional.ExileFromGraveyardOrPay(exileCount, alternativeManaCost, filter = Filters.Any)`
   — "exile N cards from your graveyard or pay {mana}" (Soaring Stoneglider: "exile two cards from
-  your graveyard or pay {1}{W}"). `CostOrPay(CostAtom.ExileFrom(GRAVEYARD, filter, exileCount), …)`;
+  your graveyard or pay {1}{W}"). `OrPay(Atom(CostAtom.ExileFrom(GRAVEYARD, filter, exileCount)), …)`;
   the exile path surfaces as a `costType = "ExileFromGraveyard"` cost and is offered only when the
-  graveyard holds at least `exileCount` matching cards.
+  graveyard holds at least `exileCount` matching cards. That `costType` pins the client's picker to
+  the graveyard, so an `ExileFrom` leg on any other zone is declined (pay path only).
 - `Costs.additional.SacrificeOrPay(filter = Filters.Any, alternativeManaCost, count = 1)` —
   "sacrifice a [filter] or pay {mana}" (Louisoix's Sacrifice: "sacrifice a legendary creature or pay
-  {2}"). `CostOrPay(CostAtom.Sacrifice(filter, count), …)`; the sacrifice path surfaces as a
+  {2}"). `OrPay(Atom(CostAtom.Sacrifice(filter, count)), …)`; the sacrifice path surfaces as a
   `costType = "SacrificePermanent"` cost (the on-battlefield picker Natural Order uses) and is
   offered only when you control at least `count` matching permanents.
 - `Costs.additional.DiscardOrPay(alternativeManaCost, filter = Filters.Any, count = 1)` — "discard a
   [filter] or pay {mana}" (Pumpkin Bombardment: "discard a card or pay {2}").
-  `CostOrPay(CostAtom.Discard(count, filter), …)`; the discard path surfaces as a `costType =
+  `OrPay(Atom(CostAtom.Discard(count, filter)), …)`; the discard path surfaces as a `costType =
   "DiscardCard"` cost (the hand picker Force of Will uses), excludes the spell being cast, and is
   offered only when you hold at least `count` other matching cards. The discard-as-cost still feeds
   the turn's discard tracking (CR 701.8), so it counts toward
@@ -499,8 +506,8 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   spell, pay exactly one of `options`" (Souls of the Lost: *"discard a card **or** sacrifice a
   permanent"*). The general, parameterized form of `Forage` — each option is itself an
   `AdditionalCost` (compose the `Sacrifice` / `Discard` / `ExileFrom` atoms). Distinct from the
-  `*OrPay` family (`CostOrPay` and its `SacrificeOrPay` / `DiscardOrPay` / `ExileFromGraveyardOrPay`
-  wordings, plus `BeholdOrPay` / `BlightOrPay`): those
+  `OrPay` family (`OrPay` and its `SacrificeOrPay` / `DiscardOrPay` / `ExileFromGraveyardOrPay` /
+  `BeholdOrPay` wordings, plus `BlightOrPay`): those
   fold a **mana** alternative into the spell's cost, whereas `Choice` is for options that are each
   independently payable **non-mana** costs (no mana-cost change). The enumerator emits **one cast
   action per payable option** (`CastSpellEnumerator.expandChoiceAdditionalCosts` +
@@ -847,7 +854,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   choose a matching permanent they control **or** reveal a matching card from hand (revealing emits
   `CardsRevealedEvent`; battlefield permanents are merely chosen). If they decline, or control no
   matching permanent and hold no matching card, `ifBeheld` does not run. Distinct from the cast-time
-  `AdditionalCost.Behold` / `AdditionalCost.BeholdOrPay` (which behold as a casting cost). Sarkhan,
+  `AdditionalCost.Behold` (on its own or as an `AdditionalCost.OrPay` leg — beholding as a casting
+  cost). Sarkhan,
   Dragon Ascendant ETB: `Effects.Behold(GameObjectFilter.Any.withSubtype(Subtype.DRAGON),
   ifBeheld = Effects.CreateTreasure())`.
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -463,52 +463,51 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   mana cost is waived — `GrantMayCastFromLinkedExile(withoutPayingManaCost = true, additionalCost =
   Costs.additional.PayLifeEqualToManaValueOfSpell)` — so the only cost paid is the life. The amount is
   read from the cast card's mana value, checked at cast time (CR 119.4 — must have at least that much life).
+- `Costs.additional.CostOrPay(atom, alternativeManaCost)` — **cost-vs-mana**: "as an additional cost
+  to cast this spell, \<pay this cost\> **or** pay {mana}". One `AdditionalCost.CostOrPay` covers the
+  whole "do X or pay {N}" family over the shared `CostAtom` vocabulary; the named shapes below are
+  its printed wordings and are one-line facades over it. The enumerator offers up to two cast paths:
+  the **atom path** (base cost + the atom's ordinary selection prompt — the same `costType` a plain
+  atom cost of that kind emits, so no new client UI) and the **pay path** (base cost +
+  `alternativeManaCost` folded in). The atom path is offered only when the board affords the atom's
+  selection, so with nothing to pay it only the pay path is castable — but the cost as a whole is
+  always payable. Which leg was taken is recovered at payment time from **which
+  `additionalCostPayment` field the client populated**, so `atom` must be a selection-carrying atom
+  (`Sacrifice` / `Discard` / `ExileFrom` / `TapPermanents` / `ReturnToHand`) and must not share its
+  field with another additional cost on the same card. `CastSpellHandler.reduceCostAlternatives`
+  then rewrites the cost to a plain `AdditionalCost.Atom` (leg paid) or drops it (pay path), so
+  validation, payment, LKI snapshots and discard tracking (CR 701.8) reuse the atom paths verbatim.
+  `BlightOrPay` / `BeholdOrPay` stay separate types because blight and behold aren't `CostAtom`s.
 - `Costs.additional.ExileFromGraveyardOrPay(exileCount, alternativeManaCost, filter = Filters.Any)`
-  — "as an additional cost to cast this spell, exile N cards from your graveyard or pay {mana}"
-  (Soaring Stoneglider: "exile two cards from your graveyard or pay {1}{W}"). The sibling of the
-  `BlightOrPay` / `BeholdOrPay` "do X or pay mana" shapes. The enumerator offers up to two cast
-  paths: the **exile path** (base cost + a graveyard-card selection of exactly `exileCount` cards
-  matching `filter`, surfaced as a `costType = "ExileFromGraveyard"` cost — the same client picker
-  used by a mandatory graveyard-exile cost) and the **pay path** (base cost + `alternativeManaCost`
-  folded in). The chosen path is recovered at payment time from whether the cast action's
-  `additionalCostPayment.exiledCards` is non-empty; the exile path is only offered when the
+  — "exile N cards from your graveyard or pay {mana}" (Soaring Stoneglider: "exile two cards from
+  your graveyard or pay {1}{W}"). `CostOrPay(CostAtom.ExileFrom(GRAVEYARD, filter, exileCount), …)`;
+  the exile path surfaces as a `costType = "ExileFromGraveyard"` cost and is offered only when the
   graveyard holds at least `exileCount` matching cards.
-- `Costs.additional.SacrificeOrPay(filter = Filters.Any, alternativeManaCost, count = 1)` — "as an
-  additional cost to cast this spell, sacrifice a [filter] or pay {mana}" (Louisoix's Sacrifice:
-  "sacrifice a legendary creature or pay {2}"). The sibling of `ExileFromGraveyardOrPay` /
-  `BlightOrPay` / `BeholdOrPay` for the "sacrifice a permanent or pay mana" shape. The enumerator
-  offers up to two cast paths: the **sacrifice path** (base cost + a battlefield selection of
-  exactly `count` permanents you control matching `filter`, surfaced as a `costType =
-  "SacrificePermanent"` cost — the same on-battlefield picker used by a plain sacrifice cost like
-  Natural Order) and the **pay path** (base cost + `alternativeManaCost` folded in). The chosen path
-  is recovered at payment time from whether the cast action's `additionalCostPayment.sacrificedPermanents`
-  is non-empty; the sacrifice path is only offered when you control at least `count` matching
-     permanents, so with nothing to sacrifice only the pay path is castable.
-- `Costs.additional.DiscardOrPay(alternativeManaCost, filter = Filters.Any, count = 1)` — "as an
-  additional cost to cast this spell, discard a [filter] or pay {mana}" (Pumpkin Bombardment:
-  "discard a card or pay {2}"). The sibling of `SacrificeOrPay` / `ExileFromGraveyardOrPay` /
-  `BlightOrPay` / `BeholdOrPay` for the "discard a card or pay mana" shape. The enumerator offers up
-  to two cast paths: the **discard path** (base cost + a hand selection of exactly `count` cards
-  matching `filter`, excluding the spell being cast, surfaced as a `costType = "DiscardCard"` cost —
-  the same hand picker used by a plain discard cost like Force of Will) and the **pay path** (base
-  cost + `alternativeManaCost` folded in). The chosen path is recovered at payment time from whether
-  the cast action's `additionalCostPayment.discardedCards` is non-empty; the discard path is only
-  offered when you hold at least `count` other matching cards, so with an empty hand only the pay
-  path is castable. The discard-as-cost still feeds the turn's discard tracking (CR 701.8), so it
-  counts toward `DynamicAmounts.cardsDiscardedThisTurn()` / `Conditions.YouDiscardedThisCardThisTurn`
-  (Mayhem).
+- `Costs.additional.SacrificeOrPay(filter = Filters.Any, alternativeManaCost, count = 1)` —
+  "sacrifice a [filter] or pay {mana}" (Louisoix's Sacrifice: "sacrifice a legendary creature or pay
+  {2}"). `CostOrPay(CostAtom.Sacrifice(filter, count), …)`; the sacrifice path surfaces as a
+  `costType = "SacrificePermanent"` cost (the on-battlefield picker Natural Order uses) and is
+  offered only when you control at least `count` matching permanents.
+- `Costs.additional.DiscardOrPay(alternativeManaCost, filter = Filters.Any, count = 1)` — "discard a
+  [filter] or pay {mana}" (Pumpkin Bombardment: "discard a card or pay {2}").
+  `CostOrPay(CostAtom.Discard(count, filter), …)`; the discard path surfaces as a `costType =
+  "DiscardCard"` cost (the hand picker Force of Will uses), excludes the spell being cast, and is
+  offered only when you hold at least `count` other matching cards. The discard-as-cost still feeds
+  the turn's discard tracking (CR 701.8), so it counts toward
+  `DynamicAmounts.cardsDiscardedThisTurn()` / `Conditions.YouDiscardedThisCardThisTurn` (Mayhem).
 - `Costs.additional.Choice(vararg options)` — **cost-vs-cost**: "as an additional cost to cast this
   spell, pay exactly one of `options`" (Souls of the Lost: *"discard a card **or** sacrifice a
   permanent"*). The general, parameterized form of `Forage` — each option is itself an
   `AdditionalCost` (compose the `Sacrifice` / `Discard` / `ExileFrom` atoms). Distinct from the
-  `*OrPay` family (`SacrificeOrPay` / `DiscardOrPay` / `ExileFromGraveyardOrPay` / `BeholdOrPay` / `BlightOrPay`): those
+  `*OrPay` family (`CostOrPay` and its `SacrificeOrPay` / `DiscardOrPay` / `ExileFromGraveyardOrPay`
+  wordings, plus `BeholdOrPay` / `BlightOrPay`): those
   fold a **mana** alternative into the spell's cost, whereas `Choice` is for options that are each
   independently payable **non-mana** costs (no mana-cost change). The enumerator emits **one cast
   action per payable option** (`CastSpellEnumerator.expandChoiceAdditionalCosts` +
   `ChoiceCostResolver`), each carrying that option's existing picker (`SacrificePermanent` /
   `DiscardCard` / `ExileFromGraveyard`) — so the caster picks the sub-cost by choosing which action to
   play, with **no new client UI**. The plain (un-expanded) base action is dropped, since a mandatory
-  choice cost can't be skipped. At payment time `CastSpellHandler.reduceChoiceCosts` collapses the
+  choice cost can't be skipped. At payment time `CastSpellHandler.reduceCostAlternatives` collapses the
   `Choice` to the single option the caller populated (or, for a server-initiated free/AI cast with no
   payment, the first payable option — mirroring `ForageCostResolver`'s engine-direct fallback), so
   validation, application, and the free-cast selection pause all handle it as a plain atom. Keep the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -528,21 +528,24 @@ object Costs {
             storeAs: String = "beheld"
         ): AdditionalCost = AdditionalCost.Behold(filter, count, storeAs)
 
-        /** Behold a [filter] card or pay [alternativeManaCost] instead. */
+        /**
+         * Pay [cost] or pay [alternativeManaCost] instead — the general "do X or pay {N}" shape
+         * ([AdditionalCost.OrPay]). [cost] must be a selection-carrying cost: a [Behold], or an
+         * atom cost over sacrifice / discard / exile-from-a-zone / tap / return-to-hand. The named
+         * shapes below are the printed wordings, and a new one is a one-line facade over this.
+         */
+        fun OrPay(cost: AdditionalCost, alternativeManaCost: String): AdditionalCost =
+            AdditionalCost.OrPay(cost, alternativeManaCost)
+
+        /** Behold a [filter] card or pay [alternativeManaCost] instead (Lys Alana Dignitary). */
         fun BeholdOrPay(
             filter: GameObjectFilter = GameObjectFilter.Any,
             alternativeManaCost: String,
             storeAs: String = "beheld"
-        ): AdditionalCost = AdditionalCost.BeholdOrPay(filter, alternativeManaCost, storeAs)
-
-        /**
-         * Pay [atom] or pay [alternativeManaCost] instead — the general "do X or pay {N}" shape
-         * ([AdditionalCost.CostOrPay]). [atom] must be a selection-carrying atom (sacrifice,
-         * discard, exile from a zone, tap, return to hand); the named shapes below are the printed
-         * wordings, and a new one is a one-line facade over this.
-         */
-        fun CostOrPay(atom: CostAtom, alternativeManaCost: String): AdditionalCost =
-            AdditionalCost.CostOrPay(atom, alternativeManaCost)
+        ): AdditionalCost = OrPay(
+            AdditionalCost.Behold(filter, count = 1, storeAs = storeAs),
+            alternativeManaCost
+        )
 
         /**
          * Exile [exileCount] cards matching [filter] from your graveyard, or pay
@@ -552,8 +555,8 @@ object Costs {
             exileCount: Int,
             alternativeManaCost: String,
             filter: GameObjectFilter = GameObjectFilter.Any,
-        ): AdditionalCost = CostOrPay(
-            CostAtom.ExileFrom(Zone.GRAVEYARD, filter, exileCount),
+        ): AdditionalCost = OrPay(
+            AdditionalCost.Atom(CostAtom.ExileFrom(Zone.GRAVEYARD, filter, exileCount)),
             alternativeManaCost
         )
 
@@ -565,7 +568,10 @@ object Costs {
             filter: GameObjectFilter = GameObjectFilter.Any,
             alternativeManaCost: String,
             count: Int = 1,
-        ): AdditionalCost = CostOrPay(CostAtom.Sacrifice(filter, count), alternativeManaCost)
+        ): AdditionalCost = OrPay(
+            AdditionalCost.Atom(CostAtom.Sacrifice(filter, count)),
+            alternativeManaCost
+        )
 
         /**
          * Discard [count] card(s) matching [filter] from your hand, or pay
@@ -575,7 +581,10 @@ object Costs {
             alternativeManaCost: String,
             filter: GameObjectFilter = GameObjectFilter.Any,
             count: Int = 1,
-        ): AdditionalCost = CostOrPay(CostAtom.Discard(count, filter), alternativeManaCost)
+        ): AdditionalCost = OrPay(
+            AdditionalCost.Atom(CostAtom.Discard(count, filter)),
+            alternativeManaCost
+        )
 
         /** "Behold a [filter] and exile it" — [Behold] + [ExileFromStorage] composed. */
         fun BeholdAndExile(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -536,6 +536,15 @@ object Costs {
         ): AdditionalCost = AdditionalCost.BeholdOrPay(filter, alternativeManaCost, storeAs)
 
         /**
+         * Pay [atom] or pay [alternativeManaCost] instead — the general "do X or pay {N}" shape
+         * ([AdditionalCost.CostOrPay]). [atom] must be a selection-carrying atom (sacrifice,
+         * discard, exile from a zone, tap, return to hand); the named shapes below are the printed
+         * wordings, and a new one is a one-line facade over this.
+         */
+        fun CostOrPay(atom: CostAtom, alternativeManaCost: String): AdditionalCost =
+            AdditionalCost.CostOrPay(atom, alternativeManaCost)
+
+        /**
          * Exile [exileCount] cards matching [filter] from your graveyard, or pay
          * [alternativeManaCost] instead (Soaring Stoneglider).
          */
@@ -543,8 +552,10 @@ object Costs {
             exileCount: Int,
             alternativeManaCost: String,
             filter: GameObjectFilter = GameObjectFilter.Any,
-        ): AdditionalCost =
-            AdditionalCost.ExileFromGraveyardOrPay(exileCount, alternativeManaCost, filter)
+        ): AdditionalCost = CostOrPay(
+            CostAtom.ExileFrom(Zone.GRAVEYARD, filter, exileCount),
+            alternativeManaCost
+        )
 
         /**
          * Sacrifice [count] permanent(s) matching [filter] you control, or pay
@@ -554,8 +565,7 @@ object Costs {
             filter: GameObjectFilter = GameObjectFilter.Any,
             alternativeManaCost: String,
             count: Int = 1,
-        ): AdditionalCost =
-            AdditionalCost.SacrificeOrPay(filter, alternativeManaCost, count)
+        ): AdditionalCost = CostOrPay(CostAtom.Sacrifice(filter, count), alternativeManaCost)
 
         /**
          * Discard [count] card(s) matching [filter] from your hand, or pay
@@ -565,8 +575,7 @@ object Costs {
             alternativeManaCost: String,
             filter: GameObjectFilter = GameObjectFilter.Any,
             count: Int = 1,
-        ): AdditionalCost =
-            AdditionalCost.DiscardOrPay(alternativeManaCost, filter, count)
+        ): AdditionalCost = CostOrPay(CostAtom.Discard(count, filter), alternativeManaCost)
 
         /** "Behold a [filter] and exile it" — [Behold] + [ExileFromStorage] composed. */
         fun BeholdAndExile(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -19,9 +19,10 @@ import kotlinx.serialization.Serializable
  *
  * The payable things shared with the other cost contexts (sacrifice, discard, pay life, exile from a
  * zone, tap permanents) live in the [CostAtom] vocabulary and are carried here by [Atom]. The remaining
- * subtypes are genuinely casting-context-specific: alternative "X or pay mana" shapes (Blight/Behold),
- * pipeline-storage flow (Behold/ExileFromStorage/Composite), per-target life, variable exile, and the
- * cross-zone [ChooseEntity] pick.
+ * subtypes are genuinely casting-context-specific: the "X or pay mana" wrapper ([OrPay], plus
+ * [BlightOrPay] which has no standalone cost to wrap), pipeline-storage flow
+ * (Behold/ExileFromStorage/Composite), per-target life, variable exile, and the cross-zone
+ * [ChooseEntity] pick.
  */
 @Serializable
 sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
@@ -140,9 +141,9 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
      * options compose the same atoms every other cost uses (Sacrifice / Discard / ExileFrom / …).
      *
      * **Boundary — what this is *not*:** [Choice] is for options that are each *independently payable
-     * non-mana costs*. Options where one branch instead pays *additional mana* ("… or pay {2}") are the
-     * separate `*OrPay` family ([CostOrPay], [BeholdOrPay], [BlightOrPay]) — those fold the
-     * alternative into the spell's mana cost, which [Choice] never does.
+     * non-mana costs*. Options where one branch instead pays *additional mana* ("… or pay {2}") are
+     * [OrPay] (and [BlightOrPay], the one shape it can't wrap) — those fold the alternative into the
+     * spell's mana cost, which [Choice] never does.
      * [Forage] (CR 701.61) is the named keyword shortcut for a fixed two-option cost-vs-cost (exile
      * three from your graveyard / sacrifice a Food); [Choice] is its open, parameterized generalization.
      *
@@ -233,9 +234,10 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
      * The enumerator produces two legal actions: one for the blight path (base cost + creature selection)
      * and one for the pay path (base cost + [alternativeManaCost]).
      *
-     * Its own type rather than a [CostOrPay] leg because blighting is not a [CostAtom]: it places
-     * counters on a chosen creature and exposes the amount to the spell's effects
-     * (`ChoiceSlot.BLIGHT_AMOUNT`), neither of which the shared cost vocabulary carries.
+     * Its own type rather than an [OrPay] leg because there is no standalone blight [AdditionalCost]
+     * for [OrPay] to wrap: blighting places counters on a chosen creature and exposes the amount to
+     * the spell's effects (`ChoiceSlot.BLIGHT_AMOUNT`), and only ever appears as this or-pay shape
+     * and as [BlightVariable]. Give it one and this collapses into [OrPay] too.
      *
      * @property blightAmount Number of -1/-1 counters to place
      * @property alternativeManaCost Extra mana to pay instead of blighting (e.g., "{1}")
@@ -291,92 +293,53 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
-     * Behold a matching card or pay additional mana: the caster must either behold
-     * (choose a matching permanent they control or reveal a matching card from their hand)
-     * or pay extra mana on top of the spell's base mana cost. Unlike [BeholdAndExile],
-     * this does not exile the beheld card.
-     * Used by Lorwyn Eclipsed cards (e.g., Lys Alana Dignitary).
-     *
-     * The enumerator produces two legal actions: one for the behold path (base cost +
-     * card selection) and one for the pay path (base cost + [alternativeManaCost]).
-     *
-     * Its own type rather than a [CostOrPay] leg because beholding is not a [CostAtom]: it reveals
-     * from hand, spans battlefield *and* hand in one candidate pool, and feeds pipeline storage —
-     * casting-context behavior the shared cost vocabulary deliberately leaves out.
-     *
-     * @property filter Which cards/permanents can be beheld
-     * @property alternativeManaCost Extra mana to pay instead of beholding (e.g., "{2}")
-     * @property storeAs Pipeline storage key for the chosen cards (unused by cost itself,
-     *   reserved for downstream composition)
-     */
-    @SerialName("BeholdOrPay")
-    @Serializable
-    data class BeholdOrPay(
-        val filter: GameObjectFilter = GameObjectFilter.Any,
-        val alternativeManaCost: String,
-        val storeAs: String = "beheld"
-    ) : AdditionalCost {
-        override val description: String = buildString {
-            append("Behold ")
-            val filterDesc = filter.description
-            val article = if (filterDesc.firstOrNull()?.lowercase() in listOf("a", "e", "i", "o", "u")) "an" else "a"
-            append("$article ")
-            append(filterDesc)
-            append(" or pay ")
-            append(alternativeManaCost)
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Pay [atom], **or** pay [alternativeManaCost] on top of the spell's mana cost — the whole
-     * "do X or pay {N}" shape over the shared [CostAtom] vocabulary. One cost covers every printed
-     * variant: Louisoix's Sacrifice ("sacrifice a legendary creature or pay {2}"), Pumpkin
+     * Pay [cost], **or** pay [alternativeManaCost] on top of the spell's mana cost — the whole
+     * "do X or pay {N}" shape, parameterized by the cost on the non-mana leg. One type covers every
+     * printed variant: Louisoix's Sacrifice ("sacrifice a legendary creature or pay {2}"), Pumpkin
      * Bombardment ("discard a card or pay {2}"), Soaring Stoneglider ("exile two cards from your
-     * graveyard or pay {1}{W}") differ only in which atom sits on the non-mana leg.
+     * graveyard or pay {1}{W}") and Lys Alana Dignitary ("behold an Elf or pay {2}") differ only in
+     * which cost sits on that leg.
      *
-     * The enumerator produces up to two legal actions: the **atom path** (base cost + the atom's
-     * ordinary selection prompt — the same picker a plain [Atom] cost of the same kind uses, so no
-     * new client UI) and the **pay path** (base cost + [alternativeManaCost] folded in). The atom
-     * path is offered only when the board actually affords it — with nothing to sacrifice / discard
-     * / exile, only the pay path is castable. The pay path is always available, so the cost as a
+     * The enumerator produces up to two legal actions: the **leg path** (base cost + [cost]'s
+     * ordinary selection prompt — the same picker that cost uses on its own, so no new client UI)
+     * and the **pay path** (base cost + [alternativeManaCost] folded in). The leg path is offered
+     * only when the board actually affords it — with nothing to sacrifice / discard / exile /
+     * behold, only the pay path is castable. The pay path is always available, so the cost as a
      * whole is always payable.
      *
      * Which leg the caster took is recovered at payment time from **which
      * [AdditionalCostPayment] field the client populated** — the same disambiguation [Choice] uses.
      * Two consequences:
      *
-     *  - [atom] must be a *selection-carrying* atom, i.e. one whose payment lands in its own field:
-     *    [CostAtom.Sacrifice], [CostAtom.Discard], [CostAtom.ExileFrom], [CostAtom.TapPermanents],
-     *    [CostAtom.ReturnToHand]. Atoms that are auto-paid with no selection ([CostAtom.PayLife],
-     *    [CostAtom.Mill]) leave no trace to read the choice from, so they can't sit on this leg.
+     *  - [cost] must be a *selection-carrying* cost, i.e. one whose payment lands in its own field:
+     *    [Behold], or an [Atom] over [CostAtom.Sacrifice], [CostAtom.Discard], [CostAtom.ExileFrom],
+     *    [CostAtom.TapPermanents], [CostAtom.ReturnToHand]. Costs that are auto-paid with no
+     *    selection ([CostAtom.PayLife], [CostAtom.Mill]) leave no trace to read the choice from, so
+     *    they can't sit on this leg.
      *  - Don't pair it on one card with another additional cost that consumes the *same* payment
      *    field (e.g. a mandatory discard cost alongside a "discard a card or pay {2}") — the two
      *    would be indistinguishable.
      *
-     * Once the leg is known, the atom path is paid through the ordinary [Atom] machinery
-     * (`CastSpellHandler` reduces this cost to `Atom(atom)`), so validation, payment, LKI snapshots
-     * and the turn's discard tracking (CR 701.8) all behave exactly as for a plain atom cost.
+     * Once the leg is known, it is paid through [cost]'s own ordinary machinery (`CastSpellHandler`
+     * reduces this to plain `cost`), so validation, payment, LKI snapshots, behold's pipeline
+     * storage and the turn's discard tracking (CR 701.8) all behave exactly as for that cost
+     * standing alone.
      *
-     * @property atom The non-mana leg — what the caster pays instead of the extra mana.
-     * @property alternativeManaCost Extra mana to pay instead of [atom] (e.g. "{2}", "{1}{W}").
+     * @property cost The non-mana leg — what the caster pays instead of the extra mana.
+     * @property alternativeManaCost Extra mana to pay instead of [cost] (e.g. "{2}", "{1}{W}").
      */
-    @SerialName("CostOrPay")
+    @SerialName("OrPay")
     @Serializable
-    data class CostOrPay(
-        val atom: CostAtom,
+    data class OrPay(
+        val cost: AdditionalCost,
         val alternativeManaCost: String,
     ) : AdditionalCost {
-        override val description: String get() =
-            "${atom.description.replaceFirstChar { it.uppercase() }} or pay $alternativeManaCost"
+        // Both Atom and Behold already lead with a capital, as additional-cost clauses do.
+        override val description: String get() = "${cost.description} or pay $alternativeManaCost"
 
         override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newAtom = atom.applyTextReplacement(replacer)
-            return if (newAtom !== atom) copy(atom = newAtom) else this
+            val newCost = cost.applyTextReplacement(replacer)
+            return if (newCost !== cost) copy(cost = newCost) else this
         }
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -141,8 +141,8 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
      *
      * **Boundary — what this is *not*:** [Choice] is for options that are each *independently payable
      * non-mana costs*. Options where one branch instead pays *additional mana* ("… or pay {2}") are the
-     * separate `*OrPay` family ([SacrificeOrPay], [ExileFromGraveyardOrPay], [BeholdOrPay],
-     * [BlightOrPay]) — those fold the alternative into the spell's mana cost, which [Choice] never does.
+     * separate `*OrPay` family ([CostOrPay], [BeholdOrPay], [BlightOrPay]) — those fold the
+     * alternative into the spell's mana cost, which [Choice] never does.
      * [Forage] (CR 701.61) is the named keyword shortcut for a fixed two-option cost-vs-cost (exile
      * three from your graveyard / sacrifice a Food); [Choice] is its open, parameterized generalization.
      *
@@ -233,6 +233,10 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
      * The enumerator produces two legal actions: one for the blight path (base cost + creature selection)
      * and one for the pay path (base cost + [alternativeManaCost]).
      *
+     * Its own type rather than a [CostOrPay] leg because blighting is not a [CostAtom]: it places
+     * counters on a chosen creature and exposes the amount to the spell's effects
+     * (`ChoiceSlot.BLIGHT_AMOUNT`), neither of which the shared cost vocabulary carries.
+     *
      * @property blightAmount Number of -1/-1 counters to place
      * @property alternativeManaCost Extra mana to pay instead of blighting (e.g., "{1}")
      */
@@ -296,6 +300,10 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
      * The enumerator produces two legal actions: one for the behold path (base cost +
      * card selection) and one for the pay path (base cost + [alternativeManaCost]).
      *
+     * Its own type rather than a [CostOrPay] leg because beholding is not a [CostAtom]: it reveals
+     * from hand, spans battlefield *and* hand in one candidate pool, and feeds pipeline storage —
+     * casting-context behavior the shared cost vocabulary deliberately leaves out.
+     *
      * @property filter Which cards/permanents can be beheld
      * @property alternativeManaCost Extra mana to pay instead of beholding (e.g., "{2}")
      * @property storeAs Pipeline storage key for the chosen cards (unused by cost itself,
@@ -325,134 +333,50 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
-     * Exile [exileCount] cards matching [filter] from your graveyard, or pay additional mana:
-     * the caster must either exile that many matching cards from their graveyard, or pay extra mana
-     * on top of the spell's base mana cost. The sibling of [BlightOrPay] / [BeholdOrPay] for the
-     * "exile from graveyard or pay" shape (e.g. Soaring Stoneglider — "exile two cards from your
-     * graveyard or pay {1}{W}").
+     * Pay [atom], **or** pay [alternativeManaCost] on top of the spell's mana cost — the whole
+     * "do X or pay {N}" shape over the shared [CostAtom] vocabulary. One cost covers every printed
+     * variant: Louisoix's Sacrifice ("sacrifice a legendary creature or pay {2}"), Pumpkin
+     * Bombardment ("discard a card or pay {2}"), Soaring Stoneglider ("exile two cards from your
+     * graveyard or pay {1}{W}") differ only in which atom sits on the non-mana leg.
      *
-     * The enumerator produces up to two legal actions: one for the exile path (base cost + card
-     * selection from the graveyard) and one for the pay path (base cost + [alternativeManaCost]).
-     * The exile path is only offered when the graveyard holds at least [exileCount] matching cards.
-     * The chosen path is recovered at payment time from whether
-     * [AdditionalCostPayment.exiledCards] is non-empty.
+     * The enumerator produces up to two legal actions: the **atom path** (base cost + the atom's
+     * ordinary selection prompt — the same picker a plain [Atom] cost of the same kind uses, so no
+     * new client UI) and the **pay path** (base cost + [alternativeManaCost] folded in). The atom
+     * path is offered only when the board actually affords it — with nothing to sacrifice / discard
+     * / exile, only the pay path is castable. The pay path is always available, so the cost as a
+     * whole is always payable.
      *
-     * @property exileCount How many matching cards to exile from the graveyard
-     * @property alternativeManaCost Extra mana to pay instead of exiling (e.g., "{1}{W}")
-     * @property filter Which graveyard cards qualify (default any card)
+     * Which leg the caster took is recovered at payment time from **which
+     * [AdditionalCostPayment] field the client populated** — the same disambiguation [Choice] uses.
+     * Two consequences:
+     *
+     *  - [atom] must be a *selection-carrying* atom, i.e. one whose payment lands in its own field:
+     *    [CostAtom.Sacrifice], [CostAtom.Discard], [CostAtom.ExileFrom], [CostAtom.TapPermanents],
+     *    [CostAtom.ReturnToHand]. Atoms that are auto-paid with no selection ([CostAtom.PayLife],
+     *    [CostAtom.Mill]) leave no trace to read the choice from, so they can't sit on this leg.
+     *  - Don't pair it on one card with another additional cost that consumes the *same* payment
+     *    field (e.g. a mandatory discard cost alongside a "discard a card or pay {2}") — the two
+     *    would be indistinguishable.
+     *
+     * Once the leg is known, the atom path is paid through the ordinary [Atom] machinery
+     * (`CastSpellHandler` reduces this cost to `Atom(atom)`), so validation, payment, LKI snapshots
+     * and the turn's discard tracking (CR 701.8) all behave exactly as for a plain atom cost.
+     *
+     * @property atom The non-mana leg — what the caster pays instead of the extra mana.
+     * @property alternativeManaCost Extra mana to pay instead of [atom] (e.g. "{2}", "{1}{W}").
      */
-    @SerialName("ExileFromGraveyardOrPay")
+    @SerialName("CostOrPay")
     @Serializable
-    data class ExileFromGraveyardOrPay(
-        val exileCount: Int,
+    data class CostOrPay(
+        val atom: CostAtom,
         val alternativeManaCost: String,
-        val filter: GameObjectFilter = GameObjectFilter.Any,
     ) : AdditionalCost {
-        override val description: String = buildString {
-            append("Exile $exileCount ")
-            append(filter.description)
-            append(if (exileCount == 1) " card from your graveyard or pay " else " cards from your graveyard or pay ")
-            append(alternativeManaCost)
-        }
+        override val description: String get() =
+            "${atom.description.replaceFirstChar { it.uppercase() }} or pay $alternativeManaCost"
 
         override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Sacrifice [count] permanent(s) matching [filter] you control, or pay additional mana: the
-     * caster must either sacrifice that many matching permanents, or pay extra mana on top of the
-     * spell's base mana cost. The sibling of [BlightOrPay] / [BeholdOrPay] /
-     * [ExileFromGraveyardOrPay] for the "sacrifice a permanent or pay" shape (e.g. Louisoix's
-     * Sacrifice — "sacrifice a legendary creature or pay {2}").
-     *
-     * The enumerator produces up to two legal actions: one for the sacrifice path (base cost +
-     * permanent selection from the battlefield, surfaced with `costType = "SacrificePermanent"`
-     * like Natural Order's plain sacrifice cost) and one for the pay path (base cost +
-     * [alternativeManaCost]). The sacrifice path is only offered when the caster controls at least
-     * [count] permanents matching [filter]. The chosen path is recovered at payment time from
-     * whether [AdditionalCostPayment.sacrificedPermanents] is non-empty.
-     *
-     * @property filter Which permanents you control qualify (e.g. legendary creature)
-     * @property alternativeManaCost Extra mana to pay instead of sacrificing (e.g. "{2}")
-     * @property count How many matching permanents to sacrifice on the sacrifice path
-     */
-    @SerialName("SacrificeOrPay")
-    @Serializable
-    data class SacrificeOrPay(
-        val filter: GameObjectFilter = GameObjectFilter.Any,
-        val alternativeManaCost: String,
-        val count: Int = 1,
-    ) : AdditionalCost {
-        override val description: String = buildString {
-            append("Sacrifice ")
-            if (count == 1) {
-                val filterDesc = filter.description
-                val article = if (filterDesc.firstOrNull()?.lowercase() in listOf("a", "e", "i", "o", "u")) "an" else "a"
-                append("$article ")
-                append(filterDesc)
-            } else {
-                append("$count ")
-                append(filter.description)
-                append("s")
-            }
-            append(" or pay ")
-            append(alternativeManaCost)
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
-        }
-    }
-
-    /**
-     * Discard [count] card(s) matching [filter] from your hand, or pay additional mana: the caster
-     * must either discard that many matching cards, or pay extra mana on top of the spell's base
-     * mana cost. The sibling of [BlightOrPay] / [BeholdOrPay] / [ExileFromGraveyardOrPay] /
-     * [SacrificeOrPay] for the "discard a card or pay" shape (e.g. Pumpkin Bombardment —
-     * "discard a card or pay {2}").
-     *
-     * The enumerator produces up to two legal actions: one for the discard path (base cost + card
-     * selection from hand, surfaced with `costType = "DiscardCard"` like Force of Will's plain
-     * discard cost) and one for the pay path (base cost + [alternativeManaCost]). The discard path
-     * is only offered when the caster holds at least [count] cards matching [filter] (excluding the
-     * spell being cast). The chosen path is recovered at payment time from whether
-     * [AdditionalCostPayment.discardedCards] is non-empty. The discard-as-cost still counts toward
-     * the turn's discard tracking (CR 701.8), like every other discard site.
-     *
-     * @property alternativeManaCost Extra mana to pay instead of discarding (e.g. "{2}")
-     * @property filter Which hand cards qualify (default any card)
-     * @property count How many matching cards to discard on the discard path
-     */
-    @SerialName("DiscardOrPay")
-    @Serializable
-    data class DiscardOrPay(
-        val alternativeManaCost: String,
-        val filter: GameObjectFilter = GameObjectFilter.Any,
-        val count: Int = 1,
-    ) : AdditionalCost {
-        override val description: String = buildString {
-            append("Discard ")
-            if (count == 1) {
-                val filterDesc = filter.description
-                val article = if (filterDesc.firstOrNull()?.lowercase() in listOf("a", "e", "i", "o", "u")) "an" else "a"
-                append("$article ")
-                append(filterDesc)
-            } else {
-                append("$count ")
-                append(filter.description)
-                append("s")
-            }
-            append(" or pay ")
-            append(alternativeManaCost)
-        }
-
-        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
-            val newFilter = filter.applyTextReplacement(replacer)
-            return if (newFilter !== filter) copy(filter = newFilter) else this
+            val newAtom = atom.applyTextReplacement(replacer)
+            return if (newAtom !== atom) copy(atom = newAtom) else this
         }
     }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -513,7 +513,8 @@ enum class DamageRecipient {
 /**
  * "Behold a [filter]" as a resolution-time effect (CR: a player beholds a permanent by either
  * choosing a matching permanent they control or revealing a matching card from their hand).
- * Unlike the cast-time [AdditionalCost.Behold] / [AdditionalCost.BeholdOrPay], this is the
+ * Unlike the cast-time [AdditionalCost.Behold] (on its own or as an [AdditionalCost.OrPay] leg),
+ * this is the
  * *effect-side* behold used inside abilities such as Sarkhan, Dragon Ascendant's ETB
  * ("you may behold a Dragon. If you do, create a Treasure token.").
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -306,7 +306,6 @@ object CardLinter {
         put("CastFromCollectionWithoutPayingCost" to "storeCastTo", write(Space.COLLECTION))
         put("CounterAllOnStack" to "storeCountAs", write(Space.COLLECTION))
         put("Behold" to "storeAs", write(Space.COLLECTION))
-        put("BeholdOrPay" to "storeAs", write(Space.COLLECTION))
         put("ChooseEntity" to "storeAs", write(Space.COLLECTION))
         put("ChooseOnePerCategory" to "storeAs", write(Space.COLLECTION))
         put("StoreNumber" to "name", write(Space.NUMBER))

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -10546,8 +10546,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "BeholdOrPay",
-                "filter": "Kithkin",
+                "type": "OrPay",
+                "cost": {
+                    "type": "Behold",
+                    "filter": "Kithkin"
+                },
                 "alternativeManaCost": "{2}"
             }
         ]
@@ -11551,8 +11554,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "BeholdOrPay",
-                "filter": "Elf",
+                "type": "OrPay",
+                "cost": {
+                    "type": "Behold",
+                    "filter": "Elf"
+                },
                 "alternativeManaCost": "{2}"
             }
         ]
@@ -12870,8 +12876,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "BeholdOrPay",
-                "filter": "Goblin",
+                "type": "OrPay",
+                "cost": {
+                    "type": "Behold",
+                    "filter": "Goblin"
+                },
                 "alternativeManaCost": "{2}"
             }
         ]
@@ -15899,8 +15908,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "BeholdOrPay",
-                "filter": "Merfolk",
+                "type": "OrPay",
+                "cost": {
+                    "type": "Behold",
+                    "filter": "Merfolk"
+                },
                 "alternativeManaCost": "{2}"
             }
         ]
@@ -16268,8 +16280,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "BeholdOrPay",
-                "filter": "Elemental",
+                "type": "OrPay",
+                "cost": {
+                    "type": "Behold",
+                    "filter": "Elemental"
+                },
                 "alternativeManaCost": "{2}"
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -11412,12 +11412,15 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificeOrPay",
-                "filter": {
-                    "cardPredicates": [
-                        "IsCreature",
-                        "IsLegendary"
-                    ]
+                "type": "CostOrPay",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsLegendary"
+                        ]
+                    }
                 },
                 "alternativeManaCost": "{2}"
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -11412,14 +11412,17 @@
         ],
         "additionalCosts": [
             {
-                "type": "CostOrPay",
-                "atom": {
-                    "type": "AtomSacrifice",
-                    "filter": {
-                        "cardPredicates": [
-                            "IsCreature",
-                            "IsLegendary"
-                        ]
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "IsLegendary"
+                            ]
+                        }
                     }
                 },
                 "alternativeManaCost": "{2}"

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -847,10 +847,13 @@
         ],
         "additionalCosts": [
             {
-                "type": "CostOrPay",
-                "atom": {
-                    "type": "AtomSacrifice",
-                    "filter": "creature"
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
                 },
                 "alternativeManaCost": "{3}{B}"
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -847,8 +847,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "SacrificeOrPay",
-                "filter": "creature",
+                "type": "CostOrPay",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                },
                 "alternativeManaCost": "{3}{B}"
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -14793,8 +14793,12 @@
     "script": {
         "additionalCosts": [
             {
-                "type": "ExileFromGraveyardOrPay",
-                "exileCount": 2,
+                "type": "CostOrPay",
+                "atom": {
+                    "type": "AtomExileFrom",
+                    "zone": "Graveyard",
+                    "count": 2
+                },
                 "alternativeManaCost": "{1}{W}"
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -14793,11 +14793,14 @@
     "script": {
         "additionalCosts": [
             {
-                "type": "CostOrPay",
-                "atom": {
-                    "type": "AtomExileFrom",
-                    "zone": "Graveyard",
-                    "count": 2
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomExileFrom",
+                        "zone": "Graveyard",
+                        "count": 2
+                    }
                 },
                 "alternativeManaCost": "{1}{W}"
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -7068,7 +7068,8 @@
         ],
         "additionalCosts": [
             {
-                "type": "DiscardOrPay",
+                "type": "CostOrPay",
+                "atom": "AtomDiscard",
                 "alternativeManaCost": "{2}"
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -7068,8 +7068,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "CostOrPay",
-                "atom": "AtomDiscard",
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": "AtomDiscard"
+                },
                 "alternativeManaCost": "{2}"
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -2330,8 +2330,11 @@
         ],
         "additionalCosts": [
             {
-                "type": "BeholdOrPay",
-                "filter": "Dragon",
+                "type": "OrPay",
+                "cost": {
+                    "type": "Behold",
+                    "filter": "Dragon"
+                },
                 "alternativeManaCost": "{1}"
             }
         ]

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1133,9 +1133,8 @@ class CostHandler {
             // The "… or pay {N}" family: always payable, because the caster can always decline the
             // non-mana leg and fold the alternative mana into the spell's cost instead. Whether the
             // non-mana leg is *available* only decides which cast paths the enumerator offers.
-            is AdditionalCost.CostOrPay,
-            is AdditionalCost.BlightOrPay,
-            is AdditionalCost.BeholdOrPay -> true
+            is AdditionalCost.OrPay,
+            is AdditionalCost.BlightOrPay -> true
             is AdditionalCost.BlightVariable -> {
                 // X = 0 is always legal (default minCount = 0); higher minCounts
                 // require a creature you control whose toughness >= minCount.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1130,10 +1130,12 @@ class CostHandler {
                 // Payability determined by the preceding cost that populated the storage
                 true
             }
-            is AdditionalCost.BlightOrPay -> {
-                // Always payable: player can always choose the "pay mana" path
-                true
-            }
+            // The "… or pay {N}" family: always payable, because the caster can always decline the
+            // non-mana leg and fold the alternative mana into the spell's cost instead. Whether the
+            // non-mana leg is *available* only decides which cast paths the enumerator offers.
+            is AdditionalCost.CostOrPay,
+            is AdditionalCost.BlightOrPay,
+            is AdditionalCost.BeholdOrPay -> true
             is AdditionalCost.BlightVariable -> {
                 // X = 0 is always legal (default minCount = 0); higher minCounts
                 // require a creature you control whose toughness >= minCount.
@@ -1156,22 +1158,6 @@ class CostHandler {
             is AdditionalCost.PayLifeEqualToManaValueOfSpell -> {
                 // Affordability is per-cast (depends on the cast card's mana value), so it is
                 // checked at CastSpellHandler time, not here. Always "payable" at this generic gate.
-                true
-            }
-            is AdditionalCost.BeholdOrPay -> {
-                // Always payable: player can always choose the "pay mana" path
-                true
-            }
-            is AdditionalCost.ExileFromGraveyardOrPay -> {
-                // Always payable: player can always choose the "pay mana" path
-                true
-            }
-            is AdditionalCost.SacrificeOrPay -> {
-                // Always payable: player can always choose the "pay mana" path
-                true
-            }
-            is AdditionalCost.DiscardOrPay -> {
-                // Always payable: player can always choose the "pay mana" path
                 true
             }
             is AdditionalCost.Composite -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1455,37 +1455,43 @@ class CastSpellHandler(
      *     no payment (mirrors [ForageCostResolver]'s engine-direct fallback); else
      *  3. the first option (nothing payable — downstream validation/selection then rejects the cast).
      *
-     * Cost-vs-mana ([AdditionalCost.CostOrPay]) reduces to its atom when the caster populated that
-     * atom's payment field, and to *nothing* otherwise: declining the atom means they took the pay
+     * Cost-vs-mana ([AdditionalCost.OrPay]) reduces to its leg cost when the caster populated that
+     * cost's payment field, and to *nothing* otherwise: declining the leg means they took the pay
      * path, whose only consequence — the extra mana — is already folded into the spell's cost by
-     * [applyOrPayManaAdjustments]. Paying the atom then runs through the ordinary
-     * [AdditionalCost.Atom] machinery, so the or-pay family needs no validation or payment code of
-     * its own.
+     * [applyOrPayManaAdjustments]. Paying the leg then runs through that cost's ordinary machinery,
+     * so the or-pay shape needs no validation or payment code of its own.
+     *
+     * [AdditionalCost.Composite] steps are flattened on the way in and out, so an alternative
+     * nested inside a composite is reduced (and priced) like a top-level one.
      */
     private fun reduceCostAlternatives(
         costs: List<AdditionalCost>,
         state: GameState,
         playerId: EntityId,
         payment: AdditionalCostPayment?,
-    ): List<AdditionalCost> = costs.flatMap { cost ->
+    ): List<AdditionalCost> = flattenComposites(costs).flatMap { cost ->
         when (cost) {
             is AdditionalCost.Choice -> listOf(
-                cost.options.firstOrNull { optionPaymentSatisfied(it, payment) }
+                cost.options.firstOrNull { paymentSatisfied(it, payment) }
                     ?: cost.options.firstOrNull { costHandler.canPayAdditionalCost(state, it, playerId) }
                     ?: cost.options.first()
             )
-            is AdditionalCost.CostOrPay ->
-                if (atomPaymentSatisfied(cost.atom, payment)) listOf(AdditionalCost.Atom(cost.atom))
-                else emptyList()
+            is AdditionalCost.OrPay ->
+                if (paymentSatisfied(cost.cost, payment)) listOf(cost.cost) else emptyList()
             else -> listOf(cost)
         }
-    }
+    }.let(::flattenComposites)
+
+    /** Expand [AdditionalCost.Composite] wrappers so every cost in the list stands on its own. */
+    private fun flattenComposites(costs: List<AdditionalCost>): List<AdditionalCost> =
+        costs.flatMap { if (it is AdditionalCost.Composite) flattenComposites(it.steps) else listOf(it) }
 
     /**
      * Fold the alternative mana of every "… or pay {N}" additional cost in [costs] whose non-mana
      * leg the caster declined into [cost] (CR 601.2f — the total cost is locked in as the spell is
      * cast). Which leg was taken is read off which [AdditionalCostPayment] field the client
-     * populated, exactly as [reduceCostAlternatives] reads it.
+     * populated, exactly as [reduceCostAlternatives] reads it — and composites are flattened the
+     * same way, so the two always agree on which costs they see.
      *
      * Shared by validate() and execute() so the cast is priced identically in both.
      */
@@ -1493,39 +1499,35 @@ class CastSpellHandler(
         cost: ManaCost,
         costs: List<AdditionalCost>,
         payment: AdditionalCostPayment?,
-    ): ManaCost = costs.fold(cost) { acc, additionalCost ->
+    ): ManaCost = flattenComposites(costs).fold(cost) { acc, additionalCost ->
         val declinedLegPrice = when (additionalCost) {
-            is AdditionalCost.CostOrPay ->
-                additionalCost.alternativeManaCost.takeUnless { atomPaymentSatisfied(additionalCost.atom, payment) }
+            is AdditionalCost.OrPay ->
+                additionalCost.alternativeManaCost.takeUnless { paymentSatisfied(additionalCost.cost, payment) }
             is AdditionalCost.BlightOrPay ->
                 additionalCost.alternativeManaCost.takeIf { payment?.blightTargets.isNullOrEmpty() }
-            is AdditionalCost.BeholdOrPay ->
-                additionalCost.alternativeManaCost.takeIf { payment?.beheldCards.isNullOrEmpty() }
             else -> null
         }
         if (declinedLegPrice == null) acc else acc + ManaCost.parse(declinedLegPrice)
     }
 
-    /** True when [payment] already carries a selection for the field [option]'s atom consumes. */
-    private fun optionPaymentSatisfied(option: AdditionalCost, payment: AdditionalCostPayment?): Boolean {
-        val atom = (option as? AdditionalCost.Atom)?.atom ?: return false
-        return atomPaymentSatisfied(atom, payment)
-    }
-
     /**
-     * True when [payment] carries a selection in the field [atom] consumes — the signal that the
-     * caster paid this atom rather than an alternative offered alongside it. Atoms with no
+     * True when [payment] carries a selection in the field [cost] consumes — the signal that the
+     * caster paid this cost rather than an alternative offered alongside it. Costs with no
      * selection of their own (mana, life, mill, …) are never distinguishable this way, so they
-     * report false; [AdditionalCost.CostOrPay] and [AdditionalCost.Choice] document that boundary.
+     * report false; [AdditionalCost.OrPay] and [AdditionalCost.Choice] document that boundary.
      */
-    private fun atomPaymentSatisfied(atom: CostAtom, payment: AdditionalCostPayment?): Boolean {
+    private fun paymentSatisfied(cost: AdditionalCost, payment: AdditionalCostPayment?): Boolean {
         val p = payment ?: return false
-        return when (atom) {
-            is CostAtom.Sacrifice -> p.sacrificedPermanents.isNotEmpty()
-            is CostAtom.Discard -> p.discardedCards.isNotEmpty()
-            is CostAtom.ExileFrom -> p.exiledCards.isNotEmpty()
-            is CostAtom.TapPermanents -> p.tappedPermanents.isNotEmpty()
-            is CostAtom.ReturnToHand -> p.bouncedPermanents.isNotEmpty()
+        return when (cost) {
+            is AdditionalCost.Behold -> p.beheldCards.isNotEmpty()
+            is AdditionalCost.Atom -> when (cost.atom) {
+                is CostAtom.Sacrifice -> p.sacrificedPermanents.isNotEmpty()
+                is CostAtom.Discard -> p.discardedCards.isNotEmpty()
+                is CostAtom.ExileFrom -> p.exiledCards.isNotEmpty()
+                is CostAtom.TapPermanents -> p.tappedPermanents.isNotEmpty()
+                is CostAtom.ReturnToHand -> p.bouncedPermanents.isNotEmpty()
+                else -> false
+            }
             else -> false
         }
     }
@@ -1537,7 +1539,6 @@ class CastSpellHandler(
     ): String? {
         val projected = state.projectedState
         val flattenedCosts = reduceCostAlternatives(additionalCosts, state, action.playerId, action.additionalCostPayment)
-            .flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }
         for (additionalCost in flattenedCosts) {
             when (additionalCost) {
                 is AdditionalCost.Atom -> when (val atom = additionalCost.atom) {
@@ -1880,41 +1881,10 @@ class CastSpellHandler(
                         return "Pay X life: X ($amount) cannot exceed your life total ($currentLife)"
                     }
                 }
-                is AdditionalCost.BeholdOrPay -> {
-                    // BeholdOrPay: player chose behold if beheldCards is non-empty,
-                    // otherwise chose to pay extra mana (validated via mana payment)
-                    val beheld = action.additionalCostPayment?.beheldCards ?: emptyList()
-                    if (beheld.isNotEmpty()) {
-                        val handZone = ZoneKey(action.playerId, Zone.HAND)
-                        val handCards = state.getZone(handZone)
-                        val battlefieldCards = state.getBattlefield()
-                        val context = PredicateContext(controllerId = action.playerId)
-                        for (cardId in beheld) {
-                            val inHand = cardId in handCards && cardId != action.cardId
-                            val onBattlefield = cardId in battlefieldCards &&
-                                projected.getController(cardId) == action.playerId
-                            if (!inHand && !onBattlefield) {
-                                return "Beheld card must be a card in your hand or a permanent you control"
-                            }
-                            if (onBattlefield) {
-                                if (!predicateEvaluator.matches(state, projected, cardId, additionalCost.filter, context)) {
-                                    val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
-                                    return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
-                                }
-                            } else {
-                                if (!predicateEvaluator.matches(state, state.projectedState, cardId, additionalCost.filter, context)) {
-                                    val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
-                                    return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
-                                }
-                            }
-                        }
-                    }
-                    // If beheldCards is empty, the player is paying extra mana instead
-                }
-                is AdditionalCost.CostOrPay -> {
-                    // Unreachable: reduceCostAlternatives already replaced this with its atom (the
-                    // caster paid the non-mana leg — validated by the Atom branch above) or dropped
-                    // it (pay path — the alternative mana is validated as part of the mana payment).
+                is AdditionalCost.OrPay -> {
+                    // Unreachable: reduceCostAlternatives already replaced this with its leg cost
+                    // (the caster paid the non-mana leg — validated by that cost's branch above) or
+                    // dropped it (pay path — the alternative mana is validated with the mana payment).
                 }
                 is AdditionalCost.PayLifePerTarget -> {
                     val required = additionalCost.amountPerTarget * action.targets.size
@@ -2285,7 +2255,6 @@ class CastSpellHandler(
         }
 
         val flattenedAllCosts = reduceCostAlternatives(allAdditionalCosts, currentState, action.playerId, action.additionalCostPayment)
-            .flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }
 
         // Server-initiated free cast: pay the spell's printed additional costs even though the
         // mana cost is waived (CR 601.2f / 118.9). A normal client cast arrives with the
@@ -2588,36 +2557,11 @@ class CastSpellHandler(
                             }
                         }
                     }
-                    is AdditionalCost.BeholdOrPay -> {
-                        // Store beheld card IDs in pipeline and reveal them, if behold path chosen
-                        val chosen = action.additionalCostPayment.beheldCards
-                        if (chosen.isNotEmpty()) {
-                            beheldCards.addAll(chosen)
-                            costPipelineCollections[additionalCost.storeAs] = chosen
-
-                            val cardNames = chosen.mapNotNull { currentState.getEntity(it)?.get<CardComponent>()?.name }
-                            val imageUris = chosen.map { id ->
-                                val defId = currentState.getEntity(id)?.get<CardComponent>()?.cardDefinitionId
-                                defId?.let { cardRegistry.getCard(it)?.metadata?.imageUri }
-                            }
-                            val battlefield = currentState.getBattlefield()
-                            val anyOnBattlefield = chosen.any { it in battlefield }
-                            events.add(CardsRevealedEvent(
-                                revealingPlayerId = action.playerId,
-                                cardIds = chosen,
-                                cardNames = cardNames,
-                                imageUris = imageUris,
-                                source = cardComponent.name,
-                                revealToSelf = anyOnBattlefield
-                            ))
-                        }
-                        // If beheldCards is empty, "pay mana" path — extra mana already added to effectiveCost
-                    }
-                    is AdditionalCost.CostOrPay -> {
-                        // Unreachable: reduceCostAlternatives already replaced this with its atom
-                        // (paid by the Atom branch above, including LKI snapshots and discard
-                        // tracking) or dropped it (pay path — the alternative mana was folded into
-                        // effectiveCost).
+                    is AdditionalCost.OrPay -> {
+                        // Unreachable: reduceCostAlternatives already replaced this with its leg
+                        // cost (paid by that cost's branch above, including LKI snapshots, discard
+                        // tracking and behold's pipeline storage) or dropped it (pay path — the
+                        // alternative mana was folded into effectiveCost).
                     }
                     is AdditionalCost.PayLifePerTarget -> {
                         // Handled in the auto-pay pre-pass above (life total scales with target count).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -975,69 +975,12 @@ class CastSpellHandler(
             }
         }
 
-        // Apply BlightOrPay "pay mana" adjustment in validation
+        // Fold in the "… or pay {N}" alternative mana for every or-pay cost whose non-mana leg the
+        // caster declined (validation side; execute() applies the same rule to the cost it charges).
         if (cardDef != null && !playForFree) {
-            val blightOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.BlightOrPay>()
-                .firstOrNull()
-            if (blightOrPay != null) {
-                val choseBlight = action.additionalCostPayment?.blightTargets?.isNotEmpty() == true
-                if (!choseBlight) {
-                    effectiveCost = effectiveCost + ManaCost.parse(blightOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply BeholdOrPay "pay mana" adjustment in validation
-        if (cardDef != null && !playForFree) {
-            val beholdOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.BeholdOrPay>()
-                .firstOrNull()
-            if (beholdOrPay != null) {
-                val choseBehold = action.additionalCostPayment?.beheldCards?.isNotEmpty() == true
-                if (!choseBehold) {
-                    effectiveCost = effectiveCost + ManaCost.parse(beholdOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply ExileFromGraveyardOrPay "pay mana" adjustment in validation
-        if (cardDef != null && !playForFree) {
-            val exileOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.ExileFromGraveyardOrPay>()
-                .firstOrNull()
-            if (exileOrPay != null) {
-                val choseExile = action.additionalCostPayment?.exiledCards?.isNotEmpty() == true
-                if (!choseExile) {
-                    effectiveCost = effectiveCost + ManaCost.parse(exileOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply SacrificeOrPay "pay mana" adjustment in validation
-        if (cardDef != null && !playForFree) {
-            val sacOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.SacrificeOrPay>()
-                .firstOrNull()
-            if (sacOrPay != null) {
-                val choseSacrifice = action.additionalCostPayment?.sacrificedPermanents?.isNotEmpty() == true
-                if (!choseSacrifice) {
-                    effectiveCost = effectiveCost + ManaCost.parse(sacOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply DiscardOrPay "pay mana" adjustment in validation
-        if (cardDef != null && !playForFree) {
-            val discardOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.DiscardOrPay>()
-                .firstOrNull()
-            if (discardOrPay != null) {
-                val choseDiscard = action.additionalCostPayment?.discardedCards?.isNotEmpty() == true
-                if (!choseDiscard) {
-                    effectiveCost = effectiveCost + ManaCost.parse(discardOrPay.alternativeManaCost)
-                }
-            }
+            effectiveCost = applyOrPayManaAdjustments(
+                effectiveCost, cardDef.script.additionalCosts, action.additionalCostPayment
+            )
         }
 
         // Apply spell-level waterbend additional cost (Avatar: The Last Airbender). Adds the
@@ -1501,30 +1444,81 @@ class CastSpellHandler(
     }
 
     /**
-     * Reduce each cost-vs-cost [AdditionalCost.Choice] in [costs] to the single option the caster is
-     * actually paying, so every downstream cost path (validation, application, free-cast selection)
-     * handles it as a plain atom with no [Choice] awareness. The chosen option is:
+     * Reduce each cost that offers the caster a *choice of legs* to the leg they actually took, so
+     * every downstream cost path (validation, application, free-cast selection) handles a plain
+     * cost with no alternatives awareness.
+     *
+     * Cost-vs-cost ([AdditionalCost.Choice]) reduces to the single option being paid:
      *  1. the option whose [AdditionalCostPayment] field the client populated — a normal cast, where
      *     each option surfaced as its own legal action so exactly one field is filled; else
      *  2. the first option payable from the current board — server-initiated free/AI casts arrive with
      *     no payment (mirrors [ForageCostResolver]'s engine-direct fallback); else
      *  3. the first option (nothing payable — downstream validation/selection then rejects the cast).
+     *
+     * Cost-vs-mana ([AdditionalCost.CostOrPay]) reduces to its atom when the caster populated that
+     * atom's payment field, and to *nothing* otherwise: declining the atom means they took the pay
+     * path, whose only consequence — the extra mana — is already folded into the spell's cost by
+     * [applyOrPayManaAdjustments]. Paying the atom then runs through the ordinary
+     * [AdditionalCost.Atom] machinery, so the or-pay family needs no validation or payment code of
+     * its own.
      */
-    private fun reduceChoiceCosts(
+    private fun reduceCostAlternatives(
         costs: List<AdditionalCost>,
         state: GameState,
         playerId: EntityId,
         payment: AdditionalCostPayment?,
-    ): List<AdditionalCost> = costs.map { cost ->
-        if (cost !is AdditionalCost.Choice) cost
-        else cost.options.firstOrNull { optionPaymentSatisfied(it, payment) }
-            ?: cost.options.firstOrNull { costHandler.canPayAdditionalCost(state, it, playerId) }
-            ?: cost.options.first()
+    ): List<AdditionalCost> = costs.flatMap { cost ->
+        when (cost) {
+            is AdditionalCost.Choice -> listOf(
+                cost.options.firstOrNull { optionPaymentSatisfied(it, payment) }
+                    ?: cost.options.firstOrNull { costHandler.canPayAdditionalCost(state, it, playerId) }
+                    ?: cost.options.first()
+            )
+            is AdditionalCost.CostOrPay ->
+                if (atomPaymentSatisfied(cost.atom, payment)) listOf(AdditionalCost.Atom(cost.atom))
+                else emptyList()
+            else -> listOf(cost)
+        }
+    }
+
+    /**
+     * Fold the alternative mana of every "… or pay {N}" additional cost in [costs] whose non-mana
+     * leg the caster declined into [cost] (CR 601.2f — the total cost is locked in as the spell is
+     * cast). Which leg was taken is read off which [AdditionalCostPayment] field the client
+     * populated, exactly as [reduceCostAlternatives] reads it.
+     *
+     * Shared by validate() and execute() so the cast is priced identically in both.
+     */
+    private fun applyOrPayManaAdjustments(
+        cost: ManaCost,
+        costs: List<AdditionalCost>,
+        payment: AdditionalCostPayment?,
+    ): ManaCost = costs.fold(cost) { acc, additionalCost ->
+        val declinedLegPrice = when (additionalCost) {
+            is AdditionalCost.CostOrPay ->
+                additionalCost.alternativeManaCost.takeUnless { atomPaymentSatisfied(additionalCost.atom, payment) }
+            is AdditionalCost.BlightOrPay ->
+                additionalCost.alternativeManaCost.takeIf { payment?.blightTargets.isNullOrEmpty() }
+            is AdditionalCost.BeholdOrPay ->
+                additionalCost.alternativeManaCost.takeIf { payment?.beheldCards.isNullOrEmpty() }
+            else -> null
+        }
+        if (declinedLegPrice == null) acc else acc + ManaCost.parse(declinedLegPrice)
     }
 
     /** True when [payment] already carries a selection for the field [option]'s atom consumes. */
     private fun optionPaymentSatisfied(option: AdditionalCost, payment: AdditionalCostPayment?): Boolean {
         val atom = (option as? AdditionalCost.Atom)?.atom ?: return false
+        return atomPaymentSatisfied(atom, payment)
+    }
+
+    /**
+     * True when [payment] carries a selection in the field [atom] consumes — the signal that the
+     * caster paid this atom rather than an alternative offered alongside it. Atoms with no
+     * selection of their own (mana, life, mill, …) are never distinguishable this way, so they
+     * report false; [AdditionalCost.CostOrPay] and [AdditionalCost.Choice] document that boundary.
+     */
+    private fun atomPaymentSatisfied(atom: CostAtom, payment: AdditionalCostPayment?): Boolean {
         val p = payment ?: return false
         return when (atom) {
             is CostAtom.Sacrifice -> p.sacrificedPermanents.isNotEmpty()
@@ -1542,7 +1536,7 @@ class CastSpellHandler(
         action: CastSpell
     ): String? {
         val projected = state.projectedState
-        val flattenedCosts = reduceChoiceCosts(additionalCosts, state, action.playerId, action.additionalCostPayment)
+        val flattenedCosts = reduceCostAlternatives(additionalCosts, state, action.playerId, action.additionalCostPayment)
             .flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }
         for (additionalCost in flattenedCosts) {
             when (additionalCost) {
@@ -1917,77 +1911,10 @@ class CastSpellHandler(
                     }
                     // If beheldCards is empty, the player is paying extra mana instead
                 }
-                is AdditionalCost.ExileFromGraveyardOrPay -> {
-                    // ExileFromGraveyardOrPay: player chose the exile path if exiledCards is
-                    // non-empty, otherwise they pay extra mana (validated via mana payment).
-                    val exiled = action.additionalCostPayment?.exiledCards ?: emptyList()
-                    if (exiled.isNotEmpty()) {
-                        if (exiled.size != additionalCost.exileCount) {
-                            return "You must exile exactly ${additionalCost.exileCount} card(s) from your graveyard"
-                        }
-                        val graveyard = state.getZone(ZoneKey(action.playerId, Zone.GRAVEYARD))
-                        val context = PredicateContext(controllerId = action.playerId)
-                        for (cardId in exiled) {
-                            if (cardId !in graveyard) {
-                                return "Card to exile is not in your graveyard"
-                            }
-                            if (!predicateEvaluator.matches(state, state.projectedState, cardId, additionalCost.filter, context)) {
-                                val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
-                                return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
-                            }
-                        }
-                    }
-                    // If exiledCards is empty, the player is paying extra mana instead
-                }
-                is AdditionalCost.SacrificeOrPay -> {
-                    // SacrificeOrPay: player chose the sacrifice path if sacrificedPermanents is
-                    // non-empty, otherwise they pay extra mana (validated via mana payment).
-                    val sacrificed = action.additionalCostPayment?.sacrificedPermanents ?: emptyList()
-                    if (sacrificed.isNotEmpty()) {
-                        if (sacrificed.size != additionalCost.count) {
-                            val spellName = state.getEntity(action.cardId)?.get<CardComponent>()?.name ?: "this spell"
-                            return "You must sacrifice exactly ${additionalCost.count} permanent(s) for $spellName"
-                        }
-                        val context = PredicateContext(controllerId = action.playerId)
-                        for (permId in sacrificed) {
-                            if (permId !in state.getBattlefield()) {
-                                return "Permanent to sacrifice is not on the battlefield"
-                            }
-                            if (projected.getController(permId) != action.playerId) {
-                                return "You can only sacrifice permanents you control"
-                            }
-                            if (!predicateEvaluator.matches(state, projected, permId, additionalCost.filter, context)) {
-                                val permName = state.getEntity(permId)?.get<CardComponent>()?.name ?: "Permanent"
-                                return "$permName doesn't match the required filter: ${additionalCost.filter.description}"
-                            }
-                        }
-                    }
-                    // If sacrificedPermanents is empty, the player is paying extra mana instead
-                }
-                is AdditionalCost.DiscardOrPay -> {
-                    // DiscardOrPay: player chose the discard path if discardedCards is non-empty,
-                    // otherwise they pay extra mana (validated via mana payment).
-                    val discarded = action.additionalCostPayment?.discardedCards ?: emptyList()
-                    if (discarded.isNotEmpty()) {
-                        if (discarded.size != additionalCost.count) {
-                            return "You must discard exactly ${additionalCost.count} card(s) from your hand"
-                        }
-                        val handCards = state.getZone(ZoneKey(action.playerId, Zone.HAND))
-                        val context = PredicateContext(controllerId = action.playerId)
-                        for (cardId in discarded) {
-                            if (cardId !in handCards) {
-                                return "Card to discard is not in your hand"
-                            }
-                            if (cardId == action.cardId) {
-                                return "Cannot discard the spell being cast"
-                            }
-                            if (!predicateEvaluator.matches(state, state.projectedState, cardId, additionalCost.filter, context)) {
-                                val cardName = state.getEntity(cardId)?.get<CardComponent>()?.name ?: "Card"
-                                return "$cardName doesn't match the required filter: ${additionalCost.filter.description}"
-                            }
-                        }
-                    }
-                    // If discardedCards is empty, the player is paying extra mana instead
+                is AdditionalCost.CostOrPay -> {
+                    // Unreachable: reduceCostAlternatives already replaced this with its atom (the
+                    // caster paid the non-mana leg — validated by the Atom branch above) or dropped
+                    // it (pay path — the alternative mana is validated as part of the mana payment).
                 }
                 is AdditionalCost.PayLifePerTarget -> {
                     val required = additionalCost.amountPerTarget * action.targets.size
@@ -2246,72 +2173,12 @@ class CastSpellHandler(
             }
         }
 
-        // Apply BlightOrPay: if player chose "pay mana" path (no blight targets), add extra mana
+        // Fold in the "… or pay {N}" alternative mana for every or-pay cost whose non-mana leg the
+        // caster declined — the same rule validate() priced the cast with.
         if (cardDef != null && !playForFreeInExecute) {
-            val blightOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.BlightOrPay>()
-                .firstOrNull()
-            if (blightOrPay != null) {
-                val choseBlight = action.additionalCostPayment?.blightTargets?.isNotEmpty() == true
-                if (!choseBlight) {
-                    effectiveCost = effectiveCost + ManaCost.parse(blightOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply BeholdOrPay: if player chose "pay mana" path (no beheld cards), add extra mana
-        if (cardDef != null && !playForFreeInExecute) {
-            val beholdOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.BeholdOrPay>()
-                .firstOrNull()
-            if (beholdOrPay != null) {
-                val choseBehold = action.additionalCostPayment?.beheldCards?.isNotEmpty() == true
-                if (!choseBehold) {
-                    effectiveCost = effectiveCost + ManaCost.parse(beholdOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply ExileFromGraveyardOrPay: if player chose the "pay mana" path (no exiled cards),
-        // add the extra mana on top of the base cost.
-        if (cardDef != null && !playForFreeInExecute) {
-            val exileOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.ExileFromGraveyardOrPay>()
-                .firstOrNull()
-            if (exileOrPay != null) {
-                val choseExile = action.additionalCostPayment?.exiledCards?.isNotEmpty() == true
-                if (!choseExile) {
-                    effectiveCost = effectiveCost + ManaCost.parse(exileOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply SacrificeOrPay: if player chose the "pay mana" path (no sacrificed permanents),
-        // add the extra mana on top of the base cost.
-        if (cardDef != null && !playForFreeInExecute) {
-            val sacOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.SacrificeOrPay>()
-                .firstOrNull()
-            if (sacOrPay != null) {
-                val choseSacrifice = action.additionalCostPayment?.sacrificedPermanents?.isNotEmpty() == true
-                if (!choseSacrifice) {
-                    effectiveCost = effectiveCost + ManaCost.parse(sacOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply DiscardOrPay: if player chose the "pay mana" path (no discarded cards), add the
-        // extra mana on top of the base cost.
-        if (cardDef != null && !playForFreeInExecute) {
-            val discardOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.DiscardOrPay>()
-                .firstOrNull()
-            if (discardOrPay != null) {
-                val choseDiscard = action.additionalCostPayment?.discardedCards?.isNotEmpty() == true
-                if (!choseDiscard) {
-                    effectiveCost = effectiveCost + ManaCost.parse(discardOrPay.alternativeManaCost)
-                }
-            }
+            effectiveCost = applyOrPayManaAdjustments(
+                effectiveCost, cardDef.script.additionalCosts, action.additionalCostPayment
+            )
         }
 
         // Apply spell-level waterbend additional cost (Avatar: The Last Airbender) — add the
@@ -2417,7 +2284,7 @@ class CastSpellHandler(
                 ?.additionalCost?.let { add(it) }
         }
 
-        val flattenedAllCosts = reduceChoiceCosts(allAdditionalCosts, currentState, action.playerId, action.additionalCostPayment)
+        val flattenedAllCosts = reduceCostAlternatives(allAdditionalCosts, currentState, action.playerId, action.additionalCostPayment)
             .flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }
 
         // Server-initiated free cast: pay the spell's printed additional costs even though the
@@ -2746,77 +2613,11 @@ class CastSpellHandler(
                         }
                         // If beheldCards is empty, "pay mana" path — extra mana already added to effectiveCost
                     }
-                    is AdditionalCost.ExileFromGraveyardOrPay -> {
-                        // Exile the chosen graveyard cards if the player chose the exile path.
-                        // If exiledCards is empty, "pay mana" path — extra mana already added above.
-                        val exiledCards = action.additionalCostPayment.exiledCards
-                        for (cardId in exiledCards) {
-                            val cardContainer = currentState.getEntity(cardId) ?: continue
-                            val card = cardContainer.get<CardComponent>() ?: continue
-                            val sourceZone = ZoneKey(action.playerId, Zone.GRAVEYARD)
-                            val exileZone = ZoneKey(action.playerId, Zone.EXILE)
-
-                            currentState = currentState.removeFromZone(sourceZone, cardId)
-                            currentState = currentState.addToZone(exileZone, cardId)
-
-                            events.add(ZoneChangeEvent(
-                                entityId = cardId,
-                                entityName = card.name,
-                                fromZone = Zone.GRAVEYARD,
-                                toZone = Zone.EXILE,
-                                ownerId = action.playerId
-                            ))
-                        }
-                        exiledCardCount += exiledCards.size
-                    }
-                    is AdditionalCost.SacrificeOrPay -> {
-                        // Sacrifice the chosen permanents if the player chose the sacrifice path.
-                        // If sacrificedPermanents is empty, "pay mana" path — extra mana already
-                        // added above. Mirrors the CostAtom.Sacrifice payment, including the
-                        // last-known-information snapshot (CR 112.7a / 608.2h) so a sacrificed
-                        // permanent's stats survive onto downstream effects/triggers.
-                        val sacrificed = action.additionalCostPayment.sacrificedPermanents
-                        if (sacrificed.isNotEmpty()) {
-                            val projectedBeforeSacrifice = currentState.projectedState
-                            sacrificedSnapshots.addAll(
-                                captureEntitySnapshots(sacrificed, projectedBeforeSacrifice)
-                            )
-                            for (permId in sacrificed) {
-                                if (currentState.getEntity(permId) == null) continue
-                                currentState = sacrificePermanentAsCost(currentState, permId, action.playerId, events)
-                            }
-                        }
-                    }
-                    is AdditionalCost.DiscardOrPay -> {
-                        // Discard the chosen cards if the player chose the discard path.
-                        // If discardedCards is empty, "pay mana" path — extra mana already added
-                        // above. Mirrors the CostAtom.Discard payment, including the discard
-                        // tracking (CR 701.8) that feeds Mayhem / "discarded this turn" reads.
-                        val discardedCards = action.additionalCostPayment.discardedCards
-                        if (discardedCards.isNotEmpty()) {
-                            discardedAsCostCards.addAll(discardedCards)
-                            for (cardId in discardedCards) {
-                                val cardContainer = currentState.getEntity(cardId) ?: continue
-                                val card = cardContainer.get<CardComponent>() ?: continue
-                                val handZone = ZoneKey(action.playerId, Zone.HAND)
-                                val graveyardZone = ZoneKey(action.playerId, Zone.GRAVEYARD)
-
-                                currentState = currentState.removeFromZone(handZone, cardId)
-                                currentState = currentState.addToZone(graveyardZone, cardId)
-
-                                events.add(ZoneChangeEvent(
-                                    entityId = cardId,
-                                    entityName = card.name,
-                                    fromZone = Zone.HAND,
-                                    toZone = Zone.GRAVEYARD,
-                                    ownerId = action.playerId
-                                ))
-                            }
-                            val discardNames = discardedCards.map { currentState.getEntity(it)?.get<CardComponent>()?.name ?: "Card" }
-                            events.add(CardsDiscardedEvent(action.playerId, discardedCards, discardNames))
-                            currentState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                                .trackDiscard(currentState, action.playerId, discardedCards)
-                        }
+                    is AdditionalCost.CostOrPay -> {
+                        // Unreachable: reduceCostAlternatives already replaced this with its atom
+                        // (paid by the Atom branch above, including LKI snapshots and discard
+                        // tracking) or dropped it (pay path — the alternative mana was folded into
+                        // effectiveCost).
                     }
                     is AdditionalCost.PayLifePerTarget -> {
                         // Handled in the auto-pay pre-pass above (life total scales with target count).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -209,12 +209,8 @@ class CastSpellEnumerator : ActionEnumerator {
             var payXLifeMaxX = 0
             var beholdOrPayCost: AdditionalCost.BeholdOrPay? = null
             var beholdOrPayTargets = emptyList<EntityId>()
-            var exileOrPayCost: AdditionalCost.ExileFromGraveyardOrPay? = null
-            var exileOrPayTargets = emptyList<EntityId>()
-            var sacOrPayCost: AdditionalCost.SacrificeOrPay? = null
-            var sacOrPayTargets = emptyList<EntityId>()
-            var discardOrPayCost: AdditionalCost.DiscardOrPay? = null
-            var discardOrPayTargets = emptyList<EntityId>()
+            var costOrPay: AdditionalCost.CostOrPay? = null
+            var costOrPayTargets = emptyList<EntityId>()
             var canPayAdditionalCosts = true
             val flattenedCosts = additionalCosts.flatMap {
                 if (it is AdditionalCost.Composite) it.steps else listOf(it)
@@ -367,37 +363,11 @@ class CastSpellEnumerator : ActionEnumerator {
                             .filter { context.predicateEvaluator.matches(state, state.projectedState, it, cost.filter, predicateContext) }
                         beholdOrPayTargets = battlefieldMatches + handMatches
                     }
-                    is AdditionalCost.ExileFromGraveyardOrPay -> {
-                        // Always payable: player can always choose the "pay mana" path.
-                        // Surface the graveyard cards eligible for the exile path.
-                        exileOrPayCost = cost
-                        exileOrPayTargets = context.costUtils.findExileTargets(
-                            state, playerId, cost.filter, Zone.GRAVEYARD
-                        )
-                    }
-                    is AdditionalCost.SacrificeOrPay -> {
-                        // Always payable: player can always choose the "pay mana" path.
-                        // Surface the permanents you control eligible for the sacrifice path.
-                        sacOrPayCost = cost
-                        sacOrPayTargets = context.costUtils.findSacrificeTargets(
-                            state, playerId, CostAtom.Sacrifice(cost.filter, cost.count)
-                        )
-                    }
-                    is AdditionalCost.DiscardOrPay -> {
-                        // Always payable: player can always choose the "pay mana" path.
-                        // Surface the hand cards eligible for the discard path (excluding the
-                        // spell being cast).
-                        discardOrPayCost = cost
-                        val handZone = ZoneKey(playerId, Zone.HAND)
-                        val handCards = state.getZone(handZone).filter { it != cardId }
-                        val predicateContext = PredicateContext(controllerId = playerId)
-                        discardOrPayTargets = if (cost.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) {
-                            handCards
-                        } else {
-                            handCards.filter {
-                                context.predicateEvaluator.matches(state, state.projectedState, it, cost.filter, predicateContext)
-                            }
-                        }
+                    is AdditionalCost.CostOrPay -> {
+                        // Always payable: the player can always choose the "pay mana" path.
+                        // Surface the candidates for the atom path, whichever atom it carries.
+                        costOrPay = cost
+                        costOrPayTargets = orPayAtomCandidates(context, playerId, cardId, cost.atom)
                     }
                     is AdditionalCost.ChooseEntity -> {
                         // Search each (zone, filter) pair in `cost.zoneFilters`. Battlefield
@@ -464,22 +434,10 @@ class CastSpellEnumerator : ActionEnumerator {
                 effectiveCost = effectiveCost + ManaCost.parse(beholdOrPayCost.alternativeManaCost)
             }
 
-            // Save base cost for exile-from-graveyard path, then add extra mana for the "pay" path
-            val exileOrPayBaseCost = effectiveCost
-            if (exileOrPayCost != null) {
-                effectiveCost = effectiveCost + ManaCost.parse(exileOrPayCost.alternativeManaCost)
-            }
-
-            // Save base cost for sacrifice path, then add extra mana for the "pay" path
-            val sacOrPayBaseCost = effectiveCost
-            if (sacOrPayCost != null) {
-                effectiveCost = effectiveCost + ManaCost.parse(sacOrPayCost.alternativeManaCost)
-            }
-
-            // Save base cost for discard path, then add extra mana for the "pay" path
-            val discardOrPayBaseCost = effectiveCost
-            if (discardOrPayCost != null) {
-                effectiveCost = effectiveCost + ManaCost.parse(discardOrPayCost.alternativeManaCost)
+            // Save base cost for the atom path, then add extra mana for the "pay" path
+            val costOrPayBaseCost = effectiveCost
+            if (costOrPay != null) {
+                effectiveCost = effectiveCost + ManaCost.parse(costOrPay.alternativeManaCost)
             }
 
             // Spell-level waterbend additional cost (Avatar: The Last Airbender). A *mandatory*
@@ -625,29 +583,20 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, beholdBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
-            // Check exile-from-graveyard path affordability (base cost without the extra mana, but
-            // needs enough matching cards in the graveyard to exile).
-            val canAffordExileOrPayPath = if (exileOrPayCost != null && exileOrPayTargets.size >= exileOrPayCost.exileCount) {
-                context.manaSolver.canPay(state, playerId, exileOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
-            } else false
-
-            // Check sacrifice path affordability (base cost without the extra mana, but needs
-            // enough matching permanents on the battlefield to sacrifice).
-            val canAffordSacOrPayPath = if (sacOrPayCost != null && sacOrPayTargets.size >= sacOrPayCost.count) {
-                context.manaSolver.canPay(state, playerId, sacOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
-            } else false
-
-            // Check discard path affordability (base cost without the extra mana, but needs
-            // enough matching cards in hand to discard).
-            val canAffordDiscardOrPayPath = if (discardOrPayCost != null && discardOrPayTargets.size >= discardOrPayCost.count) {
-                context.manaSolver.canPay(state, playerId, discardOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
+            // Check the atom path's affordability (base cost without the extra mana, but needs
+            // enough candidates for the atom's own selection — permanents to sacrifice, cards to
+            // discard/exile, …).
+            val canAffordCostOrPayPath = if (costOrPay != null &&
+                costOrPayTargets.size >= costOrPay.atom.selectionCount
+            ) {
+                context.manaSolver.canPay(state, playerId, costOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
             // A `MayCastWithoutPayingManaCost` battlefield permission (e.g. Weftwalking) makes the
             // spell affordable for {0} when its gates are open. Emitted by its own branch below;
             // don't continue out before reaching it.
             val canAffordFreeCast = context.freeCastPermissionFor(cardId)
-            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordCleave && !canAffordBlightPath && !canAffordBeholdPath && !canAffordExileOrPayPath && !canAffordSacOrPayPath && !canAffordDiscardOrPayPath && !canAffordFreeCast) {
+            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordCleave && !canAffordBlightPath && !canAffordBeholdPath && !canAffordCostOrPayPath && !canAffordFreeCast) {
                 // The primary face can't be paid for by any path. Normally we skip it entirely.
                 // But if this is an Adventure/Omen/modal-DFC card whose *secondary* face is
                 // affordable, surface a grayed-out placeholder for the primary face so the
@@ -681,91 +630,56 @@ class CastSpellEnumerator : ActionEnumerator {
                 payXLifeCost, payXLifeMaxX
             )
 
-            // Compute blight path info (separate legal action with lower mana cost + blight target selection)
+            // Compute the "… or pay {N}" cast paths — one extra legal action each, carrying the
+            // base cost (without the alternative mana) plus that leg's own selection prompt.
+            fun orPayPath(label: String, baseCost: ManaCost, legCostInfo: AdditionalCostData) = OrPayPath(
+                label = label,
+                manaCostString = baseCost.toString(),
+                autoTapPreview = if (context.skipAutoTapPreview) null else {
+                    context.manaSolver.solve(state, playerId, baseCost, precomputedSources = cachedSources)
+                        ?.sources?.map { it.entityId }
+                },
+                costInfo = legCostInfo,
+            )
+
             val blightPathInfo = if (canAffordBlightPath && blightOrPayCost != null) {
-                val blightManaCostString = blightBaseCost.toString()
-                val blightAutoTapPreview = if (context.skipAutoTapPreview) null else {
-                    context.manaSolver.solve(state, playerId, blightBaseCost, precomputedSources = cachedSources)
-                        ?.sources?.map { it.entityId }
-                }
-                val blightCostInfo = AdditionalCostData(
-                    description = "creature to blight",
-                    costType = "Blight",
-                    validBlightTargets = blightCreatures,
-                    blightAmount = blightOrPayCost.blightAmount
+                orPayPath(
+                    label = "Blight ${blightOrPayCost.blightAmount}",
+                    baseCost = blightBaseCost,
+                    legCostInfo = AdditionalCostData(
+                        description = "creature to blight",
+                        costType = "Blight",
+                        validBlightTargets = blightCreatures,
+                        blightAmount = blightOrPayCost.blightAmount
+                    )
                 )
-                Triple(blightManaCostString, blightAutoTapPreview, blightCostInfo)
             } else null
 
-            // Compute behold path info (separate legal action with lower mana cost + behold target selection)
             val beholdPathInfo = if (canAffordBeholdPath && beholdOrPayCost != null) {
-                val beholdManaCostString = beholdBaseCost.toString()
-                val beholdAutoTapPreview = if (context.skipAutoTapPreview) null else {
-                    context.manaSolver.solve(state, playerId, beholdBaseCost, precomputedSources = cachedSources)
-                        ?.sources?.map { it.entityId }
-                }
-                val beholdCostInfo = AdditionalCostData(
-                    description = beholdOrPayCost.description,
-                    costType = "Behold",
-                    validBeholdTargets = beholdOrPayTargets,
-                    beholdCount = 1
+                orPayPath(
+                    label = "Behold",
+                    baseCost = beholdBaseCost,
+                    legCostInfo = AdditionalCostData(
+                        description = beholdOrPayCost.description,
+                        costType = "Behold",
+                        validBeholdTargets = beholdOrPayTargets,
+                        beholdCount = 1
+                    )
                 )
-                Triple(beholdManaCostString, beholdAutoTapPreview, beholdCostInfo)
             } else null
 
-            // Compute exile-from-graveyard path info (separate legal action with lower mana cost +
-            // exile card selection). The player exiles exactly `exileCount` matching graveyard cards.
-            val exileOrPayPathInfo = if (canAffordExileOrPayPath && exileOrPayCost != null) {
-                val exileManaCostString = exileOrPayBaseCost.toString()
-                val exileAutoTapPreview = if (context.skipAutoTapPreview) null else {
-                    context.manaSolver.solve(state, playerId, exileOrPayBaseCost, precomputedSources = cachedSources)
-                        ?.sources?.map { it.entityId }
+            // The atom leg reuses the atom's own client picker ("SacrificePermanent",
+            // "DiscardCard", …), so a plain sacrifice/discard/exile cost and the or-pay variant
+            // drive the exact same selection UI.
+            val costOrPayPathInfo = if (canAffordCostOrPayPath && costOrPay != null) {
+                orPayAtomCostData(costOrPay.atom, costOrPayTargets)?.let { (label, legCostInfo) ->
+                    orPayPath(label = label, baseCost = costOrPayBaseCost, legCostInfo = legCostInfo)
                 }
-                val exileCostInfo = AdditionalCostData(
-                    description = "Exile ${exileOrPayCost.exileCount} card(s) from your graveyard",
-                    costType = "ExileFromGraveyard",
-                    validExileTargets = exileOrPayTargets,
-                    exileMinCount = exileOrPayCost.exileCount,
-                    exileMaxCount = exileOrPayCost.exileCount,
-                )
-                Triple(exileManaCostString, exileAutoTapPreview, exileCostInfo)
             } else null
 
-            // Compute sacrifice path info (separate legal action with lower mana cost + permanent
-            // selection). Reuses the "SacrificePermanent" cost type so the client drives the same
-            // on-battlefield sacrifice selection used by Natural Order's plain sacrifice cost.
-            val sacOrPayPathInfo = if (canAffordSacOrPayPath && sacOrPayCost != null) {
-                val sacManaCostString = sacOrPayBaseCost.toString()
-                val sacAutoTapPreview = if (context.skipAutoTapPreview) null else {
-                    context.manaSolver.solve(state, playerId, sacOrPayBaseCost, precomputedSources = cachedSources)
-                        ?.sources?.map { it.entityId }
-                }
-                val sacCostInfo = AdditionalCostData(
-                    description = sacOrPayCost.description,
-                    costType = "SacrificePermanent",
-                    validSacrificeTargets = sacOrPayTargets,
-                    sacrificeCount = sacOrPayCost.count,
-                )
-                Triple(sacManaCostString, sacAutoTapPreview, sacCostInfo)
-            } else null
-
-            // Compute discard path info (separate legal action with lower mana cost + hand card
-            // selection). Reuses the "DiscardCard" cost type so the client drives the same hand
-            // discard selection used by Force of Will's plain discard cost.
-            val discardOrPayPathInfo = if (canAffordDiscardOrPayPath && discardOrPayCost != null) {
-                val discardManaCostString = discardOrPayBaseCost.toString()
-                val discardAutoTapPreview = if (context.skipAutoTapPreview) null else {
-                    context.manaSolver.solve(state, playerId, discardOrPayBaseCost, precomputedSources = cachedSources)
-                        ?.sources?.map { it.entityId }
-                }
-                val discardCostInfo = AdditionalCostData(
-                    description = discardOrPayCost.description,
-                    costType = "DiscardCard",
-                    validDiscardTargets = discardOrPayTargets,
-                    discardCount = discardOrPayCost.count,
-                )
-                Triple(discardManaCostString, discardAutoTapPreview, discardCostInfo)
-            } else null
+            // Every or-pay leg emits the same shape of extra cast action, so the emission sites
+            // below just loop over them.
+            val orPayPaths = listOfNotNull(blightPathInfo, beholdPathInfo, costOrPayPathInfo)
 
             // Calculate X cost info if the spell has X in its cost (printed, or the waterbend {X}
             // folded in above).
@@ -967,9 +881,9 @@ class CastSpellEnumerator : ActionEnumerator {
                                     minChooseCount = all
                                 ),
                                 baseEffectiveCost = blightBaseCost,
-                                additionalCostInfo = blightPathInfo.third,
-                                manaCostString = blightPathInfo.first,
-                                autoTapPreview = blightPathInfo.second,
+                                additionalCostInfo = blightPathInfo.costInfo,
+                                manaCostString = blightPathInfo.manaCostString,
+                                autoTapPreview = blightPathInfo.autoTapPreview,
                                 descriptionSuffix = " (Blight ${blightOrPayCost.blightAmount})"
                             )
                         )
@@ -1230,69 +1144,17 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = freeCastResult.autoTapPreview
                             ))
                         }
-                        if (blightPathInfo != null) {
+                        for (path in orPayPaths) {
                             result.add(LegalAction(
                                 actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Blight ${blightOrPayCost!!.blightAmount})",
+                                description = "Cast ${cardComponent.name} (${path.label})",
                                 action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget)),
-                                additionalCostInfo = blightPathInfo.third,
-                                manaCostString = blightPathInfo.first,
+                                additionalCostInfo = path.costInfo,
+                                manaCostString = path.manaCostString,
                                 requiresDamageDistribution = requiresDamageDistribution,
                                 totalDamageToDistribute = totalDamageToDistribute,
                                 minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = blightPathInfo.second
-                            ))
-                        }
-                        if (beholdPathInfo != null) {
-                            result.add(LegalAction(
-                                actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Behold)",
-                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget)),
-                                additionalCostInfo = beholdPathInfo.third,
-                                manaCostString = beholdPathInfo.first,
-                                requiresDamageDistribution = requiresDamageDistribution,
-                                totalDamageToDistribute = totalDamageToDistribute,
-                                minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = beholdPathInfo.second
-                            ))
-                        }
-                        if (exileOrPayPathInfo != null) {
-                            result.add(LegalAction(
-                                actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Exile from graveyard)",
-                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget)),
-                                additionalCostInfo = exileOrPayPathInfo.third,
-                                manaCostString = exileOrPayPathInfo.first,
-                                requiresDamageDistribution = requiresDamageDistribution,
-                                totalDamageToDistribute = totalDamageToDistribute,
-                                minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = exileOrPayPathInfo.second
-                            ))
-                        }
-                        if (sacOrPayPathInfo != null) {
-                            result.add(LegalAction(
-                                actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Sacrifice)",
-                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget)),
-                                additionalCostInfo = sacOrPayPathInfo.third,
-                                manaCostString = sacOrPayPathInfo.first,
-                                requiresDamageDistribution = requiresDamageDistribution,
-                                totalDamageToDistribute = totalDamageToDistribute,
-                                minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = sacOrPayPathInfo.second
-                            ))
-                        }
-                        if (discardOrPayPathInfo != null) {
-                            result.add(LegalAction(
-                                actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Discard)",
-                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget)),
-                                additionalCostInfo = discardOrPayPathInfo.third,
-                                manaCostString = discardOrPayPathInfo.first,
-                                requiresDamageDistribution = requiresDamageDistribution,
-                                totalDamageToDistribute = totalDamageToDistribute,
-                                minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = discardOrPayPathInfo.second
+                                autoTapPreview = path.autoTapPreview
                             ))
                         }
                     } else {
@@ -1436,10 +1298,10 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = freeCastResult.autoTapPreview
                             ))
                         }
-                        if (blightPathInfo != null) {
+                        for (path in orPayPaths) {
                             result.add(LegalAction(
                                 actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Blight ${blightOrPayCost!!.blightAmount})",
+                                description = "Cast ${cardComponent.name} (${path.label})",
                                 action = CastSpell(playerId, cardId),
                                 validTargets = firstReqInfo.validTargets,
                                 requiresTargets = true,
@@ -1449,96 +1311,12 @@ class CastSpellEnumerator : ActionEnumerator {
                                 targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
                                 xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
                                 xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
-                                additionalCostInfo = blightPathInfo.third,
-                                manaCostString = blightPathInfo.first,
+                                additionalCostInfo = path.costInfo,
+                                manaCostString = path.manaCostString,
                                 requiresDamageDistribution = requiresDamageDistribution,
                                 totalDamageToDistribute = totalDamageToDistribute,
                                 minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = blightPathInfo.second
-                            ))
-                        }
-                        if (beholdPathInfo != null) {
-                            result.add(LegalAction(
-                                actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Behold)",
-                                action = CastSpell(playerId, cardId),
-                                validTargets = firstReqInfo.validTargets,
-                                requiresTargets = true,
-                                targetCount = firstReqInfo.maxTargets,
-                                minTargets = firstReq.effectiveMinCount,
-                                targetDescription = firstReq.description,
-                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
-                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
-                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
-                                additionalCostInfo = beholdPathInfo.third,
-                                manaCostString = beholdPathInfo.first,
-                                requiresDamageDistribution = requiresDamageDistribution,
-                                totalDamageToDistribute = totalDamageToDistribute,
-                                minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = beholdPathInfo.second
-                            ))
-                        }
-                        if (exileOrPayPathInfo != null) {
-                            result.add(LegalAction(
-                                actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Exile from graveyard)",
-                                action = CastSpell(playerId, cardId),
-                                validTargets = firstReqInfo.validTargets,
-                                requiresTargets = true,
-                                targetCount = firstReqInfo.maxTargets,
-                                minTargets = firstReq.effectiveMinCount,
-                                targetDescription = firstReq.description,
-                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
-                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
-                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
-                                additionalCostInfo = exileOrPayPathInfo.third,
-                                manaCostString = exileOrPayPathInfo.first,
-                                requiresDamageDistribution = requiresDamageDistribution,
-                                totalDamageToDistribute = totalDamageToDistribute,
-                                minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = exileOrPayPathInfo.second
-                            ))
-                        }
-                        if (sacOrPayPathInfo != null) {
-                            result.add(LegalAction(
-                                actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Sacrifice)",
-                                action = CastSpell(playerId, cardId),
-                                validTargets = firstReqInfo.validTargets,
-                                requiresTargets = true,
-                                targetCount = firstReqInfo.maxTargets,
-                                minTargets = firstReq.effectiveMinCount,
-                                targetDescription = firstReq.description,
-                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
-                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
-                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
-                                additionalCostInfo = sacOrPayPathInfo.third,
-                                manaCostString = sacOrPayPathInfo.first,
-                                requiresDamageDistribution = requiresDamageDistribution,
-                                totalDamageToDistribute = totalDamageToDistribute,
-                                minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = sacOrPayPathInfo.second
-                            ))
-                        }
-                        if (discardOrPayPathInfo != null) {
-                            result.add(LegalAction(
-                                actionType = "CastSpell",
-                                description = "Cast ${cardComponent.name} (Discard)",
-                                action = CastSpell(playerId, cardId),
-                                validTargets = firstReqInfo.validTargets,
-                                requiresTargets = true,
-                                targetCount = firstReqInfo.maxTargets,
-                                minTargets = firstReq.effectiveMinCount,
-                                targetDescription = firstReq.description,
-                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
-                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
-                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
-                                additionalCostInfo = discardOrPayPathInfo.third,
-                                manaCostString = discardOrPayPathInfo.first,
-                                requiresDamageDistribution = requiresDamageDistribution,
-                                totalDamageToDistribute = totalDamageToDistribute,
-                                minDamagePerTarget = minDamagePerTarget,
-                                autoTapPreview = discardOrPayPathInfo.second
+                                autoTapPreview = path.autoTapPreview
                             ))
                         }
                     }
@@ -1617,54 +1395,14 @@ class CastSpellEnumerator : ActionEnumerator {
                         autoTapPreview = freeCastResult.autoTapPreview
                     ))
                 }
-                if (blightPathInfo != null) {
+                for (path in orPayPaths) {
                     result.add(LegalAction(
                         actionType = "CastSpell",
-                        description = "Cast ${cardComponent.name} (Blight ${blightOrPayCost!!.blightAmount})",
+                        description = "Cast ${cardComponent.name} (${path.label})",
                         action = CastSpell(playerId, cardId),
-                        additionalCostInfo = blightPathInfo.third,
-                        manaCostString = blightPathInfo.first,
-                        autoTapPreview = blightPathInfo.second
-                    ))
-                }
-                if (beholdPathInfo != null) {
-                    result.add(LegalAction(
-                        actionType = "CastSpell",
-                        description = "Cast ${cardComponent.name} (Behold)",
-                        action = CastSpell(playerId, cardId),
-                        additionalCostInfo = beholdPathInfo.third,
-                        manaCostString = beholdPathInfo.first,
-                        autoTapPreview = beholdPathInfo.second
-                    ))
-                }
-                if (exileOrPayPathInfo != null) {
-                    result.add(LegalAction(
-                        actionType = "CastSpell",
-                        description = "Cast ${cardComponent.name} (Exile from graveyard)",
-                        action = CastSpell(playerId, cardId),
-                        additionalCostInfo = exileOrPayPathInfo.third,
-                        manaCostString = exileOrPayPathInfo.first,
-                        autoTapPreview = exileOrPayPathInfo.second
-                    ))
-                }
-                if (sacOrPayPathInfo != null) {
-                    result.add(LegalAction(
-                        actionType = "CastSpell",
-                        description = "Cast ${cardComponent.name} (Sacrifice)",
-                        action = CastSpell(playerId, cardId),
-                        additionalCostInfo = sacOrPayPathInfo.third,
-                        manaCostString = sacOrPayPathInfo.first,
-                        autoTapPreview = sacOrPayPathInfo.second
-                    ))
-                }
-                if (discardOrPayPathInfo != null) {
-                    result.add(LegalAction(
-                        actionType = "CastSpell",
-                        description = "Cast ${cardComponent.name} (Discard)",
-                        action = CastSpell(playerId, cardId),
-                        additionalCostInfo = discardOrPayPathInfo.third,
-                        manaCostString = discardOrPayPathInfo.first,
-                        autoTapPreview = discardOrPayPathInfo.second
+                        additionalCostInfo = path.costInfo,
+                        manaCostString = path.manaCostString,
+                        autoTapPreview = path.autoTapPreview
                     ))
                 }
             }
@@ -2530,6 +2268,108 @@ class CastSpellEnumerator : ActionEnumerator {
                 beholdCount = beholdCount
             )
         } else null
+    }
+
+    /**
+     * One extra cast action for the non-mana leg of an "… or pay {N}" additional cost
+     * ([AdditionalCost.CostOrPay] / [AdditionalCost.BeholdOrPay] / [AdditionalCost.BlightOrPay]):
+     * the spell's base cost *without* the alternative mana, plus that leg's own selection prompt.
+     * The pay path needs nothing extra — it is the ordinary cast action, whose cost already carries
+     * the alternative mana.
+     *
+     * @property label Parenthesised suffix on the action description ("Sacrifice", "Blight 2", …).
+     */
+    private data class OrPayPath(
+        val label: String,
+        val manaCostString: String,
+        val autoTapPreview: List<EntityId>?,
+        val costInfo: AdditionalCostData,
+    )
+
+    /**
+     * Candidates the caster could pick to pay [atom] as the non-mana leg of an
+     * [AdditionalCost.CostOrPay], excluding the spell being cast ([cardId]) — it is on the stack,
+     * not in the zone the cost draws from.
+     *
+     * Covers exactly the selection-carrying atoms the cast-time payment machinery can tell apart by
+     * payment field (see [AdditionalCost.CostOrPay]); anything else returns no candidates, so only
+     * the pay path is offered.
+     */
+    private fun orPayAtomCandidates(
+        context: EnumerationContext,
+        playerId: EntityId,
+        cardId: EntityId,
+        atom: CostAtom,
+    ): List<EntityId> {
+        val state = context.state
+        return when (atom) {
+            is CostAtom.Sacrifice -> context.costUtils.findSacrificeTargets(state, playerId, atom)
+            is CostAtom.ExileFrom -> context.costUtils.findExileTargets(state, playerId, atom.filter, atom.zone)
+                .filter { it != cardId }
+            is CostAtom.Discard -> {
+                val handCards = state.getZone(ZoneKey(playerId, Zone.HAND)).filter { it != cardId }
+                if (atom.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) handCards
+                else {
+                    val predicateContext = PredicateContext(controllerId = playerId)
+                    handCards.filter {
+                        context.predicateEvaluator.matches(state, state.projectedState, it, atom.filter, predicateContext)
+                    }
+                }
+            }
+            is CostAtom.TapPermanents -> context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                .filter { it != cardId }
+            is CostAtom.ReturnToHand -> context.costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
+                .filter { it != cardId }
+            else -> emptyList()
+        }
+    }
+
+    /**
+     * The action-description label and client cost data for paying [atom] as an or-pay leg, or null
+     * when [atom] carries no selection the client could drive (so the leg isn't offered).
+     *
+     * Deliberately reuses the same `costType`s a plain [AdditionalCost.Atom] cost of that kind
+     * emits, so the or-pay leg drives the existing pickers with no client-side changes.
+     */
+    private fun orPayAtomCostData(
+        atom: CostAtom,
+        candidates: List<EntityId>,
+    ): Pair<String, AdditionalCostData>? {
+        val description = atom.description.replaceFirstChar { it.uppercase() }
+        return when (atom) {
+            is CostAtom.Sacrifice -> "Sacrifice" to AdditionalCostData(
+                description = description,
+                costType = "SacrificePermanent",
+                validSacrificeTargets = candidates,
+                sacrificeCount = atom.count,
+            )
+            is CostAtom.Discard -> "Discard" to AdditionalCostData(
+                description = description,
+                costType = "DiscardCard",
+                validDiscardTargets = candidates,
+                discardCount = atom.count,
+            )
+            is CostAtom.ExileFrom -> "Exile from ${atom.zone.name.lowercase()}" to AdditionalCostData(
+                description = description,
+                costType = "ExileFromGraveyard",
+                validExileTargets = candidates,
+                exileMinCount = atom.count,
+                exileMaxCount = atom.count,
+            )
+            is CostAtom.TapPermanents -> "Tap" to AdditionalCostData(
+                description = description,
+                costType = "TapPermanents",
+                validTapTargets = candidates,
+                tapCount = atom.count,
+            )
+            is CostAtom.ReturnToHand -> "Return to hand" to AdditionalCostData(
+                description = description,
+                costType = "ReturnToHand",
+                validBounceTargets = candidates,
+                bounceCount = atom.count,
+            )
+            else -> null
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -207,10 +207,8 @@ class CastSpellEnumerator : ActionEnumerator {
             var blightVariableMaxX = 0
             var payXLifeCost: AdditionalCost.PayXLife? = null
             var payXLifeMaxX = 0
-            var beholdOrPayCost: AdditionalCost.BeholdOrPay? = null
-            var beholdOrPayTargets = emptyList<EntityId>()
-            var costOrPay: AdditionalCost.CostOrPay? = null
-            var costOrPayTargets = emptyList<EntityId>()
+            var orPayCost: AdditionalCost.OrPay? = null
+            var orPayTargets = emptyList<EntityId>()
             var canPayAdditionalCosts = true
             val flattenedCosts = additionalCosts.flatMap {
                 if (it is AdditionalCost.Composite) it.steps else listOf(it)
@@ -348,26 +346,11 @@ class CastSpellEnumerator : ActionEnumerator {
                         payXLifeCost = cost
                         payXLifeMaxX = currentLife
                     }
-                    is AdditionalCost.BeholdOrPay -> {
-                        // Always payable: player can always choose the "pay mana" path
-                        // Find valid behold targets (battlefield permanents + hand cards matching filter)
-                        beholdOrPayCost = cost
-                        val projected = state.projectedState
-                        val predicateContext = PredicateContext(controllerId = playerId)
-                        val battlefieldMatches = projected.getBattlefieldControlledBy(playerId).filter { permId ->
-                            context.predicateEvaluator.matches(state, projected, permId, cost.filter, predicateContext)
-                        }
-                        val handZone = ZoneKey(playerId, Zone.HAND)
-                        val handMatches = state.getZone(handZone)
-                            .filter { it != cardId } // Exclude the card being cast
-                            .filter { context.predicateEvaluator.matches(state, state.projectedState, it, cost.filter, predicateContext) }
-                        beholdOrPayTargets = battlefieldMatches + handMatches
-                    }
-                    is AdditionalCost.CostOrPay -> {
+                    is AdditionalCost.OrPay -> {
                         // Always payable: the player can always choose the "pay mana" path.
-                        // Surface the candidates for the atom path, whichever atom it carries.
-                        costOrPay = cost
-                        costOrPayTargets = orPayAtomCandidates(context, playerId, cardId, cost.atom)
+                        // Surface the candidates for the leg path, whichever cost it carries.
+                        orPayCost = cost
+                        orPayTargets = orPayLegCandidates(context, playerId, cardId, cost.cost)
                     }
                     is AdditionalCost.ChooseEntity -> {
                         // Search each (zone, filter) pair in `cost.zoneFilters`. Battlefield
@@ -428,16 +411,10 @@ class CastSpellEnumerator : ActionEnumerator {
                 effectiveCost = effectiveCost + ManaCost.parse(blightOrPayCost.alternativeManaCost)
             }
 
-            // Save base cost for behold path, then add extra mana for the "pay" path
-            val beholdBaseCost = effectiveCost
-            if (beholdOrPayCost != null) {
-                effectiveCost = effectiveCost + ManaCost.parse(beholdOrPayCost.alternativeManaCost)
-            }
-
-            // Save base cost for the atom path, then add extra mana for the "pay" path
-            val costOrPayBaseCost = effectiveCost
-            if (costOrPay != null) {
-                effectiveCost = effectiveCost + ManaCost.parse(costOrPay.alternativeManaCost)
+            // Save base cost for the or-pay leg path, then add extra mana for the "pay" path
+            val orPayBaseCost = effectiveCost
+            if (orPayCost != null) {
+                effectiveCost = effectiveCost + ManaCost.parse(orPayCost.alternativeManaCost)
             }
 
             // Spell-level waterbend additional cost (Avatar: The Last Airbender). A *mandatory*
@@ -578,25 +555,20 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, blightBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
-            // Check behold path affordability (base cost without the extra mana, but needs a beholdable target)
-            val canAffordBeholdPath = if (beholdOrPayCost != null && beholdOrPayTargets.isNotEmpty()) {
-                context.manaSolver.canPay(state, playerId, beholdBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
-            } else false
-
-            // Check the atom path's affordability (base cost without the extra mana, but needs
-            // enough candidates for the atom's own selection — permanents to sacrifice, cards to
-            // discard/exile, …).
-            val canAffordCostOrPayPath = if (costOrPay != null &&
-                costOrPayTargets.size >= costOrPay.atom.selectionCount
+            // Check the or-pay leg path's affordability (base cost without the extra mana, but needs
+            // enough candidates for the leg cost's own selection — permanents to sacrifice, cards to
+            // discard/exile/behold, …).
+            val canAffordOrPayPath = if (orPayCost != null &&
+                orPayTargets.size >= orPayLegSelectionCount(orPayCost.cost)
             ) {
-                context.manaSolver.canPay(state, playerId, costOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
+                context.manaSolver.canPay(state, playerId, orPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
             // A `MayCastWithoutPayingManaCost` battlefield permission (e.g. Weftwalking) makes the
             // spell affordable for {0} when its gates are open. Emitted by its own branch below;
             // don't continue out before reaching it.
             val canAffordFreeCast = context.freeCastPermissionFor(cardId)
-            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordCleave && !canAffordBlightPath && !canAffordBeholdPath && !canAffordCostOrPayPath && !canAffordFreeCast) {
+            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordCleave && !canAffordBlightPath && !canAffordOrPayPath && !canAffordFreeCast) {
                 // The primary face can't be paid for by any path. Normally we skip it entirely.
                 // But if this is an Adventure/Omen/modal-DFC card whose *secondary* face is
                 // affordable, surface a grayed-out placeholder for the primary face so the
@@ -655,31 +627,18 @@ class CastSpellEnumerator : ActionEnumerator {
                 )
             } else null
 
-            val beholdPathInfo = if (canAffordBeholdPath && beholdOrPayCost != null) {
-                orPayPath(
-                    label = "Behold",
-                    baseCost = beholdBaseCost,
-                    legCostInfo = AdditionalCostData(
-                        description = beholdOrPayCost.description,
-                        costType = "Behold",
-                        validBeholdTargets = beholdOrPayTargets,
-                        beholdCount = 1
-                    )
-                )
-            } else null
-
-            // The atom leg reuses the atom's own client picker ("SacrificePermanent",
-            // "DiscardCard", …), so a plain sacrifice/discard/exile cost and the or-pay variant
+            // The leg reuses its own cost's client picker ("SacrificePermanent", "DiscardCard",
+            // "Behold", …), so a plain sacrifice/discard/exile/behold cost and the or-pay variant
             // drive the exact same selection UI.
-            val costOrPayPathInfo = if (canAffordCostOrPayPath && costOrPay != null) {
-                orPayAtomCostData(costOrPay.atom, costOrPayTargets)?.let { (label, legCostInfo) ->
-                    orPayPath(label = label, baseCost = costOrPayBaseCost, legCostInfo = legCostInfo)
+            val orPayPathInfo = if (canAffordOrPayPath && orPayCost != null) {
+                orPayLegCostData(orPayCost.cost, orPayTargets)?.let { (label, legCostInfo) ->
+                    orPayPath(label = label, baseCost = orPayBaseCost, legCostInfo = legCostInfo)
                 }
             } else null
 
             // Every or-pay leg emits the same shape of extra cast action, so the emission sites
             // below just loop over them.
-            val orPayPaths = listOfNotNull(blightPathInfo, beholdPathInfo, costOrPayPathInfo)
+            val orPayPaths = listOfNotNull(blightPathInfo, orPayPathInfo)
 
             // Calculate X cost info if the spell has X in its cost (printed, or the waterbend {X}
             // folded in above).
@@ -2245,7 +2204,9 @@ class CastSpellEnumerator : ActionEnumerator {
             val bounceCost = additionalCosts.firstNotNullOfOrNull { (it as? AdditionalCost.Atom)?.atom as? CostAtom.ReturnToHand }
             AdditionalCostData(
                 description = bounceCost?.description?.replaceFirstChar { it.uppercase() } ?: "Return a permanent you control to its owner's hand",
-                costType = "ReturnToHand",
+                // "BouncePermanent" is the bounce picker's costType everywhere else (activated
+                // abilities, Sneak, Web-slinging); "ReturnToHand" matches no client phase.
+                costType = "BouncePermanent",
                 validBounceTargets = bounceTargets,
                 bounceCount = bounceCount
             )
@@ -2272,7 +2233,7 @@ class CastSpellEnumerator : ActionEnumerator {
 
     /**
      * One extra cast action for the non-mana leg of an "… or pay {N}" additional cost
-     * ([AdditionalCost.CostOrPay] / [AdditionalCost.BeholdOrPay] / [AdditionalCost.BlightOrPay]):
+     * ([AdditionalCost.OrPay] / [AdditionalCost.BlightOrPay]):
      * the spell's base cost *without* the alternative mana, plus that leg's own selection prompt.
      * The pay path needs nothing extra — it is the ordinary cast action, whose cost already carries
      * the alternative mana.
@@ -2287,89 +2248,120 @@ class CastSpellEnumerator : ActionEnumerator {
     )
 
     /**
-     * Candidates the caster could pick to pay [atom] as the non-mana leg of an
-     * [AdditionalCost.CostOrPay], excluding the spell being cast ([cardId]) — it is on the stack,
-     * not in the zone the cost draws from.
+     * Candidates the caster could pick to pay [leg] as the non-mana leg of an
+     * [AdditionalCost.OrPay], excluding the spell being cast ([cardId]) — it is on the stack, not in
+     * the zone the cost draws from.
      *
-     * Covers exactly the selection-carrying atoms the cast-time payment machinery can tell apart by
-     * payment field (see [AdditionalCost.CostOrPay]); anything else returns no candidates, so only
-     * the pay path is offered.
+     * Covers exactly the selection-carrying costs the cast-time payment machinery can tell apart by
+     * payment field (see [AdditionalCost.OrPay]); anything else returns no candidates, so only the
+     * pay path is offered.
      */
-    private fun orPayAtomCandidates(
+    private fun orPayLegCandidates(
         context: EnumerationContext,
         playerId: EntityId,
         cardId: EntityId,
-        atom: CostAtom,
+        leg: AdditionalCost,
     ): List<EntityId> {
         val state = context.state
-        return when (atom) {
-            is CostAtom.Sacrifice -> context.costUtils.findSacrificeTargets(state, playerId, atom)
-            is CostAtom.ExileFrom -> context.costUtils.findExileTargets(state, playerId, atom.filter, atom.zone)
-                .filter { it != cardId }
-            is CostAtom.Discard -> {
-                val handCards = state.getZone(ZoneKey(playerId, Zone.HAND)).filter { it != cardId }
-                if (atom.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) handCards
-                else {
-                    val predicateContext = PredicateContext(controllerId = playerId)
-                    handCards.filter {
+        val predicateContext = PredicateContext(controllerId = playerId)
+        return when (leg) {
+            // Behold spans battlefield *and* hand in one candidate pool.
+            is AdditionalCost.Behold -> {
+                val projected = state.projectedState
+                val battlefieldMatches = projected.getBattlefieldControlledBy(playerId).filter { permId ->
+                    context.predicateEvaluator.matches(state, projected, permId, leg.filter, predicateContext)
+                }
+                val handMatches = state.getZone(ZoneKey(playerId, Zone.HAND))
+                    .filter { it != cardId }
+                    .filter { context.predicateEvaluator.matches(state, projected, it, leg.filter, predicateContext) }
+                battlefieldMatches + handMatches
+            }
+            is AdditionalCost.Atom -> when (val atom = leg.atom) {
+                is CostAtom.Sacrifice -> context.costUtils.findSacrificeTargets(state, playerId, atom)
+                is CostAtom.ExileFrom -> context.costUtils.findExileTargets(state, playerId, atom.filter, atom.zone)
+                    .filter { it != cardId }
+                is CostAtom.Discard -> {
+                    val handCards = state.getZone(ZoneKey(playerId, Zone.HAND)).filter { it != cardId }
+                    if (atom.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) handCards
+                    else handCards.filter {
                         context.predicateEvaluator.matches(state, state.projectedState, it, atom.filter, predicateContext)
                     }
                 }
+                is CostAtom.TapPermanents -> context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                    .let { if (atom.excludeSelf) it.filter { id -> id != cardId } else it }
+                is CostAtom.ReturnToHand -> context.costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
+                else -> emptyList()
             }
-            is CostAtom.TapPermanents -> context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
-                .filter { it != cardId }
-            is CostAtom.ReturnToHand -> context.costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
-                .filter { it != cardId }
             else -> emptyList()
         }
     }
 
+    /** How many entities the caster must pick to pay [leg] — 0 when it carries no selection. */
+    private fun orPayLegSelectionCount(leg: AdditionalCost): Int = when (leg) {
+        is AdditionalCost.Behold -> leg.count
+        is AdditionalCost.Atom -> leg.atom.selectionCount
+        else -> 0
+    }
+
     /**
-     * The action-description label and client cost data for paying [atom] as an or-pay leg, or null
-     * when [atom] carries no selection the client could drive (so the leg isn't offered).
+     * The action-description label and client cost data for paying [leg] as an or-pay leg, or null
+     * when [leg] carries no selection the client could drive (so the leg isn't offered).
      *
-     * Deliberately reuses the same `costType`s a plain [AdditionalCost.Atom] cost of that kind
-     * emits, so the or-pay leg drives the existing pickers with no client-side changes.
+     * Deliberately reuses the same `costType`s the leg cost emits when it stands alone, so the
+     * or-pay leg drives the existing pickers with no client-side changes. `"ExileFromGraveyard"`
+     * pins the client's picker to the graveyard, so a non-graveyard exile leg is declined rather
+     * than shown against the wrong zone.
      */
-    private fun orPayAtomCostData(
-        atom: CostAtom,
+    private fun orPayLegCostData(
+        leg: AdditionalCost,
         candidates: List<EntityId>,
-    ): Pair<String, AdditionalCostData>? {
-        val description = atom.description.replaceFirstChar { it.uppercase() }
-        return when (atom) {
-            is CostAtom.Sacrifice -> "Sacrifice" to AdditionalCostData(
-                description = description,
-                costType = "SacrificePermanent",
-                validSacrificeTargets = candidates,
-                sacrificeCount = atom.count,
-            )
-            is CostAtom.Discard -> "Discard" to AdditionalCostData(
-                description = description,
-                costType = "DiscardCard",
-                validDiscardTargets = candidates,
-                discardCount = atom.count,
-            )
-            is CostAtom.ExileFrom -> "Exile from ${atom.zone.name.lowercase()}" to AdditionalCostData(
-                description = description,
-                costType = "ExileFromGraveyard",
-                validExileTargets = candidates,
-                exileMinCount = atom.count,
-                exileMaxCount = atom.count,
-            )
-            is CostAtom.TapPermanents -> "Tap" to AdditionalCostData(
-                description = description,
-                costType = "TapPermanents",
-                validTapTargets = candidates,
-                tapCount = atom.count,
-            )
-            is CostAtom.ReturnToHand -> "Return to hand" to AdditionalCostData(
-                description = description,
-                costType = "ReturnToHand",
-                validBounceTargets = candidates,
-                bounceCount = atom.count,
-            )
-            else -> null
+    ): Pair<String, AdditionalCostData>? = when (leg) {
+        is AdditionalCost.Behold -> "Behold" to AdditionalCostData(
+            description = leg.description,
+            costType = "Behold",
+            validBeholdTargets = candidates,
+            beholdCount = leg.count,
+        )
+        is AdditionalCost.Atom -> {
+            val description = leg.description
+            when (val atom = leg.atom) {
+                is CostAtom.Sacrifice -> "Sacrifice" to AdditionalCostData(
+                    description = description,
+                    costType = "SacrificePermanent",
+                    validSacrificeTargets = candidates,
+                    sacrificeCount = atom.count,
+                )
+                is CostAtom.Discard -> "Discard" to AdditionalCostData(
+                    description = description,
+                    costType = "DiscardCard",
+                    validDiscardTargets = candidates,
+                    discardCount = atom.count,
+                )
+                is CostAtom.ExileFrom -> if (atom.zone != Zone.GRAVEYARD) null else {
+                    "Exile from graveyard" to AdditionalCostData(
+                        description = description,
+                        costType = "ExileFromGraveyard",
+                        validExileTargets = candidates,
+                        exileMinCount = atom.count,
+                        exileMaxCount = atom.count,
+                    )
+                }
+                is CostAtom.TapPermanents -> "Tap" to AdditionalCostData(
+                    description = description,
+                    costType = "TapPermanents",
+                    validTapTargets = candidates,
+                    tapCount = atom.count,
+                )
+                is CostAtom.ReturnToHand -> "Return to hand" to AdditionalCostData(
+                    description = description,
+                    costType = "BouncePermanent",
+                    validBounceTargets = candidates,
+                    bounceCount = atom.count,
+                )
+                else -> null
+            }
         }
+        else -> null
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -3739,8 +3739,8 @@ class StackResolver(
 /**
  * Build pipeline `storedCollections` for cost-chosen card IDs.
  *
- * The chosen IDs (from [AdditionalCost.Behold], [AdditionalCost.BeholdOrPay], or
- * [AdditionalCost.ChooseEntity]) are stored on the stack object as
+ * The chosen IDs (from [AdditionalCost.Behold] — on its own or as an [AdditionalCost.OrPay] leg —
+ * or [AdditionalCost.ChooseEntity]) are stored on the stack object as
  * [SpellOnStackComponent.beheldCards]. Each of those costs declares its own
  * `storeAs` key that the card's resolution-time effects reference (e.g. via
  * `EntityReference.FromCostStorage`). To keep the effect's reference
@@ -3758,16 +3758,15 @@ internal fun buildBeheldStoredCollections(
 ): Map<String, List<EntityId>> {
     if (beheldCards.isEmpty()) return emptyMap()
     val keys = mutableSetOf("beheld")
-    cardDef?.script?.additionalCosts?.forEach { cost ->
-        val flat = if (cost is AdditionalCost.Composite) cost.steps else listOf(cost)
-        for (c in flat) {
-            when (c) {
-                is AdditionalCost.Behold -> keys += c.storeAs
-                is AdditionalCost.BeholdOrPay -> keys += c.storeAs
-                is AdditionalCost.ChooseEntity -> keys += c.storeAs
-                else -> {}
-            }
+    fun collect(cost: AdditionalCost) {
+        when (cost) {
+            is AdditionalCost.Behold -> keys += cost.storeAs
+            is AdditionalCost.ChooseEntity -> keys += cost.storeAs
+            is AdditionalCost.Composite -> cost.steps.forEach(::collect)
+            is AdditionalCost.OrPay -> collect(cost.cost)
+            else -> {}
         }
     }
+    cardDef?.script?.additionalCosts?.forEach(::collect)
     return keys.associateWith { beheldCards }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CausticExhaleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CausticExhaleScenarioTest.kt
@@ -17,7 +17,7 @@ import io.kotest.matchers.shouldBe
  * "As an additional cost to cast this spell, behold a Dragon or pay {1}.
  *  Target creature gets -3/-3 until end of turn."
  *
- * Exercises the `AdditionalCost.BeholdOrPay` cost (Dragon filter) plus the {1}-mana
+ * Exercises the behold leg of `AdditionalCost.OrPay` (Dragon filter) plus the {1}-mana
  * alternative, with the -3/-3 spell effect on a targeted creature.
  */
 class CausticExhaleScenarioTest : ScenarioTestBase() {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LouisoixsSacrificeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LouisoixsSacrificeScenarioTest.kt
@@ -22,8 +22,8 @@ import io.kotest.matchers.shouldBe
  * As an additional cost to cast this spell, sacrifice a legendary creature or pay {2}.
  * Counter target activated ability, triggered ability, or noncreature spell.
  *
- * Exercises the new [com.wingedsheep.sdk.scripting.AdditionalCost.SacrificeOrPay] additional cost
- * (sacrifice path vs pay path) and the union target "(ability) OR (noncreature spell)" that
+ * Exercises the sacrifice leg of [com.wingedsheep.sdk.scripting.AdditionalCost.OrPay] (sacrifice
+ * path vs pay path) and the union target "(ability) OR (noncreature spell)" that
  * excludes creature spells.
  */
 class LouisoixsSacrificeScenarioTest : ScenarioTestBase() {
@@ -45,7 +45,7 @@ class LouisoixsSacrificeScenarioTest : ScenarioTestBase() {
     init {
         cardRegistry.register(listOf(testLegend, testVanillaCreature))
 
-        context("SacrificeOrPay additional cost") {
+        context("sacrifice-or-pay additional cost") {
             test("sacrifice path counters a noncreature spell and sacrifices the legendary creature") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PumpkinBombardmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PumpkinBombardmentScenarioTest.kt
@@ -19,8 +19,8 @@ import io.kotest.matchers.shouldBe
  * As an additional cost to cast this spell, discard a card or pay {2}.
  * Pumpkin Bombardment deals 3 damage to target creature.
  *
- * Exercises the new [com.wingedsheep.sdk.scripting.AdditionalCost.DiscardOrPay] additional cost
- * (discard path vs pay path), including the case where an empty hand leaves only the pay path.
+ * Exercises the discard leg of [com.wingedsheep.sdk.scripting.AdditionalCost.OrPay] (discard path
+ * vs pay path), including the case where an empty hand leaves only the pay path.
  */
 class PumpkinBombardmentScenarioTest : ScenarioTestBase() {
 
@@ -41,7 +41,7 @@ class PumpkinBombardmentScenarioTest : ScenarioTestBase() {
     init {
         cardRegistry.register(listOf(testBear, spareCard))
 
-        context("DiscardOrPay additional cost") {
+        context("discard-or-pay additional cost") {
             test("discard path: discards a card and deals 3 damage to the target creature") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoaringStonegliderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoaringStonegliderScenarioTest.kt
@@ -21,7 +21,7 @@ import io.kotest.matchers.shouldBe
  *
  * "As an additional cost to cast this spell, exile two cards from your graveyard or pay {1}{W}."
  *
- * Exercises the new [com.wingedsheep.sdk.scripting.AdditionalCost.ExileFromGraveyardOrPay] cost:
+ * Exercises the exile-from-graveyard leg of [com.wingedsheep.sdk.scripting.AdditionalCost.OrPay]:
  *  - the enumerator offers both the exile path (base {2}{W}) and the pay path ({2}{W} + {1}{W});
  *  - paying via the exile path moves two graveyard cards to exile;
  *  - paying via the pay path leaves the graveyard untouched;


### PR DESCRIPTION
# Collapse the `*OrPay` additional-cost family into one `AdditionalCost.OrPay`

Five near-identical cast-time cost types — `SacrificeOrPay`, `DiscardOrPay`,
`ExileFromGraveyardOrPay`, `BeholdOrPay` and their shared enumerator/handler plumbing — differed
only in *which cost sat on the non-mana leg*. They collapse into one type parameterized by that
cost:

```kotlin
data class OrPay(val cost: AdditionalCost, val alternativeManaCost: String) : AdditionalCost
```

`BlightOrPay` is the one holdout: there is no standalone blight `AdditionalCost` for `OrPay` to
wrap, so collapsing it means introducing one first. Noted in
`backlog/sdk-reusability-consolidation.md`, which proposed this change.

## Why it's smaller

`CastSpellHandler.reduceCostAlternatives` rewrites an `OrPay` to its **leg cost** when the caster
populated that cost's payment field, and drops it otherwise (the pay path — whose only consequence,
the extra mana, is folded in by `applyOrPayManaAdjustments`). Downstream, the leg is just a plain
`Atom` / `Behold` cost, so validation, payment, LKI snapshots (CR 112.7a / 608.2h), behold's
pipeline storage and the turn's discard tracking (CR 701.8) are inherited rather than
re-implemented per or-pay type. `applyOrPayManaAdjustments` is shared by `validate()` and
`execute()` so a cast is priced identically in both.

In the enumerator, every or-pay leg now produces the same `OrPayPath` record, so the three
`LegalAction` emission sites loop over one list instead of repeating a near-identical construction
per cost type.

No card definitions changed: the printed wordings (`Costs.additional.SacrificeOrPay`, `.DiscardOrPay`,
`.ExileFromGraveyardOrPay`, `.BeholdOrPay`) survive as one-line facades over `OrPay`.

## Fixes carried along

- **`costType = "ReturnToHand"` → `"BouncePermanent"`.** `"ReturnToHand"` is in no client cost-type
  list; every other bounce-cost site (activated abilities, Sneak, Web-slinging) emits
  `"BouncePermanent"`. A spell with a `ReturnToHand` additional cost would have surfaced an action
  the client could not prompt for. Pre-existing; fixed on both the plain-atom and or-pay paths.
- **Non-graveyard `ExileFrom` legs are declined rather than mislabelled.** The
  `"ExileFromGraveyard"` costType pins the client's picker to the graveyard, so an `ExileFrom` leg
  on another zone now offers only the pay path instead of showing the wrong zone.
- **`AdditionalCost.Composite` is flattened before alternatives are reduced**, in both
  `reduceCostAlternatives` and `applyOrPayManaAdjustments`, so an alternative nested in a composite
  is reduced *and* priced like a top-level one. Previously a nested or-pay would have been silently
  free.
- **`TapPermanents.excludeSelf`** is now honoured on the or-pay leg, matching the plain-atom path.

## Behaviour note — payment-size tolerance

The deleted `SacrificeOrPay` / `DiscardOrPay` / `ExileFromGraveyardOrPay` validators rejected a
payment whose size was `!= count`. The shared `Atom` validators they now route through check
`size < count`, so an over-sized payment (two permanents for "sacrifice a legendary creature") would
be accepted and both sacrificed. This aligns these four cards with how every other atom cost in the
engine already behaves, and the client always sends exactly `count`. Tightening `<` to `!=` is a
reasonable follow-up but is an engine-wide change to every atom cost, deliberately out of scope
here.

## Verification

- `:rules-engine:test` and `:mtg-sdk:test` — full suites green.
- `:mtg-sets:test --tests "*CardDefinitionSnapshotTest"` — goldens re-blessed; only ECL / FIN / MID /
  SOS / SPM / TDM or-pay cards moved.
- Existing scenario coverage exercises both legs and the leg-unavailable case for each shape:
  `LouisoixsSacrificeScenarioTest`, `PumpkinBombardmentScenarioTest`, `SoaringStonegliderScenarioTest`,
  `CausticExhaleScenarioTest` (behold leg), `SoulsOfTheLostScenarioTest` (the neighbouring `Choice`
  cost-vs-cost shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
