### PR TITLE
Stop "you may discard a card" paying out on an empty hand

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1962,6 +1962,18 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   round-trip via `PendingTrigger.carriedPipeline`/`TriggeredAbilityOnStackComponent.carriedPipeline`.
   This differs from the cast-time path (`TargetValidator.effectiveMaxCount`), where the pipeline isn't
   live yet — pipeline-linked caps only work on reflexive/resolution-time targets.
+  With `optional = true`, `ReflexiveTriggerEffectExecutor.isActionFeasible` decides whether the "may
+  [action]?" question is worth asking at all: an action that can't be performed is skipped silently,
+  because answering yes would no-op the action while still firing the reflexive payoff. Alongside
+  `SelectTargetEffect` / `SacrificeEffect` / `ChooseActionEffect` / `PayFixedCountersEffect`, it scores
+  the **Gather → Select → Move pipeline** every discard pattern compiles to — a `SelectFromCollection`
+  whose `SelectionMode` carries a minimum (`ChooseExactly`, `Random`) against the size of the collection
+  the preceding `GatherCards` will produce. So `ReflexiveTriggerEffect(action = Effects.Discard(1),
+  optional = true, …)` on an empty hand never prompts and never pays out (Inti, Seneschal of the Sun).
+  Minimum-less modes (`ChooseUpTo`, `All`, `ChooseAnyNumber`) stay feasible — discarding zero cards is a
+  legal way to perform "discard your hand" (Vaultguard Trooper). Gather sizes are read off the
+  pre-action state, so the bookkeeping stops at the first composite step that is neither a gather nor a
+  select; later selections then fail open rather than being judged against a stale count.
 - **Branching on gathered properties** — "reveal/look, if it's a [type] do X, otherwise Y" needs no
   bespoke effect type; it is the partition + collection-gate composition:
   1. **Partition:** `FilterCollection(from, CollectionFilter.MatchesFilter(filter), storeMatching,

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1962,18 +1962,26 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   round-trip via `PendingTrigger.carriedPipeline`/`TriggeredAbilityOnStackComponent.carriedPipeline`.
   This differs from the cast-time path (`TargetValidator.effectiveMaxCount`), where the pipeline isn't
   live yet — pipeline-linked caps only work on reflexive/resolution-time targets.
-  With `optional = true`, `ReflexiveTriggerEffectExecutor.isActionFeasible` decides whether the "may
-  [action]?" question is worth asking at all: an action that can't be performed is skipped silently,
-  because answering yes would no-op the action while still firing the reflexive payoff. Alongside
+  `ReflexiveTriggerEffectExecutor.isActionFeasible` decides up front whether the action can happen at
+  all; when it can't, the whole effect is skipped silently. An impossible action never happens, so
+  CR 603.12's "when you do" never triggers — for `optional = true` that means the "may [action]?"
+  question isn't worth asking (answering yes would no-op the action while still firing the payoff),
+  and for `optional = false` it means a vacuous action must not pay out either. Alongside
   `SelectTargetEffect` / `SacrificeEffect` / `ChooseActionEffect` / `PayFixedCountersEffect`, it scores
-  the **Gather → Select → Move pipeline** every discard pattern compiles to — a `SelectFromCollection`
-  whose `SelectionMode` carries a minimum (`ChooseExactly`, `Random`) against the size of the collection
-  the preceding `GatherCards` will produce. So `ReflexiveTriggerEffect(action = Effects.Discard(1),
-  optional = true, …)` on an empty hand never prompts and never pays out (Inti, Seneschal of the Sun).
-  Minimum-less modes (`ChooseUpTo`, `All`, `ChooseAnyNumber`) stay feasible — discarding zero cards is a
-  legal way to perform "discard your hand" (Vaultguard Trooper). Gather sizes are read off the
-  pre-action state, so the bookkeeping stops at the first composite step that is neither a gather nor a
-  select; later selections then fail open rather than being judged against a stale count.
+  the **Gather → Select → Move pipeline** that `Effects.Discard` and the counted `Patterns.Hand`
+  discards compile to — a `SelectFromCollection` whose `SelectionMode` carries a minimum
+  (`ChooseExactly`, `Random`) drawing from a collection the preceding `GatherCards` will leave empty.
+  So `ReflexiveTriggerEffect(action = Effects.Discard(1), …)` on an empty hand never prompts and never
+  pays out (Inti, Seneschal of the Sun). Two deliberate gaps, both fail-open: minimum-less modes
+  (`ChooseUpTo`, `All`, `ChooseAnyNumber`) stay feasible, because discarding zero cards genuinely
+  performs "discard any number of cards" (Miasma Demon); and a non-empty collection smaller than the
+  requested count stays feasible, because `SelectFromCollectionExecutor` clamps the count to the
+  collection size (with one card in hand, "discard two cards" discards one and succeeds). Gather sizes
+  are read off the pre-action state, so the bookkeeping stops at the first composite step that is
+  neither a gather nor a select — including inside nested composites, so `Effects.DrawCards(1).then(
+  Effects.Discard(1))` is still offered on an empty hand rather than being judged against the pre-draw
+  count. Note `Patterns.Hand.discardHand` is a bare Gather → Move with no selection step, so it is
+  never gated by this at all.
 - **Branching on gathered properties** — "reveal/look, if it's a [type] do X, otherwise Y" needs no
   bespoke effect type; it is the partition + collection-gate composition:
   1. **Partition:** `FilterCollection(from, CollectionFilter.MatchesFilter(filter), storeMatching,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CoolButRude.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CoolButRude.kt
@@ -4,8 +4,10 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.effects.SearchDestination
 import com.wingedsheep.sdk.scripting.references.Player
@@ -34,10 +36,17 @@ val CoolButRude = card("Cool but Rude") {
         "{1}{R}: Level 3\nWhen this Class becomes level 3, search your library for a card, put it into your hand, shuffle, then discard a card at random."
 
     // Level 1: Whenever you attack, you may discard a card. If you do, draw a card.
+    // The draw hangs off `IfYouDo`, not off the may-decision: an empty hand discards nothing, so
+    // nothing is drawn (CR 701.8a — you can't discard a card you don't have). `feasibility` keeps
+    // the trigger from asking an unanswerable question on every single attack.
     triggeredAbility {
         trigger = Triggers.YouAttack
         effect = MayEffect(
-            Patterns.Hand.discardCards(1).then(Effects.DrawCards(1))
+            effect = Effects.IfYouDo(
+                action = Patterns.Hand.discardCards(1),
+                ifYouDo = Effects.DrawCards(1)
+            ),
+            feasibility = FeasibilityCheck.HasCardsInZone(Zone.HAND)
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CoolButRude.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CoolButRude.kt
@@ -36,9 +36,9 @@ val CoolButRude = card("Cool but Rude") {
         "{1}{R}: Level 3\nWhen this Class becomes level 3, search your library for a card, put it into your hand, shuffle, then discard a card at random."
 
     // Level 1: Whenever you attack, you may discard a card. If you do, draw a card.
-    // The draw hangs off `IfYouDo`, not off the may-decision: an empty hand discards nothing, so
-    // nothing is drawn (CR 701.8a — you can't discard a card you don't have). `feasibility` keeps
-    // the trigger from asking an unanswerable question on every single attack.
+    // The draw hangs off `IfYouDo`, not off the may-decision: discarding is moving a card from hand
+    // to graveyard (CR 701.9a), so an empty hand discards nothing and nothing is drawn.
+    // `feasibility` keeps the trigger from asking an unanswerable question on every single attack.
     triggeredAbility {
         trigger = Triggers.YouAttack
         effect = MayEffect(

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1248,48 +1248,60 @@
                 "binding": "ANY",
                 "effect": {
                     "type": "Gated",
-                    "gate": "Gate.MayDecide",
+                    "gate": {
+                        "type": "Gate.MayDecide",
+                        "feasibility": {
+                            "type": "HasCardsInZone",
+                            "zone": "Hand"
+                        }
+                    },
                     "then": {
-                        "type": "Composite",
-                        "effects": [
-                            {
-                                "type": "GatherCards",
-                                "source": {
-                                    "type": "FromZone",
-                                    "zone": "Hand"
-                                },
-                                "storeAs": "hand"
-                            },
-                            {
-                                "type": "SelectFromCollection",
-                                "from": "hand",
-                                "selection": {
-                                    "type": "ChooseExactly",
-                                    "count": {
-                                        "type": "Fixed",
-                                        "amount": 1
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
                                     }
-                                },
-                                "storeSelected": "discarded",
-                                "prompt": "Choose 1 card to discard"
-                            },
-                            {
-                                "type": "MoveCollection",
-                                "from": "discarded",
-                                "destination": {
-                                    "type": "ToZone",
-                                    "zone": "Graveyard"
-                                },
-                                "moveType": "Discard"
-                            },
-                            {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                                ]
                             }
-                        ]
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -4,18 +4,27 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import java.util.UUID
 import kotlin.reflect.KClass
@@ -54,6 +63,8 @@ class ReflexiveTriggerEffectExecutor(
 ) : EffectExecutor<ReflexiveTriggerEffect> {
 
     override val effectType: KClass<ReflexiveTriggerEffect> = ReflexiveTriggerEffect::class
+
+    private val predicateEvaluator = PredicateEvaluator()
 
     override fun execute(
         state: GameState,
@@ -134,13 +145,24 @@ class ReflexiveTriggerEffectExecutor(
      *  - [SacrificeEffect] with fewer controlled matches than its count → infeasible
      *    (e.g. Shire Shirriff's "you may sacrifice a token" when you control no token)
      *  - [ChooseActionEffect] with no feasible choice → infeasible
-     *  - [CompositeEffect] → feasible iff every step is feasible (top-level sequencing)
+     *  - [SelectFromCollectionEffect] whose minimum can't be met by the collection a preceding
+     *    [GatherCardsEffect] will produce → infeasible. This is the Gather → Select → Move discard
+     *    pipeline ([com.wingedsheep.sdk.dsl.Effects.Discard]): "you may discard a card" with an
+     *    empty hand is impossible, so Inti, Seneschal of the Sun must not hand out its +1/+1
+     *    counter for a discard that never happens.
+     *  - [CompositeEffect] → feasible iff every step is feasible, walked in order so the gathered
+     *    collection sizes are known by the time a select step is scored (top-level sequencing)
      *  - any other effect → assumed feasible (don't gate on shapes we don't recognize)
+     *
+     * @param gathered Sizes of the pipeline collections produced by preceding [GatherCardsEffect]
+     * steps of the enclosing composite. A collection that isn't in the map is unknown, and any
+     * selection from it fails open.
      */
     private fun isActionFeasible(
         state: GameState,
         action: Effect,
-        context: EffectContext
+        context: EffectContext,
+        gathered: Map<String, Int> = emptyMap()
     ): Boolean = when (action) {
         is SelectTargetEffect -> targetFinder.findLegalTargets(
             state = state,
@@ -167,7 +189,12 @@ class ReflexiveTriggerEffectExecutor(
         is ChooseActionEffect -> action.choices.any { choice ->
             checkFeasibility(state, context.controllerId, choice.feasibilityCheck)
         }
-        is CompositeEffect -> action.effects.all { isActionFeasible(state, it, context) }
+        is SelectFromCollectionEffect -> {
+            val available = gathered[action.from]
+            val minimum = minimumSelection(state, action.selection, context)
+            available == null || minimum == null || available >= minimum
+        }
+        is CompositeEffect -> isCompositeFeasible(state, action, context, gathered)
         // "You may pay {E}{E}{E}" (Guide of Souls) — an all-or-nothing player-counter payment
         // is only feasible if the payer already has at least that many. Mirrors the SacrificeEffect
         // case: without this, the "may pay" prompt would be offered even at 0 energy, and
@@ -182,6 +209,74 @@ class ReflexiveTriggerEffectExecutor(
             current >= action.amount
         }
         else -> true
+    }
+
+    /**
+     * Walk a composite action's steps in order, threading the sizes of the collections its
+     * [GatherCardsEffect] steps produce so a later [SelectFromCollectionEffect] is scored against
+     * real numbers — the Gather → Select → Move shape every discard pattern compiles to.
+     *
+     * Gather sizes are read off the *pre-action* state, so they're only recorded while every step
+     * so far has been a gather or a select. The first step of any other kind stops the bookkeeping:
+     * from there on selections fail open rather than being judged against a stale count, so
+     * "you may draw a card, then discard a card" is still offered on an empty hand.
+     */
+    private fun isCompositeFeasible(
+        state: GameState,
+        action: CompositeEffect,
+        context: EffectContext,
+        gathered: Map<String, Int>
+    ): Boolean {
+        var known = gathered
+        var trackable = true
+        for (step in action.effects) {
+            if (!isActionFeasible(state, step, context, known)) return false
+            when (step) {
+                is GatherCardsEffect -> if (trackable) {
+                    val count = gatherableCount(state, step, context)
+                    if (count == null) trackable = false else known = known + (step.storeAs to count)
+                }
+                is SelectFromCollectionEffect -> Unit
+                else -> trackable = false
+            }
+        }
+        return true
+    }
+
+    /**
+     * How many cards a selection mode *requires*, or null when it has no minimum
+     * ([SelectionMode.ChooseUpTo], [SelectionMode.All], [SelectionMode.ChooseAnyNumber] — each is
+     * satisfied by selecting nothing, so an empty collection doesn't make them impossible; cf.
+     * Vaultguard Trooper, where "you may discard your hand" is a legal choice on an empty hand).
+     */
+    private fun minimumSelection(
+        state: GameState,
+        selection: SelectionMode,
+        context: EffectContext
+    ): Int? = when (selection) {
+        is SelectionMode.ChooseExactly -> amountEvaluator.evaluate(state, selection.count, context)
+        is SelectionMode.Random -> amountEvaluator.evaluate(state, selection.count, context)
+        else -> null
+    }
+
+    /**
+     * How many cards a [GatherCardsEffect] would collect right now, or null when the source isn't a
+     * plain single-player zone read (target-driven and multi-player sources are left unscored, so
+     * the enclosing feasibility check fails open).
+     */
+    private fun gatherableCount(
+        state: GameState,
+        gather: GatherCardsEffect,
+        context: EffectContext
+    ): Int? {
+        val source = gather.source as? CardSource.FromZone ?: return null
+        val playerId = TargetResolutionUtils.resolvePlayerRef(source.player, context, state) ?: return null
+        val cards = state.getZone(ZoneKey(playerId, source.zone))
+        if (source.filter == GameObjectFilter.Any) return cards.size
+        val predicateContext = PredicateContext.fromEffectContext(context)
+        return cards.count { cardId ->
+            predicateEvaluator.matches(state, state.projectedState, cardId, source.filter, predicateContext)
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -71,6 +71,15 @@ class ReflexiveTriggerEffectExecutor(
         effect: ReflexiveTriggerEffect,
         context: EffectContext
     ): EffectResult {
+        // An action that can't be performed never happens, so CR 603.12's "when you do" never
+        // triggers. Gating here rather than inside the optional branch covers both templates:
+        // the "you may [action]" prompt is meaningless (saying yes would no-op the action while
+        // still firing the payoff), and a mandatory [action] would otherwise resolve vacuously —
+        // a discard pipeline on an empty hand auto-selects nothing and reports success, which
+        // `executeActionThenEmit`'s `result.isSuccess` check can't distinguish from a real discard.
+        if (!isActionFeasible(state, effect.action, context)) {
+            return EffectResult.success(state)
+        }
         if (effect.optional) {
             return presentOptionalChoice(state, effect, context)
         }
@@ -82,13 +91,6 @@ class ReflexiveTriggerEffectExecutor(
         effect: ReflexiveTriggerEffect,
         context: EffectContext
     ): EffectResult {
-        // If the action can't be performed, skip the may decision entirely. Saying "yes"
-        // to "you may [action]. If you do, [reflexive]" is meaningless when [action] is
-        // impossible — the reflexive payoff must not fire.
-        if (!isActionFeasible(state, effect.action, context)) {
-            return EffectResult.success(state)
-        }
-
         val playerId = context.controllerId
         val sourceName = context.sourceId?.let { sourceId ->
             state.getEntity(sourceId)?.get<CardComponent>()?.name
@@ -136,33 +138,36 @@ class ReflexiveTriggerEffectExecutor(
     }
 
     /**
-     * Check whether the action half of a "you may [action]. If you do, [reflexive]" trigger can
-     * actually be performed. When false, presenting a yes/no decision is meaningless — saying yes
-     * would silently no-op the action while still firing the reflexive payoff.
+     * Check whether the action half of a "[action]. When you do, [reflexive]" trigger can actually
+     * be performed. When false the whole effect is skipped: for the optional template presenting a
+     * yes/no is meaningless (saying yes would silently no-op the action while still firing the
+     * reflexive payoff), and for the mandatory one the action would resolve vacuously to the same
+     * end.
      *
      * Walks the action effect tree looking for gating sub-effects:
      *  - [SelectTargetEffect] with no legal targets → infeasible
      *  - [SacrificeEffect] with fewer controlled matches than its count → infeasible
      *    (e.g. Shire Shirriff's "you may sacrifice a token" when you control no token)
      *  - [ChooseActionEffect] with no feasible choice → infeasible
-     *  - [SelectFromCollectionEffect] whose minimum can't be met by the collection a preceding
-     *    [GatherCardsEffect] will produce → infeasible. This is the Gather → Select → Move discard
-     *    pipeline ([com.wingedsheep.sdk.dsl.Effects.Discard]): "you may discard a card" with an
-     *    empty hand is impossible, so Inti, Seneschal of the Sun must not hand out its +1/+1
-     *    counter for a discard that never happens.
+     *  - [SelectFromCollectionEffect] carrying a minimum, drawing from a collection a preceding
+     *    [GatherCardsEffect] will leave empty → infeasible. This is the Gather → Select → Move
+     *    discard pipeline ([com.wingedsheep.sdk.dsl.Effects.Discard]): "you may discard a card"
+     *    with an empty hand is impossible, so Inti, Seneschal of the Sun must not hand out its
+     *    +1/+1 counter for a discard that never happens.
      *  - [CompositeEffect] → feasible iff every step is feasible, walked in order so the gathered
      *    collection sizes are known by the time a select step is scored (top-level sequencing)
      *  - any other effect → assumed feasible (don't gate on shapes we don't recognize)
      *
      * @param gathered Sizes of the pipeline collections produced by preceding [GatherCardsEffect]
      * steps of the enclosing composite. A collection that isn't in the map is unknown, and any
-     * selection from it fails open.
+     * selection from it fails open; `null` means the bookkeeping has stopped altogether, so every
+     * selection fails open (see [isCompositeFeasible]).
      */
     private fun isActionFeasible(
         state: GameState,
         action: Effect,
         context: EffectContext,
-        gathered: Map<String, Int> = emptyMap()
+        gathered: Map<String, Int>? = emptyMap()
     ): Boolean = when (action) {
         is SelectTargetEffect -> targetFinder.findLegalTargets(
             state = state,
@@ -190,9 +195,13 @@ class ReflexiveTriggerEffectExecutor(
             checkFeasibility(state, context.controllerId, choice.feasibilityCheck)
         }
         is SelectFromCollectionEffect -> {
-            val available = gathered[action.from]
+            val available = gathered?.get(action.from)
             val minimum = minimumSelection(state, action.selection, context)
-            available == null || minimum == null || available >= minimum
+            // "Non-empty", not "at least `minimum`": SelectFromCollectionExecutor clamps a
+            // ChooseExactly/Random count down to the collection size, so "discard two cards" with
+            // one card in hand discards that one and succeeds. Only an empty collection makes a
+            // minimum-carrying selection impossible.
+            available == null || minimum == null || minimum == 0 || available > 0
         }
         is CompositeEffect -> isCompositeFeasible(state, action, context, gathered)
         // "You may pay {E}{E}{E}" (Guide of Souls) — an all-or-nothing player-counter payment
@@ -214,30 +223,34 @@ class ReflexiveTriggerEffectExecutor(
     /**
      * Walk a composite action's steps in order, threading the sizes of the collections its
      * [GatherCardsEffect] steps produce so a later [SelectFromCollectionEffect] is scored against
-     * real numbers — the Gather → Select → Move shape every discard pattern compiles to.
+     * real numbers — the Gather → Select → Move shape the counted discards compile to. (The
+     * uncounted `Patterns.Hand.discardHand` is a bare Gather → Move with no selection step, so it
+     * has nothing to score and is never gated.)
      *
      * Gather sizes are read off the *pre-action* state, so they're only recorded while every step
-     * so far has been a gather or a select. The first step of any other kind stops the bookkeeping:
-     * from there on selections fail open rather than being judged against a stale count, so
-     * "you may draw a card, then discard a card" is still offered on an empty hand.
+     * so far has been a gather or a select. The first step of any other kind stops the bookkeeping
+     * by collapsing the map to `null`: from there on every selection fails open rather than being
+     * judged against a stale count, so "you may draw a card, then discard a card" is still offered
+     * on an empty hand. The stopped state is threaded *into* nested composites too — `Effect.then`
+     * only flattens when its receiver is already a composite, so that draw-then-discard shape is
+     * `Composite[Draw, Composite[Gather, Select, Move]]`, and a per-call flag would let the inner
+     * walk start scoring again against the pre-draw hand.
      */
     private fun isCompositeFeasible(
         state: GameState,
         action: CompositeEffect,
         context: EffectContext,
-        gathered: Map<String, Int>
+        gathered: Map<String, Int>?
     ): Boolean {
         var known = gathered
-        var trackable = true
         for (step in action.effects) {
             if (!isActionFeasible(state, step, context, known)) return false
-            when (step) {
-                is GatherCardsEffect -> if (trackable) {
-                    val count = gatherableCount(state, step, context)
-                    if (count == null) trackable = false else known = known + (step.storeAs to count)
+            known = when (step) {
+                is GatherCardsEffect -> known?.let { sizes ->
+                    gatherableCount(state, step, context)?.let { sizes + (step.storeAs to it) }
                 }
-                is SelectFromCollectionEffect -> Unit
-                else -> trackable = false
+                is SelectFromCollectionEffect -> known
+                else -> null
             }
         }
         return true
@@ -247,7 +260,14 @@ class ReflexiveTriggerEffectExecutor(
      * How many cards a selection mode *requires*, or null when it has no minimum
      * ([SelectionMode.ChooseUpTo], [SelectionMode.All], [SelectionMode.ChooseAnyNumber] — each is
      * satisfied by selecting nothing, so an empty collection doesn't make them impossible; cf.
-     * Vaultguard Trooper, where "you may discard your hand" is a legal choice on an empty hand).
+     * Miasma Demon, whose "you may discard any number of cards" (`Patterns.Hand.discardAnyNumber`,
+     * a [SelectionMode.ChooseAnyNumber]) is still a legal action on an empty hand — discarding zero
+     * performs it, and the reflexive payoff then targets up to zero creatures).
+     *
+     * Only the [SelectionMode] is scored; [SelectFromCollectionEffect.restrictions] are ignored.
+     * That's safe in the fail-open direction as long as no restriction *raises* a minimum —
+     * [com.wingedsheep.sdk.scripting.effects.SelectionRestriction.ReducedMinimumIfMatches] only
+     * lowers it, and the rest narrow the maximum.
      */
     private fun minimumSelection(
         state: GameState,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AwakenTheHonoredDeadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AwakenTheHonoredDeadScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Awaken the Honored Dead ({B}{G}{U} Enchantment — Saga) — Tarkir: Dragonstorm.
+ *
+ * "III — You may discard a card. When you do, return target creature or land card from your
+ *  graveyard to your hand."
+ *
+ * Chapter III is a reflexive trigger (CR 603.12): the return targets nothing when the chapter
+ * triggers, only when the *reflexive* ability goes on the stack after a card is actually discarded.
+ * Chapter II has milled three cards by then, so the graveyard always holds legal targets — which is
+ * what makes the empty-hand case worth pinning. Without the feasibility gate the discard pipeline
+ * would auto-select nothing, report success, and hand out a free return.
+ */
+class AwakenTheHonoredDeadScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    fun GameTestDriver.emptyHand(playerId: EntityId) {
+        val handZone = ZoneKey(playerId, Zone.HAND)
+        var emptied = state
+        getHand(playerId).toList().forEach { card -> emptied = emptied.removeFromZone(handZone, card) }
+        replaceState(emptied)
+    }
+
+    /** Advance to the active player's *next* precombat main. */
+    fun GameTestDriver.advanceToNextTurnMain() {
+        passPriorityUntil(Step.END, maxPasses = 300)
+        passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+    }
+
+    /**
+     * Drain pending decisions and stack objects. Answers any "you may discard" with [discard] and
+     * records whether a reflexive target was ever chosen.
+     */
+    fun GameTestDriver.settle(you: EntityId, discard: Boolean = false): Boolean {
+        var targeted = false
+        var guard = 0
+        while (guard++ < 120) {
+            when (val dec = pendingDecision) {
+                is YesNoDecision -> submitYesNo(you, discard)
+                is SelectCardsDecision ->
+                    submitCardSelection(you, dec.options.take(dec.minSelections.coerceAtLeast(1)))
+                is ChooseTargetsDecision -> {
+                    submitTargetSelection(you, dec.legalTargets[0].orEmpty().take(1))
+                    targeted = true
+                }
+                else -> if (state.stack.isNotEmpty()) bothPass() else return targeted
+            }
+        }
+        return targeted
+    }
+
+    /**
+     * Cast the Saga and settle chapter I (which destroys a target nonland permanent — an opponent
+     * creature is provided so the chapter has something legal to point at).
+     */
+    fun GameTestDriver.castSaga(you: EntityId, opponent: EntityId): EntityId {
+        putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val spell = putCardInHand(you, "Awaken the Honored Dead")
+        giveMana(you, Color.BLACK, 1)
+        giveMana(you, Color.GREEN, 1)
+        giveMana(you, Color.BLUE, 1)
+        castSpell(you, spell)
+        settle(you)
+        return findPermanent(you, "Awaken the Honored Dead")!!
+    }
+
+    test("chapter III on an empty hand: no discard prompt and nothing returns from the graveyard") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+
+        val saga = d.castSaga(you, opponent)
+        saga shouldNotBe null
+
+        d.advanceToNextTurnMain() // opponent's turn
+        d.advanceToNextTurnMain() // chapter II — mills three
+        d.settle(you)
+        d.advanceToNextTurnMain() // opponent's turn
+        d.advanceToNextTurnMain() // chapter III triggers
+
+        // Empty the hand while the chapter III trigger is still waiting to resolve.
+        d.emptyHand(you)
+        val graveyardBefore = d.getGraveyard(you).toSet()
+        graveyardBefore.isEmpty() shouldBe false // chapter II milled, so a legal return target exists
+
+        // Answering "yes" is impossible — the question must never be asked, and the reflexive
+        // return must never go on the stack.
+        d.settle(you, discard = true) shouldBe false
+        d.getHandSize(you) shouldBe 0
+        // Nothing left the graveyard. It *grows* by the Saga itself, sacrificed after its final
+        // chapter (CR 714.4), so assert on the contents rather than the count.
+        d.getGraveyard(you).toSet().containsAll(graveyardBefore) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoolButRudeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoolButRudeScenarioTest.kt
@@ -20,8 +20,8 @@ import io.kotest.matchers.shouldBe
  * The draw is gated on the *discard actually happening* ([com.wingedsheep.sdk.dsl.Effects.IfYouDo]),
  * not on the yes/no answer — an empty hand can't discard, so it can't draw either. That case is also
  * declared infeasible up front, so this attack trigger stops asking an unanswerable question every
- * single combat. (Contrast Vaultguard Trooper's "you may discard your hand", where discarding zero
- * cards is a legal way to perform the action and the payoff does happen.)
+ * single combat. (Contrast Miasma Demon's "you may discard any number of cards", where discarding
+ * zero cards is a legal way to perform the action and the payoff does happen.)
  */
 class CoolButRudeScenarioTest : FunSpec({
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoolButRudeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoolButRudeScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cool but Rude ({1}{R} Enchantment — Class) — Through the Mists.
+ *
+ * Level 1: "Whenever you attack, you may discard a card. If you do, draw a card."
+ *
+ * The draw is gated on the *discard actually happening* ([com.wingedsheep.sdk.dsl.Effects.IfYouDo]),
+ * not on the yes/no answer — an empty hand can't discard, so it can't draw either. That case is also
+ * declared infeasible up front, so this attack trigger stops asking an unanswerable question every
+ * single combat. (Contrast Vaultguard Trooper's "you may discard your hand", where discarding zero
+ * cards is a legal way to perform the action and the payoff does happen.)
+ */
+class CoolButRudeScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+    }
+
+    fun GameTestDriver.emptyHand(playerId: EntityId) {
+        val handZone = ZoneKey(playerId, Zone.HAND)
+        var emptied = state
+        getHand(playerId).toList().forEach { card -> emptied = emptied.removeFromZone(handZone, card) }
+        replaceState(emptied)
+    }
+
+    /** Drain the attack triggers, answering the "you may discard a card" yes/no with [discard]. */
+    fun GameTestDriver.resolveAttackTriggers(you: EntityId, discard: Boolean): Boolean {
+        var asked = false
+        var guard = 0
+        while (guard++ < 40) {
+            when (val dec = pendingDecision) {
+                is YesNoDecision -> { asked = true; submitYesNo(you, discard) }
+                is SelectCardsDecision ->
+                    submitCardSelection(you, dec.options.take(dec.minSelections.coerceAtLeast(1)))
+                else -> if (state.stack.isNotEmpty()) bothPass() else return asked
+            }
+        }
+        return asked
+    }
+
+    test("discarding on attack draws a replacement card") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+
+        d.putPermanentOnBattlefield(you, "Cool but Rude")
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        d.removeSummoningSickness(bear)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val handBefore = d.getHandSize(you)
+        d.declareAttackers(you, listOf(bear), opponent)
+
+        d.resolveAttackTriggers(you, discard = true) shouldBe true
+
+        // One card discarded, one drawn — hand size unchanged, graveyard up by one.
+        d.getHandSize(you) shouldBe handBefore
+        d.getGraveyard(you).size shouldBe 1
+    }
+
+    test("declining the discard draws nothing") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+
+        d.putPermanentOnBattlefield(you, "Cool but Rude")
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        d.removeSummoningSickness(bear)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val handBefore = d.getHandSize(you)
+        d.declareAttackers(you, listOf(bear), opponent)
+
+        d.resolveAttackTriggers(you, discard = false) shouldBe true
+
+        d.getHandSize(you) shouldBe handBefore
+        d.getGraveyard(you).isEmpty() shouldBe true
+    }
+
+    test("an empty hand is never asked, and never draws") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+
+        d.putPermanentOnBattlefield(you, "Cool but Rude")
+        val bear = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        d.removeSummoningSickness(bear)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        // Empty the hand *after* the draw step, so nothing is left to discard.
+        d.emptyHand(you)
+        d.getHandSize(you) shouldBe 0
+
+        d.declareAttackers(you, listOf(bear), opponent)
+
+        d.resolveAttackTriggers(you, discard = true) shouldBe false
+
+        // No discard means no draw: the payoff hangs off the action, not off answering "yes".
+        d.getHandSize(you) shouldBe 0
+        d.getGraveyard(you).isEmpty() shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntiSeneschalOfTheSunScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntiSeneschalOfTheSunScenarioTest.kt
@@ -5,12 +5,14 @@ import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
@@ -136,6 +138,39 @@ class IntiSeneschalOfTheSunScenarioTest : FunSpec({
         // Cast (-1) plus the two discarded cards (-2).
         d.getHandSize(you) shouldBe handBefore - 3
         d.getExileCardNames(you) shouldBe listOf("Savannah Lions")
+    }
+
+    test("an empty hand is not offered the discard at all — no counter, no trample, no impulse exile") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+
+        val inti = d.putCreatureOnBattlefield(you, "Inti, Seneschal of the Sun")
+        d.removeSummoningSickness(inti)
+        d.putCardOnTopOfLibrary(you, "Savannah Lions")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        // Empty the hand *after* the draw step, so nothing is left to discard.
+        val handZone = ZoneKey(you, Zone.HAND)
+        var emptied = d.state
+        d.getHand(you).toList().forEach { card -> emptied = emptied.removeFromZone(handZone, card) }
+        d.replaceState(emptied)
+        d.getHandSize(you) shouldBe 0
+
+        d.declareAttackers(you, listOf(inti), opponent)
+
+        // With no card to discard the action is impossible, so the "you may discard a card"
+        // question is never asked — answering it would hand out the reflexive payoff for free.
+        var guard = 0
+        while (guard++ < 40) {
+            val dec = d.pendingDecision
+            if (dec != null) error("No decision should be offered with an empty hand, got: $dec")
+            if (d.state.stack.isNotEmpty()) d.bothPass() else break
+        }
+
+        d.plusOneCounters(inti) shouldBe 0
+        projector.project(d.state).hasKeyword(inti, Keyword.TRAMPLE) shouldBe false
+        d.getExileCardNames(you).contains("Savannah Lions") shouldBe false
     }
 
     test("declining the optional discard leaves no counter, no trample, and no impulse exile") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReflexiveTriggerFeasibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReflexiveTriggerFeasibilityTest.kt
@@ -1,0 +1,199 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine-level coverage for `ReflexiveTriggerEffectExecutor.isActionFeasible` — the walker that
+ * decides whether a "[action]. When you do, [reflexive]" ability's action can happen at all.
+ *
+ * An impossible action never happens, so CR 603.12's "when you do" never triggers. The bug this
+ * guards against is the opposite of a missing prompt: a discard pipeline on an empty hand
+ * auto-selects nothing and *reports success*, so without the walker the reflexive payoff fires for
+ * a discard that never occurred (Inti, Seneschal of the Sun).
+ *
+ * The walker must be conservative in the other direction too — it only ever removes an impossible
+ * prompt, never a possible one. These cards are defined inline because each pins one branch of that
+ * conservatism, and no printed card currently exercises them:
+ *
+ *  - a **nested composite** (`draw, then discard`): `Effect.then` only flattens when its receiver is
+ *    already a composite, so this is `Composite[Draw, Composite[Gather, Select, Move]]`. The gather
+ *    sizes are read off pre-action state, so once a non-gather step is seen the bookkeeping must stop
+ *    *and stay stopped inside the nested walk* — otherwise the inner discard is judged against the
+ *    pre-draw hand and an empty hand wrongly suppresses the whole ability.
+ *  - a **count larger than the hand**: `SelectFromCollectionExecutor` clamps a `ChooseExactly` count
+ *    down to the collection size, so "discard two cards" with one card in hand discards that one and
+ *    succeeds. Only an *empty* collection makes the action impossible.
+ *
+ * The mandatory (`optional = false`) case is here too: it shares the same gate, so a vacuous action
+ * must not pay out even when there was never a yes/no question to skip.
+ */
+class ReflexiveTriggerFeasibilityTest : FunSpec({
+
+    /** "Whenever you attack, you may discard a card. When you do, you gain 3 life." */
+    val Prompter = card("Feasibility Test Prompter") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever you attack, you may discard a card. When you do, you gain 3 life."
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            effect = ReflexiveTriggerEffect(
+                action = Effects.Discard(1),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(3)
+            )
+        }
+    }
+
+    /** "Whenever you attack, you may draw a card, then discard a card. When you do, you gain 3 life." */
+    val DrawThenDiscard = card("Feasibility Test Draw Then Discard") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever you attack, you may draw a card, then discard a card. " +
+            "When you do, you gain 3 life."
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            effect = ReflexiveTriggerEffect(
+                action = Effects.DrawCards(1).then(Patterns.Hand.discardCards(1)),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(3)
+            )
+        }
+    }
+
+    /** "Whenever you attack, you may discard two cards. When you do, you gain 3 life." */
+    val DiscardTwo = card("Feasibility Test Discard Two") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever you attack, you may discard two cards. When you do, you gain 3 life."
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            effect = ReflexiveTriggerEffect(
+                action = Effects.Discard(2),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(3)
+            )
+        }
+    }
+
+    /** "Whenever you attack, discard a card. When you do, you gain 3 life." (mandatory) */
+    val MandatoryDiscard = card("Feasibility Test Mandatory Discard") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever you attack, discard a card. When you do, you gain 3 life."
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            effect = ReflexiveTriggerEffect(
+                action = Effects.Discard(1),
+                optional = false,
+                reflexiveEffect = Effects.GainLife(3)
+            )
+        }
+    }
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(Prompter, DrawThenDiscard, DiscardTwo, MandatoryDiscard))
+        initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+    }
+
+    fun GameTestDriver.emptyHand(playerId: EntityId) {
+        val handZone = ZoneKey(playerId, Zone.HAND)
+        var emptied = state
+        getHand(playerId).toList().forEach { card -> emptied = emptied.removeFromZone(handZone, card) }
+        replaceState(emptied)
+    }
+
+    /** Drain the attack triggers, answering any "may" yes/no with [accept]. Returns whether one was asked. */
+    fun GameTestDriver.resolveAttackTriggers(you: EntityId, accept: Boolean): Boolean {
+        var asked = false
+        var guard = 0
+        while (guard++ < 60) {
+            when (val dec = pendingDecision) {
+                is YesNoDecision -> { asked = true; submitYesNo(you, accept) }
+                is SelectCardsDecision ->
+                    submitCardSelection(you, dec.options.take(dec.minSelections.coerceAtLeast(1)))
+                else -> if (state.stack.isNotEmpty()) bothPass() else return asked
+            }
+        }
+        return asked
+    }
+
+    /** Attack with a freshly-made [cardName], after [setUpHand] has arranged the hand. */
+    fun attackWith(cardName: String, setUpHand: GameTestDriver.(EntityId) -> Unit): GameTestDriver {
+        val d = driver()
+        val you = d.activePlayer!!
+        val attacker = d.putCreatureOnBattlefield(you, cardName)
+        d.removeSummoningSickness(attacker)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.setUpHand(you)
+        d.declareAttackers(you, listOf(attacker), d.getOpponent(you))
+        return d
+    }
+
+    test("an empty hand is never asked to discard, and never pays out") {
+        val d = attackWith("Feasibility Test Prompter") { emptyHand(it) }
+        val you = d.activePlayer!!
+
+        d.resolveAttackTriggers(you, accept = true) shouldBe false
+        d.getLifeTotal(you) shouldBe 20
+    }
+
+    test("a mandatory discard on an empty hand pays out nothing either") {
+        val d = attackWith("Feasibility Test Mandatory Discard") { emptyHand(it) }
+        val you = d.activePlayer!!
+
+        // No yes/no to skip here — the gate has to stop the vacuous discard from reporting success.
+        d.resolveAttackTriggers(you, accept = true) shouldBe false
+        d.getLifeTotal(you) shouldBe 20
+        d.getGraveyard(you).isEmpty() shouldBe true
+    }
+
+    test("draw-then-discard is still offered on an empty hand — the draw supplies the card") {
+        val d = attackWith("Feasibility Test Draw Then Discard") { emptyHand(it) }
+        val you = d.activePlayer!!
+
+        // The gather is scored against the pre-action (empty) hand, so the bookkeeping must have
+        // stopped at the Draw step — including inside the nested composite the discard pipeline is.
+        d.resolveAttackTriggers(you, accept = true) shouldBe true
+        d.getLifeTotal(you) shouldBe 23
+        d.getHandSize(you) shouldBe 0
+        d.getGraveyard(you).size shouldBe 1
+    }
+
+    test("discard two with only one card in hand discards that one and pays out") {
+        val d = attackWith("Feasibility Test Discard Two") { you ->
+            emptyHand(you)
+            putCardInHand(you, "Mountain")
+        }
+        val you = d.activePlayer!!
+
+        // The executor clamps ChooseExactly(2) to the single eligible card, so the action succeeds —
+        // feasibility must not demand the full count.
+        d.resolveAttackTriggers(you, accept = true) shouldBe true
+        d.getLifeTotal(you) shouldBe 23
+        d.getHandSize(you) shouldBe 0
+        d.getGraveyard(you).size shouldBe 1
+    }
+})


### PR DESCRIPTION
"You may discard a card. When you do, [payoff]" was paying out on an empty hand.

A discard compiles to a Gather → Select → Move pipeline. With nothing in hand the
gather collects nothing, `SelectFromCollection` auto-selects nothing, and the
pipeline reports **success** — indistinguishable, to the reflexive executor, from a
real discard. So Inti, Seneschal of the Sun handed out its +1/+1 counter and trample
for a discard that never happened, and the attack trigger asked an unanswerable
yes/no every single combat.

## What this does

**Teaches `ReflexiveTriggerEffectExecutor.isActionFeasible` to read the discard
pipeline.** It already recognised `SelectTargetEffect`, `SacrificeEffect`,
`ChooseActionEffect` and `PayFixedCountersEffect`; it now also scores a
`SelectFromCollection` carrying a minimum against the size of the collection the
preceding `GatherCards` will produce. An impossible action never happens, so
CR 603.12's "when you do" never triggers — the whole effect is skipped.

This is deliberately at the engine layer rather than a per-card `feasibility`
declaration, so it fixes every reflexive discard at once: Inti, Shriek Treblemaker,
Awaken the Honored Dead, Gigapede.

**Rebuilds Cool but Rude out of the right primitives.** Level 1 is "you may discard
a card. **If you do**, draw a card" — the draw hangs off the *action outcome*, not
off the yes/no answer, so it becomes `MayEffect(IfYouDo(discard, draw))`. Paired with
the existing `feasibility = HasCardsInZone(Zone.HAND)` so the trigger stops asking
when the hand is empty. No new SDK types; both primitives already existed.

## Conservative in both directions

The walker only ever removes an *impossible* prompt, never a possible one. Three
deliberate fail-open gaps, each with a test:

- **Minimum-less selection modes** (`ChooseUpTo`, `All`, `ChooseAnyNumber`) stay
  feasible — discarding zero cards genuinely performs "discard any number of cards"
  (Miasma Demon), and the reflexive payoff then targets up to zero creatures.
- **A non-empty collection smaller than the requested count** stays feasible.
  `SelectFromCollectionExecutor` clamps the count to the collection size, so with one
  card in hand "discard two cards" discards it and succeeds.
- **Gather sizes are read off pre-action state**, so bookkeeping stops at the first
  step that is neither a gather nor a select — and stays stopped inside nested
  composites. `Effect.then` only flattens when its receiver is already a composite,
  so `DrawCards(1).then(Discard(1))` is `Composite[Draw, Composite[Gather, Select,
  Move]]`; a per-call flag would let the inner walk restart and judge the discard
  against the pre-draw hand.

Unknown gather sources (target-driven, multi-player) and unknown collection names
also fail open.

The gate covers the **mandatory** template too (`optional = false`), not just the
"you may" one — there is no prompt to skip there, but a vacuous action must not pay
out either.

## Tests

- `ReflexiveTriggerFeasibilityTest` — engine-level, named for the mechanic: empty-hand
  suppression, the mandatory path, draw-then-discard staying offered, and
  discard-two-with-one-card paying out.
- `CoolButRudeScenarioTest` — discard-and-draw, decline, and empty hand.
- `IntiSeneschalOfTheSunScenarioTest` — empty hand yields no counter, no trample, no
  impulse exile, and no decision at all.
- `AwakenTheHonoredDeadScenarioTest` — chapter III on an empty hand returns nothing,
  even though chapter II milled legal targets.

Full `:rules-engine:test` + `:mtg-sets:test`: **9850 tests, 0 failures, 0 errors.**

`docs/card-sdk-language-reference.md` is updated with the feasibility contract and
both fail-open gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01At5SgAMrk4ozjg4zhi9ghv
