### PR TITLE
Add three cards to The Hobbit

### DIFF
--- a/backlog/sets/the-hobbit/cards.md
+++ b/backlog/sets/the-hobbit/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 193 cards revealed as of 2026-08-04
 **Release Date:** August 14, 2026
-**Implemented:** 48 / 193
+**Implemented:** 51 / 193
 Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. This list covers only cards revealed as of that date.
 
 - [x] 1. Long-Bodied Grey Dog
@@ -14,7 +14,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 7. Celebrate the Mountain-king
 - [ ] 8. Dáin, Lord of the Iron Hills
 - [x] 9. Dwarven Provisioner
-- [ ] 10. Dwarven Shortsword
+- [x] 10. Dwarven Shortsword
 - [ ] 11. Eagle of the Great Shelf
 - [ ] 12. The Eagles Are Coming!
 - [ ] 13. Esgaroth Garrison
@@ -119,7 +119,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 112. Snowslope Hunter
 - [ ] 113. Stone-Giant of High Pass
 - [ ] 114. Thorin, Mountain-king
-- [ ] 115. Tidings of War
+- [x] 115. Tidings of War
 - [x] 116. Attercop
 - [ ] 117. Bejeweled Warg
 - [ ] 118. Beorn, Reluctant Host
@@ -160,7 +160,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 153. Duskwatch Hunter
 - [ ] 154. Dwalin, Weaponmaster
 - [ ] 155. Eagle's Rescue
-- [ ] 156. Fearsome Goblin Pair
+- [x] 156. Fearsome Goblin Pair
 - [ ] 157. Goblin Plate Mail
 - [ ] 158. The Great Goblin
 - [x] 159. Large Bear

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DwarvenShortsword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DwarvenShortsword.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dwarven Shortsword
+ * {3}{W}
+ * Artifact — Equipment
+ *
+ * When this Equipment enters, create a 2/2 red Dwarf creature token, then attach this Equipment to it.
+ * Equipped creature gets +1/+2.
+ * Equip {2}
+ */
+val DwarvenShortsword = card("Dwarven Shortsword") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, create a 2/2 red Dwarf creature token, then attach this Equipment to it.\n" +
+        "Equipped creature gets +1/+2.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dwarf"),
+            imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537",
+        ).then(Effects.AttachEquipment(EffectTarget.PipelineTarget(CREATED_TOKENS, 0)))
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 2)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Manuel Castañón"
+        flavorText = "Dwarves lived long lives if not felled in battle, and they forged their blades to last even longer."
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2341cf3-4d2c-4a4f-9aea-8834104a8910.jpg?1785496931"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/FearsomeGoblinPair.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/FearsomeGoblinPair.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fearsome Goblin Pair
+ * {2}{B/R}
+ * Creature — Goblin Soldier
+ * 1/1
+ *
+ * When this creature dies, amass Goblins 4.
+ */
+val FearsomeGoblinPair = card("Fearsome Goblin Pair") {
+    manaCost = "{2}{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Goblin Soldier"
+    oracleText = "When this creature dies, amass Goblins 4. (Put four +1/+1 counters on an Army you control. " +
+        "It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)"
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Amass(4, "Goblin")
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "156"
+        artist = "Michele Giorgi"
+        flavorText = "Out jumped the Goblins: big Goblins, small Goblins, great ugly-looking Goblins, lots of Goblins!"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2efe2dc7-3eaa-47f6-b1ae-f974c4a8ae79.jpg?1785324572"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TidingsOfWar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TidingsOfWar.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Tidings of War
+ * {R}
+ * Sorcery
+ *
+ * Amass Goblins 1. If this spell was cast from a graveyard, amass Goblins 3 instead.
+ * Flashback {3}{R}
+ */
+val TidingsOfWar = card("Tidings of War") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Amass Goblins 1. If this spell was cast from a graveyard, amass Goblins 3 instead. " +
+        "(To amass Goblins X, put X +1/+1 counters on an Army you control. It's also a Goblin. " +
+        "If you don't control an Army, create a 0/0 black Goblin Army creature token first.)\n" +
+        "Flashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        effect = ConditionalEffect(
+            condition = Conditions.WasCastFromGraveyard,
+            effect = Effects.Amass(3, "Goblin"),
+            elseEffect = Effects.Amass(1, "Goblin"),
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{3}{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Pavel Kolomeyets"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/38c16a0a-375e-48cb-9720-dbbc08c603ae.jpg?1785497148"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -402,6 +402,96 @@
     ]
 }
 
+// Dwarven Shortsword
+{
+    "name": "Dwarven Shortsword",
+    "manaCost": "{3}{W}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, create a 2/2 red Dwarf creature token, then attach this Equipment to it.\nEquipped creature gets +1/+2.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "RED"
+                            ],
+                            "creatureTypes": [
+                                "Dwarf"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 2
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Manuel Castañón",
+        "flavorText": "Dwarves lived long lives if not felled in battle, and they forged their blades to last even longer.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2341cf3-4d2c-4a4f-9aea-8834104a8910.jpg?1785496931"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Elven Raft-Steerer
 {
     "name": "Elven Raft-Steerer",
@@ -566,6 +656,49 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Fearsome Goblin Pair
+{
+    "name": "Fearsome Goblin Pair",
+    "manaCost": "{2}{B/R}",
+    "typeLine": "Creature — Goblin Soldier",
+    "oracleText": "When this creature dies, amass Goblins 4. (Put four +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Amass",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "subtype": "Goblin"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "rarity": "UNCOMMON",
+        "artist": "Michele Giorgi",
+        "flavorText": "Out jumped the Goblins: big Goblins, small Goblins, great ugly-looking Goblins, lots of Goblins!",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2efe2dc7-3eaa-47f6-b1ae-f974c4a8ae79.jpg?1785324572"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -2220,6 +2353,55 @@
         "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad0dba36-d056-4bc1-987a-391da26ad267.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Tidings of War
+{
+    "name": "Tidings of War",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Amass Goblins 1. If this spell was cast from a graveyard, amass Goblins 3 instead. (To amass Goblins X, put X +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{3}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "WasCastFromZone",
+                    "zone": "Graveyard"
+                }
+            },
+            "then": {
+                "type": "Amass",
+                "amount": {
+                    "type": "Fixed",
+                    "amount": 3
+                },
+                "subtype": "Goblin"
+            },
+            "otherwise": {
+                "type": "Amass",
+                "subtype": "Goblin"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Pavel Kolomeyets",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/38c16a0a-375e-48cb-9720-dbbc08c603ae.jpg?1785497148"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Troll Negotiations


### PR DESCRIPTION
## Summary
- implement Dwarven Shortsword with its Dwarf token and automatic attachment
- implement Fearsome Goblin Pair with amass Goblins 4
- implement Tidings of War with its graveyard-cast replacement and flashback
- update the HOB backlog and card snapshot

## Verification
- `just build`
- `just check-card-printing "Dwarven Shortsword"`
- `just check-card-printing "Fearsome Goblin Pair"`
- `just check-card-printing "Tidings of War"`
- `git diff --check`
- verified all Scryfall card/token image URLs return HTTP 200