### PR TITLE
Route each target requirement to a UI that can collect it

### DIFF
--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -455,7 +455,15 @@ isn't clickable card-by-card on the board), everything else to `BattlefieldTarge
 highlights board objects through `decisionSelectionState`. The two can mix inside one decision —
 The Spot, Living Portal exiles "up to one target nonland permanent **and** up to one target
 nonland permanent card from a graveyard" — so the choice must not be made once for the whole
-decision. The cast-time equivalent is `TargetingOverlay`'s `ZoneCardTargetingOverlay` routing.
+decision. Both collectors take the restored picks as `initialSelection`, so Back keeps its
+confirmed selection whichever UI owns the slot. The cast-time equivalent is `TargetingOverlay`'s
+`ZoneCardTargetingOverlay` routing.
+
+The wording on a pile slot ("Exile" vs "Put onto Battlefield" vs "Shuffle into Library") comes
+from `derivePileAction` in `utils/targeting.ts`, which sniffs the decision's `effectHint` prose.
+That hint describes the effect as a whole rather than the individual requirement, so a composite
+whose slots take different verbs would mislabel one of them; the durable fix is a per-requirement
+action hint on `TargetRequirementInfo`.
 
 ## Type Mapping
 

--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -446,8 +446,16 @@ Confirming a step snapshots the outgoing `TargetingState` onto
 stack so the player can revise an already-confirmed target before the action is submitted —
 the restored step keeps its confirmed picks selected, and re-confirming recomputes later
 steps' valid-target pools against the revised selection. The resolution-time
-`ChooseTargetsDecision` flow (`BattlefieldTargetingUI`) implements the same back navigation
-over its local requirement index. Cancel still aborts the whole action.
+`ChooseTargetsDecision` flow (`ChooseTargetsUI`) implements the same back navigation over its
+requirement index. Cancel still aborts the whole action.
+
+`ChooseTargetsUI` also decides, **per requirement**, which UI collects that slot: a requirement
+whose legal targets all live in a graveyard or exile pile goes to `GraveyardTargetingUI` (a pile
+isn't clickable card-by-card on the board), everything else to `BattlefieldTargetingUI`, which
+highlights board objects through `decisionSelectionState`. The two can mix inside one decision —
+The Spot, Living Portal exiles "up to one target nonland permanent **and** up to one target
+nonland permanent card from a graveyard" — so the choice must not be made once for the whole
+decision. The cast-time equivalent is `TargetingOverlay`'s `ZoneCardTargetingOverlay` routing.
 
 ## Type Mapping
 

--- a/manual-scenarios/cards/t/the-spot-living-portal.json
+++ b/manual-scenarios/cards/t/the-spot-living-portal.json
@@ -1,0 +1,58 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "The Spot, Living Portal",
+      "Murder"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [
+      "Savannah Lions",
+      "Lightning Bolt"
+    ],
+    "library": [
+      "Plains",
+      "Swamp",
+      "Plains",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Icy Manipulator"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [
+      "Serra Angel",
+      "Disenchant"
+    ],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/web-client/src/components/decisions/BattlefieldTargetingUI.tsx
+++ b/web-client/src/components/decisions/BattlefieldTargetingUI.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
 import type { DecisionSelectionState } from '@/store/slices'
 import type { EntityId, ChooseTargetsDecision } from '@/types'
@@ -9,39 +9,45 @@ import { DraggableBanner } from './DraggableBanner'
 import styles from './DecisionUI.module.css'
 
 /**
- * Battlefield targeting UI for ChooseTargetsDecision (non-player, non-graveyard targets).
- * Shows a side banner with Confirm/Decline buttons, uses decisionSelectionState for toggle-to-select.
+ * Board targeting UI for **one** requirement of a ChooseTargetsDecision (battlefield permanents,
+ * players, stack objects — anything clickable on the board). Shows a side banner with
+ * Confirm/Decline buttons and uses decisionSelectionState for toggle-to-select.
+ *
+ * Requirement walking (which slot we're on, accumulating picks, submitting) lives in the parent
+ * [ChooseTargetsUI]: a decision can mix a board slot with a graveyard slot (The Spot, Living
+ * Portal), and only the parent can hand each slot to the UI that can collect it.
  */
 export function BattlefieldTargetingUI({
   decision,
+  requirementIndex,
+  totalRequirements,
+  legalTargets,
+  initialSelection,
+  onComplete,
+  onBack,
 }: {
   decision: ChooseTargetsDecision
+  requirementIndex: number
+  totalRequirements: number
+  /** Legal targets for this requirement, already stripped of picks made for earlier requirements. */
+  legalTargets: readonly EntityId[]
+  /** Picks to pre-select — non-empty when the player stepped Back into this requirement. */
+  initialSelection: readonly EntityId[]
+  onComplete: (targets: readonly EntityId[]) => void
+  /** Present when an earlier requirement can be revised. */
+  onBack?: () => void
 }) {
   const startDecisionSelection = useGameStore((s) => s.startDecisionSelection)
   const decisionSelectionState = useGameStore((s) => s.decisionSelectionState)
   const cancelDecisionSelection = useGameStore((s) => s.cancelDecisionSelection)
-  const submitTargetsDecision = useGameStore((s) => s.submitTargetsDecision)
   const submitCancelDecision = useGameStore((s) => s.submitCancelDecision)
   const gameState = useGameStore((s) => s.gameState)
   const [isHoveringSource, setIsHoveringSource] = useState(false)
   const responsive = useResponsive()
 
-  // Multi-requirement state: track which requirement we're on and accumulated targets
-  const [currentReqIndex, setCurrentReqIndex] = useState(0)
-  const [collectedTargets, setCollectedTargets] = useState<Record<number, readonly EntityId[]>>({})
-  // Picks to pre-select when the requirement changes because the player stepped Back;
-  // consumed (and cleared) by the selection-state effect below.
-  const restoredSelectionRef = useRef<readonly EntityId[] | null>(null)
-
-  const totalRequirements = decision.targetRequirements.length
-  const targetReq = decision.targetRequirements[currentReqIndex]
+  const targetReq = decision.targetRequirements[requirementIndex]
   const minTargets = targetReq?.minTargets ?? 1
   const maxTargets = targetReq?.maxTargets ?? 1
-  const legalTargets = decision.legalTargets[currentReqIndex] ?? []
-
-  // For multi-requirement, exclude already-selected targets from valid options
-  const alreadySelected = Object.values(collectedTargets).flat()
-  const filteredLegalTargets = legalTargets.filter((id) => !alreadySelected.includes(id))
 
   // Look up source card image from game state
   const sourceId = decision.context.sourceId
@@ -52,19 +58,18 @@ export function BattlefieldTargetingUI({
   useEffect(() => {
     const selectionState: DecisionSelectionState = {
       decisionId: decision.id,
-      validOptions: [...filteredLegalTargets],
-      selectedOptions: restoredSelectionRef.current ? [...restoredSelectionRef.current] : [],
+      validOptions: [...legalTargets],
+      selectedOptions: [...initialSelection],
       minSelections: minTargets,
       maxSelections: maxTargets,
       prompt: targetReq?.description ?? decision.prompt,
     }
-    restoredSelectionRef.current = null
     startDecisionSelection(selectionState)
 
     return () => {
       cancelDecisionSelection()
     }
-  }, [decision.id, currentReqIndex])
+  }, [decision.id, requirementIndex])
 
   const selectedCount = decisionSelectionState?.selectedOptions.length ?? 0
   const canConfirm = selectedCount >= minTargets && selectedCount <= maxTargets
@@ -72,31 +77,15 @@ export function BattlefieldTargetingUI({
 
   const handleConfirm = () => {
     if (canConfirm && decisionSelectionState) {
-      const updatedTargets = { ...collectedTargets, [currentReqIndex]: decisionSelectionState.selectedOptions }
-
-      if (currentReqIndex + 1 < totalRequirements) {
-        // More requirements — advance to the next one
-        setCollectedTargets(updatedTargets)
-        cancelDecisionSelection()
-        setCurrentReqIndex(currentReqIndex + 1)
-      } else {
-        // All requirements satisfied — submit
-        submitTargetsDecision(updatedTargets)
-        cancelDecisionSelection()
-      }
+      const selected = decisionSelectionState.selectedOptions
+      cancelDecisionSelection()
+      onComplete(selected)
     }
   }
 
   const handleDecline = () => {
-    const updatedTargets = { ...collectedTargets, [currentReqIndex]: [] as EntityId[] }
-    if (currentReqIndex + 1 < totalRequirements) {
-      setCollectedTargets(updatedTargets)
-      cancelDecisionSelection()
-      setCurrentReqIndex(currentReqIndex + 1)
-    } else {
-      submitTargetsDecision(updatedTargets)
-      cancelDecisionSelection()
-    }
+    cancelDecisionSelection()
+    onComplete([])
   }
 
   const handleCancel = () => {
@@ -105,21 +94,12 @@ export function BattlefieldTargetingUI({
   }
 
   const handleBack = () => {
-    // Step back to the previous requirement, restoring its confirmed picks so the
-    // player can revise them. The current requirement's in-progress picks are
-    // discarded; its pool is recomputed on re-confirm against the revised selection.
-    if (currentReqIndex === 0) return
-    const prevIndex = currentReqIndex - 1
-    restoredSelectionRef.current = collectedTargets[prevIndex] ?? []
-    const remaining = { ...collectedTargets }
-    delete remaining[prevIndex]
-    setCollectedTargets(remaining)
     cancelDecisionSelection()
-    setCurrentReqIndex(prevIndex)
+    onBack?.()
   }
 
   const requirementLabel = totalRequirements > 1
-    ? `Choose Target (${currentReqIndex + 1}/${totalRequirements})`
+    ? `Choose Target (${requirementIndex + 1}/${totalRequirements})`
     : 'Choose Target'
 
   const promptText = targetReq?.description ?? decision.prompt
@@ -154,7 +134,7 @@ export function BattlefieldTargetingUI({
       </div>
 
       <div className={styles.buttonContainerSmall}>
-        {currentReqIndex > 0 && (
+        {onBack && (
           <button onClick={handleBack} className={`${styles.confirmButton} ${styles.confirmButtonSmall}`}>
             ← Back
           </button>

--- a/web-client/src/components/decisions/ChooseTargetsUI.tsx
+++ b/web-client/src/components/decisions/ChooseTargetsUI.tsx
@@ -75,6 +75,7 @@ export function ChooseTargetsUI({ decision }: { decision: ChooseTargetsDecision 
         responsive={responsive}
         requirementIndex={currentReqIndex}
         totalRequirements={totalRequirements}
+        initialSelection={restoredSelection}
         onComplete={handleComplete}
         {...backProps}
       />

--- a/web-client/src/components/decisions/ChooseTargetsUI.tsx
+++ b/web-client/src/components/decisions/ChooseTargetsUI.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { useGameStore } from '@/store/gameStore.ts'
+import type { ChooseTargetsDecision, EntityId } from '@/types'
+import { useResponsive } from '@/hooks/useResponsive.ts'
+import { getPileTargetCards } from '@/utils/targeting.ts'
+import { BattlefieldTargetingUI } from './BattlefieldTargetingUI'
+import { GraveyardTargetingUI } from './GraveyardTargetingUI'
+
+/**
+ * Walks a ChooseTargetsDecision one target requirement at a time, routing **each** requirement to
+ * the UI that can collect it, and submits every slot together once the last one is answered.
+ *
+ * The routing has to be per requirement, not per decision: a requirement whose legal targets all
+ * live in a graveyard or exile pile needs the pile picker ([GraveyardTargetingUI]) because a pile
+ * isn't clickable card-by-card on the board, while everything else is picked by clicking the board
+ * ([BattlefieldTargetingUI]). The Spot, Living Portal's ETB has one of each — "exile up to one
+ * target nonland permanent **and** up to one target nonland permanent card from a graveyard" — so
+ * deciding once for the whole decision strands one of the two slots: the graveyard card would have
+ * no clickable target at all, and a graveyard-first decision would submit slot 0 and silently drop
+ * the rest.
+ *
+ * Player-only lone requirements are handled before this by PlayerTargetingUI (click a life orb).
+ */
+export function ChooseTargetsUI({ decision }: { decision: ChooseTargetsDecision }) {
+  const gameState = useGameStore((s) => s.gameState)
+  const submitTargetsDecision = useGameStore((s) => s.submitTargetsDecision)
+  const responsive = useResponsive()
+
+  const [currentReqIndex, setCurrentReqIndex] = useState(0)
+  const [collectedTargets, setCollectedTargets] = useState<Record<number, readonly EntityId[]>>({})
+  // Picks to pre-select because the player stepped Back into a requirement they'd already answered.
+  const [restoredSelection, setRestoredSelection] = useState<readonly EntityId[]>([])
+
+  const totalRequirements = decision.targetRequirements.length
+
+  // Targets confirmed for other requirements can't be picked again (collectedTargets never holds
+  // the current index — Back deletes it before stepping into it).
+  const alreadySelected = Object.values(collectedTargets).flat()
+  const legalTargets = (decision.legalTargets[currentReqIndex] ?? [])
+    .filter((id) => !alreadySelected.includes(id))
+
+  const handleComplete = (targets: readonly EntityId[]) => {
+    const updatedTargets = { ...collectedTargets, [currentReqIndex]: targets }
+    if (currentReqIndex + 1 < totalRequirements) {
+      setCollectedTargets(updatedTargets)
+      setRestoredSelection([])
+      setCurrentReqIndex(currentReqIndex + 1)
+    } else {
+      submitTargetsDecision(updatedTargets)
+    }
+  }
+
+  const handleBack = () => {
+    // Step back to the previous requirement, restoring its confirmed picks so the player can
+    // revise them. The current requirement's in-progress picks are discarded; its pool is
+    // recomputed on re-confirm against the revised selection.
+    if (currentReqIndex === 0) return
+    const prevIndex = currentReqIndex - 1
+    setRestoredSelection(collectedTargets[prevIndex] ?? [])
+    const remaining = { ...collectedTargets }
+    delete remaining[prevIndex]
+    setCollectedTargets(remaining)
+    setCurrentReqIndex(prevIndex)
+  }
+
+  const backProps = currentReqIndex > 0 ? { onBack: handleBack } : {}
+  const pileCards = getPileTargetCards(legalTargets, gameState?.cards)
+
+  if (pileCards) {
+    return (
+      <GraveyardTargetingUI
+        key={currentReqIndex}
+        decision={decision}
+        graveyardCards={pileCards}
+        responsive={responsive}
+        requirementIndex={currentReqIndex}
+        totalRequirements={totalRequirements}
+        onComplete={handleComplete}
+        {...backProps}
+      />
+    )
+  }
+
+  return (
+    <BattlefieldTargetingUI
+      decision={decision}
+      requirementIndex={currentReqIndex}
+      totalRequirements={totalRequirements}
+      legalTargets={legalTargets}
+      initialSelection={restoredSelection}
+      onComplete={handleComplete}
+      {...backProps}
+    />
+  )
+}

--- a/web-client/src/components/decisions/DecisionUI.tsx
+++ b/web-client/src/components/decisions/DecisionUI.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useGameStore } from '@/store/gameStore.ts'
-import type { EntityId, ChooseTargetsDecision, ClientGameState } from '@/types'
+import type { EntityId, ChooseTargetsDecision } from '@/types'
 import { ZoneType } from '@/types'
 import { useResponsive } from '@/hooks/useResponsive.ts'
 import { LibrarySearchUI } from './LibrarySearchUI'
@@ -18,9 +18,8 @@ import { ChooseColorDecisionUI } from './ChooseColorDecisionUI'
 import { CardSelectionDecision } from './CardSelectionDecisionUI'
 import { BattlefieldSelectionUI } from './BattlefieldSelectionUI'
 import { MultiZoneSelectionUI } from './MultiZoneSelectionUI'
-import { BattlefieldTargetingUI } from './BattlefieldTargetingUI'
+import { ChooseTargetsUI } from './ChooseTargetsUI'
 import { PlayerTargetingUI } from './PlayerTargetingUI'
-import { GraveyardTargetingUI } from './GraveyardTargetingUI'
 import { SplitPilesUI } from './SplitPilesUI'
 import { ManaSourceSelectionUI } from './ManaSourceSelectionUI'
 import { isLoneTargetRequirement } from '@/utils/targeting.ts'
@@ -32,8 +31,8 @@ import styles from './DecisionUI.module.css'
  * Only then is the simple auto-submit [PlayerTargetingUI] banner appropriate. A decision with more
  * than one target requirement (e.g. Iroh, Tea Master: "target opponent" + "target permanent you
  * control") — or a single requirement wanting more than one target (e.g. Parker Luck: "two target
- * players", maxTargets = 2) — must route to [BattlefieldTargetingUI], which walks each requirement
- * in turn and accumulates player-orb selection through decisionSelectionState with a Confirm step.
+ * players", maxTargets = 2) — must route to [ChooseTargetsUI], which walks each requirement in turn
+ * and accumulates player-orb selection through decisionSelectionState with a Confirm step.
  * [PlayerTargetingUI] can only collect a lone player slot and would strand the rest.
  */
 function isPlayerOnlyTargeting(decision: ChooseTargetsDecision, playerIds: EntityId[]): boolean {
@@ -41,33 +40,6 @@ function isPlayerOnlyTargeting(decision: ChooseTargetsDecision, playerIds: Entit
   const legalTargets = decision.legalTargets[0] ?? []
   if (legalTargets.length === 0) return false
   return legalTargets.every((targetId) => playerIds.includes(targetId))
-}
-
-/**
- * Check if all legal targets in a ChooseTargetsDecision live in a hidden-from-battlefield zone
- * (graveyard or exile). Returns the cards if true, null otherwise — the caller routes the
- * resulting list into [GraveyardTargetingUI], which handles both zones (rendering owner-keyed
- * tabs and selection) since their pile semantics are identical for targeting.
- *
- * Mixed-zone target sets fall through to `null` here so they reach the battlefield targeting
- * path instead — that's a degenerate case today (Blade of the Swarm only targets exile, no
- * known card mixes graveyard + exile in one target slot).
- */
-function getGraveyardOrExileTargets(decision: ChooseTargetsDecision, gameState: ClientGameState | null) {
-  if (!gameState) return null
-  const legalTargets = decision.legalTargets[0] ?? []
-  if (legalTargets.length === 0) return null
-
-  const cards = []
-  for (const targetId of legalTargets) {
-    const card = gameState.cards[targetId]
-    const zoneType = card?.zone?.zoneType
-    if (!card || (zoneType !== ZoneType.GRAVEYARD && zoneType !== ZoneType.EXILE)) {
-      return null
-    }
-    cards.push(card)
-  }
-  return cards
 }
 
 /**
@@ -269,30 +241,18 @@ export function DecisionUI() {
   // Handle ChooseTargetsDecision
   if (pendingDecision.type === 'ChooseTargetsDecision') {
     const playerIds = gameState?.players.map((p) => p.playerId) ?? []
-    const isPlayerOnly = isPlayerOnlyTargeting(pendingDecision, playerIds)
-    const zoneTargets = getGraveyardOrExileTargets(pendingDecision, gameState)
-
-    // If all targets are in graveyards or exile, show a pile-selection overlay
-    if (zoneTargets && zoneTargets.length > 0) {
-      return (
-        <GraveyardTargetingUI
-          decision={pendingDecision}
-          graveyardCards={zoneTargets}
-          responsive={responsive}
-        />
-      )
-    }
 
     // Player-only targeting: simple banner (auto-submit via LifeDisplay click)
-    if (isPlayerOnly) {
+    if (isPlayerOnlyTargeting(pendingDecision, playerIds)) {
       return (
         <PlayerTargetingUI decision={pendingDecision} />
       )
     }
 
-    // Battlefield targeting: use selection state with Confirm/Decline buttons
+    // Everything else walks the requirements one at a time, routing each to the pile picker
+    // or the board-click banner depending on where that requirement's legal targets live.
     return (
-      <BattlefieldTargetingUI decision={pendingDecision} />
+      <ChooseTargetsUI key={pendingDecision.id} decision={pendingDecision} />
     )
   }
 

--- a/web-client/src/components/decisions/GraveyardTargetingUI.tsx
+++ b/web-client/src/components/decisions/GraveyardTargetingUI.tsx
@@ -5,6 +5,7 @@ import type { EntityId, ChooseTargetsDecision, ClientCard } from '@/types'
 import { calculateFittingCardWidth, type ResponsiveSizes } from '@/hooks/useResponsive.ts'
 import { ZoneSelectionUI, type ZoneCardInfo } from './ZoneSelectionUI'
 import { getCardImageUrl } from '@/utils/cardImages.ts'
+import { derivePileAction } from '@/utils/targeting.ts'
 import styles from './DecisionUI.module.css'
 
 /**
@@ -23,6 +24,7 @@ export function GraveyardTargetingUI({
   responsive,
   requirementIndex,
   totalRequirements,
+  initialSelection,
   onComplete,
   onBack,
 }: {
@@ -31,6 +33,8 @@ export function GraveyardTargetingUI({
   responsive: ResponsiveSizes
   requirementIndex: number
   totalRequirements: number
+  /** Picks to pre-select — non-empty when the player stepped Back into this requirement. */
+  initialSelection: readonly EntityId[]
   onComplete: (targets: readonly EntityId[]) => void
   /** Present when an earlier requirement can be revised. */
   onBack?: () => void
@@ -114,31 +118,15 @@ export function GraveyardTargetingUI({
     ? `${baseTitle} (${requirementIndex + 1}/${totalRequirements})`
     : baseTitle
 
-  // Derive the action verb from effectHint so the button/text matches the actual effect
-  // (e.g., "Exile card in a graveyard" → "Exile"; "Shuffle … into its owner's library" → "Shuffle
-  // into Library"; "Put … onto the battlefield" → "Put onto Battlefield"; "Return … to its owner's
-  // hand" → "Return to Hand"). Effects can be wrapped (ForEachTargetEffect, CompositeEffect, etc.)
-  // so the keyword may not be at the start — match anywhere in the hint. "Return to Hand" is only
-  // the fallback, so reanimation effects (Shark Shredder) must be detected explicitly or they'd
-  // mislabel as returning the opponent's card to hand.
-  const effectHint = decision.context.effectHint?.toLowerCase() ?? ''
-  const isExile = effectHint.includes('exile')
-  const isReanimate = effectHint.includes('battlefield')
-  const isShuffleIntoLibrary = effectHint.includes('shuffle') && effectHint.includes('library')
-  const optionalConfirmText = isReanimate
-    ? 'Put onto Battlefield'
-    : isShuffleIntoLibrary
-      ? 'Shuffle into Library'
-      : isExile
-        ? 'Exile'
-        : 'Return to Hand'
-  const actionVerb = isReanimate
-    ? 'put onto the battlefield'
-    : isShuffleIntoLibrary
-      ? 'shuffle into your library'
-      : isExile
-        ? 'exile'
-        : 'return to your hand'
+  // Derive the action wording from effectHint so the button/text matches the actual effect.
+  //
+  // TODO(per-requirement action hints): effectHint describes the effect as a whole, while this UI
+  // now collects one requirement of it. Both of The Spot's slots exile, so a single verb still
+  // fits; a composite whose slots take different verbs ("destroy target creature and return target
+  // card from a graveyard to your hand") would mislabel this slot. The durable fix is an action
+  // hint on TargetRequirementInfo instead of sniffing prose — a server-side change.
+  const { confirmText: optionalConfirmText, verb: actionVerb } =
+    derivePileAction(decision.context.effectHint)
 
   const numWord = (n: number): string =>
     ({ 1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five' } as Record<number, string>)[n] ?? String(n)
@@ -158,8 +146,10 @@ export function GraveyardTargetingUI({
     ? `Optional: choose ${countPhrase} to ${actionVerb}, or decline.`
     : `Choose ${countPhrase} to ${actionVerb}.`
 
-  // Lift selection state to persist across tab switches
-  const [selectedCards, setSelectedCards] = useState<EntityId[]>([])
+  // Lift selection state to persist across tab switches. Seeded from initialSelection so stepping
+  // Back into this requirement keeps its confirmed picks — the parent remounts on requirement
+  // change (key={currentReqIndex}), so the initializer re-runs per slot.
+  const [selectedCards, setSelectedCards] = useState<EntityId[]>(() => [...initialSelection])
   const [minimized, setMinimized] = useState(false)
 
   // If only one graveyard, use simple UI
@@ -172,6 +162,7 @@ export function GraveyardTargetingUI({
         cards={cards}
         minSelections={minTargets}
         maxSelections={maxTargets}
+        initialSelection={initialSelection}
         responsive={responsive}
         onConfirm={handleConfirm}
         confirmText={isOptionalTarget ? optionalConfirmText : 'Confirm Target'}

--- a/web-client/src/components/decisions/GraveyardTargetingUI.tsx
+++ b/web-client/src/components/decisions/GraveyardTargetingUI.tsx
@@ -8,21 +8,33 @@ import { getCardImageUrl } from '@/utils/cardImages.ts'
 import styles from './DecisionUI.module.css'
 
 /**
- * Graveyard / exile pile targeting UI — uses the shared ZoneSelectionUI component.
- * Supports selecting from multiple piles with owner tabs. Labels adapt to the cards'
- * actual zone (Graveyard vs Exile) so the same component renders Blade of the Swarm's
- * exile-targeting mode and the existing graveyard-target spells with the right wording.
+ * Graveyard / exile pile targeting UI for **one** requirement of a ChooseTargetsDecision — uses the
+ * shared ZoneSelectionUI component. Supports selecting from multiple piles with owner tabs. Labels
+ * adapt to the cards' actual zone (Graveyard vs Exile) so the same component renders Blade of the
+ * Swarm's exile-targeting mode and the existing graveyard-target spells with the right wording.
+ *
+ * The picked cards go back to the parent [ChooseTargetsUI] rather than straight to the server: the
+ * pile slot may be one of several requirements (The Spot, Living Portal exiles a battlefield
+ * permanent *and* a graveyard card), and only the parent knows whether more slots follow.
  */
 export function GraveyardTargetingUI({
   decision,
   graveyardCards,
   responsive,
+  requirementIndex,
+  totalRequirements,
+  onComplete,
+  onBack,
 }: {
   decision: ChooseTargetsDecision
   graveyardCards: ClientCard[]
   responsive: ResponsiveSizes
+  requirementIndex: number
+  totalRequirements: number
+  onComplete: (targets: readonly EntityId[]) => void
+  /** Present when an earlier requirement can be revised. */
+  onBack?: () => void
 }) {
-  const submitTargetsDecision = useGameStore((s) => s.submitTargetsDecision)
   const submitCancelDecision = useGameStore((s) => s.submitCancelDecision)
   const gameState = useGameStore((s) => s.gameState)
   const viewingPlayerId = gameState?.viewingPlayerId
@@ -85,19 +97,22 @@ export function GraveyardTargetingUI({
   }
 
   const handleConfirm = (selectedCards: EntityId[]) => {
-    // Submit with the selected targets for target index 0
-    // If minTargets is 0 (optional ability), submitting with 0 cards declines the ability
-    submitTargetsDecision({ 0: selectedCards })
+    // Hand this requirement's picks to the walker, which advances or submits.
+    // If minTargets is 0 (optional ability), confirming 0 cards declines this slot.
+    onComplete(selectedCards)
   }
 
   // Get target requirements
-  const targetReq = decision.targetRequirements[0]
+  const targetReq = decision.targetRequirements[requirementIndex]
   const minTargets = targetReq?.minTargets ?? 1
   const maxTargets = targetReq?.maxTargets ?? 1
   const isOptionalTarget = minTargets === 0
   const isMultiTarget = maxTargets > 1
   const sourceName = decision.context.sourceName ?? 'this ability'
-  const title = isOptionalTarget ? `Resolve ${sourceName}` : `Choose from ${pileNoun}`
+  const baseTitle = isOptionalTarget ? `Resolve ${sourceName}` : `Choose from ${pileNoun}`
+  const title = totalRequirements > 1
+    ? `${baseTitle} (${requirementIndex + 1}/${totalRequirements})`
+    : baseTitle
 
   // Derive the action verb from effectHint so the button/text matches the actual effect
   // (e.g., "Exile card in a graveyard" → "Exile"; "Shuffle … into its owner's library" → "Shuffle
@@ -165,7 +180,13 @@ export function GraveyardTargetingUI({
         confirmRequiresSelection={isOptionalTarget}
         sortByType={true}
         useGlobalHover={true}
-        onCancel={decision.canCancel ? () => submitCancelDecision() : undefined}
+        // The secondary button is "← Back" mid-walk (revise an earlier requirement) and
+        // "Cancel" otherwise; a cancellable cast can still be cancelled from requirement 0.
+        {...(onBack
+          ? { onCancel: onBack, cancelText: '← Back' }
+          : decision.canCancel
+            ? { onCancel: () => submitCancelDecision() }
+            : {})}
       />
     )
   }
@@ -246,6 +267,7 @@ export function GraveyardTargetingUI({
         confirmText={isOptionalTarget ? optionalConfirmText : 'Confirm Target'}
         declineText={isOptionalTarget ? 'Decline Trigger' : undefined}
         confirmRequiresSelection={isOptionalTarget}
+        {...(onBack ? { onBack } : {})}
       />
     </div>
   )
@@ -268,6 +290,7 @@ function GraveyardCardSelection({
   confirmText,
   declineText,
   confirmRequiresSelection,
+  onBack,
 }: {
   cards: ZoneCardInfo[]
   selectedCards: EntityId[]
@@ -281,6 +304,7 @@ function GraveyardCardSelection({
   confirmText: string
   declineText?: string | undefined
   confirmRequiresSelection: boolean
+  onBack?: () => void
 }) {
   const [hoveredCardId, setHoveredCardId] = useState<EntityId | null>(null)
   const hoverCard = useGameStore((s) => s.hoverCard)
@@ -412,6 +436,14 @@ function GraveyardCardSelection({
 
       {/* Action buttons */}
       <div className={styles.optionButtonRow}>
+        {onBack && (
+          <button
+            onClick={onBack}
+            className={styles.viewBattlefieldButton}
+          >
+            ← Back
+          </button>
+        )}
         <button
           onClick={onMinimize}
           className={styles.viewBattlefieldButton}

--- a/web-client/src/components/decisions/ZoneSelectionUI.tsx
+++ b/web-client/src/components/decisions/ZoneSelectionUI.tsx
@@ -30,6 +30,8 @@ interface ZoneSelectionUIProps {
   minSelections: number
   /** Maximum number of cards to select */
   maxSelections: number
+  /** Cards to pre-select on mount (e.g. picks restored by stepping Back into a target requirement) */
+  initialSelection?: readonly EntityId[]
   /** Responsive sizing info */
   responsive: ResponsiveSizes
   /** Called when selection is confirmed */
@@ -73,6 +75,7 @@ export function ZoneSelectionUI({
   cards,
   minSelections,
   maxSelections,
+  initialSelection = [],
   responsive,
   onConfirm,
   filterDescription,
@@ -85,7 +88,7 @@ export function ZoneSelectionUI({
   onCancel,
   cancelText = 'Cancel',
 }: ZoneSelectionUIProps) {
-  const [selectedCards, setSelectedCards] = useState<EntityId[]>([])
+  const [selectedCards, setSelectedCards] = useState<EntityId[]>(() => [...initialSelection])
   const [hoveredCardId, setHoveredCardId] = useState<EntityId | null>(null)
   const [minimized, setMinimized] = useState(false)
   const hoverCard = useGameStore((s) => s.hoverCard)

--- a/web-client/src/utils/targeting.test.ts
+++ b/web-client/src/utils/targeting.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { isLoneTargetRequirement } from './targeting'
-import type { ChooseTargetsDecision, TargetRequirementInfo } from '@/types'
+import { getPileTargetCards, isLoneTargetRequirement } from './targeting'
+import type { ChooseTargetsDecision, ClientCard, EntityId, TargetRequirementInfo } from '@/types'
+import { ZoneType } from '@/types'
 import { entityId } from '@/types/entities.ts'
 
 const req = (overrides: Partial<TargetRequirementInfo> = {}): TargetRequirementInfo => ({
@@ -11,14 +12,17 @@ const req = (overrides: Partial<TargetRequirementInfo> = {}): TargetRequirementI
   ...overrides,
 })
 
-const decision = (requirements: TargetRequirementInfo[]): ChooseTargetsDecision => ({
+const decision = (
+  requirements: TargetRequirementInfo[],
+  legalTargets: Record<number, readonly EntityId[]> = {},
+): ChooseTargetsDecision => ({
   type: 'ChooseTargetsDecision',
   id: 'd1',
   playerId: entityId('p1'),
   prompt: 'Choose targets',
   context: { phase: 'TRIGGER' },
   targetRequirements: requirements,
-  legalTargets: {},
+  legalTargets,
 })
 
 describe('isLoneTargetRequirement', () => {
@@ -40,5 +44,71 @@ describe('isLoneTargetRequirement', () => {
 
   it('is false for a decision with no requirements', () => {
     expect(isLoneTargetRequirement(decision([]))).toBe(false)
+  })
+})
+
+const owner = entityId('p2')
+
+const card = (id: string, zoneType: ZoneType | null): ClientCard =>
+  ({
+    id: entityId(id),
+    name: id,
+    ownerId: owner,
+    zone: zoneType === null ? null : { zoneType, ownerId: owner },
+  }) as unknown as ClientCard
+
+const cardMap = (...cards: ClientCard[]) =>
+  Object.fromEntries(cards.map((c) => [c.id, c])) as Record<string, ClientCard>
+
+describe('getPileTargetCards', () => {
+  const bears = card('bears', ZoneType.BATTLEFIELD)
+  const courser = card('courser', ZoneType.GRAVEYARD)
+  const exiled = card('exiled', ZoneType.EXILE)
+  const cards = cardMap(bears, courser, exiled)
+
+  it('returns the cards when every legal target sits in a graveyard', () => {
+    expect(getPileTargetCards([courser.id], cards)).toEqual([courser])
+  })
+
+  it('returns the cards when every legal target sits in exile', () => {
+    expect(getPileTargetCards([exiled.id], cards)).toEqual([exiled])
+  })
+
+  it('treats graveyard and exile as one pile set', () => {
+    expect(getPileTargetCards([courser.id, exiled.id], cards)).toEqual([courser, exiled])
+  })
+
+  it('returns null when any legal target is on the battlefield', () => {
+    expect(getPileTargetCards([bears.id, courser.id], cards)).toBeNull()
+  })
+
+  it('returns null for an empty legal-target set', () => {
+    expect(getPileTargetCards([], cards)).toBeNull()
+  })
+
+  it('returns null when a target is missing from the client card map', () => {
+    expect(getPileTargetCards([entityId('unknown')], cards)).toBeNull()
+  })
+
+  it('returns null when a target card carries no zone', () => {
+    const zoneless = card('zoneless', null)
+    expect(getPileTargetCards([zoneless.id], cardMap(zoneless))).toBeNull()
+  })
+
+  it('routes per requirement: The Spot, Living Portal exiles a permanent AND a graveyard card', () => {
+    // "exile up to one target nonland permanent and up to one target nonland permanent card
+    // from a graveyard" — slot 0 is a board click, slot 1 needs the pile picker.
+    const spot = decision(
+      [
+        req({ index: 0, minTargets: 0, description: 'up to one target nonland permanent' }),
+        req({ index: 1, minTargets: 0, description: 'up to one target nonland permanent card from a graveyard' }),
+      ],
+      { 0: [bears.id], 1: [courser.id] },
+    )
+    const legalTargets = spot.legalTargets
+
+    expect(spot.targetRequirements).toHaveLength(2)
+    expect(getPileTargetCards(legalTargets[0] ?? [], cards)).toBeNull()
+    expect(getPileTargetCards(legalTargets[1] ?? [], cards)).toEqual([courser])
   })
 })

--- a/web-client/src/utils/targeting.test.ts
+++ b/web-client/src/utils/targeting.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getPileTargetCards, isLoneTargetRequirement } from './targeting'
+import { derivePileAction, getPileTargetCards, isLoneTargetRequirement } from './targeting'
 import type { ChooseTargetsDecision, ClientCard, EntityId, TargetRequirementInfo } from '@/types'
 import { ZoneType } from '@/types'
 import { entityId } from '@/types/entities.ts'
@@ -107,8 +107,59 @@ describe('getPileTargetCards', () => {
     )
     const legalTargets = spot.legalTargets
 
-    expect(spot.targetRequirements).toHaveLength(2)
     expect(getPileTargetCards(legalTargets[0] ?? [], cards)).toBeNull()
     expect(getPileTargetCards(legalTargets[1] ?? [], cards)).toEqual([courser])
+  })
+})
+
+describe('derivePileAction', () => {
+  it('labels an exile effect', () => {
+    expect(derivePileAction('Exile target card from a graveyard')).toEqual({
+      confirmText: 'Exile',
+      verb: 'exile',
+    })
+  })
+
+  it('labels a reanimation effect', () => {
+    expect(derivePileAction('Put target creature card from a graveyard onto the battlefield')).toEqual({
+      confirmText: 'Put onto Battlefield',
+      verb: 'put onto the battlefield',
+    })
+  })
+
+  it('labels a shuffle-into-library effect', () => {
+    expect(derivePileAction('Shuffle target card from a graveyard into its owner\'s library')).toEqual({
+      confirmText: 'Shuffle into Library',
+      verb: 'shuffle into your library',
+    })
+  })
+
+  it('falls back to return-to-hand', () => {
+    expect(derivePileAction('Return target creature card from your graveyard to your hand')).toEqual({
+      confirmText: 'Return to Hand',
+      verb: 'return to your hand',
+    })
+  })
+
+  it('falls back to return-to-hand for a missing hint', () => {
+    expect(derivePileAction(undefined).confirmText).toBe('Return to Hand')
+  })
+
+  it('reads The Spot, Living Portal as exile, not reanimation', () => {
+    // ExileUntilLeavesEffect renders "…until this permanent leaves the battlefield", and The Spot
+    // composes two of them (CompositeEffect joins with ". "). A bare "battlefield" test would
+    // offer "Put onto Battlefield" for a card the effect exiles.
+    const hint =
+      'Exile up to one target nonland permanent until this permanent leaves the battlefield. ' +
+      'Exile up to one target nonland permanent card from a graveyard until this permanent ' +
+      'leaves the battlefield'
+
+    expect(derivePileAction(hint)).toEqual({ confirmText: 'Exile', verb: 'exile' })
+  })
+
+  it('still reads a blink as reanimation despite the leaves-the-battlefield clause', () => {
+    const hint = 'Exile target creature, then return it to the battlefield when this leaves the battlefield'
+
+    expect(derivePileAction(hint).confirmText).toBe('Put onto Battlefield')
   })
 })

--- a/web-client/src/utils/targeting.ts
+++ b/web-client/src/utils/targeting.ts
@@ -49,3 +49,45 @@ export function getPileTargetCards(
   }
   return pileCards
 }
+
+/**
+ * Boilerplate that hangs off the *exile* verb in O-Ring style effects — `ExileUntilLeavesEffect`
+ * renders "Exile … until this permanent leaves the battlefield". It names the battlefield without
+ * the effect ever putting anything there, so it must not read as reanimation (The Spot, Living
+ * Portal composes two of them and would otherwise offer "Put onto Battlefield" for a card it exiles).
+ */
+const LEAVES_BATTLEFIELD_BOILERPLATE = 'leaves the battlefield'
+
+/** What a pile-targeting requirement will do to the picked cards, in button and sentence form. */
+export interface PileAction {
+  /** Label for the confirm button on an optional pile target. */
+  confirmText: string
+  /** Verb phrase for the helper sentence: "Choose a card to <verb>." */
+  verb: string
+}
+
+/**
+ * Derive the action wording for a pile-targeting requirement from the decision's effect hint:
+ * "Exile card in a graveyard" → Exile; "Shuffle … into its owner's library" → Shuffle into Library;
+ * "Put … onto the battlefield" → Put onto Battlefield.
+ *
+ * Effects can be wrapped (ForEachTargetEffect, CompositeEffect, …) so the keyword may not be at the
+ * start — match anywhere in the hint. "Return to Hand" is only the fallback, so reanimation effects
+ * (Shark Shredder) must be detected explicitly or they'd mislabel as returning the opponent's card
+ * to hand. [LEAVES_BATTLEFIELD_BOILERPLATE] is discounted first; every other mention of the
+ * battlefield is a destination.
+ */
+export function derivePileAction(effectHint: string | null | undefined): PileAction {
+  const hint = (effectHint?.toLowerCase() ?? '').replaceAll(LEAVES_BATTLEFIELD_BOILERPLATE, '')
+
+  if (hint.includes('battlefield')) {
+    return { confirmText: 'Put onto Battlefield', verb: 'put onto the battlefield' }
+  }
+  if (hint.includes('shuffle') && hint.includes('library')) {
+    return { confirmText: 'Shuffle into Library', verb: 'shuffle into your library' }
+  }
+  if (hint.includes('exile')) {
+    return { confirmText: 'Exile', verb: 'exile' }
+  }
+  return { confirmText: 'Return to Hand', verb: 'return to your hand' }
+}

--- a/web-client/src/utils/targeting.ts
+++ b/web-client/src/utils/targeting.ts
@@ -1,4 +1,5 @@
-import type { ChooseTargetsDecision } from '@/types'
+import type { ChooseTargetsDecision, ClientCard, ClientGameState, EntityId } from '@/types'
+import { ZoneType } from '@/types'
 
 /**
  * A ChooseTargetsDecision that the lone-player click-to-submit path can satisfy: exactly one
@@ -14,4 +15,37 @@ import type { ChooseTargetsDecision } from '@/types'
 export function isLoneTargetRequirement(decision: ChooseTargetsDecision): boolean {
   if (decision.targetRequirements.length !== 1) return false
   return (decision.targetRequirements[0]?.maxTargets ?? 1) <= 1
+}
+
+/** Zones whose cards are only reachable through a pile picker — never clickable on the board. */
+const PILE_ZONES: ReadonlySet<ZoneType> = new Set([ZoneType.GRAVEYARD, ZoneType.EXILE])
+
+/**
+ * The cards for one target requirement when *all* of its legal targets sit in a pile zone
+ * (graveyard or exile), else `null`.
+ *
+ * A pile isn't individually clickable on the board, so such a requirement has to be collected by
+ * [GraveyardTargetingUI]; anything else (battlefield permanents, players, stack objects) is picked
+ * by clicking the board through `decisionSelectionState` ([BattlefieldTargetingUI]). This is
+ * evaluated **per requirement**, not once for the whole decision: The Spot, Living Portal's ETB
+ * asks for a battlefield permanent *and* a graveyard card, so the two slots route to different UIs.
+ *
+ * All-or-nothing on purpose — one battlefield target in the set means the board path must handle
+ * the slot, and a target the client can't resolve (missing card, null zone) is treated as
+ * not-a-pile so the requirement still reaches a UI that can show *something*.
+ */
+export function getPileTargetCards(
+  legalTargets: readonly EntityId[],
+  cards: ClientGameState['cards'] | undefined,
+): ClientCard[] | null {
+  if (!cards || legalTargets.length === 0) return null
+
+  const pileCards: ClientCard[] = []
+  for (const targetId of legalTargets) {
+    const card = cards[targetId]
+    const zoneType = card?.zone?.zoneType
+    if (!card || !zoneType || !PILE_ZONES.has(zoneType)) return null
+    pileCards.push(card)
+  }
+  return pileCards
 }


### PR DESCRIPTION
Route each target requirement of a `ChooseTargetsDecision` to a UI that can actually collect it,
instead of picking one UI for the whole decision.

## The problem

`DecisionUI` decided once per decision: if every legal target in `legalTargets[0]` sat in a
graveyard or exile pile, the whole decision went to `GraveyardTargetingUI`; otherwise all of it went
to `BattlefieldTargetingUI`. Both assumptions break on a decision that mixes zones.

The Spot, Living Portal's ETB is exactly that — "exile up to one target nonland permanent **and** up
to one target nonland permanent card from a graveyard". One slot is a board click, the other needs a
pile picker, and neither UI could serve both:

- routed to the board path, the graveyard card had no clickable target at all;
- routed to the pile path, `GraveyardTargetingUI` hard-coded `submitTargetsDecision({ 0: … })` and
  would have silently dropped every later slot.

## The change

A new `ChooseTargetsUI` owns the walk — `currentReqIndex`, `collectedTargets`, Back — and asks, per
requirement, which UI can collect that slot. `BattlefieldTargetingUI` and `GraveyardTargetingUI`
become per-requirement collectors taking `(requirementIndex, legalTargets, initialSelection,
onComplete, onBack)`; the parent submits every slot together once the last one is answered.

The routing predicate is `getPileTargetCards` in `utils/targeting.ts` — extracted rather than left
inline because the client has no component-test setup, so a pure function is the only thing this
repo can test.

Riding along: `key={pendingDecision.id}` on `ChooseTargetsUI`. Previously two consecutive decisions
reusing the mounted `BattlefieldTargetingUI` kept a stale `currentReqIndex`.

## Review fixes (second commit)

Both were found by reviewing the first commit, and both are visible on The Spot specifically:

- **The pile slot was labeled "Put onto Battlefield" for a card it exiles.** The action wording
  sniffed `effectHint` for `"battlefield"` before `"exile"`, but `ExileUntilLeavesEffect` renders
  `"Exile … until this permanent leaves the battlefield"` and `CompositeEffect` joins The Spot's two
  of them. Extracted the derivation to `derivePileAction` and discounted that boilerplate before the
  sniff. Genuine reanimation always names the battlefield as a *destination* ("onto/to the
  battlefield"), so blink and return-from-exile effects still classify correctly.
- **Back into a pile slot dropped its confirmed picks.** `ChooseTargetsUI` kept `restoredSelection`
  but handed it only to `BattlefieldTargetingUI`. Threaded `initialSelection` into
  `GraveyardTargetingUI` and both its paths, which meant a new optional `initialSelection` prop on
  the shared `ZoneSelectionUI` (defaults to `[]`, so library search and the other callers are
  unaffected).

## Known gap, recorded not fixed

`effectHint` describes the effect as a whole, while this UI now collects one requirement of it. Both
of The Spot's slots exile, so one verb still fits; a composite whose slots take different verbs
("destroy target creature **and** return target card from a graveyard to your hand") would mislabel
the pile slot. The durable fix is an action hint on `TargetRequirementInfo` rather than sniffing
prose — a server-side change, out of scope here. Left as a `TODO(per-requirement action hints)` in
`GraveyardTargetingUI` and noted in `docs/web-client-architecture.md`.

## Scope

Client only. No SDK types, no engine changes — The Spot itself is already implemented
(`mtg-sets/.../spm/cards/TheSpotLivingPortal.kt`) and covered by
`TheSpotLivingPortalScenarioTest`, which passes today; the engine was never the problem, the UI
just couldn't collect what the engine asked for.

## Testing

- `npx tsc --noEmit` — clean (run with `tsconfig.tsbuildinfo` removed, so no incremental caching).
- `targeting.test.ts` covers `getPileTargetCards` (8 cases: graveyard, exile, mixed piles, a
  battlefield target, empty set, missing card, null zone, and the two-slot Spot routing) and
  `derivePileAction` (7 cases, including The Spot's real composed hint string and a blink whose
  text contains both "to the battlefield" and "leaves the battlefield").
- **`npm test` was not run** — the dev container's `node_modules` carries a macOS rolldown binding
  (`@rolldown/binding-darwin-arm64`) so vitest can't start there. The `derivePileAction` cases were
  verified by running the function body directly under node; please let CI confirm the suite.
- **No screenshot** — the firewalled container can't run the stack, and `web-client/AGENTS.md` asks
  for one on user-visible changes. Happy to add a capture of The Spot's two-step flow (board slot →
  pile slot, with the corrected "Exile" wording) before merge if you want it.

## Follow-ups not taken

- An `e2e-scenarios` spec for the two-slot walk (`tests/portal/gravedigger.spec.ts` is the closest
  precedent). Nothing automated exercises the walk itself today — it would have caught the
  mislabeling above. `manual-scenarios/cards/t/the-spot-living-portal.json` is committed as a
  manual aid, not coverage.
- `ZoneSelectionUI` has one secondary-button slot, so Back displaces Cancel on a pile slot while the
  board banner renders both. A cancellable cast can therefore be aborted from a board slot but not
  from a pile slot at the same index.
