### PR TITLE
Add three madness cards to Innistrad Remastered

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BloodhallPriest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BloodhallPriest.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/** Bloodhall Priest — Eldritch Moon #181. */
+val BloodhallPriest = card("Bloodhall Priest") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Vampire Cleric"
+    oracleText = "Whenever this creature enters or attacks, if you have no cards in hand, this " +
+        "creature deals 2 damage to any target.\n" +
+        "Madness {1}{B}{R} (If you discard this card, discard it into exile. When you do, cast it " +
+        "for its madness cost or put it into your graveyard.)"
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.EmptyHand
+        val damageTarget = target("any target", Targets.Any)
+        effect = ConditionalEffect(
+            condition = Conditions.EmptyHand,
+            effect = Effects.DealDamage(2, damageTarget),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.EmptyHand
+        val damageTarget = target("any target", Targets.Any)
+        effect = ConditionalEffect(
+            condition = Conditions.EmptyHand,
+            effect = Effects.DealDamage(2, damageTarget),
+        )
+    }
+
+    madness("{1}{B}{R}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "181"
+        artist = "Mark Winters"
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4824cca-0039-4486-be8f-650dac2c8e9f.jpg?1783937434"
+        ruling("2025-01-24", "If you have a card in hand at the moment the trigger condition occurs, Bloodhall Priest's ability won't trigger. If you have a card in hand as the ability resolves, no damage will be dealt.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AsylumVisitorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AsylumVisitorReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Asylum Visitor reprint in Innistrad Remastered. */
+val AsylumVisitorReprint = Printing(
+    oracleId = "870deab4-8570-40e9-aeda-ac3726cebb84",
+    name = "Asylum Visitor",
+    setCode = "INR",
+    collectorNumber = "96",
+    scryfallId = "02046824-6c48-40bb-9f0b-4fd280c6ed85",
+    artist = "Bastien L. Deharme",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/02046824-6c48-40bb-9f0b-4fd280c6ed85.jpg?1783908149",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BloodhallPriestReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/BloodhallPriestReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Bloodhall Priest reprint in Innistrad Remastered. */
+val BloodhallPriestReprint = Printing(
+    oracleId = "2eed5eb1-ab67-4f23-885d-922131364aba",
+    name = "Bloodhall Priest",
+    setCode = "INR",
+    collectorNumber = "232",
+    scryfallId = "b4ea5e44-0487-4e72-983a-02d7db26d075",
+    artist = "Mark Winters",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b4ea5e44-0487-4e72-983a-02d7db26d075.jpg?1783908080",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/StensiaMasqueradeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/StensiaMasqueradeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Stensia Masquerade reprint in Innistrad Remastered. */
+val StensiaMasqueradeReprint = Printing(
+    oracleId = "88f5d146-420b-417c-bcf1-fe0e78312a74",
+    name = "Stensia Masquerade",
+    setCode = "INR",
+    collectorNumber = "172",
+    scryfallId = "faaf031f-2c77-4248-8a29-f47e64773cfd",
+    artist = "Willian Murai",
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/faaf031f-2c77-4248-8a29-f47e64773cfd.jpg?1783908112",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AsylumVisitor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/AsylumVisitor.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/** Asylum Visitor — Shadows over Innistrad #99. */
+val AsylumVisitor = card("Asylum Visitor") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Wizard"
+    oracleText = "At the beginning of each player's upkeep, if that player has no cards in hand, " +
+        "you draw a card and you lose 1 life.\n" +
+        "Madness {1}{B} (If you discard this card, discard it into exile. When you do, cast it " +
+        "for its madness cost or put it into your graveyard.)"
+    power = 3
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EachUpkeep
+        triggerCondition = activePlayerHasEmptyHand()
+        effect = ConditionalEffect(
+            condition = activePlayerHasEmptyHand(),
+            effect = Effects.DrawCards(1).then(Effects.LoseLife(1)),
+        )
+    }
+
+    madness("{1}{B}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "99"
+        artist = "Bastien L. Deharme"
+        flavorText = "\"The ravings of the mad are laced with eldritch knowledge.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55a4bf6c-167a-4122-a55b-7bc28ca4f0d4.jpg?1783937781"
+        ruling("2016-04-08", "Asylum Visitor's triggered ability checks the active player's hand as the upkeep begins and as the trigger resolves. If that player has a card in hand as it resolves, you won't draw a card or lose 1 life.")
+    }
+}
+
+private fun activePlayerHasEmptyHand() = Compare(
+    DynamicAmount.Count(Player.TriggeringPlayer, Zone.HAND),
+    ComparisonOperator.EQ,
+    DynamicAmount.Fixed(0),
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StensiaMasquerade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/StensiaMasquerade.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/** Stensia Masquerade — Shadows over Innistrad #184. */
+val StensiaMasquerade = card("Stensia Masquerade") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Attacking creatures you control have first strike.\n" +
+        "Whenever a Vampire you control deals combat damage to a player, put a +1/+1 counter on it.\n" +
+        "Madness {2}{R} (If you discard this card, discard it into exile. When you do, cast it " +
+        "for its madness cost or put it into your graveyard.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.FIRST_STRIKE,
+            GroupFilter(GameObjectFilter.Creature.attacking().youControl()),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.withSubtype(Subtype.VAMPIRE).youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            1,
+            EffectTarget.TriggeringEntity,
+        )
+    }
+
+    madness("{2}{R}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "184"
+        artist = "Willian Murai"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48f1b024-d7d5-4e81-b016-06826e2b8bbf.jpg?1783937740"
+        ruling("2016-04-08", "Losing or gaining first strike after first-strike damage has been dealt won't cause a creature to deal combat damage twice or to not deal combat damage.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/StensiaMasqueradeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/StensiaMasqueradeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Stensia Masquerade reprint in Crimson Vow Commander. */
+val StensiaMasqueradeReprint = Printing(
+    oracleId = "88f5d146-420b-417c-bcf1-fe0e78312a74",
+    name = "Stensia Masquerade",
+    setCode = "VOC",
+    collectorNumber = "150",
+    scryfallId = "12ea7e21-b500-47cb-807a-a0849038fd56",
+    artist = "Willian Murai",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/12ea7e21-b500-47cb-807a-a0849038fd56.jpg?1783924945",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -187,6 +187,124 @@
     ]
 }
 
+// Bloodhall Priest
+{
+    "name": "Bloodhall Priest",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Creature — Vampire Cleric",
+    "oracleText": "Whenever this creature enters or attacks, if you have no cards in hand, this creature deals 2 damage to any target.\nMadness {1}{B}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{1}{B}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Hand",
+                            "negate": true
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "any target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Hand",
+                    "negate": true
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Hand",
+                            "negate": true
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "any target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Hand",
+                    "negate": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "RARE",
+        "artist": "Mark Winters",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4824cca-0039-4486-be8f-650dac2c8e9f.jpg?1783937434",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "If you have a card in hand at the moment the trigger condition occurs, Bloodhall Priest's ability won't trigger. If you have a card in hand as the ability resolves, no damage will be dealt."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Borrowed Hostility
 {
     "name": "Borrowed Hostility",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -743,6 +743,107 @@
     ]
 }
 
+// Asylum Visitor
+{
+    "name": "Asylum Visitor",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Wizard",
+    "oracleText": "At the beginning of each player's upkeep, if that player has no cards in hand, you draw a card and you lose 1 life.\nMadness {1}{B} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{1}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "TriggeringPlayer",
+                                "zone": "Hand"
+                            },
+                            "operator": "EQ",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 0
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "TriggeringPlayer",
+                        "zone": "Hand"
+                    },
+                    "operator": "EQ",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 0
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "RARE",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "\"The ravings of the mad are laced with eldritch knowledge.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55a4bf6c-167a-4122-a55b-7bc28ca4f0d4.jpg?1783937781",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "Asylum Visitor's triggered ability checks the active player's hand as the upkeep begins and as the trigger resolves. If that player has a card in hand as it resolves, you won't draw a card or lose 1 life."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Bloodmad Vampire
 {
     "name": "Bloodmad Vampire",
@@ -3172,6 +3273,67 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Stensia Masquerade
+{
+    "name": "Stensia Masquerade",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Attacking creatures you control have first strike.\nWhenever a Vampire you control deals combat damage to a player, put a +1/+1 counter on it.\nMadness {2}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "keywords": [
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{2}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": "creature Vampire ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "TriggeringEntity"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FIRST_STRIKE",
+                "filter": {
+                    "baseFilter": "creature attacking ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "UNCOMMON",
+        "artist": "Willian Murai",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48f1b024-d7d5-4e81-b016-06826e2b8bbf.jpg?1783937740",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "Losing or gaining first strike after first-strike damage has been dealt won't cause a creature to deal combat damage twice or to not deal combat damage."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
## Summary
- implement Asylum Visitor and Stensia Masquerade canonically in Shadows over Innistrad
- implement Bloodhall Priest canonically in Eldritch Moon
- add Innistrad Remastered printing rows for all three cards
- add the missing Crimson Vow Commander printing row for Stensia Masquerade
- update SOI and EMN card-definition snapshots

## Verification
- `just build`
- `just check-card-printing "Stensia Masquerade"`
- `just check-card-printing "Asylum Visitor"`
- `just check-card-printing "Bloodhall Priest"`
- `just check-backlog`
- verified all six canonical/INR image URLs return HTTP 200