### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/backlog/sets/the-hobbit/cards.md
+++ b/backlog/sets/the-hobbit/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 193 cards revealed as of 2026-08-04
 **Release Date:** August 14, 2026
-**Implemented:** 56 / 193
+**Implemented:** 61 / 193
 Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. This list covers only cards revealed as of that date.
 
 - [x] 1. Long-Bodied Grey Dog
@@ -101,7 +101,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [x] 94. Dori, Bearer of Friends
 - [ ] 95. Dwarven Mauler
 - [ ] 96. Gandalf, Goblins' Bane
-- [ ] 97. Gandalf, Spark Starter
+- [x] 97. Gandalf, Spark Starter
 - [ ] 98. Getaway Barrel
 - [ ] 99. Glóin the Mighty
 - [ ] 100. Goblin-town Flunkies
@@ -114,7 +114,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 107. Pinecone Strike
 - [x] 108. Ragged Short Spear
 - [ ] 109. Smaug, the Great Calamity
-- [ ] 110. Smaug the Magnificent
+- [x] 110. Smaug the Magnificent
 - [x] 111. Smaug's Fury
 - [ ] 112. Snowslope Hunter
 - [ ] 113. Stone-Giant of High Pass
@@ -141,7 +141,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 134. Part in Friendship
 - [x] 135. Quarrel
 - [ ] 136. Radagast of Rhosgobel
-- [ ] 137. Through the Forest Gate
+- [x] 137. Through the Forest Gate
 - [x] 138. Troll Negotiations
 - [x] 139. Warg Tactics
 - [x] 140. Wargling
@@ -154,10 +154,10 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 147. Bifur, Melodic Rider
 - [ ] 148. Bolg of the North
 - [ ] 149. Bolg's Company
-- [ ] 150. The Chief Warg
+- [x] 150. The Chief Warg
 - [ ] 151. Chief Warg's Company
 - [ ] 152. Dáin's Company
-- [ ] 153. Duskwatch Hunter
+- [x] 153. Duskwatch Hunter
 - [ ] 154. Dwalin, Weaponmaster
 - [ ] 155. Eagle's Rescue
 - [x] 156. Fearsome Goblin Pair

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DuskwatchHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DuskwatchHunter.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Duskwatch Hunter — The Hobbit #153
+ * {2}{B/G} · Creature — Wolf · Common
+ * 3/1
+ *
+ * This creature can't be blocked by tokens.
+ * When this creature enters, put a +1/+1 counter on target creature.
+ *
+ * Modeling notes:
+ *  - "Can't be blocked by tokens" narrows to creature tokens in practice — only creatures block —
+ *    so the evasion is `CantBeBlockedBy(Creature.token())`.
+ *  - The ETB counter targets *any* creature, including Duskwatch Hunter itself (making it a 4/2)
+ *    and creatures an opponent controls; it is not optional, so a legal target must be chosen if
+ *    one exists.
+ */
+val DuskwatchHunter = card("Duskwatch Hunter") {
+    manaCost = "{2}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Wolf"
+    power = 3
+    toughness = 1
+    oracleText = "This creature can't be blocked by tokens.\n" +
+        "When this creature enters, put a +1/+1 counter on target creature."
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.token())
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetCreature()
+        effect = Effects.AddCounters("+1/+1", 1, EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Samuele Bandini"
+        flavorText = "Packs of evil wolves lived under the shadow of the Goblin-infested mountains, " +
+            "over the Edge of the Wild on the borders of the unknown."
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/3685c783-d837-4466-a960-ab3098db64c3.jpg?1785323286"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GandalfSparkStarter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GandalfSparkStarter.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Gandalf, Spark Starter — The Hobbit #97
+ * {4}{R}{R} · Legendary Creature — Avatar Wizard · Uncommon
+ * 4/3
+ *
+ * Reach
+ * When Gandalf enters, he deals 3 damage divided as you choose among one, two, or three targets.
+ *
+ * Modeling notes:
+ *  - The division is announced as the trigger goes on the stack, alongside the targets — that's
+ *    what [AnyTarget] (one to three) plus [DividedDamageEffect] models (cf. Twin Bolt, Arc
+ *    Lightning). Each chosen target must be assigned at least 1 damage, so three targets means
+ *    exactly 1 each.
+ *  - "Any target" is creature / player / planeswalker / battle, not just creatures.
+ */
+val GandalfSparkStarter = card("Gandalf, Spark Starter") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 4
+    toughness = 3
+    oracleText = "Reach\n" +
+        "When Gandalf enters, he deals 3 damage divided as you choose among one, two, or three targets."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = AnyTarget(count = 3, minCount = 1)
+        effect = DividedDamageEffect(
+            totalDamage = 3,
+            minTargets = 1,
+            maxTargets = 3
+        )
+        description = "When Gandalf, Spark Starter enters, he deals 3 damage divided as you choose " +
+            "among one, two, or three targets."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "97"
+        artist = "Javier Charro"
+        flavorText = "Gandalf thought of most things; and though he could not do everything, he could " +
+            "do a great deal for friends in a tight corner."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c5c6f1c-35cf-4172-b5a1-b73222b0723b.jpg?1784895032"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SmaugTheMagnificent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SmaugTheMagnificent.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Smaug the Magnificent — The Hobbit #110
+ * {2}{R}{R} · Legendary Creature — Dragon · Mythic
+ * 4/3
+ *
+ * Flying, haste
+ * Whenever Smaug attacks, he deals damage equal to the number of Treasures you control to any target.
+ * At the beginning of your upkeep, create a Treasure token.
+ *
+ * Modeling notes:
+ *  - The attack trigger targets when it goes on the stack, but the Treasure count is read at
+ *    resolution — sacrificing Treasures for mana in response shrinks the damage, and it can be
+ *    zero (the ability still resolves and deals no damage).
+ *  - Treasures are counted by subtype rather than by name, so a Treasure token from any source
+ *    (and any nontoken Treasure artifact) counts.
+ */
+val SmaugTheMagnificent = card("Smaug the Magnificent") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dragon"
+    power = 4
+    toughness = 3
+    oracleText = "Flying, haste\n" +
+        "Whenever Smaug attacks, he deals damage equal to the number of Treasures you control to any target.\n" +
+        "At the beginning of your upkeep, create a Treasure token."
+
+    keywords(Keyword.FLYING, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        target = AnyTarget()
+        effect = Effects.DealDamage(
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Artifact.withSubtype(Subtype.TREASURE)
+            ).count(),
+            EffectTarget.ContextTarget(0)
+        )
+        description = "Whenever Smaug the Magnificent attacks, he deals damage equal to the number " +
+            "of Treasures you control to any target."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.CreateTreasure()
+        description = "At the beginning of your upkeep, create a Treasure token."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "110"
+        artist = "Francisco Miyara"
+        flavorText = "\"You think you will get a fair share? If you get off alive, you will be lucky.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a5d8fad-2ffd-4645-8c49-907999b6cecf.jpg?1783902784"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheChiefWarg.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheChiefWarg.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Chief Warg — The Hobbit #150
+ * {2}{B}{G} · Legendary Creature — Wolf · Uncommon
+ * 3/3
+ *
+ * Menace
+ * Ferocious — Whenever you attack while you control a creature with power 4 or greater,
+ * you draw a card and lose 1 life.
+ *
+ * Modeling notes:
+ *  - "Whenever you attack" is the once-per-combat group trigger ([Triggers.YouAttack]) — it fires
+ *    once no matter how many creatures attack, and it does not require The Chief Warg itself to be
+ *    among the attackers.
+ *  - The "while you control a creature with power 4 or greater" clause is an intervening-if style
+ *    condition checked when the trigger would fire (and again on resolution), which is what
+ *    `triggerCondition` models. The Chief Warg is 3/3, so it never satisfies this on its own.
+ */
+val TheChiefWarg = card("The Chief Warg") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Wolf"
+    power = 3
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Ferocious — Whenever you attack while you control a creature with power 4 or greater, " +
+        "you draw a card and lose 1 life."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Effects.LoseLife(1, EffectTarget.Controller)
+        )
+        description = "Ferocious — Whenever you attack while you control a creature with power 4 or " +
+            "greater, you draw a card and lose 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "150"
+        artist = "Tomas Duchek"
+        flavorText = "Even magic rings were not much use against wolves—especially against the evil " +
+            "packs that lived near Goblin-infested mountains."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c397a298-bf7f-49d7-a26a-206ccf9e8120.jpg?1784377030"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThroughTheForestGate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThroughTheForestGate.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Through the Forest Gate — The Hobbit #137
+ * {6}{G}{G} · Sorcery · Rare
+ *
+ * Look at the top twenty cards of your library, put any number of land cards from among them
+ * onto the battlefield tapped, then shuffle. You gain 8 life.
+ *
+ * Modeling notes:
+ *  - Built from the atomic Gather → Select → Move pipeline (cf. Choco, Seeker of Paradise).
+ *    "Look at" is a private gather (`revealed = false`), which leaves the cards in the library —
+ *    only the ones selected are moved out, so the trailing shuffle naturally scrambles the
+ *    seventeen-or-so cards the player looked at but declined.
+ *  - The land pick is a `ChooseAnyNumber` filtered to lands with `showAllCards = true`, so the
+ *    player sees all twenty looked-at cards but can only pick the lands ("any number" includes
+ *    zero — declining is legal).
+ *  - A library holding fewer than twenty cards simply yields what's there; an empty library
+ *    yields nothing and the spell still shuffles and gains 8 life.
+ */
+val ThroughTheForestGate = card("Through the Forest Gate") {
+    manaCost = "{6}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top twenty cards of your library, put any number of land cards from " +
+        "among them onto the battlefield tapped, then shuffle. You gain 8 life."
+
+    spell {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(20), player = Player.You),
+                storeAs = "looked"
+            ),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseAnyNumber,
+                filter = GameObjectFilter.Land,
+                showAllCards = true,
+                storeSelected = "toBattlefield",
+                prompt = "Put any number of land cards onto the battlefield tapped",
+                selectedLabel = "Onto the battlefield tapped",
+                remainderLabel = "Leave in your library"
+            ),
+            MoveCollectionEffect(
+                from = "toBattlefield",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You, ZonePlacement.Tapped)
+            ),
+            ShuffleLibraryEffect(),
+            Effects.GainLife(8)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "137"
+        artist = "Leon Tukker"
+        flavorText = "\"Well, here is Mirkwood—the greatest of the forests of the northern world. " +
+            "I hope you like the look of it.\"\n—Gandalf"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/880adfc8-69cf-4062-a804-e65b6cb6056d.jpg?1784895046"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -346,6 +346,65 @@
     ]
 }
 
+// Duskwatch Hunter
+{
+    "name": "Duskwatch Hunter",
+    "manaCost": "{2}{B/G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "This creature can't be blocked by tokens.\nWhen this creature enters, put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        "IsToken"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Samuele Bandini",
+        "flavorText": "Packs of evil wolves lived under the shadow of the Goblin-infested mountains, over the Edge of the Wild on the borders of the unknown.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/3685c783-d837-4466-a960-ab3098db64c3.jpg?1785323286"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Dwarven Provisioner
 {
     "name": "Dwarven Provisioner",
@@ -803,6 +862,52 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Gandalf, Spark Starter
+{
+    "name": "Gandalf, Spark Starter",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Legendary Creature — Avatar Wizard",
+    "oracleText": "Reach\nWhen Gandalf enters, he deals 3 damage divided as you choose among one, two, or three targets.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DividedDamage",
+                    "totalDamage": 3
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "count": 3,
+                    "minCount": 1
+                },
+                "descriptionOverride": "When Gandalf, Spark Starter enters, he deals 3 damage divided as you choose among one, two, or three targets."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "UNCOMMON",
+        "artist": "Javier Charro",
+        "flavorText": "Gandalf thought of most things; and though he could not do everything, he could do a great deal for friends in a tight corner.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c5c6f1c-35cf-4172-b5a1-b73222b0723b.jpg?1784895032"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2228,6 +2333,67 @@
     ]
 }
 
+// Smaug the Magnificent
+{
+    "name": "Smaug the Magnificent",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Legendary Creature — Dragon",
+    "oracleText": "Flying, haste\nWhenever Smaug attacks, he deals damage equal to the number of Treasures you control to any target.\nAt the beginning of your upkeep, create a Treasure token.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact Treasure"
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": "AnyTarget",
+                "descriptionOverride": "Whenever Smaug the Magnificent attacks, he deals damage equal to the number of Treasures you control to any target."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, create a Treasure token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "MYTHIC",
+        "artist": "Francisco Miyara",
+        "flavorText": "\"You think you will get a fair share? If you get off alive, you will be lucky.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a5d8fad-2ffd-4645-8c49-907999b6cecf.jpg?1783902784"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Smaug's Fury
 {
     "name": "Smaug's Fury",
@@ -2365,6 +2531,68 @@
     ]
 }
 
+// The Chief Warg
+{
+    "name": "The Chief Warg",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Legendary Creature — Wolf",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nFerocious — Whenever you attack while you control a creature with power 4 or greater, you draw a card and lose 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                },
+                "descriptionOverride": "Ferocious — Whenever you attack while you control a creature with power 4 or greater, you draw a card and lose 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "UNCOMMON",
+        "artist": "Tomas Duchek",
+        "flavorText": "Even magic rings were not much use against wolves—especially against the evil packs that lived near Goblin-infested mountains.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c397a298-bf7f-49d7-a26a-206ccf9e8120.jpg?1784377030"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Thorin's Last Stand
 {
     "name": "Thorin's Last Stand",
@@ -2443,6 +2671,70 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Through the Forest Gate
+{
+    "name": "Through the Forest Gate",
+    "manaCost": "{6}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top twenty cards of your library, put any number of land cards from among them onto the battlefield tapped, then shuffle. You gain 8 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 20
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": "ChooseAnyNumber",
+                    "filter": "land",
+                    "storeSelected": "toBattlefield",
+                    "prompt": "Put any number of land cards onto the battlefield tapped",
+                    "selectedLabel": "Onto the battlefield tapped",
+                    "remainderLabel": "Leave in your library",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toBattlefield",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                },
+                "ShuffleLibrary",
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "RARE",
+        "artist": "Leon Tukker",
+        "flavorText": "\"Well, here is Mirkwood—the greatest of the forests of the northern world. I hope you like the look of it.\"\n—Gandalf",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/880adfc8-69cf-4062-a804-e65b6cb6056d.jpg?1784895046"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DuskwatchHunterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DuskwatchHunterScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Duskwatch Hunter (HOB) — {2}{B/G} Creature — Wolf 3/1.
+ *
+ * "This creature can't be blocked by tokens.
+ *  When this creature enters, put a +1/+1 counter on target creature."
+ *
+ * The evasion has to distinguish a token blocker from an otherwise identical nontoken one, and the
+ * ETB counter is a real counter on any creature — the Hunter itself included.
+ */
+class DuskwatchHunterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Duskwatch Hunter") {
+
+            test("its ETB puts a +1/+1 counter on a chosen creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Duskwatch Hunter")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.castSpell(1, "Duskwatch Hunter").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+                game.selectTargets(listOf(courser)).error shouldBe null
+                game.resolveStack()
+
+                withClue("a permanent +1/+1 counter, not a temporary pump") {
+                    game.state.getEntity(courser)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                    game.state.projectedState.getPower(courser) shouldBe 4
+                    game.state.projectedState.getToughness(courser) shouldBe 4
+                }
+            }
+
+            test("the ETB may target the Hunter itself, making it a 4/2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Duskwatch Hunter")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Duskwatch Hunter").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val hunter = game.findPermanent("Duskwatch Hunter")!!
+                (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+                game.selectTargets(listOf(hunter)).error shouldBe null
+                game.resolveStack()
+
+                game.state.projectedState.getPower(hunter) shouldBe 4
+                game.state.projectedState.getToughness(hunter) shouldBe 2
+            }
+
+            test("a token can't block it, but the same creature as a nontoken can") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Duskwatch Hunter")
+                    .withCardOnBattlefield(2, "Grizzly Bears", isToken = true)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Duskwatch Hunter" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("the Bears is a token, so it can't block the Hunter") {
+                    game.declareBlockers(mapOf("Grizzly Bears" to listOf("Duskwatch Hunter")))
+                        .error shouldNotBe null
+                }
+                withClue("a nontoken creature blocks it just fine") {
+                    game.declareBlockers(mapOf("Centaur Courser" to listOf("Duskwatch Hunter")))
+                        .error shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfSparkStarterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfSparkStarterScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DistributeDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gandalf, Spark Starter (HOB) — {4}{R}{R} Legendary Creature — Avatar Wizard 4/3.
+ *
+ * "Reach
+ *  When Gandalf enters, he deals 3 damage divided as you choose among one, two, or three targets."
+ *
+ * The division is announced with the targets as the trigger goes on the stack. "Any target" must
+ * reach players as well as creatures, and every chosen target has to receive at least 1 damage.
+ */
+class GandalfSparkStarterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Gandalf, Spark Starter") {
+
+            test("it is a 4/3 with reach") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gandalf, Spark Starter")
+                    .build()
+
+                val gandalf = game.findPermanent("Gandalf, Spark Starter")!!
+                game.state.projectedState.getPower(gandalf) shouldBe 4
+                game.state.projectedState.getToughness(gandalf) shouldBe 3
+                game.state.projectedState.hasKeyword(gandalf, Keyword.REACH) shouldBe true
+            }
+
+            test("the ETB splits 3 damage across two chosen creatures") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gandalf, Spark Starter")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.castSpell(1, "Gandalf, Spark Starter").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the ETB trigger asks for its targets") {
+                    (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+                }
+                game.selectTargets(listOf(bears, courser)).error shouldBe null
+
+                val distribute = game.getPendingDecision()
+                withClue("then the 3 damage is divided among them") {
+                    (distribute is DistributeDecision) shouldBe true
+                    (distribute as DistributeDecision).totalAmount shouldBe 3
+                }
+                game.submitDistribution(mapOf(bears to 2, courser to 1)).error shouldBe null
+                game.resolveStack()
+
+                withClue("2 damage is lethal to a 2/2") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("1 damage does not kill a 3/3") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe true
+                }
+            }
+
+            test("all 3 damage can go to a single target, including a player") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gandalf, Spark Starter")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gandalf, Spark Starter").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+                game.selectTargets(listOf(game.player2Id)).error shouldBe null
+
+                val distribute = game.getPendingDecision()
+                if (distribute is DistributeDecision) {
+                    game.submitDistribution(mapOf(game.player2Id to 3)).error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("'any target' includes a player") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmaugTheMagnificentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmaugTheMagnificentScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Smaug the Magnificent (HOB) — {2}{R}{R} Legendary Creature — Dragon 4/3.
+ *
+ * "Flying, haste
+ *  Whenever Smaug attacks, he deals damage equal to the number of Treasures you control to any target.
+ *  At the beginning of your upkeep, create a Treasure token."
+ *
+ * The attack trigger's amount is read at *resolution*, so it scales with the Treasures on board then
+ * — including zero, where the ability still resolves and deals nothing.
+ */
+class SmaugTheMagnificentScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Smaug the Magnificent") {
+
+            test("it is a 4/3 with flying and haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Smaug the Magnificent")
+                    .build()
+
+                val smaug = game.findPermanent("Smaug the Magnificent")!!
+                game.state.projectedState.getPower(smaug) shouldBe 4
+                game.state.projectedState.getToughness(smaug) shouldBe 3
+                game.state.projectedState.hasKeyword(smaug, Keyword.FLYING) shouldBe true
+                game.state.projectedState.hasKeyword(smaug, Keyword.HASTE) shouldBe true
+            }
+
+            test("attacking deals damage equal to the Treasures you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Smaug the Magnificent")
+                    .withCardOnBattlefield(1, "Treasure", isToken = true)
+                    .withCardOnBattlefield(1, "Treasure", isToken = true)
+                    .withCardOnBattlefield(1, "Treasure", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Smaug the Magnificent" to 2)).error shouldBe null
+
+                withClue("the attack trigger asks for its target") {
+                    (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+                }
+                game.selectTargets(listOf(game.player2Id)).error shouldBe null
+                game.resolveStack()
+
+                withClue("three Treasures → 3 damage, before combat damage is even dealt") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+            }
+
+            test("with no Treasures the trigger still resolves and deals nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Smaug the Magnificent")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Smaug the Magnificent" to 2)).error shouldBe null
+
+                (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+                game.selectTargets(listOf(game.player2Id)).error shouldBe null
+                game.resolveStack()
+
+                game.getLifeTotal(2) shouldBe 20
+            }
+
+            test("the upkeep trigger creates a Treasure token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Smaug the Magnificent")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    // Sit in the opponent's turn so the next upkeep reached is Player 1's.
+                    .withActivePlayer(2)
+                    .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                    .build()
+
+                game.findAllPermanents("Treasure").size shouldBe 0
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.state.activePlayerId shouldBe game.player1Id
+                game.resolveStack()
+
+                withClue("Smaug hoards one Treasure per upkeep") {
+                    game.findAllPermanents("Treasure").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheChiefWargScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheChiefWargScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Chief Warg (HOB) — {2}{B}{G} Legendary Creature — Wolf 3/3.
+ *
+ * "Menace
+ *  Ferocious — Whenever you attack while you control a creature with power 4 or greater,
+ *  you draw a card and lose 1 life."
+ *
+ * Two things to pin down: the trigger is the "whenever you attack" *group* trigger — it fires once
+ * per combat and does not require the Warg itself to attack — and the ferocious clause gates it.
+ * The Chief Warg is a 3/3, so it never turns its own trigger on.
+ */
+class TheChiefWargScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Chief Warg") {
+
+            test("it is a 3/3 with menace") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Chief Warg")
+                    .build()
+
+                val warg = game.findPermanent("The Chief Warg")!!
+                game.state.projectedState.getPower(warg) shouldBe 3
+                game.state.projectedState.getToughness(warg) shouldBe 3
+                game.state.projectedState.hasKeyword(warg, Keyword.MENACE) shouldBe true
+            }
+
+            test("attacking with a power-4 creature on board draws a card and loses 1 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Chief Warg")
+                    // Serra Angel is a 4/4 — it turns ferocious on.
+                    .withCardOnBattlefield(1, "Serra Angel")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("The Chief Warg" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("ferocious is satisfied by the 4/4 sitting at home") {
+                    game.handSize(1) shouldBe handBefore + 1
+                    game.getLifeTotal(1) shouldBe 19
+                }
+            }
+
+            test("it fires once per combat, not once per attacker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Chief Warg")
+                    .withCardOnBattlefield(1, "Serra Angel")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("The Chief Warg" to 2, "Serra Angel" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("two attackers, still exactly one card drawn and 1 life lost") {
+                    game.handSize(1) shouldBe handBefore + 1
+                    game.getLifeTotal(1) shouldBe 19
+                }
+            }
+
+            test("without a power-4 creature the trigger does not fire") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Chief Warg")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("The Chief Warg" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("The Chief Warg's own 3 power doesn't satisfy ferocious") {
+                    game.handSize(1) shouldBe handBefore
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("it does not need to attack itself — another creature swinging is enough") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Chief Warg")
+                    .withCardOnBattlefield(1, "Serra Angel")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Serra Angel" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("'whenever you attack' doesn't care which creatures attacked") {
+                    game.handSize(1) shouldBe handBefore + 1
+                    game.getLifeTotal(1) shouldBe 19
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThroughTheForestGateScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThroughTheForestGateScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+/**
+ * Through the Forest Gate (HOB) — {6}{G}{G} Sorcery.
+ *
+ * "Look at the top twenty cards of your library, put any number of land cards from among them
+ *  onto the battlefield tapped, then shuffle. You gain 8 life."
+ *
+ * The points worth pinning: only land cards are selectable (nonlands are shown but not eligible),
+ * "any number" allows zero, the lands arrive *tapped*, the cards left behind stay in the library
+ * rather than going to the graveyard, and the 8 life is gained either way.
+ */
+class ThroughTheForestGateScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Through the Forest Gate") {
+
+            test("puts any number of the looked-at lands onto the battlefield tapped and gains 8 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Through the Forest Gate")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val librarySizeBefore = game.librarySize(1)
+                game.castSpell(1, "Through the Forest Gate").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("the land pick is a card selection over the looked-at cards") {
+                    (decision is SelectCardsDecision) shouldBe true
+                }
+                val options = (decision as SelectCardsDecision).options
+                withClue("only land cards are selectable — the Centaur Courser is not") {
+                    options.map { game.state.getEntity(it)?.get<CardComponent>()?.name }
+                        .shouldContainExactlyInAnyOrder("Forest", "Mountain")
+                }
+                withClue("'any number' means no card has to be chosen") {
+                    decision.minSelections shouldBe 0
+                }
+
+                game.selectCards(options).error shouldBe null
+                game.resolveStack()
+
+                withClue("both lands entered, and they entered tapped") {
+                    val forests = game.findAllPermanents("Forest")
+                    forests.size shouldBe 9
+                    val mountain = game.findPermanent("Mountain")!!
+                    game.state.getEntity(mountain)?.get<TappedComponent>() shouldBe TappedComponent
+                }
+                withClue("the nonland card stayed in the library — nothing is milled") {
+                    game.librarySize(1) shouldBe librarySizeBefore - 2
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe false
+                    game.findCardsInLibrary(1, "Centaur Courser").size shouldBe 1
+                }
+                withClue("8 life gained") {
+                    game.getLifeTotal(1) shouldBe 28
+                }
+            }
+
+            test("choosing no lands still shuffles and gains 8 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Through the Forest Gate")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val librarySizeBefore = game.librarySize(1)
+                game.castSpell(1, "Through the Forest Gate").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                (game.getPendingDecision() is SelectCardsDecision) shouldBe true
+                game.selectCards(emptyList()).error shouldBe null
+                game.resolveStack()
+
+                withClue("declining every land leaves the library untouched") {
+                    game.librarySize(1) shouldBe librarySizeBefore
+                    game.findAllPermanents("Forest").size shouldBe 8
+                }
+                withClue("the life gain is not conditional on putting lands in") {
+                    game.getLifeTotal(1) shouldBe 28
+                }
+            }
+
+            test("a library smaller than twenty cards simply offers what is there") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Through the Forest Gate")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Through the Forest Gate").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                decision.options.size shouldBe 1
+                game.selectCards(decision.options).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Mountain") shouldBe true
+                game.librarySize(1) shouldBe 0
+                game.getLifeTotal(1) shouldBe 28
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five cards from The Hobbit (HOB), picked so none of them needs a mechanic the engine doesn't have yet — the set's remaining tail is mostly gated on `recruit`, `amass`, `storied`, and hone counters, which are `add-feature` work rather than `add-card` work.

All five are built from existing SDK primitives. **No new SDK vocabulary**, so `docs/card-sdk-language-reference.md` is unchanged.

| Card | Cost | Shape |
|---|---|---|
| Through the Forest Gate | `{6}{G}{G}` | Look at top 20, put any number of lands onto the battlefield tapped, shuffle, gain 8 life |
| Gandalf, Spark Starter | `{4}{R}{R}` | Reach; ETB 3 damage divided among one, two, or three targets |
| The Chief Warg | `{2}{B}{G}` | Menace; ferocious "whenever you attack" draw-a-card / lose-1-life |
| Duskwatch Hunter | `{2}{B/G}` | Can't be blocked by tokens; ETB +1/+1 counter on target creature |
| Smaug the Magnificent | `{2}{R}{R}` | Flying, haste; attack trigger damage = Treasures you control; upkeep Treasure |

## Modeling notes

- **Through the Forest Gate** uses the atomic Gather → Select → Move pipeline (same shape as Choco, Seeker of Paradise). The "look at" is a *private* gather, which leaves the cards in the library — only the selected lands are moved out, so the trailing `ShuffleLibraryEffect` naturally scrambles the ones the player declined instead of milling them. The land pick is a `ChooseAnyNumber` filtered to lands with `showAllCards = true`, so all twenty are visible but only lands are eligible, and zero is a legal answer.
- **Gandalf** puts the division on the stack with the targets (`AnyTarget(count = 3, minCount = 1)` + `DividedDamageEffect`), so each chosen target gets at least 1. "Any target" reaches players, not just creatures.
- **The Chief Warg** uses `Triggers.YouAttack` — the once-per-combat *group* trigger. It fires whether or not the Warg itself attacks, and the Warg's own 3 power never satisfies its ferocious clause.
- **Smaug**'s damage amount is read at resolution, so sacrificing Treasures for mana in response shrinks it, down to and including zero.

## Player experience

Only two decision shapes appear, both on existing components: battlefield targeting (`ChooseTargetsUI`) for the three targeted abilities, and the card-selection overlay (`CardSelectionDecisionUI`) plus the damage-division modal for Gandalf. Through the Forest Gate's twenty-card overlay is the same scale Thunderous Debut already produces; `calculateFittingCardWidth` clamps the card width and `.cardContainer` wraps, so it lays out without horizontal overflow. No new UI work.

## Verification

- `just build` — green.
- One scenario test file per card, 18 tests total, all passing:
  - `ThroughTheForestGateScenarioTest` (3) — land-only eligibility, zero-selection, library smaller than twenty
  - `GandalfSparkStarterScenarioTest` (3) — 2/1 split kills the 2/2 and spares the 3/3, all 3 to a player's face
  - `TheChiefWargScenarioTest` (5) — fires once per combat not once per attacker, doesn't need the Warg to attack, silent without a power-4 creature
  - `DuskwatchHunterScenarioTest` (3) — a token blocker is rejected while an otherwise identical nontoken blocks fine
  - `SmaugTheMagnificentScenarioTest` (4) — damage scales with Treasures, resolves harmlessly at zero, upkeep Treasure
- `just rebless-cards` — only these five cards moved in `HOB.json`.
- `just check-card-printing` — clean for all five (HOB is each card's only real printing).
- Every field re-checked against Scryfall (mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavor, image URI); all image URIs return HTTP 200.
- Backlog ticked and resynced: The Hobbit is now 61/193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)