### PR TITLE
Stop the AI going in circles

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/StateProgress.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/StateProgress.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedEverComponent
+import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.TargetedByControllerThisTurnComponent
+import com.wingedsheep.engine.state.components.battlefield.TimestampComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * "Is this position one I have already been in?" — how the AI tells progress from a treadmill.
+ *
+ * Two shapes of the same bug live here. The first is an **inert** action, one whose resolved
+ * position is the position it started from: Aphetto Alchemist's `{T}: Untap target artifact or
+ * creature` aimed at itself taps for its own cost and then untaps itself again. The second is a
+ * **cycle** — two Alchemists untapping each other — where every single step does change the board
+ * and the sequence still goes nowhere.
+ *
+ * A leaf-scoring search has no defence against either on its own. It compares "take this action"
+ * against "pass" by scoring the two positions they lead to, and those two positions are not
+ * measured at the same point in the game: passing carries the game forward into whatever was about
+ * to happen, while a free ability that resolves back onto the same board stops right where it is.
+ * When what is about to happen is bad, doing nothing at all can therefore *outscore* passing — and
+ * once it does, it does so again from the identical position it just produced, forever. That is the
+ * bug this exists to prevent: the AI activated Aphetto Alchemist until the game had to be
+ * abandoned.
+ *
+ * So this is not a heuristic about value — the evaluator owns that question. It is the structural
+ * claim underneath it, and the rules make the same one: CR 732.3 requires a player whose actions
+ * have "resulted in the same game state being reached multiple times" to make a *different* game
+ * choice, and its example turns on the very thing [IGNORED_COMPONENTS] does — the loop repeats a
+ * position when "nothing in the game cares how many times an ability has been activated."
+ *
+ * [Strategist] is the consumer: it drops any candidate whose leaf repeats a position it has already
+ * acted from.
+ */
+object StateProgress {
+
+    /**
+     * Whether [after] is the same game position as [before], so the action between them
+     * accomplished nothing at all.
+     *
+     * Compares a digest rather than the states themselves. `GameState` equality is unusable here —
+     * a resolved ability leaves behind an orphaned stack entity, a bumped `nextEntityId` and an
+     * advanced `rng`, none of which is a game fact — so [digest] reads the position the way a
+     * player would: zone contents, and everything true of the objects and players in them.
+     */
+    fun isInert(before: GameState, after: GameState): Boolean = digest(before) == digest(after)
+
+    /**
+     * A 64-bit summary of everything about [state] that a player could point at.
+     *
+     * Deliberately blind to bookkeeping that changes on *every* activation regardless of what the
+     * ability did — see [IGNORED_COMPONENTS] — and to whose priority it is, which is what makes an
+     * action's own resolution comparable with the position it started from.
+     *
+     * Turn number and step *are* part of it, which is what keeps the repetition memory honest: the
+     * same board in a later step is a different position, so a digest can only recur inside the
+     * window where recurring means going in circles.
+     *
+     * Per-collection hashes are summed rather than folded, so a `Map` that rehashed between the two
+     * states can't read as a change; order *within* a zone still counts, because library and stack
+     * order are game facts.
+     */
+    fun digest(state: GameState): Long {
+        var h = SEED
+
+        h = h.mix(state.turnNumber)
+        h = h.mix(state.phase.hashCode())
+        h = h.mix(state.step.hashCode())
+        h = h.mix(state.activePlayerId.hashCode())
+        h = h.mix(state.gameOver.hashCode())
+        h = h.mix(state.winnerId.hashCode())
+        h = h.mix(state.stack.hashCode())
+        h = h.mix(state.continuationStack.size)
+        h = h.mix(state.floatingEffects.hashCode())
+        h = h.mix(state.delayedTriggers.hashCode())
+        h = h.mix(state.grantedTriggeredAbilities.hashCode())
+        h = h.mix(state.grantedActivatedAbilities.hashCode())
+        h = h.mix(state.grantedStaticAbilities.hashCode())
+        h = h.mix(state.grantedReplacementEffects.hashCode())
+        h = h.mix(state.grantedKeywordAbilities.hashCode())
+        h = h.mix(state.globalGrantedTriggeredAbilities.hashCode())
+        h = h.mix(state.mayPlayPermissions.hashCode())
+        h = h.mix(state.commanderDamage.hashCode())
+        h = h.mix(state.spellsCastThisTurn)
+        h = h.mix(state.permanentsSacrificedThisTurn)
+
+        var zones = 0L
+        for ((key, contents) in state.zones) {
+            var zone = key.hashCode().toLong()
+            for (entityId in contents) {
+                zone = zone.mix(entityId.hashCode())
+                // A library is hashed by its order alone: 60 cards whose components no game action
+                // touches without also moving them somewhere this digest reads in full.
+                if (key.zoneType != Zone.LIBRARY) zone = zone.mix(objectHash(state, entityId))
+            }
+            zones += zone
+        }
+        h = h.mix(zones)
+
+        var objects = 0L
+        for (entityId in state.stack) objects += objectHash(state, entityId)
+        for (playerId in state.turnOrder) objects += objectHash(state, playerId)
+        return h.mix(objects)
+    }
+
+    /** Everything the ECS records about one object, minus the ignored bookkeeping. */
+    private fun objectHash(state: GameState, entityId: EntityId): Long {
+        val container = state.getEntity(entityId) ?: return 0L
+        var h = 0L
+        for (component in container.all()) {
+            val type = component::class.java
+            if (type in IGNORED_COMPONENTS) continue
+            h += type.name.hashCode().toLong().mix(component.hashCode())
+        }
+        return h
+    }
+
+    private fun Long.mix(value: Int): Long = this * 0x100000001B3L xor value.toLong()
+
+    private fun Long.mix(value: Long): Long = this * 0x100000001B3L xor value
+
+    /**
+     * "It happened" memories, as opposed to game position.
+     *
+     * Each of these records *that* an action was taken — the once-per-turn and `MaxPerTurn`
+     * activation counts, Valiant's "has this been targeted by its controller yet this turn", and the
+     * timestamp bumped when a continuous effect is re-applied. An activation changes them even when
+     * it changed nothing else, so reading them would make every inert action look like progress —
+     * exactly the reading this object exists to avoid. Nothing is lost by the omission: whatever
+     * these memories gate (a Valiant trigger, a second activation being legal at all) shows up in
+     * the position the moment it actually does something.
+     *
+     * The list is a floor, not a ceiling: a memory component not named here makes an inert action
+     * read as progress, so the AI takes it once more than it should. Which is why it fails in that
+     * direction — a *missing* entry costs a wasted activation, whereas wrongly ignoring something
+     * real would cost the AI an ability it should have used.
+     */
+    private val IGNORED_COMPONENTS = setOf<Class<*>>(
+        AbilityActivatedThisTurnComponent::class.java,
+        AbilityActivatedEverComponent::class.java,
+        TargetedByControllerThisTurnComponent::class.java,
+        TimestampComponent::class.java,
+    )
+
+    private const val SEED = -0x340d631b7bdddcdbL
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/StateProgress.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/StateProgress.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.state.components.battlefield.TargetedByControllerT
 import com.wingedsheep.engine.state.components.battlefield.TimestampComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.GameRng
 
 /**
  * "Is this position one I have already been in?" — how the AI tells progress from a treadmill.
@@ -34,88 +35,106 @@ import com.wingedsheep.sdk.model.EntityId
  *
  * [Strategist] is the consumer: it drops any candidate whose leaf repeats a position it has already
  * acted from.
+ *
+ * **This is deliberately not behind an [AiProfile] flag**, which is the one place this codebase
+ * normally insists on one — `FrozenBaselineTest` exists to stop `AiProfile.LEGACY_V0` drifting, and
+ * Phase 4's `fillPartial` is gated for no other reason. The rule is about *strength*: a change that
+ * makes V0 play better silently rebases every published arena number. A game that has to be
+ * abandoned has no strength to compare, so there is nothing here worth freezing. `FrozenBaselineTest`
+ * stays green because its baseline deck is all-vanilla — no activated abilities, so nothing this
+ * guard can fire on — which means it is not evidence either way and shouldn't be read as any.
  */
 object StateProgress {
 
     /**
-     * Whether [after] is the same game position as [before], so the action between them
-     * accomplished nothing at all.
-     *
-     * Compares a digest rather than the states themselves. `GameState` equality is unusable here —
-     * a resolved ability leaves behind an orphaned stack entity, a bumped `nextEntityId` and an
-     * advanced `rng`, none of which is a game fact — so [digest] reads the position the way a
-     * player would: zone contents, and everything true of the objects and players in them.
-     */
-    fun isInert(before: GameState, after: GameState): Boolean = digest(before) == digest(after)
-
-    /**
      * A 64-bit summary of everything about [state] that a player could point at.
      *
-     * Deliberately blind to bookkeeping that changes on *every* activation regardless of what the
-     * ability did — see [IGNORED_COMPONENTS] — and to whose priority it is, which is what makes an
-     * action's own resolution comparable with the position it started from.
+     * `GameState` equality is unusable for this. A resolved ability leaves behind an orphaned stack
+     * entity, a bumped `nextEntityId` and an advanced `rng`, none of which is a game fact — so this
+     * reads the position the way a player would: everything `GameState` itself records, minus the
+     * bookkeeping [normalized] strips, plus everything true of the objects and players in the zones.
      *
      * Turn number and step *are* part of it, which is what keeps the repetition memory honest: the
      * same board in a later step is a different position, so a digest can only recur inside the
      * window where recurring means going in circles.
      *
-     * Per-collection hashes are summed rather than folded, so a `Map` that rehashed between the two
-     * states can't read as a change; order *within* a zone still counts, because library and stack
-     * order are game facts.
+     * Per-object hashes are summed rather than folded, so iteration order can't read as a change;
+     * order *within* a zone still counts, because library and stack order are game facts, and it is
+     * `zones` inside [normalized] that carries it.
      */
     fun digest(state: GameState): Long {
-        var h = SEED
-
-        h = h.mix(state.turnNumber)
-        h = h.mix(state.phase.hashCode())
-        h = h.mix(state.step.hashCode())
-        h = h.mix(state.activePlayerId.hashCode())
-        h = h.mix(state.gameOver.hashCode())
-        h = h.mix(state.winnerId.hashCode())
-        h = h.mix(state.stack.hashCode())
+        var h = SEED.mix(normalized(state).hashCode())
+        // Continuation frames are counted, not read. A frame holds mid-resolution bookkeeping —
+        // the stack entity being resolved, indices into it — that a re-resolution mints afresh, so
+        // hashing their contents would make an inert action look like progress. Depth alone is
+        // enough here because the states this is asked to compare are quiet ones: a leaf that
+        // paused mid-resolution comes back as `SimulationResult.NeedsDecision`, which [Strategist]
+        // never digests.
         h = h.mix(state.continuationStack.size)
-        h = h.mix(state.floatingEffects.hashCode())
-        h = h.mix(state.delayedTriggers.hashCode())
-        h = h.mix(state.grantedTriggeredAbilities.hashCode())
-        h = h.mix(state.grantedActivatedAbilities.hashCode())
-        h = h.mix(state.grantedStaticAbilities.hashCode())
-        h = h.mix(state.grantedReplacementEffects.hashCode())
-        h = h.mix(state.grantedKeywordAbilities.hashCode())
-        h = h.mix(state.globalGrantedTriggeredAbilities.hashCode())
-        h = h.mix(state.mayPlayPermissions.hashCode())
-        h = h.mix(state.commanderDamage.hashCode())
-        h = h.mix(state.spellsCastThisTurn)
-        h = h.mix(state.permanentsSacrificedThisTurn)
-
-        var zones = 0L
-        for ((key, contents) in state.zones) {
-            var zone = key.hashCode().toLong()
-            for (entityId in contents) {
-                zone = zone.mix(entityId.hashCode())
-                // A library is hashed by its order alone: 60 cards whose components no game action
-                // touches without also moving them somewhere this digest reads in full.
-                if (key.zoneType != Zone.LIBRARY) zone = zone.mix(objectHash(state, entityId))
-            }
-            zones += zone
-        }
-        h = h.mix(zones)
 
         var objects = 0L
+        for ((key, contents) in state.zones) {
+            // A library is hashed by its order alone — carried by `zones` in [normalized]. Its 60
+            // cards have no components a game action touches without also moving them somewhere
+            // this digest reads in full.
+            if (key.zoneType == Zone.LIBRARY) continue
+            for (entityId in contents) objects += objectHash(state, entityId)
+        }
         for (entityId in state.stack) objects += objectHash(state, entityId)
         for (playerId in state.turnOrder) objects += objectHash(state, playerId)
         return h.mix(objects)
     }
 
-    /** Everything the ECS records about one object, minus the ignored bookkeeping. */
+    /**
+     * [state] with everything that is not a game fact zeroed out, so the data class's own
+     * `hashCode` can supply the rest.
+     *
+     * A hand-written list of the fields to *read* was the first shape of this, and it had the
+     * failure direction backwards. `GameState` carries ~50 fields and gains more; several are
+     * turn-level riders an ability can set without touching a permanent — `turnSpellCostReductions`,
+     * `activeCounterPlacementModifiers`, `pendingUncounterableSpells`,
+     * `damageCantBePreventedThisTurn`. A field missing from a read-list makes a real action look
+     * inert, and [Strategist] then refuses it *forever*. Naming the exclusions instead means a field
+     * added tomorrow counts by default, and the worst a wrong entry here can do is cost one wasted
+     * activation.
+     *
+     * What is stripped, and why none of it is a game fact:
+     * - `entities` — read separately by [objectHash], which drops [IGNORED_COMPONENTS].
+     * - `rng`, `nextEntityId`, `timestamp` — advanced by resolving anything at all.
+     * - `priorityPlayerId`, `priorityPassedBy` — whose turn it is to speak, not what is true. This
+     *   is what makes an action's own resolution comparable with the position it started from.
+     * - `continuationStack` — counted instead; see [digest].
+     * - `pendingDecision` — the same mid-resolution bookkeeping, and never set on a quiet state.
+     *
+     * `projectedState` is a body property rather than a constructor parameter, so it is already out
+     * of `hashCode` — and would be redundant anyway, being a pure function of what is left.
+     */
+    private fun normalized(state: GameState): GameState = state.copy(
+        entities = emptyMap(),
+        rng = GameRng(0L),
+        nextEntityId = 0L,
+        timestamp = 0L,
+        priorityPlayerId = null,
+        priorityPassedBy = emptySet(),
+        continuationStack = emptyList(),
+        pendingDecision = null,
+    )
+
+    /**
+     * Everything the ECS records about one object, minus the ignored bookkeeping.
+     *
+     * The entity id is mixed with the component hash rather than added alongside it, so two objects
+     * in the same zone trading component sets is a change rather than the same sum.
+     */
     private fun objectHash(state: GameState, entityId: EntityId): Long {
         val container = state.getEntity(entityId) ?: return 0L
-        var h = 0L
+        var components = 0L
         for (component in container.all()) {
             val type = component::class.java
             if (type in IGNORED_COMPONENTS) continue
-            h += type.name.hashCode().toLong().mix(component.hashCode())
+            components += type.name.hashCode().toLong().mix(component.hashCode())
         }
-        return h
+        return entityId.hashCode().toLong().mix(components)
     }
 
     private fun Long.mix(value: Int): Long = this * 0x100000001B3L xor value.toLong()

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -136,23 +136,28 @@ class Strategist(
             leafStates += simulator.simulate(evaluationState, pass.action).state
         }
         for (action in affordable) {
-            val materialized = chooseCommittedTargets(evaluationState, action, playerId, budget)
-            val simulation = simulator.simulate(evaluationState, materialized)
-            // LegalAction affordability is necessarily a preview for costs such as convoke and
-            // modal/additional payments. If materializing the concrete action cannot pass the
-            // authoritative processor, it is not a candidate the AI may submit.
-            if (simulation is SimulationResult.Illegal) continue
-            // A line that walks back into a position we have already acted from has accomplished
-            // nothing, whatever the leaf score says — and it is not a one-off mistake, because it
-            // hands us back the very position that made it look good. Aphetto Alchemist untapping
-            // itself is the degenerate case (`here`); two of them untapping each other is the same
-            // thing one step longer. See [StateProgress].
-            if (simulation !is SimulationResult.NeedsDecision) {
-                val leaf = StateProgress.digest(simulation.state)
-                if (leaf == here || leaf in positionsActedFrom) continue
+            val (materialized, simulation) = materialize(evaluationState, action, playerId, budget, here)
+            val usable = when {
+                // LegalAction affordability is necessarily a preview for costs such as convoke and
+                // modal/additional payments. If materializing the concrete action cannot pass the
+                // authoritative processor, it is not a candidate the AI may submit.
+                simulation is SimulationResult.Illegal -> false
+                simulation is SimulationResult.NeedsDecision -> true
+                // A line that walks back into a position we have already acted from has accomplished
+                // nothing, whatever the leaf score says — and it is not a one-off mistake, because it
+                // hands us back the very position that made it look good. Aphetto Alchemist untapping
+                // itself is the degenerate case (`here`); two of them untapping each other is the same
+                // thing one step longer. See [StateProgress].
+                else -> StateProgress.digest(simulation.state)
+                    .let { leaf -> leaf != here && leaf !in positionsActedFrom }
             }
-            leaves += action.copy(action = materialized)
-            leafStates += simulation.state
+            if (usable) {
+                leaves += action.copy(action = materialized)
+                leafStates += simulation.state
+            }
+            // Every candidate cost a simulation whether or not it survived those filters, so the
+            // anytime cut is taken on all of them. Checking only after a survivor was recorded
+            // would let a board full of inert candidates run straight past the budget.
             if (budget.expired()) break
         }
 
@@ -187,14 +192,51 @@ class Strategist(
 
         val best = scored.maxByOrNull { it.second }
         return if (best != null && best.second > adjustedPassScore) {
+            remember(here)
             // Fill in targets on the returned action so the processor can execute it.
             // The committed target is chosen by simulation (not just the heuristic) so the
             // AI sees the real resolved board, including effects already on the stack.
-            remember(here)
             best.first
         } else {
             pass ?: legalActions.first()
         }
+    }
+
+    /**
+     * The concrete action the AI would submit for [action], and the position it leads to.
+     *
+     * Targets come from [chooseCommittedTargets], and are re-committed **with** simulation when the
+     * cheap pick turns out to be inert. That second attempt is the whole point of this function.
+     * Below [com.wingedsheep.ai.engine.budget.BudgetTier.NORMAL] the committed targets are
+     * [TargetSelection.rank]'s, which scores a target's board value and has no notion of whether the
+     * ability does anything *to* it — so on the quiet opponent's-turn window this guard exists for,
+     * it can hand back Aphetto Alchemist untapping itself while a tapped creature sits right there.
+     * Writing the ability off on that pick would trade a loop for a missed play.
+     *
+     * Only the inert path pays: the extra simulations are bounded by
+     * [RESCUE_TARGET_CANDIDATES] per requirement and are never reached by a candidate that already
+     * does something.
+     */
+    private fun materialize(
+        state: GameState,
+        action: LegalAction,
+        playerId: EntityId,
+        budget: DecisionBudget,
+        here: Long,
+    ): Pair<GameAction, SimulationResult> {
+        val materialized = chooseCommittedTargets(state, action, playerId, budget)
+        val simulation = simulator.simulate(state, materialized)
+        // Ordered so the budget that already refines pays nothing at all here — no digest, no
+        // second simulation. `chooseAction` digests the leaf it keeps either way.
+        if (budget.allowances.refineTargetsBySimulation) return materialized to simulation
+        if (simulation is SimulationResult.Illegal || simulation is SimulationResult.NeedsDecision) {
+            return materialized to simulation
+        }
+        if (StateProgress.digest(simulation.state) != here) return materialized to simulation
+
+        val refined = chooseCommittedTargets(state, action, playerId, budget, forceTargetRefinement = true)
+        if (refined == materialized) return materialized to simulation
+        return refined to simulator.simulate(state, refined)
     }
 
     /**
@@ -295,9 +337,10 @@ class Strategist(
      * gains nothing over neutralizing a second, still-able blocker (which [BoardPresence] now prices
      * lower). Requirements are resolved greedily — others held at their heuristic best — and only
      * the top `budget.allowances.targetCandidates` per requirement are simulated to bound cost. A
-     * budget below [com.wingedsheep.ai.engine.budget.BudgetTier.NORMAL] skips the refinement
-     * entirely and keeps the heuristic pick: this loop is the most expensive thing a routine
-     * priority window can pay for.
+     * budget below [com.wingedsheep.ai.engine.budget.BudgetTier.NORMAL] skips the refinement and
+     * keeps the heuristic pick: this loop is the most expensive thing a routine priority window can
+     * pay for. [materialize] buys it back for the one case where the heuristic pick is not merely
+     * worse but useless — see [forceTargetRefinement].
      *
      * Deliberately **not** used inside a rollout playout — see [PlayoutPolicy]. Simulating to pick
      * targets inside a simulation is what would make a playout quadratic.
@@ -307,10 +350,17 @@ class Strategist(
         action: LegalAction,
         playerId: EntityId,
         budget: DecisionBudget = DecisionBudget.legacy(),
+        /**
+         * Refine by simulation whatever the budget says, and raise the per-requirement cap to
+         * [RESCUE_TARGET_CANDIDATES]. Set only by [materialize], and only for an action the cheap
+         * pick already made inert — a tier that skips refinement can also cap candidates at 1,
+         * which would leave the rescue with nothing to choose between.
+         */
+        forceTargetRefinement: Boolean = false,
     ): com.wingedsheep.engine.core.GameAction {
         val baseAction = withAutomaticPayments(action)
         if (TargetSelection.targetsAlreadyFilled(baseAction) != false) return baseAction
-        if (!budget.allowances.refineTargetsBySimulation) {
+        if (!budget.allowances.refineTargetsBySimulation && !forceTargetRefinement) {
             return heuristicTargets(state, action, playerId)
         }
         val targetInfos = TargetSelection.fillableRequirements(action, useMeaningfulFilter)
@@ -333,15 +383,23 @@ class Strategist(
             chosenTargetIds += selectedId
         }
 
-        val here = StateProgress.digest(state)
+        // Only paid for once a requirement actually has rival targets to simulate — every
+        // requirement having at most one candidate is the common case, and digesting the whole
+        // position for each affordable candidate to find that out is waste.
+        val here by lazy(LazyThreadSafetyMode.NONE) { StateProgress.digest(state) }
+        val targetCandidates =
+            if (forceTargetRefinement) maxOf(budget.allowances.targetCandidates, RESCUE_TARGET_CANDIDATES)
+            else budget.allowances.targetCandidates
         for (i in targetInfos.indices) {
-            if (budget.expired()) break
+            // A forced refinement ignores the clock: it runs only on the inert path, where the
+            // alternative is dropping an ability that may well have had a productive target.
+            if (budget.expired() && !forceTargetRefinement) break
             val info = targetInfos[i]
             val priorIds = chosenTargetIds.take(i).toSet()
             val candidates = info.validTargets
                 .filterNot { info.mustDifferFromEarlier && it in priorIds }
                 .sortedByDescending { TargetSelection.rank(state, it, playerId, intents) }
-                .take(budget.allowances.targetCandidates)
+                .take(targetCandidates)
             if (candidates.size <= 1) continue
             val best = candidates.maxByOrNull { candidate ->
                 val trial = chosenTargets.toMutableList()
@@ -583,6 +641,13 @@ class Strategist(
 
         /** How many acted-from positions [remember] keeps. See it for why a short memory suffices. */
         const val POSITION_MEMORY = 32
+
+        /**
+         * Targets simulated per requirement when rescuing a candidate the cheap pick made inert.
+         * A tier below [com.wingedsheep.ai.engine.budget.BudgetTier.NORMAL] can cap candidates at
+         * 1, so the rescue needs its own floor; this is the legacy cap.
+         */
+        const val RESCUE_TARGET_CANDIDATES = 8
 
         const val MOMIR_TARGET_X = 8
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -86,6 +86,14 @@ class Strategist(
 ) {
     private val holdPolicy = HoldPolicy(intents)
 
+    /**
+     * Positions this player has already taken a non-pass action from, oldest first.
+     *
+     * The AI's only memory across decisions, and it exists for one reason: a leaf score cannot see
+     * that it is being handed the same position over and over. See [StateProgress] and [remember].
+     */
+    private val positionsActedFrom = ArrayDeque<Long>()
+
     fun chooseAction(
         state: GameState,
         legalActions: List<LegalAction>,
@@ -112,6 +120,7 @@ class Strategist(
         if (affordable.isEmpty()) return pass ?: legalActions.first()
 
         val budget = budgetPolicy.budgetFor(state, playerId, affordable)
+        val here = StateProgress.digest(evaluationState)
 
         // ── Pass 1: one simulation per candidate, to the quiet state it leads to ──
         // The anytime contract: candidates are simulated in order and the budget only cuts the
@@ -133,6 +142,15 @@ class Strategist(
             // modal/additional payments. If materializing the concrete action cannot pass the
             // authoritative processor, it is not a candidate the AI may submit.
             if (simulation is SimulationResult.Illegal) continue
+            // A line that walks back into a position we have already acted from has accomplished
+            // nothing, whatever the leaf score says — and it is not a one-off mistake, because it
+            // hands us back the very position that made it look good. Aphetto Alchemist untapping
+            // itself is the degenerate case (`here`); two of them untapping each other is the same
+            // thing one step longer. See [StateProgress].
+            if (simulation !is SimulationResult.NeedsDecision) {
+                val leaf = StateProgress.digest(simulation.state)
+                if (leaf == here || leaf in positionsActedFrom) continue
+            }
             leaves += action.copy(action = materialized)
             leafStates += simulation.state
             if (budget.expired()) break
@@ -172,10 +190,27 @@ class Strategist(
             // Fill in targets on the returned action so the processor can execute it.
             // The committed target is chosen by simulation (not just the heuristic) so the
             // AI sees the real resolved board, including effects already on the stack.
+            remember(here)
             best.first
         } else {
             pass ?: legalActions.first()
         }
+    }
+
+    /**
+     * Record a position we are about to act from, so a later candidate that leads back to it is
+     * recognised as the circle it is.
+     *
+     * Only positions we *act* from go in: passing may repeat as often as it likes, and recording it
+     * would fill the memory with the windows where the AI does nothing. Bounded because a loop is
+     * always short — the two-Alchemist cycle is length two — while a game is thousands of positions,
+     * and because a digest carries its turn and step, so an entry can only ever match inside the
+     * window where matching means going in circles.
+     */
+    private fun remember(digest: Long) {
+        if (digest in positionsActedFrom) return
+        positionsActedFrom.addLast(digest)
+        if (positionsActedFrom.size > POSITION_MEMORY) positionsActedFrom.removeFirst()
     }
 
     /**
@@ -298,6 +333,7 @@ class Strategist(
             chosenTargetIds += selectedId
         }
 
+        val here = StateProgress.digest(state)
         for (i in targetInfos.indices) {
             if (budget.expired()) break
             val info = targetInfos[i]
@@ -311,7 +347,15 @@ class Strategist(
                 val trial = chosenTargets.toMutableList()
                 trial[i] = TargetSelection.toChosenTarget(state, info, candidate, playerId)
                 val result = simulator.simulate(state, TargetSelection.applyTargets(baseAction, trial))
-                evaluator.evaluate(result.state, result.state.projectedState, playerId)
+                // A target that resolves back into the position we are standing in is not a target
+                // choice, it is a no-op wearing one — Aphetto Alchemist untapping itself. Rank it
+                // below every real option, so `chooseAction` only ever drops the whole ability as
+                // inert when *no* target does anything.
+                if (StateProgress.digest(result.state) == here) {
+                    Double.NEGATIVE_INFINITY
+                } else {
+                    evaluator.evaluate(result.state, result.state.projectedState, playerId)
+                }
             } ?: continue
             chosenTargets[i] = TargetSelection.toChosenTarget(state, info, best, playerId)
             chosenTargetIds[i] = best
@@ -536,6 +580,9 @@ class Strategist(
     private companion object {
         /** Cap on the number of X values an X-cost ability is expanded into (keeps the highest). */
         const val MAX_X_CANDIDATES = 5
+
+        /** How many acted-from positions [remember] keeps. See it for why a short memory suffices. */
+        const val POSITION_MEMORY = 32
 
         const val MOMIR_TARGET_X = 8
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/TargetSelection.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/TargetSelection.kt
@@ -107,14 +107,31 @@ object TargetSelection {
 
         val chosenTargets = mutableListOf<ChosenTarget>()
         val chosenIds = mutableSetOf<EntityId>()
-        targetInfos.forEach { info ->
+        for ((index, info) in targetInfos.withIndex()) {
             val available = if (info.mustDifferFromEarlier) {
                 info.validTargets.filterNot(chosenIds::contains)
             } else {
                 info.validTargets
             }
+            // Nothing left for this slot. [fillableRequirements] guarantees `validTargets` is not
+            // empty, so the only way here is an "other target" requirement (CR 601.2c) whose every
+            // legal target was already spent on an earlier slot: Mabel's Mettle's "up to one *other*
+            // target creature" with a single creature on the board. The enumerator cannot know which
+            // target the earlier slot will take, so it offers that creature for both.
+            //
+            // Targets are submitted as one flat list sliced back by max counts, so only *trailing*
+            // slots may be left empty — filling around a hole would silently re-attribute every
+            // later target. When the rest is optional the prefix is a legal list; otherwise there is
+            // no legal list at all and the action goes back unfilled, for the caller's simulation
+            // (or the engine) to reject. Either beats `first()` on an empty list, which is what this
+            // used to do — an `?: available.first()` that could only ever run when `available` was
+            // empty, and so could only ever throw.
             val selectedId = available.maxByOrNull { rank(state, it, playerId, intents) }
-                ?: available.first()
+                ?: return if (targetInfos.drop(index).all { it.minTargets == 0 }) {
+                    applyTargets(baseAction, chosenTargets)
+                } else {
+                    action.action
+                }
             chosenTargets += toChosenTarget(state, info, selectedId, playerId)
             chosenIds += selectedId
         }
@@ -155,18 +172,6 @@ object TargetSelection {
             modeTargetsOrdered = orderedTargets,
             targets = orderedTargets.flatten(),
         )
-    }
-
-    /** The heuristically best [ChosenTarget] for one requirement. */
-    fun bestTarget(
-        state: GameState,
-        info: TargetInfo,
-        playerId: EntityId,
-        intents: IntentCatalog = IntentCatalog.NONE,
-    ): ChosenTarget {
-        val best = info.validTargets.maxByOrNull { rank(state, it, playerId, intents) }
-            ?: info.validTargets.first()
-        return toChosenTarget(state, info, best, playerId)
     }
 
     /**

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/LoopingActionAiTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/LoopingActionAiTest.kt
@@ -1,8 +1,14 @@
 package com.wingedsheep.ai.engine
 
+import com.wingedsheep.ai.engine.budget.BudgetPolicy
+import com.wingedsheep.ai.engine.budget.BudgetTier
+import com.wingedsheep.ai.engine.budget.DecisionBudget
+import com.wingedsheep.ai.engine.budget.LegacyBudgetPolicy
+import com.wingedsheep.ai.engine.budget.SearchAllowances
 import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -11,9 +17,11 @@ import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Regression: the AI must never spend a priority window going in circles.
@@ -48,9 +56,13 @@ class LoopingActionAiTest : FunSpec({
         driver.submitSuccess(PassPriority(activePlayer))
     }
 
-    fun strategistFor(registry: CardRegistry, step: Step): Strategist {
+    fun strategistFor(
+        registry: CardRegistry,
+        step: Step,
+        budgetPolicy: BudgetPolicy = LegacyBudgetPolicy,
+    ): Strategist {
         val simulator = GameSimulator(registry)
-        return Strategist(simulator, stepPreferring(step))
+        return Strategist(simulator, stepPreferring(step), budgetPolicy = budgetPolicy)
     }
 
     fun chooseFor(strategist: Strategist, registry: CardRegistry, state: GameState, playerId: EntityId) =
@@ -78,11 +90,47 @@ class LoopingActionAiTest : FunSpec({
             targets = listOf(ChosenTarget.Permanent(target)),
         )
 
+        val here = StateProgress.digest(driver.state)
+
         val self = simulator.simulate(driver.state, untap(alchemist))
-        StateProgress.isInert(driver.state, self.state) shouldBe true
+        withClue("untapping itself pays its own cost back") {
+            StateProgress.digest(self.state) shouldBe here
+        }
 
         val other = simulator.simulate(driver.state, untap(partner))
-        StateProgress.isInert(driver.state, other.state) shouldBe false
+        withClue("untapping the tapped partner is a real change") {
+            StateProgress.digest(other.state) shouldNotBe here
+        }
+    }
+
+    test("an ability with one inert target and one productive one is aimed, not dropped") {
+        // Every tier, because the guard's whole failure mode is tier-dependent: below NORMAL the
+        // committed targets are `TargetSelection.rank`'s heuristic pick, which ranks board value
+        // and cannot see that untapping an untapped creature does nothing.
+        for (tier in BudgetTier.entries) {
+            val registry = registry()
+            val driver = GameTestDriver()
+            val (ai, human) = openWindow(driver)
+            val alchemist = driver.putCreatureOnBattlefield(ai, "Aphetto Alchemist")
+            driver.removeSummoningSickness(alchemist)
+            val partner = driver.putCreatureOnBattlefield(ai, "Grizzly Bears")
+            driver.removeSummoningSickness(partner)
+            driver.tapPermanent(partner)
+            handPriorityToNonActivePlayer(driver, human)
+
+            // Untapping itself does nothing; untapping the tapped Bears does. Dropping the whole
+            // ability because the *heuristic* target pick happened to be the inert one would trade
+            // the loop for a missed play — and below NORMAL that pick is all there is unless
+            // `materialize` buys the simulated one back.
+            val strategist = strategistFor(registry, Step.END_COMBAT, FixedTierBudgetPolicy(tier))
+            val chosen = chooseFor(strategist, registry, driver.state, ai)
+
+            withClue("tier $tier") {
+                val activation = chosen.action.shouldBeInstanceOf<ActivateAbility>()
+                activation.sourceId shouldBe alchemist
+                activation.targets shouldBe listOf(ChosenTarget.Permanent(partner))
+            }
+        }
     }
 
     test("the AI passes rather than activate an ability that changes nothing") {
@@ -124,3 +172,21 @@ class LoopingActionAiTest : FunSpec({
         reply.actionType shouldBe "PassPriority"
     }
 })
+
+/**
+ * Pins every decision to one [BudgetTier], so a test can say which allowances it is exercising
+ * instead of hoping `TieredBudgetPolicy` picks the tier it had in mind from the board.
+ */
+private class FixedTierBudgetPolicy(private val tier: BudgetTier) : BudgetPolicy {
+    private fun budget() = DecisionBudget(tier, SearchAllowances.forMillis(tier.millis), tier.millis)
+
+    override fun budgetFor(
+        state: GameState,
+        playerId: EntityId,
+        meaningfulActions: List<LegalAction>,
+    ): DecisionBudget = budget()
+
+    override fun budgetForDecision(state: GameState, playerId: EntityId): DecisionBudget = budget()
+
+    override fun toString(): String = "fixed-$tier"
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/LoopingActionAiTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/LoopingActionAiTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression: the AI must never spend a priority window going in circles.
+ *
+ * Reported from a real game — the AI activated Aphetto Alchemist ({T}: Untap target artifact or
+ * creature) eleven times in a row and would have kept going, because aiming it at itself pays its
+ * own cost back and leaves the board exactly as it was.
+ *
+ * The evaluator is stubbed here, and deliberately: the scoring bias that made the AI *want* the
+ * no-op is that a candidate's leaf is scored where the action leaves the game while passing's leaf
+ * is scored after the game has moved on. `stepPreferring` is the smallest honest model of it —
+ * "passing lets the next step happen, and the next step is bad" — and it makes the loop reproduce
+ * on demand instead of only on the board that happened to be in front of the player. What is under
+ * test is that [StateProgress] refuses the line whatever the score says.
+ */
+class LoopingActionAiTest : FunSpec({
+
+    /** Prefers standing still: any leaf still in [step] beats one where the game has moved on. */
+    fun stepPreferring(step: Step) = BoardEvaluator { state, _, _ -> if (state.step == step) 0.0 else -100.0 }
+
+    fun registry(): CardRegistry = CardRegistry().apply { register(TestCards.all) }
+
+    /** A game where [ai] holds priority in the opponent's end-of-combat step, with nothing to do. */
+    fun openWindow(driver: GameTestDriver): Pair<EntityId, EntityId> {
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        return driver.player2 to driver.player1
+    }
+
+    fun handPriorityToNonActivePlayer(driver: GameTestDriver, activePlayer: EntityId) {
+        driver.passPriorityUntil(Step.END_COMBAT)
+        driver.submitSuccess(PassPriority(activePlayer))
+    }
+
+    fun strategistFor(registry: CardRegistry, step: Step): Strategist {
+        val simulator = GameSimulator(registry)
+        return Strategist(simulator, stepPreferring(step))
+    }
+
+    fun chooseFor(strategist: Strategist, registry: CardRegistry, state: GameState, playerId: EntityId) =
+        strategist.chooseAction(state, GameSimulator(registry).getLegalActions(state, playerId), playerId)
+
+    test("untapping itself leaves the position untouched, untapping another creature does not") {
+        val registry = registry()
+        val driver = GameTestDriver()
+        val (ai, human) = openWindow(driver)
+        val alchemist = driver.putCreatureOnBattlefield(ai, "Aphetto Alchemist")
+        driver.removeSummoningSickness(alchemist)
+        val partner = driver.putCreatureOnBattlefield(ai, "Grizzly Bears")
+        driver.removeSummoningSickness(partner)
+        driver.tapPermanent(partner)
+        handPriorityToNonActivePlayer(driver, human)
+
+        val simulator = GameSimulator(registry)
+        val abilityId = simulator.getLegalActions(driver.state, ai)
+            .mapNotNull { it.action as? ActivateAbility }
+            .first { it.sourceId == alchemist }
+            .abilityId
+
+        fun untap(target: EntityId) = ActivateAbility(
+            playerId = ai, sourceId = alchemist, abilityId = abilityId,
+            targets = listOf(ChosenTarget.Permanent(target)),
+        )
+
+        val self = simulator.simulate(driver.state, untap(alchemist))
+        StateProgress.isInert(driver.state, self.state) shouldBe true
+
+        val other = simulator.simulate(driver.state, untap(partner))
+        StateProgress.isInert(driver.state, other.state) shouldBe false
+    }
+
+    test("the AI passes rather than activate an ability that changes nothing") {
+        val registry = registry()
+        val driver = GameTestDriver()
+        val (ai, human) = openWindow(driver)
+        val alchemist = driver.putCreatureOnBattlefield(ai, "Aphetto Alchemist")
+        driver.removeSummoningSickness(alchemist)
+        handPriorityToNonActivePlayer(driver, human)
+
+        val strategist = strategistFor(registry, Step.END_COMBAT)
+        val chosen = chooseFor(strategist, registry, driver.state, ai)
+
+        chosen.actionType shouldBe "PassPriority"
+    }
+
+    test("the AI unwinds a two-untapper cycle instead of riding it forever") {
+        val registry = registry()
+        val driver = GameTestDriver()
+        val (ai, human) = openWindow(driver)
+        val first = driver.putCreatureOnBattlefield(ai, "Aphetto Alchemist")
+        val second = driver.putCreatureOnBattlefield(ai, "Aphetto Alchemist")
+        driver.removeSummoningSickness(first)
+        driver.removeSummoningSickness(second)
+        driver.tapPermanent(second)
+        handPriorityToNonActivePlayer(driver, human)
+
+        val strategist = strategistFor(registry, Step.END_COMBAT)
+        val simulator = GameSimulator(registry)
+
+        // Untapping the tapped one is a real change, so the AI is allowed to want it.
+        val opening = chooseFor(strategist, registry, driver.state, ai)
+        opening.actionType shouldNotBe "PassPriority"
+        val afterOpening = simulator.simulate(driver.state, opening.action).state
+
+        // Untapping it straight back would return the game to the position we just acted from —
+        // the whole cycle. The only other option, untapping itself, changes nothing at all.
+        val reply = chooseFor(strategist, registry, afterOpening, ai)
+        reply.actionType shouldBe "PassPriority"
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/OtherTargetFillAiTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/OtherTargetFillAiTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression: an "other target" slot (CR 601.2c) whose every legal target was already spent on an
+ * earlier slot used to crash the AI.
+ *
+ * The enumerator cannot know which target the earlier slot will take, so it offers the same
+ * creature for both — and [TargetSelection.fillHeuristically] then had nothing left for the second,
+ * where its `?: available.first()` fallback could only ever run on an empty list. Found by fuzzing
+ * self-play with random decks; it takes the AI's whole priority window down with it, which in a
+ * served game means the AI simply stops playing.
+ */
+class OtherTargetFillAiTest : FunSpec({
+
+    fun registry(): CardRegistry = CardRegistry().apply { register(TestCards.all) }
+
+    /** A game in the AI's own main phase, with [mana] of [color] available. */
+    fun mainPhase(driver: GameTestDriver, color: Color, mana: Int): EntityId {
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(driver.player1, color, mana)
+        return driver.player1
+    }
+
+    fun castOf(registry: CardRegistry, driver: GameTestDriver, player: EntityId, cardId: EntityId) =
+        GameSimulator(registry).getLegalActions(driver.state, player)
+            .first { (it.action as? CastSpell)?.cardId == cardId }
+
+    test("an optional other-target slot with nothing left is simply left empty") {
+        val registry = registry()
+        val driver = GameTestDriver()
+        val player = mainPhase(driver, Color.WHITE, 2)
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        // "Target creature gets +2/+2. Up to one *other* target creature gets +1/+1." — with one
+        // creature on the board the second slot has nothing left once the first has taken it.
+        val mettle = driver.putCardInHand(player, "Mabel's Mettle")
+
+        val filled = TargetSelection.fillHeuristically(
+            driver.state, castOf(registry, driver, player, mettle), player, fillPartialRequirements = false
+        )
+
+        (filled as CastSpell).targets shouldBe listOf(ChosenTarget.Permanent(bears))
+        // A flat target list may leave trailing optional slots empty, so the engine takes this.
+        driver.submitSuccess(filled)
+    }
+
+    test("a mandatory other-target slot with nothing left leaves the action unfilled") {
+        val registry = registry()
+        val driver = GameTestDriver()
+        val player = mainPhase(driver, Color.GREEN, 6)
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(driver.player2, "Hill Giant")
+        // "Target creature you control deals damage equal to its power to each of two *other*
+        // target creatures" — three slots, only two creatures in the game.
+        val betrayal = driver.putCardInHand(player, "Betrayal at the Vault")
+
+        val action = castOf(registry, driver, player, betrayal)
+        val filled = TargetSelection.fillHeuristically(
+            driver.state, action, player, fillPartialRequirements = false
+        )
+
+        // No legal target list exists, so the AI hands the action back untouched for its own
+        // simulation — or the engine — to reject, rather than inventing an illegal one.
+        (filled as CastSpell).targets shouldBe emptyList()
+        driver.submit(filled).isSuccess shouldBe false
+    }
+
+    test("the AI survives a priority window holding such a spell") {
+        val registry = registry()
+        val driver = GameTestDriver()
+        val player = mainPhase(driver, Color.WHITE, 2)
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCardInHand(player, "Mabel's Mettle")
+
+        val ai = AIPlayer.create(registry, player, AiProfile.PRODUCTION)
+
+        shouldNotThrowAny { ai.chooseAction(driver.state) }
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/StateProgressTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/StateProgressTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.DayNight
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.GameRng
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * What [StateProgress.digest] must and must not notice.
+ *
+ * The digest decides whether an action accomplished anything, and [Strategist] permanently refuses
+ * an action that accomplished nothing — so a game fact the digest is blind to is not a rounding
+ * error, it is an ability the AI can never use again. That asymmetry is why `normalized` names the
+ * fields it *excludes* rather than the ones it reads, and this is the test that keeps it honest:
+ * the excluded list is short and fixed, so it can be checked exhaustively, while the fields that
+ * must count are open-ended and covered by spot-checking the turn-level riders an ability can set
+ * without touching any permanent.
+ */
+class StateProgressTest : FunSpec({
+
+    fun state() = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+    }.state
+
+    test("bookkeeping that every action advances is not a change") {
+        val base = state()
+        val here = StateProgress.digest(base)
+
+        // Each of these moves whenever anything resolves at all, so reading them would make every
+        // inert action look like progress — the exact misreading the guard exists to avoid.
+        withClue("rng") { StateProgress.digest(base.copy(rng = GameRng(0x5EED))) shouldBe here }
+        withClue("nextEntityId") { StateProgress.digest(base.copy(nextEntityId = 9_999L)) shouldBe here }
+        withClue("timestamp") { StateProgress.digest(base.copy(timestamp = 9_999L)) shouldBe here }
+
+        // Whose turn it is to speak is not what is true of the board. Being blind to it is what
+        // makes an action's own resolution comparable with the position it started from.
+        withClue("priorityPlayerId") {
+            StateProgress.digest(base.copy(priorityPlayerId = base.turnOrder[1])) shouldBe here
+        }
+        withClue("priorityPassedBy") {
+            StateProgress.digest(base.copy(priorityPassedBy = base.turnOrder.toSet())) shouldBe here
+        }
+    }
+
+    test("a turn-level rider an ability can set without touching a permanent is a change") {
+        val base = state()
+        val here = StateProgress.digest(base)
+
+        // None of these live on a permanent, so nothing in the per-object walk would catch them.
+        // Under the read-list this replaced they were all invisible, which would have made an
+        // ability whose only effect is one of them permanently un-takeable.
+        withClue("damageCantBePreventedThisTurn") {
+            StateProgress.digest(base.copy(damageCantBePreventedThisTurn = true)) shouldNotBe here
+        }
+        withClue("spellWarpedThisTurn") {
+            StateProgress.digest(base.copy(spellWarpedThisTurn = true)) shouldNotBe here
+        }
+        withClue("nonlandPermanentLeftBattlefieldThisTurn") {
+            StateProgress.digest(base.copy(nonlandPermanentLeftBattlefieldThisTurn = true)) shouldNotBe here
+        }
+        withClue("playersWhoCommittedCrimeThisTurn") {
+            StateProgress.digest(base.copy(playersWhoCommittedCrimeThisTurn = setOf(base.turnOrder[0]))) shouldNotBe here
+        }
+        withClue("dayNight") {
+            StateProgress.digest(base.copy(dayNight = DayNight.NIGHT)) shouldNotBe here
+        }
+    }
+
+    test("turn and step are part of the position, so a digest can only recur inside one window") {
+        val base = state()
+        val here = StateProgress.digest(base)
+
+        // This is what bounds `Strategist.positionsActedFrom`: the same board one turn later is a
+        // different position, so a remembered entry can only ever match while matching means
+        // going in circles.
+        StateProgress.digest(base.copy(turnNumber = base.turnNumber + 1)) shouldNotBe here
+    }
+})

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -52,6 +52,7 @@ AIPlayer.chooseAction(state)
      ├─ budget               ← BudgetPolicy.budgetFor(state, player, candidates)          (Phase 4b)
      ├─ pass 1: simulate each candidate (and the pass) to its quiet state
      │           └─ drop leaves that repeat a position we already acted from  ← StateProgress
+     │               (re-aiming an inert one by simulation first  ← Strategist.materialize)
      ├─ pass 2: CandidateEvaluator.scoreAll(root, leaves, player, budget)                 (Phase 7)
      ├─ pass 3: HoldPolicy timing delta + CardAdvisor override, in raw evaluator units    (Phase 6)
      └─ best > pass ? commit targets (refined by simulation) : pass
@@ -76,11 +77,22 @@ Alchemist ({T}: untap target artifact or creature, aimed at itself) eleven times
 `StateProgress.digest` reduces a `GameState` to the position a player could point at — zone
 contents, everything true of the objects and players in them, turn and step — and is deliberately
 blind to "it happened" memories such as activation counts, which change on every activation whether
-or not anything else did. `Strategist` drops any candidate whose leaf digest matches the position it
-is acting from, or one of the last 32 positions it has acted from; target refinement ranks an inert
-targeting below every real one, so an ability is only dropped when *no* target does anything. Both
-follow CR 732.3: a player whose actions have reached the same game state again must make a different
-choice.
+or not anything else did. It names what it *excludes* rather than what it reads, so a `GameState`
+field added later counts by default: a field missed by a read-list would make a real action look
+inert, and an action that looks inert is refused forever.
+
+`Strategist` drops any candidate whose leaf digest matches the position it is acting from, or one of
+the last 32 positions it has acted from. Target refinement ranks an inert targeting below every real
+one, so an ability is only dropped when *no* target does anything — and because that refinement is
+the first thing a sub-`NORMAL` budget gives up, `Strategist.materialize` buys it back for exactly
+the candidates the cheap pick made inert. Without that, the quiet opponent's-turn windows this guard
+exists for would be the ones where it fires on an ability that had a productive target. All of it
+follows CR 732.3: a player whose actions have reached the same game state again must make a
+different choice.
+
+The guard is **not** behind an `AiProfile` flag, which is the one thing this codebase normally
+insists on — see `StateProgress`'s KDoc for why an abandoned game has no strength worth freezing,
+and why `FrozenBaselineTest` staying green is not evidence either way.
 
 ---
 

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -51,6 +51,7 @@ AIPlayer.chooseAction(state)
      ├─ candidates           ← MeaningfulActionFilter.filterMeaningful                    (Phase 4a)
      ├─ budget               ← BudgetPolicy.budgetFor(state, player, candidates)          (Phase 4b)
      ├─ pass 1: simulate each candidate (and the pass) to its quiet state
+     │           └─ drop leaves that repeat a position we already acted from  ← StateProgress
      ├─ pass 2: CandidateEvaluator.scoreAll(root, leaves, player, budget)                 (Phase 7)
      ├─ pass 3: HoldPolicy timing delta + CardAdvisor override, in raw evaluator units    (Phase 6)
      └─ best > pass ? commit targets (refined by simulation) : pass
@@ -60,6 +61,26 @@ The three passes are the shape Phase 7 needed. The evaluator sees **every** cand
 is what lets it *allocate* effort rather than spend a fixed amount per candidate — sequential
 halving is impossible with a one-candidate-at-a-time API. For `StaticCandidateEvaluator` the batch
 is `map(::score)`, so `LEGACY_V0` is bit-identical; `FrozenBaselineTest` is what proves it.
+
+---
+
+## Going in circles (`StateProgress`)
+
+A leaf score cannot tell that it is being handed the same position over and over, and the comparison
+it makes is not even between comparable positions: passing carries the game forward into whatever
+was about to happen, while a free ability that resolves back onto the same board stops right where
+it is. When what is about to happen is bad, *doing nothing* can outscore passing — and then it does
+so again from the identical position it just produced. That is how the AI came to activate Aphetto
+Alchemist ({T}: untap target artifact or creature, aimed at itself) eleven times in a row.
+
+`StateProgress.digest` reduces a `GameState` to the position a player could point at — zone
+contents, everything true of the objects and players in them, turn and step — and is deliberately
+blind to "it happened" memories such as activation counts, which change on every activation whether
+or not anything else did. `Strategist` drops any candidate whose leaf digest matches the position it
+is acting from, or one of the last 32 positions it has acted from; target refinement ranks an inert
+targeting below every real one, so an ability is only dropped when *no* target does anything. Both
+follow CR 732.3: a player whose actions have reached the same game state again must make a different
+choice.
 
 ---
 


### PR DESCRIPTION
# Stop the AI going in circles

Two bugs from real games, plus the review fixes that followed.

## The loop

The AI activated Aphetto Alchemist (`{T}: Untap target artifact or creature`) eleven times in a row,
aimed at itself, until the game had to be abandoned. A leaf-scoring search has no defence against
this on its own: it compares "take this action" against "pass" by scoring the positions they lead
to, and those two positions are not measured at the same point in the game. Passing carries the game
forward into whatever was about to happen, while a free ability that resolves back onto the same
board stops right where it is. When what is about to happen is bad, doing nothing at all can
*outscore* passing — and then it does so again, from the identical position it just produced.

`StateProgress.digest` reduces a `GameState` to the position a player could point at, and
`Strategist` refuses any candidate whose leaf repeats the position it is acting from or one of the
last 32 it has acted from. That covers both shapes: the inert action (Alchemist untapping itself)
and the cycle (two Alchemists untapping each other, where every step changes the board and the
sequence still goes nowhere).

CR 732.3 makes the same structural claim, and its example turns on exactly the thing
`IGNORED_COMPONENTS` does — the loop repeats a position when "nothing in the game cares how many
times an ability has been activated."

## The crash

An "other target" slot (CR 601.2c) whose every legal target was already spent on an earlier slot
took the AI's whole priority window down with it — in a served game, the AI simply stops playing.
Found by fuzzing self-play with random decks. Mabel's Mettle's "up to one *other* target creature"
with one creature on the board is the minimal case: the enumerator cannot know which target the
earlier slot will take, so it offers that creature for both, and `fillHeuristically`'s
`?: available.first()` fallback could only ever run on an empty list.

Targets are submitted as one flat list sliced back by max counts, so only *trailing* slots may be
left empty. When the rest is optional the prefix is a legal list; otherwise there is no legal list at
all and the action goes back unfilled, for the caller's simulation or the engine to reject.

## Review fixes

The guard as first written could refuse a good play, which is worse than the loop it prevents:

- **Aim an inert ability instead of dropping it.** The target-level inert check lived in
  `chooseCommittedTargets`, which a budget below `BudgetTier.NORMAL` skips entirely — and `ROUTINE`
  is precisely the quiet opponent's-turn window the loop was reported in. There the committed target
  is `TargetSelection.rank`'s, which scores board value and has no notion of whether the ability does
  anything *to* the target, so it can hand back the Alchemist untapping itself while a tapped
  creature sits right there. `Strategist.materialize` buys the simulated pick back for exactly those
  candidates; only the inert path pays for it.
- **Name what the digest excludes, not what it reads.** The first shape was a read-list covering ~20
  of `GameState`'s ~50 fields, and it missed every turn-level rider an ability can set without
  touching a permanent — `turnSpellCostReductions`, `activeCounterPlacementModifiers`,
  `pendingUncounterableSpells`, `damageCantBePreventedThisTurn`, all with live executors. A field
  missing from a read-list makes a real action look inert, and an action that looks inert is refused
  forever; a wrong exclusion costs one wasted activation. `normalized` strips the bookkeeping and
  lets the data class's own `hashCode` supply the rest, so a field added later counts by default.
- **Take the anytime cut on every candidate.** A dropped candidate had already paid for its
  simulation, so `continue`-ing past `budget.expired()` let a board full of inert candidates run
  straight past the budget.

## On `LEGACY_V0`

The guard is **not** behind an `AiProfile` flag, which is the one thing this codebase normally
insists on — `FrozenBaselineTest` exists to stop `LEGACY_V0` drifting, and Phase 4's `fillPartial` is
gated for no other reason. That rule is about *strength*: a change that makes V0 play better silently
rebases every published arena number. A game that has to be abandoned has no strength to compare, so
there is nothing here worth freezing. `FrozenBaselineTest` stays green, but only because its baseline
deck is all-vanilla — no activated abilities, so nothing the guard can fire on. It is not evidence
either way and shouldn't be read as any. This is recorded in `StateProgress`'s KDoc so the next
person doesn't have to rediscover it.

## Tests

- `LoopingActionAiTest` — the inert action, the two-Alchemist cycle, and a sweep over all four
  `BudgetTier`s proving an ability with one inert target and one productive one gets *aimed*, not
  dropped. That sweep fails at `TRIVIAL` without `materialize` (the AI chooses `PassPriority` over
  untapping the tapped Grizzly Bears).
- `OtherTargetFillAiTest` — the optional-slot and mandatory-slot branches, plus a whole priority
  window survived under `AiProfile.PRODUCTION`.
- `StateProgressTest` — both halves of the digest contract: bookkeeping every action advances is not
  a change, a turn-level rider is.

`:ai:test` green, including `FrozenBaselineTest`. Also drops `TargetSelection.bestTarget`, which had
no callers left, and `StateProgress.isInert`, which had no production caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
