### PR TITLE
Add five cards to The Hobbit

### DIFF
--- a/backlog/sets/the-hobbit/cards.md
+++ b/backlog/sets/the-hobbit/cards.md
@@ -2,12 +2,12 @@
 
 **Set Size:** 193 cards revealed as of 2026-08-04
 **Release Date:** August 14, 2026
-**Implemented:** 51 / 193
+**Implemented:** 56 / 193
 Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. This list covers only cards revealed as of that date.
 
 - [x] 1. Long-Bodied Grey Dog
 - [x] 2. Old Thrush
-- [ ] 3. Troop of Ponies
+- [x] 3. Troop of Ponies
 - [ ] 4. Belladonna Took
 - [ ] 5. Bilbo's Gambit
 - [ ] 6. Bofur, Reliable Guardian
@@ -15,7 +15,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 8. Dáin, Lord of the Iron Hills
 - [x] 9. Dwarven Provisioner
 - [x] 10. Dwarven Shortsword
-- [ ] 11. Eagle of the Great Shelf
+- [x] 11. Eagle of the Great Shelf
 - [ ] 12. The Eagles Are Coming!
 - [ ] 13. Esgaroth Garrison
 - [ ] 14. Fíli the Pathfinder
@@ -105,7 +105,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 98. Getaway Barrel
 - [ ] 99. Glóin the Mighty
 - [ ] 100. Goblin-town Flunkies
-- [ ] 101. Gundabad Opportunist
+- [x] 101. Gundabad Opportunist
 - [ ] 102. Iron Hills Stalwart
 - [ ] 103. Last Light of Durin's Day
 - [ ] 104. The Misty Mountains Cold
@@ -130,7 +130,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 123. Dancing from Dark to Dawn
 - [ ] 124. Down in the Valley
 - [ ] 125. Galion, Elvenking's Butler
-- [ ] 126. Gigantic Big Bear
+- [x] 126. Gigantic Big Bear
 - [x] 127. Guardian of the Halls
 - [x] 128. Little Bear
 - [x] 129. Mirkwood Pathmaker
@@ -164,7 +164,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 157. Goblin Plate Mail
 - [ ] 158. The Great Goblin
 - [x] 159. Large Bear
-- [ ] 160. Mirkwood Nurturer
+- [x] 160. Mirkwood Nurturer
 - [x] 161. Nori, Teller of Tales
 - [ ] 162. Patient Instructor
 - [ ] 163. Silvan Reveler

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/EagleOfTheGreatShelf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/EagleOfTheGreatShelf.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Eagle of the Great Shelf
+ * {4}{W}
+ * Creature — Bird Soldier
+ * 2/5
+ * Flying
+ * Whenever this creature attacks, it gets +1/+1 until end of turn for each other creature you control.
+ *
+ * A one-shot pump, not a static bonus: the count is locked in when the attack trigger resolves
+ * (CR 608.2h), so creatures that leave or arrive afterwards don't change the bonus.
+ * `excludeSelf` carries the "other" — the Eagle itself never counts.
+ */
+val EagleOfTheGreatShelf = card("Eagle of the Great Shelf") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Soldier"
+    oracleText = "Flying\nWhenever this creature attacks, it gets +1/+1 until end of turn for each other creature you control."
+    power = 2
+    toughness = 5
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val otherCreatures = DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Creature,
+            excludeSelf = true
+        )
+        effect = Effects.ModifyStats(otherCreatures, otherCreatures, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "11"
+        artist = "Yuhong Ding"
+        flavorText = "The Goblins hated the Eagles and feared them, but could not reach their lofty seats or drive them from the mountains."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3feca644-5f65-4477-bbc8-d505cec6f3a5.jpg?1784797947"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GiganticBigBear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GiganticBigBear.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gigantic Big Bear
+ * {5}{G}{G}
+ * Creature — Bear
+ * 10/7
+ * This spell can't be countered.
+ * Hexproof, haste
+ *
+ * "This spell can't be countered" is a characteristic of the card while it's on the stack, not a
+ * battlefield static ability — `cantBeCountered` on the definition, not a `staticAbility`.
+ */
+val GiganticBigBear = card("Gigantic Big Bear") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    oracleText = "This spell can't be countered.\nHexproof, haste"
+    power = 10
+    toughness = 7
+
+    cantBeCountered = true
+
+    keywords(Keyword.HEXPROOF, Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "126"
+        artist = "Xabi Gaztelua"
+        flavorText = "Wargs and Goblins had few predators in the foothills of the Misty Mountains, but they did have some."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d6ece3d-8e7a-41ad-974f-3c9748de4825.jpg?1785323269"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GundabadOpportunist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GundabadOpportunist.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gundabad Opportunist
+ * {3}{R}
+ * Creature — Goblin Rogue
+ * 4/2
+ * When this creature enters, exile the top card of your library. Until the end of your next turn,
+ * you may play that card.
+ *
+ * The standard impulse-draw pipeline (cf. Alania's Pathmaker): gather the top card, move it to
+ * exile, then grant the permission bounded by [MayPlayExpiry.UntilEndOfNextTurn]. The permission
+ * is "play", so a land exiled this way still costs a land drop.
+ */
+val GundabadOpportunist = card("Gundabad Opportunist") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    oracleText = "When this creature enters, exile the top card of your library. Until the end of your next turn, you may play that card."
+    power = 4
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "exiledCard"
+                ),
+                MoveCollectionEffect(
+                    from = "exiledCard",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                ),
+                GrantMayPlayFromExileEffect("exiledCard", MayPlayExpiry.UntilEndOfNextTurn)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Michele Giorgi"
+        flavorText = "Goblins had a simple approach to ownership: whatever you could hold onto was yours."
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc4a60b8-a5bb-4dbf-8d48-95caf757eac3.jpg?1785497118"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MirkwoodNurturer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MirkwoodNurturer.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Mirkwood Nurturer
+ * {2}{G/U}
+ * Creature — Elf Ranger
+ * 3/2
+ * When this creature enters, return up to one other target permanent you control to its owner's
+ * hand. If you do, put a +1/+1 counter on this creature.
+ *
+ * "Up to one other target" is `optional = true` + `other()` — the controller may choose no target
+ * at all, and the Nurturer itself is never a legal choice. The "if you do" rider is gated on a
+ * permanent having actually been returned: gather the chosen target, move it, and branch on the
+ * *moved* collection. Choosing nothing therefore skips the counter, and so does a chosen target
+ * that never made it to hand.
+ */
+val MirkwoodNurturer = card("Mirkwood Nurturer") {
+    manaCost = "{2}{G/U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Elf Ranger"
+    oracleText = "When this creature enters, return up to one other target permanent you control to its owner's hand. If you do, put a +1/+1 counter on this creature."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "other permanent you control",
+            TargetPermanent(optional = true, filter = TargetFilter.PermanentYouControl.other())
+        )
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "bounceTarget"),
+                MoveCollectionEffect(
+                    from = "bounceTarget",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    storeMovedAs = "returned"
+                ),
+                ConditionalEffect(
+                    condition = Conditions.CollectionContainsMatch("returned"),
+                    effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "160"
+        artist = "Irina Nordsol"
+        flavorText = "\"Merry be the greenwood, while the world is yet young! And merry be all your folk!\"\n—Gandalf"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/704b45e4-566e-40f6-a33a-9151018b44e5.jpg?1785323302"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TroopOfPonies.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TroopOfPonies.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Troop of Ponies
+ * {2}
+ * Creature — Horse
+ * 2/1
+ * {2}, {T}, Sacrifice this creature: Search your library for up to two basic land cards, reveal
+ * them, put one onto the battlefield tapped and the other into your hand, then shuffle.
+ *
+ * The Cultivate split needs two selection steps, not one: pick up to two basics, then pick which
+ * of the found cards enters tapped — the remainder goes to hand. A single
+ * `Patterns.Library.searchLibrary(destination = HAND, entersTapped = true)` would silently send
+ * *both* cards to hand and drop the tapped land entirely, so the pipeline is spelled out here
+ * (same shape as Bloomvine Regent's Claim Territory). Finding only one card still works: the
+ * second select is "exactly one" of what was found, so that card can go either way.
+ */
+val TroopOfPonies = card("Troop of Ponies") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Creature — Horse"
+    oracleText = "{2}, {T}, Sacrifice this creature: Search your library for up to two basic land cards, reveal them, put one onto the battlefield tapped and the other into your hand, then shuffle."
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.BasicLand),
+                    storeAs = "searchable"
+                ),
+                SelectFromCollectionEffect(
+                    from = "searchable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    storeSelected = "found",
+                    prompt = "Search your library for up to two basic land cards"
+                ),
+                SelectFromCollectionEffect(
+                    from = "found",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "toBattlefield",
+                    storeRemainder = "toHand",
+                    selectedLabel = "Onto the battlefield tapped",
+                    remainderLabel = "Into your hand",
+                    prompt = "Choose which basic land enters the battlefield tapped; the other goes to your hand."
+                ),
+                MoveCollectionEffect(
+                    from = "toBattlefield",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped),
+                    revealed = true
+                ),
+                MoveCollectionEffect(
+                    from = "toHand",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                ShuffleLibraryEffect()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "3"
+        artist = "Christina Kraus"
+        flavorText = "The sun had only just turned west when they started on the path to Mirkwood, and till evening it lay golden on the land about them."
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b4b1c59-bcec-4779-9e27-0e6f9feb4e11.jpg?1785639568"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -492,6 +492,55 @@
     ]
 }
 
+// Eagle of the Great Shelf
+{
+    "name": "Eagle of the Great Shelf",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Bird Soldier",
+    "oracleText": "Flying\nWhenever this creature attacks, it gets +1/+1 until end of turn for each other creature you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    },
+                    "toughnessModifier": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature",
+                        "excludeSelf": true
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "rarity": "UNCOMMON",
+        "artist": "Yuhong Ding",
+        "flavorText": "The Goblins hated the Eagles and feared them, but could not reach their lofty seats or drive them from the mountains.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3feca644-5f65-4477-bbc8-d505cec6f3a5.jpg?1784797947"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Elven Raft-Steerer
 {
     "name": "Elven Raft-Steerer",
@@ -842,6 +891,35 @@
     "colorIdentityOverride": []
 }
 
+// Gigantic Big Bear
+{
+    "name": "Gigantic Big Bear",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Bear",
+    "oracleText": "This spell can't be countered.\nHexproof, haste",
+    "creatureStats": {
+        "power": 10,
+        "toughness": 7
+    },
+    "keywords": [
+        "HEXPROOF",
+        "HASTE"
+    ],
+    "script": {
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "rarity": "RARE",
+        "artist": "Xabi Gaztelua",
+        "flavorText": "Wargs and Goblins had few predators in the foothills of the Misty Mountains, but they did have some.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d6ece3d-8e7a-41ad-974f-3c9748de4825.jpg?1785323269"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Gnashing of Teeth
 {
     "name": "Gnashing of Teeth",
@@ -1029,6 +1107,71 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Gundabad Opportunist
+{
+    "name": "Gundabad Opportunist",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "When this creature enters, exile the top card of your library. Until the end of your next turn, you may play that card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "exiledCard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "exiledCard",
+                            "expiry": {
+                                "type": "UntilControllerStep",
+                                "step": "CLEANUP",
+                                "includeCurrentTurn": false
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Michele Giorgi",
+        "flavorText": "Goblins had a simple approach to ownership: whatever you could hold onto was yours.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc4a60b8-a5bb-4dbf-8d48-95caf757eac3.jpg?1785497118"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1309,6 +1452,83 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Mirkwood Nurturer
+{
+    "name": "Mirkwood Nurturer",
+    "manaCost": "{2}{G/U}",
+    "typeLine": "Creature — Elf Ranger",
+    "oracleText": "When this creature enters, return up to one other target permanent you control to its owner's hand. If you do, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "bounceTarget"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "bounceTarget",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "storeMovedAs": "returned"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "returned"
+                                }
+                            },
+                            "then": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "permanent ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "other permanent you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "artist": "Irina Nordsol",
+        "flavorText": "\"Merry be the greenwood, while the world is yet young! And merry be all your folk!\"\n—Gandalf",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/704b45e4-566e-40f6-a33a-9151018b44e5.jpg?1785323302"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
     ]
 }
 
@@ -2463,6 +2683,110 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Troop of Ponies
+{
+    "name": "Troop of Ponies",
+    "manaCost": "{2}",
+    "typeLine": "Creature — Horse",
+    "oracleText": "{2}, {T}, Sacrifice this creature: Search your library for up to two basic land cards, reveal them, put one onto the battlefield tapped and the other into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "found",
+                            "prompt": "Search your library for up to two basic land cards"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "found",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toBattlefield",
+                            "storeRemainder": "toHand",
+                            "prompt": "Choose which basic land enters the battlefield tapped; the other goes to your hand.",
+                            "selectedLabel": "Onto the battlefield tapped",
+                            "remainderLabel": "Into your hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBattlefield",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "UNCOMMON",
+        "artist": "Christina Kraus",
+        "flavorText": "The sun had only just turned west when they started on the path to Mirkwood, and till evening it lay golden on the land about them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b4b1c59-bcec-4779-9e27-0e6f9feb4e11.jpg?1785639568"
+    },
+    "colorIdentityOverride": []
 }
 
 // Uneasy Partings

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EagleOfTheGreatShelfScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EagleOfTheGreatShelfScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Eagle of the Great Shelf (HOB #11) — {4}{W} Creature — Bird Soldier 2/5
+ * "Flying. Whenever this creature attacks, it gets +1/+1 until end of turn for each other creature
+ * you control."
+ *
+ * Covers the two things the `excludeSelf` aggregate can get wrong: the Eagle counting itself, and
+ * opponents' creatures leaking into "you control".
+ */
+class EagleOfTheGreatShelfScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("the bonus counts other creatures you control, not the Eagle and not the opponent's") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Eagle of the Great Shelf", tapped = false, summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                .withCardOnBattlefield(1, "Hill Giant", tapped = false, summoningSickness = false)
+                // The opponent's creature must not be counted.
+                .withCardOnBattlefield(2, "Glory Seeker", tapped = false, summoningSickness = false)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val eagle = game.findPermanent("Eagle of the Great Shelf")!!
+
+            withClue("printed stats before combat") {
+                game.state.projectedState.getPower(eagle) shouldBe 2
+                game.state.projectedState.getToughness(eagle) shouldBe 5
+            }
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Eagle of the Great Shelf" to 2)).error shouldBe null
+            game.resolveStack()
+
+            withClue("+2/+2 for the two other creatures Player1 controls") {
+                game.state.projectedState.getPower(eagle) shouldBe 4
+                game.state.projectedState.getToughness(eagle) shouldBe 7
+            }
+        }
+
+        test("attacking alone gives no bonus") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Eagle of the Great Shelf", tapped = false, summoningSickness = false)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val eagle = game.findPermanent("Eagle of the Great Shelf")!!
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Eagle of the Great Shelf" to 2)).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Eagle never counts itself") {
+                game.state.projectedState.getPower(eagle) shouldBe 2
+                game.state.projectedState.getToughness(eagle) shouldBe 5
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MirkwoodNurturerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MirkwoodNurturerScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mirkwood Nurturer (HOB #160) — {2}{G/U} Creature — Elf Ranger 3/2
+ * "When this creature enters, return up to one other target permanent you control to its owner's
+ * hand. If you do, put a +1/+1 counter on this creature."
+ *
+ * The "if you do" rider is gated on a permanent actually reaching hand, so declining the "up to
+ * one" target must skip the counter too.
+ */
+class MirkwoodNurturerScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun game() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Mirkwood Nurturer")
+        .withCardOnBattlefield(1, "Grizzly Bears")
+        .withLandsOnBattlefield(1, "Forest", 3)
+        .withActivePlayer(1)
+        .withPriorityPlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("choosing a permanent returns it and puts a +1/+1 counter on the Nurturer") {
+            val g = game()
+            val bears = g.findPermanent("Grizzly Bears")!!
+
+            g.castSpell(1, "Mirkwood Nurturer").error shouldBe null
+            g.resolveStack()
+
+            (g.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+            g.selectTargets(listOf(bears)).error shouldBe null
+            g.resolveStack()
+
+            val nurturer = g.findPermanent("Mirkwood Nurturer")!!
+            withClue("the chosen permanent went back to its owner's hand") {
+                g.isOnBattlefield("Grizzly Bears") shouldBe false
+                g.isInHand(1, "Grizzly Bears") shouldBe true
+            }
+            withClue("the rider fired because a permanent was returned") {
+                plusOneCounters(g, nurturer) shouldBe 1
+            }
+        }
+
+        test("choosing no target returns nothing and gives no counter") {
+            val g = game()
+
+            g.castSpell(1, "Mirkwood Nurturer").error shouldBe null
+            g.resolveStack()
+
+            (g.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+            g.selectTargets(emptyList()).error shouldBe null
+            g.resolveStack()
+
+            val nurturer = g.findPermanent("Mirkwood Nurturer")!!
+            withClue("nothing was bounced") {
+                g.isOnBattlefield("Grizzly Bears") shouldBe true
+            }
+            withClue("no permanent returned means no counter") {
+                plusOneCounters(g, nurturer) shouldBe 0
+            }
+        }
+
+        test("the Nurturer itself is not a legal target") {
+            val g = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Mirkwood Nurturer")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withActivePlayer(1)
+                .withPriorityPlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            g.castSpell(1, "Mirkwood Nurturer").error shouldBe null
+            g.resolveStack()
+
+            val nurturer = g.findPermanent("Mirkwood Nurturer")!!
+            val decision = g.getPendingDecision()
+            if (decision is ChooseTargetsDecision) {
+                withClue("'other' excludes the source, so only the three Forests are offered") {
+                    decision.legalTargets.values.flatten().contains(nurturer) shouldBe false
+                }
+                g.selectTargets(emptyList()).error shouldBe null
+                g.resolveStack()
+            }
+
+            plusOneCounters(g, nurturer) shouldBe 0
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TroopOfPoniesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TroopOfPoniesScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Troop of Ponies (HOB #3) — {2} Creature — Horse 2/1
+ * "{2}, {T}, Sacrifice this creature: Search your library for up to two basic land cards, reveal
+ * them, put one onto the battlefield tapped and the other into your hand, then shuffle."
+ *
+ * The Cultivate split: a *second* selection decides which found card enters tapped and which goes
+ * to hand. The regression this guards against is both cards landing in the same zone — the shape a
+ * single-destination `searchLibrary(destination = HAND, entersTapped = true)` produces.
+ */
+class TroopOfPoniesScenarioTest : ScenarioTestBase() {
+
+    private val searchAbilityId by lazy {
+        cardRegistry.requireCard("Troop of Ponies").activatedAbilities[0].id
+    }
+
+    private fun game() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardOnBattlefield(1, "Troop of Ponies", tapped = false, summoningSickness = false)
+        .withLandsOnBattlefield(1, "Plains", 2)
+        .withCardInLibrary(1, "Forest")
+        .withCardInLibrary(1, "Mountain")
+        .withCardInLibrary(1, "Ancestral Recall")
+        .withActivePlayer(1)
+        .withPriorityPlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    init {
+        test("one basic enters tapped, the other goes to hand, and the Ponies are sacrificed") {
+            val g = game()
+            val ponies = g.findPermanent("Troop of Ponies")!!
+
+            g.execute(ActivateAbility(playerId = g.player1Id, sourceId = ponies, abilityId = searchAbilityId))
+                .error shouldBe null
+            g.resolveStack()
+
+            // First selection: which basics to find.
+            val forest = g.findCardsInLibrary(1, "Forest").first()
+            val mountain = g.findCardsInLibrary(1, "Mountain").first()
+            (g.getPendingDecision() is SelectCardsDecision) shouldBe true
+            withClue("only basic lands are searchable") {
+                (g.getPendingDecision() as SelectCardsDecision).options
+                    .contains(g.findCardsInLibrary(1, "Ancestral Recall").first()) shouldBe false
+            }
+            g.selectCards(listOf(forest, mountain)).error shouldBe null
+
+            // Second selection: which of the two enters the battlefield tapped.
+            (g.getPendingDecision() is SelectCardsDecision) shouldBe true
+            g.selectCards(listOf(forest)).error shouldBe null
+            g.resolveStack()
+
+            withClue("the Forest entered the battlefield tapped") {
+                g.isOnBattlefield("Forest") shouldBe true
+                (g.state.getEntity(g.findPermanent("Forest")!!)?.has<TappedComponent>() ?: false) shouldBe true
+            }
+            withClue("the Mountain went to hand, not the battlefield") {
+                g.isInHand(1, "Mountain") shouldBe true
+                g.isOnBattlefield("Mountain") shouldBe false
+            }
+            withClue("the sacrifice cost was paid") {
+                g.isOnBattlefield("Troop of Ponies") shouldBe false
+                g.isInGraveyard(1, "Troop of Ponies") shouldBe true
+            }
+        }
+
+        test("finding a single basic still lets it go to the battlefield tapped") {
+            val g = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Troop of Ponies", tapped = false, summoningSickness = false)
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .withPriorityPlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ponies = g.findPermanent("Troop of Ponies")!!
+
+            g.execute(ActivateAbility(playerId = g.player1Id, sourceId = ponies, abilityId = searchAbilityId))
+                .error shouldBe null
+            g.resolveStack()
+
+            var guard = 0
+            while (g.getPendingDecision() is SelectCardsDecision && guard++ < 4) {
+                val forest = g.findCardsInLibrary(1, "Forest").firstOrNull()
+                if (forest != null) g.selectCards(listOf(forest)) else g.skipSelection()
+                g.resolveStack()
+            }
+
+            withClue("the only basic found enters tapped; nothing is left over for the hand") {
+                g.isOnBattlefield("Forest") shouldBe true
+                (g.state.getEntity(g.findPermanent("Forest")!!)?.has<TappedComponent>() ?: false) shouldBe true
+                g.isInHand(1, "Forest") shouldBe false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five HOB cards, all canonical in this set (no earlier printings), all built from existing SDK primitives — no new engine vocabulary.

| Card | Text |
|---|---|
| **Gigantic Big Bear** {5}{G}{G} 10/7 | This spell can't be countered. Hexproof, haste |
| **Eagle of the Great Shelf** {4}{W} 2/5 | Flying. Whenever this creature attacks, it gets +1/+1 until end of turn for each other creature you control. |
| **Gundabad Opportunist** {3}{R} 4/2 | When this creature enters, exile the top card of your library. Until the end of your next turn, you may play that card. |
| **Mirkwood Nurturer** {2}{G/U} 3/2 | When this creature enters, return up to one other target permanent you control to its owner's hand. If you do, put a +1/+1 counter on this creature. |
| **Troop of Ponies** {2} 2/1 | {2}, {T}, Sacrifice this creature: Search your library for up to two basic land cards, reveal them, put one onto the battlefield tapped and the other into your hand, then shuffle. |

## Modelling notes

**Mirkwood Nurturer** — "up to one other target" is `optional = true` + `other()`. The "if you do" rider can't just be sequenced after the bounce: choosing zero targets still resolves the ability, and would hand out a free counter. It's gathered from `CardSource.ChosenTargets`, moved with `storeMovedAs`, and the counter is gated on `CollectionContainsMatch` over the *moved* collection — so no target (or a target that never reaches hand) means no counter.

**Troop of Ponies** — the Cultivate split is written out as two selections (find up to two basics → choose which one enters tapped, remainder to hand), mirroring Bloomvine Regent's Claim Territory rather than calling `Patterns.Library.searchLibrary`. See the pre-existing bug below.

**Eagle of the Great Shelf** — one-shot pump on the attack trigger, so the count is locked in at resolution (CR 608.2h). `AggregateBattlefield(Player.You, Creature, excludeSelf = true)` carries the "other".

## Pre-existing bug spotted, not fixed here

`Patterns.Library.searchLibrary` has a single `destination`, so `destination = SearchDestination.HAND, entersTapped = true` silently sends **both** found cards to hand and drops the tapped land entirely. Two cards are wired that way today and are wrong as a result:

- `mtg-sets/.../definitions/m11/cards/Cultivate.kt`
- `mtg-sets/.../definitions/chk/cards/KodamasReach.kt`

Both are mtgish-generated. Fixing them properly means either a split-destination pattern in `LibraryPatterns` or inlining the pipeline in each — `add-feature` territory, so it's left out of this PR to keep the change set to cards.

## Verification

- `just build` — green (full gate, including `CardLintTest` and `FacadeBoundaryTest`)
- `just rebless-cards` — only the five new cards move in `snapshots/cards/HOB.json`; the diff is pure additions
- `just check-card-printing` — canonical in HOB for all five
- `just check-backlog` — headers in sync (HOB now 56/193)
- New scenario tests, all passing: `MirkwoodNurturerScenarioTest` (3), `TroopOfPoniesScenarioTest` (2), `EagleOfTheGreatShelfScenarioTest` (2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)