### PR TITLE
Teach the AI what a Room's two halves actually do

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComp
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
@@ -136,7 +137,7 @@ object BoardPresence : BoardFeature {
         // max keeps both, and guarantees no permanent is ever valued lower than it was before
         // Phase 6 — so a position the AI played correctly on the old numbers still scores at least
         // as well.
-        val prior = intents.forName(card.name)?.let { intentValue(projected, entityId, it) } ?: 0.0
+        val prior = priorValue(projected, entityId, container, card, intents)
 
         // Planeswalkers: the flat 4.0 priced a fresh Jace and a Jace at 1 loyalty identically.
         // Loyalty is both the walker's life total and its remaining activations, so it is the one
@@ -160,6 +161,30 @@ object BoardPresence : BoardFeature {
         // text — a signet, an Oblivion Ring and a Bitterblossom scoring the same number is the
         // blindness Phase 6 exists to remove.
         return maxOf(0.5, prior)
+    }
+
+    /**
+     * The prior for the permanent [entityId] *as it currently stands*.
+     *
+     * For everything except a Room that is the card's own [CardIntent]. A Room (CR 709.5) is one
+     * permanent with a door per half, and a locked half's rules text does not exist — so its value
+     * is the sum of what its **unlocked** faces do, and unlocking a door is what raises it. Reading
+     * the card as a whole would price a Room the same however many doors are open, which is exactly
+     * why the AI would cast a half and then never pay to unlock the other: a special action that
+     * moves no evaluated number can never beat passing.
+     */
+    private fun priorValue(
+        projected: ProjectedState,
+        entityId: EntityId,
+        container: com.wingedsheep.engine.state.ComponentContainer,
+        card: CardComponent,
+        intents: IntentCatalog,
+    ): Double {
+        val room = container.get<RoomComponent>()
+            ?: return intents.forName(card.name)?.let { intentValue(projected, entityId, it) } ?: 0.0
+        return room.unlockedFaces.sumOf { face ->
+            intents.forFace(card.name, face.name)?.let { intentValue(projected, entityId, it) } ?: 0.0
+        }
     }
 
     /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.ai.engine.knowledge.CardIntent
 import com.wingedsheep.ai.engine.knowledge.IntentCatalog
 import com.wingedsheep.ai.engine.lifePoolsOf
 import com.wingedsheep.ai.engine.sidesFor
+import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
@@ -16,7 +17,6 @@ import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComp
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
@@ -164,26 +164,32 @@ object BoardPresence : BoardFeature {
     }
 
     /**
-     * The prior for the permanent [entityId] *as it currently stands*.
+     * The prior for the permanent [entityId] *as it currently stands* — which is not the same
+     * question as what its card can do.
      *
-     * For everything except a Room that is the card's own [CardIntent]. A Room (CR 709.5) is one
-     * permanent with a door per half, and a locked half's rules text does not exist — so its value
-     * is the sum of what its **unlocked** faces do, and unlocking a door is what raises it. Reading
-     * the card as a whole would price a Room the same however many doors are open, which is exactly
-     * why the AI would cast a half and then never pay to unlock the other: a special action that
-     * moves no evaluated number can never beat passing.
+     * [IntentCatalog.forPermanent] answers with one [CardIntent] per reading in force: one for an
+     * ordinary permanent, one per **unlocked** door for a Room (CR 709.5). Reading a Room as a
+     * whole card would price it the same however many doors are open, which is exactly why the AI
+     * would cast a half and then never pay to unlock the other — a special action that moves no
+     * evaluated number can never beat passing.
+     *
+     * The readings combine as a baseline plus what each one adds *over* it, rather than a plain
+     * sum. `UNKNOWN.staticPriorValue` is the value of a permanent the analyzer cannot read, and a
+     * Room with two blank halves is still one unreadable permanent, not two — summing raw would
+     * make it outrank every other unreadable permanent for no reason at all.
      */
     private fun priorValue(
         projected: ProjectedState,
         entityId: EntityId,
-        container: com.wingedsheep.engine.state.ComponentContainer,
+        container: ComponentContainer,
         card: CardComponent,
         intents: IntentCatalog,
     ): Double {
-        val room = container.get<RoomComponent>()
-            ?: return intents.forName(card.name)?.let { intentValue(projected, entityId, it) } ?: 0.0
-        return room.unlockedFaces.sumOf { face ->
-            intents.forFace(card.name, face.name)?.let { intentValue(projected, entityId, it) } ?: 0.0
+        val inForce = intents.forPermanent(container, card.name)
+        if (inForce.isEmpty()) return 0.0
+        val unreadable = CardIntent.UNKNOWN.staticPriorValue
+        return unreadable + inForce.sumOf {
+            (intentValue(projected, entityId, it) - unreadable).coerceAtLeast(0.0)
         }
     }
 
@@ -217,7 +223,7 @@ object BoardPresence : BoardFeature {
         state: GameState,
         projected: ProjectedState,
         entityId: EntityId,
-        container: com.wingedsheep.engine.state.ComponentContainer
+        container: ComponentContainer
     ): Double {
         val power = projected.getPower(entityId) ?: 0
         val toughness = projected.getToughness(entityId) ?: 0

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/RawBoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/RawBoardFeatures.kt
@@ -160,8 +160,14 @@ data class RawBoardFeatures(
                         (entity.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0) else 0,
                     lands = result.lands + if (CardType.LAND.name in types) 1 else 0,
                     untappedLands = result.untappedLands + if (CardType.LAND.name in types && !entity.has<TappedComponent>()) 1 else 0,
-                    threatsInPlay = result.threatsInPlay + if (card?.let { intents.forName(it.name) }
-                            ?.tags?.any { it in THREAT_TAGS } == true) 1 else 0,
+                    // A *permanent's* threat, not its card's: a Room's locked half and an already
+                    // spent Adventure are text that is not on the battlefield, so they must not
+                    // count here. [IntentCatalog.forPermanent] is the same reading `BoardPresence`
+                    // prices the permanent by.
+                    threatsInPlay = result.threatsInPlay + if (card != null &&
+                        intents.forPermanent(entity, card.name)
+                            .any { intent -> intent.tags.any { it in THREAT_TAGS } }
+                    ) 1 else 0,
                 )
             }
             val removal = state.getHand(playerId).count { id ->

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzer.kt
@@ -46,51 +46,82 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * ## Faces
  *
- * A multi-face card keeps its rules text on [CardFace.script], and its top-level
- * [CardDefinition.script] is empty — a Room (CR 709.5), a split card (709), an Adventure (715), a
- * modal DFC (712). Reading only the top level therefore reported *every* such card as
- * uninterpretable, which is how `Unholy Annex // Ritual Chamber` — a repeatable draw engine —
- * priced identically to a vanilla enchantment. [analyze] folds every face's script in, exactly as
- * [com.wingedsheep.engine.state.components.identity.RoomFaceStatics] does for static abilities.
+ * A multi-face card splits its rules text across [CardDefinition.script] and one or more
+ * [CardFace.script]s — a Room (CR 709.5), a split card (709), an Adventure (715), an Omen, a modal
+ * DFC (712). Reading only the top level reported a Room as uninterpretable altogether, which is how
+ * `Unholy Annex // Ritual Chamber` — a repeatable draw engine — priced identically to a vanilla
+ * enchantment.
  *
- * A tag is a claim about what the card can do *somewhere*, so unioning faces is the same
- * "anywhere on this card" reading the walk already applies within one script. What it is not is a
- * claim about a *permanent* on the battlefield: only one half of a Room functions per unlocked
- * door, so battlefield value goes through [analyzeFace] per unlocked face instead.
+ * There is no single right answer for such a card, so there are three entry points and each
+ * answers a different question:
+ *
+ *  - [analyze] — "what can this *card* do, anywhere?" Every face unioned. A tag is already an
+ *    anywhere-on-this-card claim within one script, so this is the same reading widened. It is what
+ *    a card in hand is worth deciding about: casting `Virtue of Loyalty` as its Adventure half is a
+ *    real option, and hiding that would make the AI blind to it.
+ *  - [analyzeSelf] — "what is this card doing as a *permanent*?" Top level only. In every layout
+ *    the SDK has, the face that can sit on the battlefield is the top-level one and the extra faces
+ *    are spells that never stay there (an Adventure/Omen/modal-DFC back resolves to exile, library
+ *    or graveyard; neither half of a split card is a permanent). So an already-spent Adventure must
+ *    not inflate the enchantment it left behind.
+ *  - [analyzeFace] — "what is this one face doing?" A Room is the exception to [analyzeSelf]: its
+ *    top-level script is empty and its halves are permanents, so a Room permanent is read per
+ *    *unlocked* door.
+ *
+ * `IntentCatalog.forPermanent` is the seam that picks between the last two; nothing else should
+ * have to know which layout it is holding.
  *
  * ## Purity and caching
  *
- * `analyze` is a pure function of the definition, so results are memoized process-wide by card
- * name. A card name resolves to one canonical [CardDefinition] in a
+ * Each entry point is a pure function of the definition, so results are memoized process-wide by
+ * card name. A card name resolves to one canonical [CardDefinition] in a
  * [com.wingedsheep.engine.registry.CardRegistry] (later printings are `Printing` rows, not
  * duplicate definitions), so the name is a sound key and the cost is paid once per process rather
- * than once per game — which matters when the arena plays a thousand of them. Face names are
- * unique within a card, so `"<card>//<face>"` keys the per-face results the same way.
+ * than once per game — which matters when the arena plays a thousand of them. The three readings
+ * get three caches rather than one keyed by a synthesized string, so no naming convention has to
+ * hold for them to stay apart.
  */
 object CardIntentAnalyzer {
 
-    private val cache = ConcurrentHashMap<String, CardIntent>()
+    private val cardCache = ConcurrentHashMap<String, CardIntent>()
+    private val selfCache = ConcurrentHashMap<String, CardIntent>()
+    private val faceCache = ConcurrentHashMap<FaceKey, CardIntent>()
+
+    private data class FaceKey(val cardName: String, val faceName: String)
 
     /** The [CardIntent] for [card] — its own script and every face's — computing it on first sight. */
     fun analyze(card: CardDefinition): CardIntent =
-        cache.getOrPut(card.name) { compute(card, listOf(card.script) + card.cardFaces.map { it.script }) }
+        cardCache.getOrPut(card.name) { compute(card, listOf(card.script) + card.cardFaces.map { it.script }) }
+
+    /**
+     * The [CardIntent] of [card] read as the permanent it becomes: its top-level script alone,
+     * with the spell faces (Adventure, Omen, modal-DFC back) left out.
+     *
+     * For a single-face card this is exactly [analyze]. For a Room it is empty and useless — use
+     * [analyzeFace] per unlocked door instead.
+     */
+    fun analyzeSelf(card: CardDefinition): CardIntent =
+        if (card.cardFaces.isEmpty()) analyze(card)
+        else selfCache.getOrPut(card.name) { compute(card, listOf(card.script)) }
 
     /**
      * The [CardIntent] of one face of [card], read as what that face contributes on its own.
      *
      * This is the reading a Room's battlefield value needs: a locked door's text does not exist
-     * (CR 709.5), so a permanent is worth the sum of what its *unlocked* faces do, not what the
-     * card as a whole could do. The face is analyzed against the card's own type line and keywords,
-     * because it is the card that is (or is not) a permanent.
+     * (CR 709.5), so a permanent is worth what its *unlocked* faces do, not what the card as a
+     * whole could do. The face is analyzed against the card's own type line and keywords, which is
+     * sound for a Room because both halves share the printed type line (CR 709.5a) — and it is the
+     * card that is (or is not) a permanent.
      */
     fun analyzeFace(card: CardDefinition, face: CardFace): CardIntent =
-        cache.getOrPut("${card.name}//${face.name}") { compute(card, listOf(face.script)) }
+        faceCache.getOrPut(FaceKey(card.name, face.name)) { compute(card, listOf(face.script)) }
 
     /**
      * The intent [scripts] add up to, read as belonging to [card].
      *
      * Every caller passes the scripts that are in force for what it is asking about — the whole
-     * card for [analyze], one face for [analyzeFace] — and nothing here reads [card] for anything
+     * card for [analyze], the top level for [analyzeSelf], one face for [analyzeFace] — and
+     * nothing here reads [card] for anything
      * but its printed characteristics (type line, keywords), which faces share.
      */
     private fun compute(card: CardDefinition, scripts: List<CardScript>): CardIntent {
@@ -379,11 +410,15 @@ object CardIntentAnalyzer {
     }
 
     /**
-     * False for a trigger that fires once for the object it is on and then never again while it
-     * sits there: "when *this* permanent enters/leaves the battlefield", and a Room half's "when
-     * you unlock this door" (CR 709.5), which fires on the transition rather than on a repeating
-     * event. Counting either would read every ETB permanent, and every spent Room door, as an
-     * engine.
+     * False for a trigger that fires on the event that put the object into its current state, and
+     * then not again while it stays there: "when *this* permanent enters/leaves the battlefield",
+     * and a Room half's "when you unlock this door" (CR 709.5h). Counting either would read every
+     * ETB permanent, and every already-open Room door, as an engine.
+     *
+     * A door can in principle be re-locked and unlocked again (CR 709.5g, the SDK's
+     * `LockDoorEffect`), so "fires once" is a claim about the common case, not an invariant. That
+     * is the right way round for a prior: under-reading a rare re-unlock costs the AI nothing it
+     * had, while over-reading every spent door as repeatable value is the bug this exists to avoid.
      */
     private fun canFireMoreThanOnce(ability: TriggeredAbility): Boolean {
         if (ability.binding != TriggerBinding.SELF) return true

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzer.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.ai.engine.knowledge
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardFace
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.Duration
@@ -43,29 +44,63 @@ import java.util.concurrent.ConcurrentHashMap
  * gave *every* non-creature permanent before this existed. The failure mode is "no better than
  * before", never "confidently wrong".
  *
+ * ## Faces
+ *
+ * A multi-face card keeps its rules text on [CardFace.script], and its top-level
+ * [CardDefinition.script] is empty — a Room (CR 709.5), a split card (709), an Adventure (715), a
+ * modal DFC (712). Reading only the top level therefore reported *every* such card as
+ * uninterpretable, which is how `Unholy Annex // Ritual Chamber` — a repeatable draw engine —
+ * priced identically to a vanilla enchantment. [analyze] folds every face's script in, exactly as
+ * [com.wingedsheep.engine.state.components.identity.RoomFaceStatics] does for static abilities.
+ *
+ * A tag is a claim about what the card can do *somewhere*, so unioning faces is the same
+ * "anywhere on this card" reading the walk already applies within one script. What it is not is a
+ * claim about a *permanent* on the battlefield: only one half of a Room functions per unlocked
+ * door, so battlefield value goes through [analyzeFace] per unlocked face instead.
+ *
  * ## Purity and caching
  *
  * `analyze` is a pure function of the definition, so results are memoized process-wide by card
  * name. A card name resolves to one canonical [CardDefinition] in a
  * [com.wingedsheep.engine.registry.CardRegistry] (later printings are `Printing` rows, not
  * duplicate definitions), so the name is a sound key and the cost is paid once per process rather
- * than once per game — which matters when the arena plays a thousand of them.
+ * than once per game — which matters when the arena plays a thousand of them. Face names are
+ * unique within a card, so `"<card>//<face>"` keys the per-face results the same way.
  */
 object CardIntentAnalyzer {
 
     private val cache = ConcurrentHashMap<String, CardIntent>()
 
-    /** The [CardIntent] for [card], computing it on first sight. */
-    fun analyze(card: CardDefinition): CardIntent = cache.getOrPut(card.name) { compute(card) }
+    /** The [CardIntent] for [card] — its own script and every face's — computing it on first sight. */
+    fun analyze(card: CardDefinition): CardIntent =
+        cache.getOrPut(card.name) { compute(card, listOf(card.script) + card.cardFaces.map { it.script }) }
 
-    private fun compute(card: CardDefinition): CardIntent {
-        val script = card.script
+    /**
+     * The [CardIntent] of one face of [card], read as what that face contributes on its own.
+     *
+     * This is the reading a Room's battlefield value needs: a locked door's text does not exist
+     * (CR 709.5), so a permanent is worth the sum of what its *unlocked* faces do, not what the
+     * card as a whole could do. The face is analyzed against the card's own type line and keywords,
+     * because it is the card that is (or is not) a permanent.
+     */
+    fun analyzeFace(card: CardDefinition, face: CardFace): CardIntent =
+        cache.getOrPut("${card.name}//${face.name}") { compute(card, listOf(face.script)) }
+
+    /**
+     * The intent [scripts] add up to, read as belonging to [card].
+     *
+     * Every caller passes the scripts that are in force for what it is asking about — the whole
+     * card for [analyze], one face for [analyzeFace] — and nothing here reads [card] for anything
+     * but its printed characteristics (type line, keywords), which faces share.
+     */
+    private fun compute(card: CardDefinition, scripts: List<CardScript>): CardIntent {
         // Every effect the card can produce, flattened. A tag answers "does this card do X
         // anywhere?", so where in the script the effect sat does not change the answer — the
         // origin discounts [EffectWalker.slots] carries are the rater's concern, not this one's.
-        val leaves = (EffectWalker.slots(script).map { it.effect } +
-            script.stateTriggeredAbilities.map { it.effect })
-            .flatMap { EffectWalker.leaves(it) }
+        val leaves = scripts.flatMap { script ->
+            EffectWalker.slots(script).map { it.effect } +
+                script.stateTriggeredAbilities.map { it.effect }
+        }.flatMap { EffectWalker.leaves(it) }
 
         val tags = mutableSetOf<IntentTag>()
         var removalReach: Int? = null
@@ -80,25 +115,28 @@ object CardIntentAnalyzer {
         }
 
         var anthemBonus = 0
-        for (static in script.staticAbilities) {
+        for (static in scripts.flatMap { it.staticAbilities }) {
             tags += tagsOf(static)
             anthemBonus = maxOf(anthemBonus, anthemBonusOf(static))
         }
 
-        if (script.activatedAbilities.any { it.isManaAbility }) tags += IntentTag.RAMP
-        if (script.activatedAbilities.any { !it.isManaAbility && sacrificesOthers(it.cost) }) {
+        val activated = scripts.flatMap { it.activatedAbilities }
+        if (activated.any { it.isManaAbility }) tags += IntentTag.RAMP
+        if (activated.any { !it.isManaAbility && sacrificesOthers(it.cost) }) {
             tags += IntentTag.SACRIFICE_OUTLET
         }
         // An Aura/Equipment whose whole point is the creature it sits on is a pump, not an anthem.
-        if (script.isAura && script.staticAbilities.any { it is ModifyStats }) tags += IntentTag.PUMP
+        if (scripts.any { it.isAura && it.staticAbilities.any { static -> static is ModifyStats } }) {
+            tags += IntentTag.PUMP
+        }
 
         // A combat trick is an instant pump that *expires*. A "+1/+1 counter at instant speed" is
         // a permanent investment you can make whenever you like, and holding it for combat is not
         // the same decision — so it stays PUMP and never reaches [HoldPolicy]'s no-window verdict.
-        val speed = speedOf(card, tags)
+        val speed = speedOf(card, scripts, tags)
         if (speed == Speed.INSTANT && expiringPump) tags += IntentTag.COMBAT_TRICK
 
-        val repeatable = repeatableOf(card, script)
+        val repeatable = repeatableOf(card, scripts)
         val intent = CardIntent(
             tags = tags,
             speed = speed,
@@ -306,15 +344,14 @@ object CardIntentAnalyzer {
     // Speed / repeatability
     // ═════════════════════════════════════════════════════════════════════════
 
-    private fun speedOf(card: CardDefinition, tags: Set<IntentTag>): Speed {
-        val script = card.script
+    private fun speedOf(card: CardDefinition, scripts: List<CardScript>, tags: Set<IntentTag>): Speed {
         if (!card.typeLine.isPermanent) {
             return if (card.typeLine.isInstant || Keyword.FLASH in card.keywords) Speed.INSTANT
             else Speed.SORCERY
         }
         if (Keyword.FLASH in card.keywords) return Speed.INSTANT
-        if (script.activatedAbilities.any { !it.isManaAbility }) return Speed.ACTIVATED
-        if (script.staticAbilities.isNotEmpty() || IntentTag.ANTHEM in tags) return Speed.STATIC
+        if (scripts.any { script -> script.activatedAbilities.any { !it.isManaAbility } }) return Speed.ACTIVATED
+        if (scripts.any { it.staticAbilities.isNotEmpty() } || IntentTag.ANTHEM in tags) return Speed.STATIC
         return Speed.SORCERY
     }
 
@@ -327,10 +364,12 @@ object CardIntentAnalyzer {
      * leave-the-battlefield trigger fires once per object (Banishing Light), so counting it would
      * make every ETB permanent in the catalog read as a repeatable one.
      */
-    private fun repeatableOf(card: CardDefinition, script: CardScript): Boolean {
+    private fun repeatableOf(card: CardDefinition, scripts: List<CardScript>): Boolean {
         if (!card.typeLine.isPermanent) return false
-        return script.activatedAbilities.any { !it.isManaAbility && !consumesSource(it.cost) } ||
-            script.triggeredAbilities.any { canFireMoreThanOnce(it) }
+        return scripts.any { script ->
+            script.activatedAbilities.any { !it.isManaAbility && !consumesSource(it.cost) } ||
+                script.triggeredAbilities.any { canFireMoreThanOnce(it) }
+        }
     }
 
     private fun consumesSource(cost: AbilityCost): Boolean = when (cost) {
@@ -339,11 +378,22 @@ object CardIntentAnalyzer {
         else -> false
     }
 
-    /** False exactly for "when *this* permanent enters/leaves the battlefield" — a once-per-object event. */
+    /**
+     * False for a trigger that fires once for the object it is on and then never again while it
+     * sits there: "when *this* permanent enters/leaves the battlefield", and a Room half's "when
+     * you unlock this door" (CR 709.5), which fires on the transition rather than on a repeating
+     * event. Counting either would read every ETB permanent, and every spent Room door, as an
+     * engine.
+     */
     private fun canFireMoreThanOnce(ability: TriggeredAbility): Boolean {
         if (ability.binding != TriggerBinding.SELF) return true
-        val pattern = ability.trigger as? EventPattern.ZoneChangeEvent ?: return true
-        return pattern.to != Zone.BATTLEFIELD && pattern.from != Zone.BATTLEFIELD
+        return when (val pattern = ability.trigger) {
+            is EventPattern.ZoneChangeEvent ->
+                pattern.to != Zone.BATTLEFIELD && pattern.from != Zone.BATTLEFIELD
+
+            is EventPattern.DoorUnlockedEvent -> false
+            else -> true
+        }
     }
 
     private fun sacrificesOthers(cost: AbilityCost): Boolean = when (cost) {

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/IntentCatalog.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/IntentCatalog.kt
@@ -36,6 +36,20 @@ class IntentCatalog private constructor(private val registry: CardRegistry?) {
         return CardIntentAnalyzer.analyze(definition)
     }
 
+    /**
+     * The intent of the face called [faceName] on the card called [cardName], or null when the
+     * catalog is off, the name is not a real card, or that card has no such face.
+     *
+     * What one *face* does is the question a Room asks (CR 709.5): a locked door's text does not
+     * exist, so a Room permanent is worth what its unlocked faces do — see
+     * [com.wingedsheep.ai.engine.evaluation.BoardPresence].
+     */
+    fun forFace(cardName: String, faceName: String): CardIntent? {
+        val definition = registry?.getCard(cardName) ?: return null
+        val face = definition.cardFaces.find { it.name == faceName } ?: return null
+        return CardIntentAnalyzer.analyzeFace(definition, face)
+    }
+
     /** The intent of a definition already in hand. Always answers, even on [NONE]. */
     fun forCard(card: CardDefinition): CardIntent = CardIntentAnalyzer.analyze(card)
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/IntentCatalog.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/IntentCatalog.kt
@@ -1,6 +1,9 @@
 package com.wingedsheep.ai.engine.knowledge
 
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
 import com.wingedsheep.sdk.model.CardDefinition
 
 /**
@@ -41,13 +44,40 @@ class IntentCatalog private constructor(private val registry: CardRegistry?) {
      * catalog is off, the name is not a real card, or that card has no such face.
      *
      * What one *face* does is the question a Room asks (CR 709.5): a locked door's text does not
-     * exist, so a Room permanent is worth what its unlocked faces do — see
-     * [com.wingedsheep.ai.engine.evaluation.BoardPresence].
+     * exist, so a Room permanent is worth what its unlocked faces do — see [forPermanent].
      */
     fun forFace(cardName: String, faceName: String): CardIntent? {
         val definition = registry?.getCard(cardName) ?: return null
         val face = definition.cardFaces.find { it.name == faceName } ?: return null
         return CardIntentAnalyzer.analyzeFace(definition, face)
+    }
+
+    /**
+     * Every intent currently *in force* on the battlefield permanent [container], whose card is
+     * called [cardName]. Empty when the catalog is off or the name is not a real card — which
+     * callers must read as "no information", never as "this permanent does nothing".
+     *
+     * This is the only reading a permanent should ever be valued by, and it is deliberately the
+     * one place that knows a Room from anything else:
+     *
+     *  - A Room (CR 709.5) contributes one entry per **unlocked** door, because a locked half's
+     *    rules text does not exist. Unlocking is what raises the total — and a Room put onto the
+     *    battlefield with both doors locked (CR 709.5d) contributes nothing, correctly.
+     *  - Anything else contributes its own top-level reading, with the spell faces of an
+     *    Adventure / Omen / modal DFC left out: those resolve away to exile, library or graveyard
+     *    and are never the permanent standing here.
+     *
+     * Face membership is tested the same way
+     * [com.wingedsheep.engine.state.components.identity.RoomFaceStatics] tests it — by [RoomFaceId]
+     * against the card definition's faces — so the two cannot drift on which door is open.
+     */
+    fun forPermanent(container: ComponentContainer, cardName: String): List<CardIntent> {
+        val definition = registry?.getCard(cardName) ?: return emptyList()
+        val room = container.get<RoomComponent>()
+            ?: return listOf(CardIntentAnalyzer.analyzeSelf(definition))
+        return definition.cardFaces
+            .filter { RoomFaceId(it.name) in room.unlocked }
+            .map { CardIntentAnalyzer.analyzeFace(definition, it) }
     }
 
     /** The intent of a definition already in hand. Always answers, even on [NONE]. */

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/RoomAiTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/RoomAiTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnholyAnnexRitualChamber
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The AI has to actually play Rooms (CR 709.5): cast a half, and pay to unlock the other door.
+ *
+ * Both halves of a Room carry their rules text on [com.wingedsheep.sdk.model.CardFace.script],
+ * never on the card's top-level script — so anything that reads only the top level sees a blank
+ * card. `Unholy Annex // Ritual Chamber` is the card the bug was reported on: the AI never cast the
+ * Annex half (a repeatable draw engine that reads as a vanilla enchantment) and never unlocked the
+ * Annex door (an unlock that only turns face text on moves nothing a name-keyed valuation can see).
+ */
+class RoomAiTest : FunSpec({
+
+    val allCards = TestCards.all + UnholyAnnexRitualChamber
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(allCards)
+        initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun ai(playerId: EntityId): AIPlayer =
+        AIPlayer.create(CardRegistry().apply { register(allCards) }, playerId, AiProfile.PRODUCTION)
+
+    /** Untapped Swamps for the auto-tapper to find. */
+    fun swamps(driver: GameTestDriver, playerId: EntityId, count: Int) {
+        repeat(count) { driver.putLandOnBattlefield(playerId, "Swamp") }
+    }
+
+    /** Pass until the stack is empty — a Room's door-unlock trigger needs its own round. */
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+    }
+
+    test("the AI casts the Unholy Annex half rather than passing") {
+        val d = driver()
+        val p1 = d.player1
+        val roomId = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        // {2}{B} affords the Annex half only — the choice under test is "cast this or not".
+        swamps(d, p1, 3)
+
+        val choices = d.legalActions(p1).filter {
+            (it.action as? CastSpell)?.cardId == roomId || it.action is PassPriority
+        }
+        choices.count { it.action is CastSpell } shouldBe 1
+
+        val chosen = ai(p1).chooseFrom(d.state, choices).action
+        (chosen as? CastSpell)?.faceIndex shouldBe 0
+    }
+
+    test("the AI unlocks Ritual Chamber once Unholy Annex is on the battlefield") {
+        val d = driver()
+        val p1 = d.player1
+        val roomId = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        swamps(d, p1, 8)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        settle(d)
+        d.state.getEntity(roomId)?.get<RoomComponent>()?.unlocked shouldBe setOf(RoomFaceId("Unholy Annex"))
+
+        val choices = d.legalActions(p1).filter {
+            it.action is UnlockRoomDoor || it.action is PassPriority
+        }
+        choices.count { it.action is UnlockRoomDoor } shouldBe 1
+
+        val chosen = ai(p1).chooseFrom(d.state, choices).action
+        (chosen as? UnlockRoomDoor)?.faceId shouldBe RoomFaceId("Ritual Chamber")
+    }
+
+    test("the AI unlocks Unholy Annex once Ritual Chamber is on the battlefield") {
+        val d = driver()
+        val p1 = d.player1
+        val roomId = d.putCardInHand(p1, UnholyAnnexRitualChamber.name)
+        swamps(d, p1, 8)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+        settle(d)
+        d.state.getEntity(roomId)?.get<RoomComponent>()?.unlocked shouldBe setOf(RoomFaceId("Ritual Chamber"))
+
+        val choices = d.legalActions(p1).filter {
+            it.action is UnlockRoomDoor || it.action is PassPriority
+        }
+        choices.count { it.action is UnlockRoomDoor } shouldBe 1
+
+        val chosen = ai(p1).chooseFrom(d.state, choices).action
+        (chosen as? UnlockRoomDoor)?.faceId shouldBe RoomFaceId("Unholy Annex")
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/RoomAiTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/RoomAiTest.kt
@@ -12,7 +12,9 @@ import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnholyAnnexRitualChamber
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 
 /**
@@ -44,8 +46,13 @@ class RoomAiTest : FunSpec({
 
     /** Pass until the stack is empty — a Room's door-unlock trigger needs its own round. */
     fun settle(driver: GameTestDriver) {
-        var guard = 0
-        while (driver.state.stack.isNotEmpty() && guard++ < 10) driver.bothPass()
+        var rounds = 0
+        while (driver.state.stack.isNotEmpty()) {
+            withClue("the stack never emptied, so the test's premise was never set up") {
+                rounds++ shouldBeLessThan 10
+            }
+            driver.bothPass()
+        }
     }
 
     test("the AI casts the Unholy Annex half rather than passing") {

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzerTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzerTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.ai.engine.knowledge
 
 import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnholyAnnexRitualChamber
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
@@ -18,6 +19,8 @@ import io.kotest.matchers.shouldBe
 class CardIntentAnalyzerTest : ScenarioTestBase() {
 
     private fun intentOf(name: String) = CardIntentAnalyzer.analyze(cardRegistry.requireCard(name))
+
+    private fun roomFace(name: String) = UnholyAnnexRitualChamber.cardFaces.first { it.name == name }
 
     init {
         test("a repeatable tapper reads as a repeatable tapper") {
@@ -95,6 +98,39 @@ class CardIntentAnalyzerTest : ScenarioTestBase() {
             val intent = intentOf("Grizzly Bears")
             intent.tags shouldBe emptySet()
             intent.staticPriorValue shouldBe CardIntent.UNKNOWN.staticPriorValue
+        }
+
+        test("a Room's rules text lives on its faces, and the analyzer reads it") {
+            // Top-level script is empty for a split card (CR 709) — reading only that priced this
+            // repeatable draw engine as a vanilla enchantment, and the AI never cast it.
+            val intent = CardIntentAnalyzer.analyze(UnholyAnnexRitualChamber)
+            intent.tags shouldContain IntentTag.DRAW
+            intent.tags shouldContain IntentTag.TOKEN_MAKER
+            intent.repeatable shouldBe true
+            intent.staticPriorValue shouldBeGreaterThan 2.7
+        }
+
+        test("each Room half is valued on its own, so unlocking a door is worth something") {
+            val annex = CardIntentAnalyzer.analyzeFace(UnholyAnnexRitualChamber, roomFace("Unholy Annex"))
+            withClue("an end-step draw trigger that fires every turn") {
+                annex.tags shouldContain IntentTag.DRAW
+                annex.repeatable shouldBe true
+                annex.staticPriorValue shouldBeGreaterThan 2.7
+            }
+
+            val chamber = CardIntentAnalyzer.analyzeFace(UnholyAnnexRitualChamber, roomFace("Ritual Chamber"))
+            chamber.tags shouldContain IntentTag.TOKEN_MAKER
+            withClue("'when you unlock this door' fires once for that door, like an ETB") {
+                chamber.repeatable shouldBe false
+                chamber.staticPriorValue shouldBe CardIntent.UNKNOWN.staticPriorValue
+            }
+        }
+
+        test("the catalog resolves a face by name, and shrugs at a face that isn't there") {
+            val catalog = IntentCatalog.of(cardRegistry.apply { register(UnholyAnnexRitualChamber) })
+            catalog.forFace(UnholyAnnexRitualChamber.name, "Unholy Annex")!!.tags shouldContain IntentTag.DRAW
+            catalog.forFace(UnholyAnnexRitualChamber.name, "Broom Closet") shouldBe null
+            IntentCatalog.NONE.forFace(UnholyAnnexRitualChamber.name, "Unholy Annex") shouldBe null
         }
 
         test("the catalog is off by default and answers nothing") {

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzerTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzerTest.kt
@@ -1,9 +1,16 @@
 package com.wingedsheep.ai.engine.knowledge
 
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFace
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnholyAnnexRitualChamber
+import com.wingedsheep.mtg.sets.definitions.woe.cards.VirtueOfLoyalty
 import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThan
@@ -21,6 +28,16 @@ class CardIntentAnalyzerTest : ScenarioTestBase() {
     private fun intentOf(name: String) = CardIntentAnalyzer.analyze(cardRegistry.requireCard(name))
 
     private fun roomFace(name: String) = UnholyAnnexRitualChamber.cardFaces.first { it.name == name }
+
+    /** An `Unholy Annex // Ritual Chamber` permanent with exactly [unlocked] doors open. */
+    private fun roomPermanent(vararg unlocked: String) = ComponentContainer().withComponent(
+        RoomComponent(
+            faces = UnholyAnnexRitualChamber.cardFaces.map {
+                RoomFace(RoomFaceId(it.name), it.name, it.manaCost)
+            },
+            unlocked = unlocked.map { RoomFaceId(it) }.toSet(),
+        )
+    )
 
     init {
         test("a repeatable tapper reads as a repeatable tapper") {
@@ -131,6 +148,60 @@ class CardIntentAnalyzerTest : ScenarioTestBase() {
             catalog.forFace(UnholyAnnexRitualChamber.name, "Unholy Annex")!!.tags shouldContain IntentTag.DRAW
             catalog.forFace(UnholyAnnexRitualChamber.name, "Broom Closet") shouldBe null
             IntentCatalog.NONE.forFace(UnholyAnnexRitualChamber.name, "Unholy Annex") shouldBe null
+        }
+
+        test("a spent Adventure half does not inflate the permanent it left behind") {
+            // Virtue of Loyalty is an enchantment whose Adventure (CR 715) makes a 2/2 Knight. The
+            // Adventure resolves to exile — it is never text on the battlefield — so the
+            // enchantment standing there must not be priced as a token engine.
+            val wholeCard = CardIntentAnalyzer.analyze(VirtueOfLoyalty)
+            withClue("casting the Adventure is a real option, so the card as a whole still shows it") {
+                wholeCard.tags shouldContain IntentTag.TOKEN_MAKER
+            }
+
+            val asPermanent = CardIntentAnalyzer.analyzeSelf(VirtueOfLoyalty)
+            asPermanent.tags shouldNotContain IntentTag.TOKEN_MAKER
+            withClue("a repeatable token maker prices at 3.0; this end-step trigger is worth 1.5") {
+                asPermanent.staticPriorValue shouldBeLessThan wholeCard.staticPriorValue
+            }
+        }
+
+        test("a single-face card reads the same whether asked as a card or as a permanent") {
+            val card = cardRegistry.requireCard("Icy Manipulator")
+            CardIntentAnalyzer.analyzeSelf(card) shouldBe CardIntentAnalyzer.analyze(card)
+        }
+
+        test("a permanent is read from the faces in force on it, and a Room's are its open doors") {
+            val catalog = IntentCatalog.of(
+                cardRegistry.apply { register(UnholyAnnexRitualChamber); register(VirtueOfLoyalty) }
+            )
+
+            withClue("an ordinary permanent is one reading — its own, minus the Adventure") {
+                val plain = catalog.forPermanent(ComponentContainer(), VirtueOfLoyalty.name)
+                plain.map { it.tags } shouldBe listOf(CardIntentAnalyzer.analyzeSelf(VirtueOfLoyalty).tags)
+            }
+
+            withClue("a Room contributes one reading per unlocked door, and none for a locked one") {
+                val oneDoor = catalog.forPermanent(
+                    roomPermanent("Unholy Annex"), UnholyAnnexRitualChamber.name
+                )
+                oneDoor.single().tags shouldContain IntentTag.DRAW
+                oneDoor.single().tags shouldNotContain IntentTag.TOKEN_MAKER
+
+                catalog.forPermanent(
+                    roomPermanent("Unholy Annex", "Ritual Chamber"), UnholyAnnexRitualChamber.name
+                ) shouldHaveSize 2
+            }
+
+            withClue("both doors locked (CR 709.5d) is no text at all, not the whole card") {
+                catalog.forPermanent(roomPermanent(), UnholyAnnexRitualChamber.name).shouldBeEmpty()
+            }
+
+            withClue("the off position answers nothing, so every caller keeps its old behaviour") {
+                IntentCatalog.NONE.forPermanent(
+                    roomPermanent("Unholy Annex"), UnholyAnnexRitualChamber.name
+                ).shouldBeEmpty()
+            }
         }
 
         test("the catalog is off by default and answers nothing") {

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -32,6 +32,14 @@ Plus `IntentCatalog` (Phase 6), which is card knowledge rather than a control-fl
 `BoardPresence.permanentValue`, `TargetSelection.rank`, `HoldPolicy` and the rollout policy's
 priors.
 
+Multi-face cards make "what does this card do?" and "what is this permanent doing?" different
+questions, so the catalog answers them separately and callers must pick deliberately. A card in
+hand or on the stack is `forName` — every face unioned, because casting the Adventure half is a
+real option. A permanent on the battlefield is `forPermanent`, which reads only what is in force
+there: a Room (CR 709.5) contributes one reading per *unlocked* door, and everything else drops the
+spell faces of an Adventure / Omen / modal DFC, which resolve away and never stand on the board.
+Reaching for `forName` on a battlefield permanent is the bug both of those exist to prevent.
+
 Phase 9 adds a second leaf implementation behind the existing `BoardEvaluator` seam. Composite
 profiles load from `eval-weights.json`; fitted raw-feature profiles load from
 `raw-eval-weights.json`. `AiProfile.evalWeightsId` selects either kind, and malformed raw profiles


### PR DESCRIPTION
The AI never cast `Unholy Annex` and never paid to unlock a door.

Both halves of a Room (CR 709.5) carry their rules text on `CardFace.script` and leave the card's
top-level script empty, and `CardIntentAnalyzer` read only that top level — so a repeatable draw
engine came back as `CardIntent.UNKNOWN` and was priced at the flat 0.5 every unreadable permanent
gets. Casting it then cost more in `CardAdvantage` than the board it bought was worth, so passing
won every time.

Unlocking had a second cause stacked on that: `BoardPresence` looked the prior up by card *name*,
and a name does not change when a door opens. Unlocking `Ritual Chamber` did happen — the 6/6 Demon
token it makes is visible on its own — but unlocking `Unholy Annex` moved no evaluated number at
all, and a special action that changes nothing can never beat passing.

## What this does

A multi-face card makes "what can this card do?" and "what is this permanent doing?" different
questions. The analyzer now answers them separately, and callers pick deliberately:

| Reading | Scope | Used for |
|---|---|---|
| `analyze` | every face unioned | a card in hand or on the stack |
| `analyzeSelf` | top-level script only | an ordinary permanent |
| `analyzeFace` | one face | a Room, per unlocked door |

`IntentCatalog.forPermanent(container, cardName)` is the seam that picks between the last two and
the only place that knows a Room from anything else. `BoardPresence.permanentValue` and
`RawBoardFeatures.threatsInPlay` both go through it; `TargetSelection.rank` inherits it by already
routing through `permanentValue`. The hand-side consumers (`HoldPolicy`,
`PlayoutPolicy.priorityScore`, `removalInHand`) keep `forName`, because the union is the right
reading when the decision is whether to *cast* the card.

Two behaviours follow from getting that split right:

- **A Room is worth its open doors.** A locked half's rules text does not exist, so a Room permanent
  is read per unlocked face and opening a door is worth exactly what is behind it. A Room put onto
  the battlefield with both halves locked (CR 709.5d) contributes nothing, correctly.
- **A spent Adventure does not inflate the permanent it left behind.** `Virtue of Loyalty` is an
  enchantment whose Adventure half makes a 2/2 Knight. Unioning faces tagged the enchantment
  `TOKEN_MAKER` + `repeatable` — 3.0 on the `priorValueOf` ladder, where its own end-step trigger is
  worth 1.5. The Adventure resolves to exile and is never text on the battlefield. The same holds
  for Omen and modal-DFC backs: in every layout the SDK has, the face that can sit on the
  battlefield is the top-level one.

Smaller points:

- **`"when you unlock this door"` is not a repeatable engine.** It fires on the unlock transition
  (CR 709.5h), like an ETB. A door *can* be re-locked and unlocked again (CR 709.5g, `LockDoorEffect`),
  so this is a common-case claim rather than an invariant — and it is the right direction to err in:
  under-reading a rare re-unlock costs the AI nothing it had, while reading every open door as
  repeatable value is the bug worth avoiding.
- **The unreadable floor no longer doubles.** Per-face priors combine as a baseline plus what each
  face adds over it, not a raw sum. `UNKNOWN.staticPriorValue` is what an unreadable permanent is
  worth, and a Room with two blank halves is one unreadable permanent, not two.
- **Three readings, three caches**, instead of one map keyed by a synthesized `"<card>//<face>"`
  string — no naming convention has to hold for them to stay apart.

## Tests

`RoomAiTest` pins all three decisions on the reported card — cast the Annex half, unlock
`Ritual Chamber` from the Annex, unlock the Annex from `Ritual Chamber` — and fails on the parent
commit for the cast and the Annex unlock. (The `Ritual Chamber` unlock passed before by accident,
via the Demon token being visible on its own.)

`CardIntentAnalyzerTest` covers the three readings directly: a Room's faces valued independently in
both polarities (Annex repeatable, Chamber not), `analyzeSelf` vs `analyze` on `Virtue of Loyalty`,
single-face equivalence, and `forPermanent` across a plain permanent, one open door, two open doors,
both locked, and the catalog-off position.

## Verification

`:ai:test` — **357 tests, 0 failures, 11 skipped**, run with `--rerun` (a plain run reports
`UP-TO-DATE` and executes nothing).

With card intent off (`AiProfile.LEGACY_V0`, the frozen arena baseline) every path here still
answers 0.5 exactly as before, so no published number rebases — `PuzzleSuiteTest > the AI solves
every puzzle outside KNOWN_FAILURES` and `a zero-weight agent solves strictly fewer puzzles` both
still pass.

Scope is the `ai` module plus a note in `docs/ai/architecture.md` recording the card-vs-permanent
rule. No SDK, engine, server or client contract changes; nothing outside `ai` references
`IntentCatalog` or `CardIntentAnalyzer`.
