### PR TITLE
Add three Innistrad Remastered cards: granted madness + self-discard triggers

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 272 booster cards (excluding basic lands and tokens)
 **Release Date:** November 19, 2021
-**Implemented:** 200 / 273
+**Implemented:** 201 / 273
 - [x] Abrade
 - [x] Adamant Will
 - [ ] Aim for the Head
@@ -85,7 +85,7 @@
 - [ ] Dreamshackle Geist
 - [ ] Drogskol Infantry
 - [ ] Dying to Serve
-- [ ] Edgar's Awakening
+- [x] Edgar's Awakening
 - [x] Edgar, Charmed Groom
 - [x] End the Festivities
 - [ ] Eruth, Tormented Prophet

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3757,6 +3757,12 @@ single "it" for "one or more cards".
 
 - `AnyOpponentDiscards` — whenever an opponent discards a card. (Entropic Battlecruiser.)
 - `YouDiscard` — whenever you discard a card.
+- `YouDiscardThis` — **self-bound**: "when *you* discard **this** card" (Edgar's Awakening). The
+  ability functions in hand and fires as the card is discarded, wherever the discard sends it —
+  graveyard normally, exile if the card also has madness. Detected on the discarded card itself
+  (`TriggerDetector.detectSelfDiscardTriggers`, the sibling of the cycling pass), so it needs no
+  permanent watching for it. The trigger's controller is the discarding player, which is what
+  "when you discard" means even for an opponent's Mind Rot on your hand.
 - `YouDiscardOneOrMore` — **batch wording** "whenever you discard one or more cards"
   (CR 603.2c): fires once per discard event no matter how many cards it contained
   (Inti, Seneschal of the Sun). Sequential discards in the same resolution ("discard a
@@ -6221,6 +6227,18 @@ composite abilities).
   a discarded madness *sorcery* can be cast on an opponent's turn (CR 702.35b). Both markers are stripped the moment the
   card leaves exile, so a lingering fixed cost can never re-price a later graveyard cast.
   *Fiery Temper*, *Gisa's Bidding*, *Bloodmad Vampire*.
+  - **Granting madness** — `GrantMadnessToOwnedCards(filter)` is the static half of Falkenrath Gorger:
+    *"Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its
+    mana cost."* It carries no cost field — "equal to its mana cost" is the only printed shape, so the cost is derived
+    per card. `StaticAbilityHandler` bakes it into a `GrantsMadnessToOwnedCardsComponent` on the permanent (the discard
+    replacement walks the battlefield with no `CardRegistry` in hand), and `MadnessGrants.effectiveMadnessCost` is the
+    single source of truth `ZoneMovementUtils.madnessDiscardExile` consults: printed `MadnessComponent` wins, else the
+    first matching grant controlled by the card's **owner**. Everything downstream is shared with printed madness —
+    same exile redirect, same stamped `PlayWithFixedAlternativeManaCostComponent`, same CR 702.35a cast offer (which
+    reads its cost off that stamp, so it works for both sources and survives the granter leaving the battlefield).
+    **Known simplification:** CR 616.1 lets the player choose among applicable replacements, so a discarded Vampire
+    with *printed* madness should be offered the choice of which madness exiles it; we take the printed cost without
+    asking, which is the cheaper one for every card in the pool.
 - `Suspend` (CR 702.62) — an **exile-zone** mechanic, unlike Impending/Vanishing which live on the battlefield.
   A suspended card sits in exile with **time counters**; at the beginning of its **owner's** upkeep one is removed,
   and when the last is gone its owner **may play it for free**, with **haste** if it's a creature. The lifecycle is

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1129,6 +1129,19 @@ object Triggers {
     )
 
     /**
+     * When *you* discard **this** card (Edgar's Awakening). The ability functions while the card
+     * is in your hand and fires as it is discarded, wherever the discard sends it — the graveyard
+     * normally, exile if the card also has madness.
+     *
+     * The self-bound counterpart to [YouDiscard]: that one is an observer on a permanent watching
+     * your discards, this one belongs to the discarded card itself.
+     */
+    val YouDiscardThis: TriggerSpec = TriggerSpec(
+        event = DiscardEvent(player = Player.You),
+        binding = TriggerBinding.SELF
+    )
+
+    /**
      * Whenever you discard one or more cards — batch wording (CR 603.2c): fires once per
      * discard event no matter how many cards it contained (Inti, Seneschal of the Sun).
      * Sequential discards in the same resolution are separate events and fire separately.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -311,6 +311,42 @@ data class GrantMiracleToCardsInHand(
 }
 
 /**
+ * Grants madness (CR 702.35) to cards the granter's controller **owns** that match [filter] and
+ * aren't on the battlefield, with the madness cost equal to each card's own mana cost. Models
+ * Falkenrath Gorger: "Each Vampire creature card you own that isn't on the battlefield has madness.
+ * The madness cost is equal to its mana cost."
+ *
+ * Cost-free by construction: "equal to its mana cost" is the only shape printed on a card, so the
+ * granted cost is derived per card rather than carried here. Should a grant with a fixed cost ever
+ * print, that's a second field, not a second static.
+ *
+ * Read by the discard path exactly where printed madness is read — `MadnessGrants` is consulted by
+ * the zone-change replacement that diverts a discard to exile, so a granted madness behaves
+ * identically to a printed one: same exile redirect, same CR 702.35a cast offer, same fixed
+ * alternative cost stamped on the exiled card. Because the exiled card carries the cost from that
+ * moment on, the grant leaving the battlefield mid-trigger doesn't revoke the offer.
+ *
+ * The "isn't on the battlefield" clause is the card's own wording; madness only ever *functions*
+ * from a hand (CR 702.35a replaces a discard), so in practice the grant is read for cards being
+ * discarded from their owner's hand.
+ *
+ * @property filter Which cards the controller owns gain madness (e.g. Vampire creature card).
+ */
+@SerialName("GrantMadnessToOwnedCards")
+@Serializable
+data class GrantMadnessToOwnedCards(
+    val filter: GameObjectFilter
+) : StaticAbility {
+    override val description: String =
+        "Each ${filter.description} you own that isn't on the battlefield has madness. " +
+            "The madness cost is equal to its mana cost."
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * You may cast spells matching [filter] from your graveyard, optionally by paying [lifeCost]
  * life in addition to their other costs. Only during your turn if [duringYourTurnOnly] is true.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/StromkirkOccultist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/StromkirkOccultist.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.madness
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stromkirk Occultist — Eldritch Moon #146.
+ * {2}{R}
+ * Creature — Vampire Horror
+ * 3/2
+ *
+ * Trample
+ * Whenever this creature deals combat damage to a player, exile the top card of your library.
+ * Until end of turn, you may play that card.
+ * Madness {1}{R}
+ *
+ * The combat-damage payoff is plain impulse draw ([Patterns.Exile.impulse]) — the exiled card is
+ * played for its normal cost, and the permission lapses at end of turn whether or not it was used.
+ */
+val StromkirkOccultist = card("Stromkirk Occultist") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire Horror"
+    power = 3
+    toughness = 2
+    oracleText = "Trample\n" +
+        "Whenever this creature deals combat damage to a player, exile the top card of your " +
+        "library. Until end of turn, you may play that card.\n" +
+        "Madness {1}{R} (If you discard this card, discard it into exile. When you do, cast it " +
+        "for its madness cost or put it into your graveyard.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Patterns.Exile.impulse(count = 1)
+    }
+
+    madness("{1}{R}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "146"
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1fa6a443-b23b-48ae-97bb-8fd4deec52c4.jpg?1783937451"
+        ruling("2022-12-08", "A card with madness that's discarded counts as having been discarded even though it's put into exile rather than a graveyard. If it was discarded to pay a cost, that cost is still paid. Abilities that trigger when a card is discarded will still trigger.")
+        ruling("2022-12-08", "Casting a spell with madness ignores the timing rules based on the card's card type. For example, you can cast a sorcery with madness if you discard it during an opponent's turn.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/EdgarsAwakeningReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/EdgarsAwakeningReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Edgar's Awakening reprint in Innistrad Remastered. */
+val EdgarsAwakeningReprint = Printing(
+    oracleId = "2c04371a-af69-4e42-8cda-096cf8312b5e",
+    name = "Edgar's Awakening",
+    setCode = "INR",
+    collectorNumber = "108",
+    scryfallId = "b2ff8b0a-f424-4a8d-a682-848bf1f3b07b",
+    artist = "Joshua Raphael",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2ff8b0a-f424-4a8d-a682-848bf1f3b07b.jpg?1783908145",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/FalkenrathGorgerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/FalkenrathGorgerReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Falkenrath Gorger reprint in Innistrad Remastered. */
+val FalkenrathGorgerReprint = Printing(
+    oracleId = "26aba6fa-830f-4a7f-8618-488d8e00215a",
+    name = "Falkenrath Gorger",
+    setCode = "INR",
+    collectorNumber = "152",
+    scryfallId = "16c376f5-f69b-49d4-95f4-92bdd68c564c",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/16c376f5-f69b-49d4-95f4-92bdd68c564c.jpg?1783908121",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/StromkirkOccultistReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/StromkirkOccultistReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Stromkirk Occultist reprint in Innistrad Remastered. */
+val StromkirkOccultistReprint = Printing(
+    oracleId = "3bdd140b-1406-4d07-8f35-78f2ba92de64",
+    name = "Stromkirk Occultist",
+    setCode = "INR",
+    collectorNumber = "173",
+    scryfallId = "b11fa9f0-82d1-4dd6-8f2d-45d73f908277",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b11fa9f0-82d1-4dd6-8f2d-45d73f908277.jpg?1783908112",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/FalkenrathGorger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/FalkenrathGorger.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantMadnessToOwnedCards
+
+/**
+ * Falkenrath Gorger — Shadows over Innistrad #155.
+ * {R}
+ * Creature — Vampire Berserker
+ * 2/1
+ *
+ * Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost
+ * is equal to its mana cost.
+ *
+ * The grant is read at the moment of the discard, and the exiled card carries its madness cost
+ * from then on — so, per the Oracle rulings, the Gorger leaving the battlefield before the madness
+ * trigger resolves doesn't take the cast offer away. Nor does it grant itself madness: the ability
+ * only applies while it is on the battlefield, and a card being discarded is not.
+ */
+val FalkenrathGorger = card("Falkenrath Gorger") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire Berserker"
+    power = 2
+    toughness = 1
+    oracleText = "Each Vampire creature card you own that isn't on the battlefield has madness. " +
+        "The madness cost is equal to its mana cost. (If you discard a card with madness, discard " +
+        "it into exile. When you do, cast it for its madness cost or put it into your graveyard.)"
+
+    staticAbility {
+        ability = GrantMadnessToOwnedCards(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.VAMPIRE)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "155"
+        artist = "Anna Steinbauer"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/474895d8-1f2c-45bb-b721-4cf7c290eb23.jpg?1783937755"
+        ruling("2016-04-08", "If Falkenrath Gorger leaves the battlefield before the madness trigger has resolved for a Vampire card that gained madness with its ability, the madness ability will still let you cast that Vampire card for the appropriate cost even though it no longer has madness.")
+        ruling("2016-04-08", "If you discard a Vampire creature card that already has a madness ability, you'll choose which madness ability exiles it. You may choose either the one it normally has or the one it gains from Falkenrath Gorger.")
+        ruling("2016-04-08", "Falkenrath Gorger's ability only applies while it's on the battlefield. If you discard it, it won't give itself madness.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/FalkenrathGorgerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/FalkenrathGorgerReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Falkenrath Gorger reprint in Innistrad: Crimson Vow Commander. */
+val FalkenrathGorgerReprint = Printing(
+    oracleId = "26aba6fa-830f-4a7f-8618-488d8e00215a",
+    name = "Falkenrath Gorger",
+    setCode = "VOC",
+    collectorNumber = "146",
+    scryfallId = "6d653a1d-d355-464e-82aa-92028296b7ef",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d653a1d-d355-464e-82aa-92028296b7ef.jpg?1783924948",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/StromkirkOccultistReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/voc/cards/StromkirkOccultistReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.voc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Stromkirk Occultist reprint in Innistrad: Crimson Vow Commander. */
+val StromkirkOccultistReprint = Printing(
+    oracleId = "3bdd140b-1406-4d07-8f35-78f2ba92de64",
+    name = "Stromkirk Occultist",
+    setCode = "VOC",
+    collectorNumber = "151",
+    scryfallId = "8a631816-f5c0-4608-9078-0486a0bf6a49",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a631816-f5c0-4608-9078-0486a0bf6a49.jpg?1783924945",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/EdgarsAwakening.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/EdgarsAwakening.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Edgar's Awakening — Innistrad: Crimson Vow #110.
+ * {3}{B}{B}
+ * Sorcery
+ *
+ * Return target creature card from your graveyard to the battlefield.
+ * When you discard this card, you may pay {B}. When you do, return target creature card from
+ * your graveyard to your hand.
+ *
+ * The discard half is a [Triggers.YouDiscardThis] ability — it functions from hand and fires as
+ * the card is discarded, by which point the card itself is in the graveyard (so it is a legal
+ * target of its own reflexive trigger). "You may pay {B}. When you do, …" is a genuine reflexive
+ * trigger, not an "if you do" rider: the payment happens first, then a second ability goes on the
+ * stack and picks its target, which is why [ReflexiveTriggerEffect] carries the target requirement
+ * rather than the discard trigger.
+ */
+val EdgarsAwakening = card("Edgar's Awakening") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to the battlefield.\n" +
+        "When you discard this card, you may pay {B}. When you do, return target creature card " +
+        "from your graveyard to your hand."
+
+    spell {
+        val creature = target("target creature card from your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.PutOntoBattlefield(creature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouDiscardThis
+        effect = ReflexiveTriggerEffect(
+            action = PayManaCostEffect(ManaCost.parse("{B}")),
+            reflexiveEffect = Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(Targets.CreatureCardInYourGraveyard),
+            // The composed description reads "return target to its owner's hand"; this is the
+            // yes/no prompt the player actually sees, so spell the oracle wording out.
+            descriptionOverride = "You may pay {B}. When you do, return target creature card " +
+                "from your graveyard to your hand."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "110"
+        artist = "Joshua Raphael"
+        flavorText = "\"Here you go. Can't have you sleeping through your own wedding day.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96ff9de6-f9ae-4b1c-9fd1-4ba9663922af.jpg?1783924865"
+        ruling("2021-11-19", "You can't discard Edgar's Awakening just because you want to. In order to discard it, a rule or effect needs to allow or instruct you to do so.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -3454,6 +3454,87 @@
     "colorIdentityOverride": []
 }
 
+// Stromkirk Occultist
+{
+    "name": "Stromkirk Occultist",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Vampire Horror",
+    "oracleText": "Trample\nWhenever this creature deals combat damage to a player, exile the top card of your library. Until end of turn, you may play that card.\nMadness {1}{R} (If you discard this card, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE",
+        "MADNESS"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Madness",
+            "cost": "{1}{R}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "RARE",
+        "artist": "Magali Villeneuve",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1fa6a443-b23b-48ae-97bb-8fd4deec52c4.jpg?1783937451",
+        "rulings": [
+            {
+                "date": "2022-12-08",
+                "text": "A card with madness that's discarded counts as having been discarded even though it's put into exile rather than a graveyard. If it was discarded to pay a cost, that cost is still paid. Abilities that trigger when a card is discarded will still trigger."
+            },
+            {
+                "date": "2022-12-08",
+                "text": "Casting a spell with madness ignores the timing rules based on the card's card type. For example, you can cast a sorcery with madness if you discard it during an opponent's turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Subjugator Angel
 {
     "name": "Subjugator Angel",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1521,6 +1521,49 @@
     ]
 }
 
+// Falkenrath Gorger
+{
+    "name": "Falkenrath Gorger",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Vampire Berserker",
+    "oracleText": "Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its mana cost. (If you discard a card with madness, discard it into exile. When you do, cast it for its madness cost or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantMadnessToOwnedCards",
+                "filter": "creature Vampire"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "RARE",
+        "artist": "Anna Steinbauer",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/474895d8-1f2c-45bb-b721-4cf7c290eb23.jpg?1783937755",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "If Falkenrath Gorger leaves the battlefield before the madness trigger has resolved for a Vampire card that gained madness with its ability, the madness ability will still let you cast that Vampire card for the appropriate cost even though it no longer has madness."
+            },
+            {
+                "date": "2016-04-08",
+                "text": "If you discard a Vampire creature card that already has a madness ability, you'll choose which madness ability exiles it. You may choose either the one it normally has or the one it gains from Falkenrath Gorger."
+            },
+            {
+                "date": "2016-04-08",
+                "text": "Falkenrath Gorger's ability only applies while it's on the battlefield. If you discard it, it won't give itself madness."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Game Trail
 {
     "name": "Game Trail",

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -4025,6 +4025,81 @@
     ]
 }
 
+// Edgar's Awakening
+{
+    "name": "Edgar's Awakening",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to the battlefield.\nWhen you discard this card, you may pay {B}. When you do, return target creature card from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature card from your graveyard"
+            },
+            "destination": "Battlefield"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card from your graveyard"
+            }
+        ],
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DiscardEvent",
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "PayManaCost",
+                        "cost": "{B}"
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Hand"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may pay {B}. When you do, return target creature card from your graveyard to your hand."
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "UNCOMMON",
+        "artist": "Joshua Raphael",
+        "flavorText": "\"Here you go. Can't have you sleeping through your own wedding day.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96ff9de6-f9ae-4b1c-9fd1-4ba9663922af.jpg?1783924865",
+        "rulings": [
+            {
+                "date": "2021-11-19",
+                "text": "You can't discard Edgar's Awakening just because you want to. In order to discard it, a rule or effect needs to allow or instruct you to do so."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Edgar, Charmed Groom
 {
     "name": "Edgar, Charmed Groom",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -376,6 +376,7 @@ val engineSerializersModule = SerializersModule {
         subclass(SelfZoneRedirectComponent::class)
         subclass(MadnessComponent::class)
         subclass(MadnessExiledComponent::class)
+        subclass(GrantsMadnessToOwnedCardsComponent::class)
         subclass(ToxicComponent::class)
         subclass(CopyOfComponent::class)
         subclass(RevertCopyAtEndOfTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -35,7 +35,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.EmblemSourceComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
-import com.wingedsheep.engine.state.components.identity.MadnessComponent
+import com.wingedsheep.engine.state.components.identity.PlayWithFixedAlternativeManaCostComponent
 import com.wingedsheep.engine.state.components.identity.MadnessExiledComponent
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.SuppressEntersTriggers
@@ -1433,6 +1433,13 @@ class TriggerDetector(
             detectCyclingCardTriggers(state, index.statics, event, triggers)
         }
 
+        // Handle "when you discard this card" triggers on the discarded card itself, which now
+        // sits in the graveyard (or in exile, if it also had madness) rather than in hand —
+        // e.g. Edgar's Awakening. Mirrors the cycling pass above.
+        if (event is CardsDiscardedEvent) {
+            detectSelfDiscardTriggers(state, index.statics, event, triggers)
+        }
+
         // Handle "when this card becomes plotted" triggers on the plotted card itself, which
         // now sits face up in exile rather than on the battlefield (e.g., Aloe Alchemist).
         if (event is CardPlottedEvent) {
@@ -1761,6 +1768,50 @@ class TriggerDetector(
     }
 
     /**
+     * Detect "when you discard this card" triggers on the card that was discarded (Edgar's
+     * Awakening). The ability functions in hand but the card is already in the graveyard — or in
+     * exile, if it also had madness — by the time the event fires, so the main index scan never
+     * sees it. Mirrors [detectCyclingCardTriggers].
+     *
+     * Only [TriggerBinding.SELF] discard triggers belong here: an `ANY`-bound
+     * [EventPattern.DiscardEvent] is an observer ("whenever you discard a card") owned by the
+     * battlefield pass, and would fire twice if this pass also claimed it.
+     *
+     * The trigger's controller is the discarding player, which is what "when *you* discard this
+     * card" means — an opponent's Mind Rot on your hand is your discard, and the card's owner is
+     * the one holding it.
+     */
+    private fun detectSelfDiscardTriggers(
+        state: GameState,
+        statics: BattlefieldStaticsIndex,
+        event: CardsDiscardedEvent,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        for (entityId in event.cardIds) {
+            val container = state.getEntity(entityId) ?: continue
+            val cardComponent = container.get<CardComponent>() ?: continue
+
+            val abilities =
+                abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state, statics)
+
+            for (ability in abilities) {
+                if (ability.trigger !is EventPattern.DiscardEvent) continue
+                if (ability.binding != TriggerBinding.SELF) continue
+                triggers.add(
+                    PendingTrigger(
+                        ability = ability,
+                        sourceId = entityId,
+                        sourceName = cardComponent.name,
+                        controllerId = event.playerId,
+                        triggerContext = TriggerContext.fromEvent(event)
+                            .copy(triggeringEntityId = entityId)
+                    )
+                )
+            }
+        }
+    }
+
+    /**
      * Detect "when this card becomes plotted" triggers on the plotted card itself (e.g.,
      * Aloe Alchemist). After the plot special action resolves the card sits face up in exile,
      * not on the battlefield, so the main index scan never sees it. This mirrors
@@ -1813,7 +1864,10 @@ class TriggerDetector(
         // exile in the same event batch has already stripped the marker.
         val container = state.getEntity(event.cardId) ?: return
         if (!container.has<MadnessExiledComponent>()) return
-        val cost = container.get<MadnessComponent>()?.cost ?: return
+        // The cost comes off the fixed alternative cost stamped alongside the marker rather than
+        // off the card's printed MadnessComponent: madness can also be *granted* (Falkenrath
+        // Gorger), and the stamped cost is the one the cast will actually charge either way.
+        val cost = container.get<PlayWithFixedAlternativeManaCostComponent>()?.fixedCost ?: return
 
         triggers.add(
             PendingTrigger(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -51,8 +51,10 @@ import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.identity.RevealedToComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
+import com.wingedsheep.engine.mechanics.MadnessGrants
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -596,21 +598,27 @@ object ZoneMovementUtils {
     }
 
     /**
-     * The card's Madness ability (CR 702.35a) when *this particular move* is the discard it
-     * replaces, or null otherwise. A hand → graveyard move is a discard by definition (CR 701.8a),
-     * so the from/to pair is the whole test.
+     * The madness cost that applies (CR 702.35a) when *this particular move* is the discard the
+     * madness replacement replaces, or null otherwise. A hand → graveyard move is a discard by
+     * definition (CR 701.8a), so the from/to pair is the whole test.
+     *
+     * The cost may be printed on the card or granted by a battlefield permanent (Falkenrath
+     * Gorger); [MadnessGrants] is the single place that decides which, so both readers here get
+     * granted madness for free.
      *
      * Single home for the predicate: [checkZoneChangeRedirect] uses it to divert the move to exile,
      * and `ZoneTransitionService.moveToZone` uses the same call to recognise the diverted move
      * afterwards and stamp the exiled card. Two readers, one rule.
      */
     fun madnessDiscardExile(
+        state: GameState,
+        entityId: EntityId,
         container: ComponentContainer,
         fromZone: Zone?,
         toZone: Zone
-    ): com.wingedsheep.engine.state.components.identity.MadnessComponent? =
+    ): ManaCost? =
         if (fromZone == Zone.HAND && toZone == Zone.GRAVEYARD) {
-            container.get<com.wingedsheep.engine.state.components.identity.MadnessComponent>()
+            MadnessGrants.effectiveMadnessCost(state, entityId, container)
         } else {
             null
         }
@@ -651,7 +659,7 @@ object ZoneMovementUtils {
         // exiles it instead of putting it into their graveyard." Card-intrinsic like the
         // self-redirect above (it functions from hand), and unqualified by cause: it applies to an
         // opponent's Mind Rot, a cycling cost, and the cleanup-step hand-size discard alike.
-        if (madnessDiscardExile(container, fromZone, toZone) != null) {
+        if (madnessDiscardExile(state, entityId, container, fromZone, toZone) != null) {
             return ZoneChangeRedirectResult(Zone.EXILE)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -747,11 +747,13 @@ object ZoneTransitionService {
         // is what the trigger detector turns into the cast offer; it is emitted after the
         // ZoneChangeEvent so the exile is already history by the time the trigger is built.
         if (!options.skipZoneChangeRedirect && actualDestZone == Zone.EXILE) {
-            val madness = ZoneMovementUtils.madnessDiscardExile(container, fromZone, destinationZone)
-            if (madness != null) {
+            val madnessCost = ZoneMovementUtils.madnessDiscardExile(
+                state, entityId, container, fromZone, destinationZone
+            )
+            if (madnessCost != null) {
                 newState = newState.updateEntity(entityId) { c ->
                     c.with(MadnessExiledComponent(ownerId))
-                        .with(PlayWithFixedAlternativeManaCostComponent(ownerId, madness.cost))
+                        .with(PlayWithFixedAlternativeManaCostComponent(ownerId, madnessCost))
                 }
                 events.add(CardExiledWithMadnessEvent(ownerId, entityId, cardComponent.name))
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/MadnessGrants.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/MadnessGrants.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.GrantsMadnessToOwnedCardsComponent
+import com.wingedsheep.engine.state.components.identity.MadnessComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Single source of truth for "does this card have madness, and at what cost?" — the mirror of
+ * [MiracleGrants] for CR 702.35.
+ *
+ * Madness is either printed on the card ([MadnessComponent], stamped from
+ * [com.wingedsheep.sdk.scripting.KeywordAbility.Madness]) or granted at runtime by a battlefield
+ * static ([com.wingedsheep.sdk.scripting.GrantMadnessToOwnedCards], i.e. Falkenrath Gorger: "Each
+ * Vampire creature card you own that isn't on the battlefield has madness. The madness cost is
+ * equal to its mana cost."). Routing the discard replacement through here makes a granted madness
+ * behave exactly like a printed one — same exile redirect, same CR 702.35a cast offer, same fixed
+ * alternative cost on the exiled card.
+ *
+ * **Known simplification.** CR 616.1 lets the affected object's controller pick which applicable
+ * replacement effect applies, and the Falkenrath Gorger rulings spell that out: a discarded Vampire
+ * card that *also* has printed madness offers a choice of which madness ability exiles it. We take
+ * the printed one without asking. Every printed madness cost on a Vampire creature card is strictly
+ * cheaper than that card's mana cost, so the un-asked choice is the one a player would make; a
+ * prompt mid-replacement is the only faithful fix and no card in the pool needs it yet.
+ */
+object MadnessGrants {
+
+    private val predicateEvaluator = PredicateEvaluator()
+
+    /**
+     * The madness cost [cardId] effectively has, or null if it has none. Printed madness on the
+     * card wins; otherwise the first matching battlefield grant applies at the card's own mana
+     * cost.
+     *
+     * [container] is the card's own component container, passed in because every caller already
+     * holds it while moving the card.
+     */
+    fun effectiveMadnessCost(
+        state: GameState,
+        cardId: EntityId,
+        container: ComponentContainer
+    ): ManaCost? {
+        container.get<MadnessComponent>()?.let { return it.cost }
+        return grantedMadnessCost(state, cardId, container)
+    }
+
+    /**
+     * The granted madness cost for [cardId] — its own mana cost, if some battlefield permanent
+     * grants madness to cards its controller owns matching the card.
+     *
+     * "That isn't on the battlefield" is the grant's own scope; a permanent is never discarded, so
+     * the check is cheap insurance rather than a live case.
+     */
+    private fun grantedMadnessCost(
+        state: GameState,
+        cardId: EntityId,
+        container: ComponentContainer
+    ): ManaCost? {
+        val card = container.get<CardComponent>() ?: return null
+        val ownerId = card.ownerId ?: return null
+        if (cardId in state.getBattlefield()) return null
+
+        // "You own" — only a grant controlled by the card's owner reaches it. Walking the owner's
+        // battlefield rather than the whole one is both the rule and the cheaper scan.
+        val context = PredicateContext(controllerId = ownerId)
+        for (permanentId in state.controlledBattlefield(ownerId)) {
+            val grant = state.getEntity(permanentId)
+                ?.get<GrantsMadnessToOwnedCardsComponent>() ?: continue
+            for (filter in grant.filters) {
+                if (predicateEvaluator.matches(state, state.projectedState, cardId, filter, context)) {
+                    return card.manaCost
+                }
+            }
+        }
+        return null
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSour
 import com.wingedsheep.engine.state.components.battlefield.SuppressesHexproofForGroupComponent
 import com.wingedsheep.engine.state.components.battlefield.SuppressesWardForGroupComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.GrantsMadnessToOwnedCardsComponent
 import com.wingedsheep.engine.state.components.identity.RoomFaceStatics
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.scripting.DoubleDamage
@@ -297,6 +298,15 @@ class StaticAbilityHandler(
             .map { it.filter }
         if (suppressHexproofFilters.isNotEmpty()) {
             result = result.with(SuppressesHexproofForGroupComponent(suppressHexproofFilters))
+        }
+
+        // Add component for "each [filter] card you own that isn't on the battlefield has madness"
+        // (Falkenrath Gorger) — read off the permanent by MadnessGrants at discard time.
+        val madnessGrantFilters = allStaticAbilities
+            .filterIsInstance<com.wingedsheep.sdk.scripting.GrantMadnessToOwnedCards>()
+            .map { it.filter }
+        if (madnessGrantFilters.isNotEmpty()) {
+            result = result.with(GrantsMadnessToOwnedCardsComponent(madnessGrantFilters))
         }
 
         // Add component for "ward abilities of creatures matching filter don't trigger"
@@ -975,6 +985,7 @@ class StaticAbilityHandler(
             is com.wingedsheep.sdk.scripting.OpponentsCantMakeYouSacrifice,
             is StationUsingToughness,
             is SuppressHexproofForGroup,
+            is com.wingedsheep.sdk.scripting.GrantMadnessToOwnedCards,
             is SuppressWardForGroup -> null
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/MadnessComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/MadnessComponents.kt
@@ -39,3 +39,19 @@ data class MadnessComponent(
 data class MadnessExiledComponent(
     val ownerId: EntityId
 ) : Component
+
+/**
+ * Battlefield permanent marker: this permanent grants madness to cards its controller owns that
+ * match one of [filters] and aren't on the battlefield, at each card's own mana cost (Falkenrath
+ * Gorger). Baked from [com.wingedsheep.sdk.scripting.GrantMadnessToOwnedCards] by
+ * [com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler].
+ *
+ * A component rather than a card-definition lookup for the same reason the ward and hexproof
+ * suppressors are: the discard-replacement check walks the battlefield with no [CardRegistry] in
+ * hand, so the grant has to be readable straight off the permanent. Read via
+ * [com.wingedsheep.engine.mechanics.MadnessGrants].
+ */
+@Serializable
+data class GrantsMadnessToOwnedCardsComponent(
+    val filters: List<com.wingedsheep.sdk.scripting.GameObjectFilter>
+) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EdgarsAwakeningScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EdgarsAwakeningScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+/**
+ * Edgar's Awakening (Innistrad: Crimson Vow #110) — {3}{B}{B} Sorcery.
+ *
+ * "Return target creature card from your graveyard to the battlefield.
+ *  When you discard this card, you may pay {B}. When you do, return target creature card from
+ *  your graveyard to your hand."
+ *
+ * The discard half is the only user of the "when you discard this card" self-bound trigger, so
+ * this file also covers that trigger shape: that it fires from the discarded card (already in the
+ * graveyard by then) rather than needing a permanent to watch for it, and that declining the
+ * optional {B} leaves the graveyard untouched.
+ */
+class EdgarsAwakeningScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && driver.state.pendingDecision == null && guard++ < 20) {
+            driver.bothPass()
+        }
+    }
+
+    /** Discard [cardId] as Tormenting Voice's additional cost. */
+    fun discardAsCost(driver: GameTestDriver, player: EntityId, cardId: EntityId) {
+        val voice = driver.putCardInHand(player, "Tormenting Voice")
+        driver.giveMana(player, Color.RED, 2)
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = voice,
+                additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(cardId)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+    }
+
+    test("cast normally it reanimates a creature card from your graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCardInGraveyard(player, "Grizzly Bears")
+        val awakening = driver.putCardInHand(player, "Edgar's Awakening")
+        driver.giveMana(player, Color.BLACK, 5)
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = awakening,
+                targets = listOf(ChosenTarget.Card(bears, player, Zone.GRAVEYARD)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.findPermanent(player, "Grizzly Bears").shouldNotBeNull()
+        driver.getGraveyard(player).shouldNotContain(bears)
+    }
+
+    test("discarding it offers {B} to return a creature card from your graveyard to your hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCardInGraveyard(player, "Grizzly Bears")
+        val awakening = driver.putCardInHand(player, "Edgar's Awakening")
+        discardAsCost(driver, player, awakening)
+
+        driver.getGraveyard(player) shouldContain awakening
+
+        // After the discard, so Tormenting Voice's own {1}{R} can't eat the black.
+        driver.giveMana(player, Color.BLACK, 1)
+        settle(driver)
+        driver.submitYesNo(player, true)
+        // The reflexive trigger picks its target only after the {B} is paid.
+        driver.submitTargetSelection(player, listOf(bears))
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.getHand(player) shouldContain bears
+        driver.getGraveyard(player).shouldNotContain(bears)
+    }
+
+    test("declining the {B} leaves the graveyard alone") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCardInGraveyard(player, "Grizzly Bears")
+        val awakening = driver.putCardInHand(player, "Edgar's Awakening")
+        discardAsCost(driver, player, awakening)
+
+        driver.giveMana(player, Color.BLACK, 1)
+        settle(driver)
+        driver.submitYesNo(player, false)
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.getGraveyard(player) shouldContain bears
+        driver.getHand(player).shouldNotContain(bears)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FalkenrathGorgerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FalkenrathGorgerScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+/**
+ * Falkenrath Gorger (Shadows over Innistrad #155) — {R} Creature — Vampire Berserker 2/1.
+ *
+ * "Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost
+ * is equal to its mana cost."
+ *
+ * The card is the only user of granted madness, so this file is also the coverage for the grant
+ * itself: that it reaches the discard replacement (exile instead of graveyard), that the cast offer
+ * is priced at the discarded card's *own* mana cost, that it is scoped to Vampires, and that a
+ * printed madness cost still wins when a card has both.
+ */
+class FalkenrathGorgerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && driver.state.pendingDecision == null && guard++ < 20) {
+            driver.bothPass()
+        }
+    }
+
+    /** Discard [cardId] as Tormenting Voice's additional cost. */
+    fun discardAsCost(driver: GameTestDriver, player: EntityId, cardId: EntityId) {
+        val voice = driver.putCardInHand(player, "Tormenting Voice")
+        driver.giveMana(player, Color.RED, 2)
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = voice,
+                additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(cardId)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+    }
+
+    test("a discarded Vampire creature card is exiled and castable for its own mana cost") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Falkenrath Gorger")
+        val nighthawk = driver.putCardInHand(player, "Vampire Nighthawk")
+        discardAsCost(driver, player, nighthawk)
+
+        driver.getExile(player) shouldContain nighthawk
+        driver.getGraveyard(player).shouldNotContain(nighthawk)
+
+        // Vampire Nighthawk's mana cost is {1}{B}{B} — exactly what the granted madness charges.
+        driver.giveMana(player, Color.BLACK, 3)
+        settle(driver)
+        driver.submitYesNo(player, true)
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.findPermanent(player, "Vampire Nighthawk").shouldNotBeNull()
+        driver.getExile(player).shouldNotContain(nighthawk)
+    }
+
+    test("without the Gorger on the battlefield the same discard goes to the graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val nighthawk = driver.putCardInHand(player, "Vampire Nighthawk")
+        discardAsCost(driver, player, nighthawk)
+
+        driver.getGraveyard(player) shouldContain nighthawk
+        driver.getExile(player).shouldNotContain(nighthawk)
+    }
+
+    test("the grant is scoped to Vampires — a discarded Bear still hits the graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Falkenrath Gorger")
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+        discardAsCost(driver, player, bears)
+
+        driver.getGraveyard(player) shouldContain bears
+        driver.getExile(player).shouldNotContain(bears)
+    }
+
+    test("a discarded Gorger gets no madness from itself") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gorger = driver.putCardInHand(player, "Falkenrath Gorger")
+        discardAsCost(driver, player, gorger)
+
+        driver.getGraveyard(player) shouldContain gorger
+        driver.getExile(player).shouldNotContain(gorger)
+    }
+
+    test("printed madness wins over the grant — Bloodmad Vampire still costs {1}{R}, not {2}{R}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Falkenrath Gorger")
+        val vampire = driver.putCardInHand(player, "Bloodmad Vampire")
+        discardAsCost(driver, player, vampire)
+
+        driver.getExile(player) shouldContain vampire
+
+        // Exactly two red — enough for the printed madness cost {1}{R} and one short of the
+        // {2}{R} the grant would have charged.
+        driver.giveMana(player, Color.RED, 2)
+        settle(driver)
+        driver.submitYesNo(player, true)
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.findPermanent(player, "Bloodmad Vampire").shouldNotBeNull()
+        driver.getExile(player).shouldNotContain(vampire)
+    }
+})


### PR DESCRIPTION
Innistrad Remastered's remaining tail is almost entirely blocked on unsupported mechanics — emerge (6 cards), disturb (4), soulbond (2), escalate, splice, battles, and the planeswalker/Emrakul complexities. These three were the reachable ones, so it's a small handful rather than a big one.

Each canonical `CardDefinition` lands in the card's **earliest real printing**, with `Printing(...)` rows in INR (and in VOC, which is also scaffolded here).

## Cards

### Stromkirk Occultist → EMN #146, reprint rows in VOC + INR
Trample; combat-damage impulse draw; madness {1}{R}. Pure composition over `Patterns.Exile.impulse` — no engine change.

### Falkenrath Gorger → SOI #155, reprint rows in VOC + INR
> Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its mana cost.

The first card that *grants* madness, which `Madness.kt` was already designed to anticipate:

- **SDK** — `GrantMadnessToOwnedCards(filter)`. No cost field: "equal to its mana cost" is the only printed shape, so the cost is derived per card.
- **Engine** — `StaticAbilityHandler` bakes it into a `GrantsMadnessToOwnedCardsComponent` on the permanent (the discard replacement walks the battlefield with no `CardRegistry` in hand), and a new `MadnessGrants.effectiveMadnessCost` — the mirror of `MiracleGrants` — becomes the single source of truth `ZoneMovementUtils.madnessDiscardExile` consults. Printed madness wins; otherwise the first matching grant controlled by the card's **owner**.
- Everything downstream is shared with printed madness. `detectMadnessCastTriggers` now reads its cost off the stamped `PlayWithFixedAlternativeManaCostComponent` instead of the printed keyword, so granted and printed madness travel one path — and the offer survives the granter leaving the battlefield, per the Oracle ruling.

**Known simplification, disclosed in code and in the docs:** CR 616.1 lets the affected object's controller choose among applicable replacement effects, so a discarded Vampire that *also* has printed madness should be offered a choice of which madness exiles it. We take the printed one without asking. Every printed madness cost on a Vampire creature card is cheaper than that card's mana cost, so the un-asked choice is the one a player would make; a prompt mid-replacement is the only faithful fix and no card in the pool needs it yet.

### Edgar's Awakening → VOW #110, reprint row in INR
Reanimation, plus "When you discard this card, you may pay {B}. When you do, return target creature card from your graveyard to your hand."

- **SDK** — `Triggers.YouDiscardThis`, the self-bound counterpart to `YouDiscard`.
- **Engine** — `TriggerDetector.detectSelfDiscardTriggers`, the sibling of the cycling pass: the ability functions in hand but the card is already in the graveyard (or exile, if it also had madness) when the event fires, so the index scan never sees it. Only `TriggerBinding.SELF` discard triggers are claimed here — `ANY`-bound observers stay with the battlefield pass, so nothing fires twice.
- The "when you do" half is a real `ReflexiveTriggerEffect` over a `PayManaCostEffect`, so the payment happens first and the target is chosen when the reflexive ability goes on the stack.

## Tests
- `FalkenrathGorgerScenarioTest` — 5 tests: the exile redirect, the cast at the card's own mana cost, the grant being scoped to Vampires, a discarded Gorger not granting itself madness, and printed madness winning (Bloodmad Vampire cast with exactly two red — one short of what the grant would charge).
- `EdgarsAwakeningScenarioTest` — 3 tests: normal reanimation, the discard trigger paying {B} and returning a creature card, and declining leaving the graveyard alone.
- Stromkirk Occultist is pure composition, so it rides the snapshot and lint nets.

## Verification
`just build`, `just test` (full suite), `just rebless-cards` (only the three new cards moved in EMN/SOI/VOW goldens), and `just check-card-printing` clean for all three. Every image URI returns HTTP 200. INR goes 267 → 270 of 290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)