### PR TITLE
Add Tamiyo, Field Researcher (INR tail) with delayed-trigger and emblem-static support

### DIFF
--- a/backlog/sets/bloomburrow-commander/cards.md
+++ b/backlog/sets/bloomburrow-commander/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 312 cards
 **Release Date:** August 2, 2024
-**Implemented:** 113 / 312
+**Implemented:** 114 / 312
 | Color      | Total | Done |
 |------------|-------|------|
 | White      | 37    | 0    |
@@ -281,7 +281,7 @@
 - [ ] Tainted Wood
 - [x] Talisman of Impulse
 - [ ] Talisman of Resilience
-- [ ] Tamiyo, Field Researcher
+- [x] Tamiyo, Field Researcher
 - [ ] Tear Asunder
 - [ ] Teferi, Time Raveler
 - [x] Temple of Abandon

--- a/backlog/sets/bloomburrow-commander/decks/peace-offering.md
+++ b/backlog/sets/bloomburrow-commander/decks/peace-offering.md
@@ -39,7 +39,7 @@
 
 ## Planeswalkers (1)
 
-- [ ] 1 Tamiyo, Field Researcher
+- [x] 1 Tamiyo, Field Researcher
 
 ## Instants (11)
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1394,7 +1394,8 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   Aetherdrift's "3/2 colorless Vehicle artifact token with crew 1" (Mu Yanling, Wind Rider). A *noncreature*
   artifact carrying printed P/T and the ordinary `crew 1` keyword, defined on the predefined `Vehicle`
   `CardDefinition`, so it can't attack or block until something crews it and it crews through the normal path.
-- `CreatePermanentEmblem(groupFilter, powerBonus?, toughnessBonus?, grantedKeywords?, grantedActivatedAbilities?, emblemDescription)` — permanent planeswalker emblem whose dynamically evaluated group receives the listed stats, keywords, and activated abilities. Unlike a one-shot group grant, the emblem also affects matching permanents that enter later. The activated-ability form powers Arlinn Kord's emblem.
+- `CreatePermanentEmblem(groupFilter?, powerBonus?, toughnessBonus?, grantedKeywords?, grantedActivatedAbilities?, ownedStaticAbilities?, emblemDescription)` — permanent planeswalker emblem whose dynamically evaluated group receives the listed stats, keywords, and activated abilities. Unlike a one-shot group grant, the emblem also affects matching permanents that enter later. The activated-ability form powers Arlinn Kord's emblem.
+  - `ownedStaticAbilities` carries wording the emblem has **itself** rather than grants to a group — "You may cast spells from your hand without paying their mana costs" (Tamiyo, Field Researcher's −7) is `MayCastWithoutPayingManaCost(controllerOnly = true)`, the same static Omniscience prints. Such an emblem leaves `groupFilter` and the group modifications at their defaults. The emblem entity lives outside every zone, so a scan that only walks the battlefield won't see it; the free-cast scan (`CostCalculator.hasFreeCastPermission`) consults emblem statics explicitly. `firstSpellOfTurnOnly` / `oncePerTurn` gates are rejected there rather than approximated, since both key off marking a *battlefield* source used.
 
 ### Ability granting
 
@@ -4384,7 +4385,14 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
     until expiry (double-strike combat damage). One-shot consumption happens when the trigger goes
     on the stack (`TriggerProcessor`), so a second matching event the same turn won't re-fire it.
   - `expiry` — when the resident delayed trigger is removed. `DelayedTriggerExpiry.EndOfTurn`
-    (default) drops it in the end-of-turn cleanup ("this turn" riders). `DelayedTriggerExpiry.Never`
+    (default) drops it in the end-of-turn cleanup ("this turn" riders).
+    `DelayedTriggerExpiry.UntilControllersNextTurn` is the delayed-trigger analogue of
+    `Duration.UntilYourNextTurn`, swept on the same post-untap hook keyed to the *delayed trigger's*
+    controller — for "Until your next turn, whenever …" riders that install a watcher rather than a
+    continuous effect (Tamiyo, Field Researcher's +1: "Until your next turn, whenever either of
+    those creatures deals combat damage, you draw a card", one entity-scoped watcher per chosen
+    creature so simultaneous combat damage draws twice). It survives the intervening opponents'
+    turns, which `EndOfTurn` would not. `DelayedTriggerExpiry.Never`
     keeps it across turns until it fires (pair with `fireOnce = true`) or the game ends — for
     watch-a-permanent-until-it-leaves reflexive triggers that aren't turn-scoped, e.g. Zenos yae
     Galvus's "When the chosen creature leaves the battlefield, transform Zenos yae Galvus"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1060,13 +1060,22 @@ object Effects {
     /**
      * Create a permanent emblem that grants a static modification to permanents matching a filter.
      * Used for planeswalker -X abilities that produce static-ability emblems.
+     *
+     * [ownedStaticAbilities] carries wording the emblem has *itself* rather than grants to a group —
+     * "You may cast spells from your hand without paying their mana costs" (Tamiyo, Field
+     * Researcher). Such an emblem leaves [groupFilter] and the group modifications at their
+     * defaults.
      */
     fun CreatePermanentEmblem(
-        groupFilter: com.wingedsheep.sdk.scripting.filters.unified.GroupFilter,
+        groupFilter: com.wingedsheep.sdk.scripting.filters.unified.GroupFilter =
+            com.wingedsheep.sdk.scripting.filters.unified.GroupFilter(
+                com.wingedsheep.sdk.scripting.GameObjectFilter.Any
+            ),
         powerBonus: Int = 0,
         toughnessBonus: Int = 0,
         grantedKeywords: List<String> = emptyList(),
         grantedActivatedAbilities: List<com.wingedsheep.sdk.scripting.ActivatedAbility> = emptyList(),
+        ownedStaticAbilities: List<com.wingedsheep.sdk.scripting.StaticAbility> = emptyList(),
         emblemDescription: String
     ): Effect = com.wingedsheep.sdk.scripting.effects.CreatePermanentEmblemEffect(
         groupFilter = groupFilter,
@@ -1074,6 +1083,7 @@ object Effects {
         toughnessBonus = toughnessBonus,
         grantedKeywords = grantedKeywords,
         grantedActivatedAbilities = grantedActivatedAbilities,
+        ownedStaticAbilities = ownedStaticAbilities,
         emblemDescription = emblemDescription
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -814,6 +814,21 @@ sealed interface DelayedTriggerExpiry {
     @SerialName("DelayedTriggerExpiry.Never")
     @Serializable
     data object Never : DelayedTriggerExpiry
+
+    /**
+     * Remove the delayed trigger after the untap step of its **controller's** next turn — the
+     * delayed-trigger analogue of [com.wingedsheep.sdk.scripting.Duration.UntilYourNextTurn], and
+     * expired on the same post-untap hook so both wordings wear off at the same moment.
+     *
+     * Models "Until your next turn, whenever …" riders that install a watcher rather than a
+     * continuous effect: Tamiyo, Field Researcher's +1 ("Until your next turn, whenever either of
+     * those creatures deals combat damage, you draw a card"). Unlike [EndOfTurn] the trigger
+     * survives the intervening opponents' turns, and unlike [Never] it does not outlive the
+     * controller's next untap step.
+     */
+    @SerialName("DelayedTriggerExpiry.UntilControllersNextTurn")
+    @Serializable
+    data object UntilControllersNextTurn : DelayedTriggerExpiry
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -689,20 +689,29 @@ data class GrantSpellsCantBeCounteredEffect(
  *
  * Composes with `Effects.Composite(ChooseCreatureTypeEffect, CreatePermanentEmblem(...))`.
  *
- * @property groupFilter Which permanents the emblem affects.
+ * An emblem whose text affects its **controller** rather than a group of permanents ("You may cast
+ * spells from your hand without paying their mana costs" — Tamiyo, Field Researcher's −7) carries
+ * that wording in [ownedStaticAbilities] instead, and leaves [groupFilter] at its default. The
+ * emblem entity then reads as a source of those statics exactly as a battlefield permanent printing
+ * them would, so no separate "player permission" concept is needed.
+ *
+ * @property groupFilter Which permanents the emblem affects. Unused — and so left at its default —
+ *   by an emblem that carries no group modification at all, only [ownedStaticAbilities].
  * @property powerBonus Power modification applied to each affected creature.
  * @property toughnessBonus Toughness modification applied to each affected creature.
  * @property grantedKeywords Keywords granted to each affected creature.
+ * @property ownedStaticAbilities Static abilities the *emblem itself* has, as though printed on it.
  * @property emblemDescription Human-readable description of the emblem (without the "You get an emblem with" prefix).
  */
 @SerialName("CreatePermanentEmblem")
 @Serializable
 data class CreatePermanentEmblemEffect(
-    val groupFilter: GroupFilter,
+    val groupFilter: GroupFilter = GroupFilter(GameObjectFilter.Any),
     val powerBonus: Int = 0,
     val toughnessBonus: Int = 0,
     val grantedKeywords: List<String> = emptyList(),
     val grantedActivatedAbilities: List<com.wingedsheep.sdk.scripting.ActivatedAbility> = emptyList(),
+    val ownedStaticAbilities: List<com.wingedsheep.sdk.scripting.StaticAbility> = emptyList(),
     val emblemDescription: String
 ) : Effect {
     override val description: String = "You get an emblem with \"$emblemDescription\""

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/TamiyoFieldResearcherReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/TamiyoFieldResearcherReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tamiyo, Field Researcher reprint in BLC.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, loyalty) lives in
+ * EMN's `cards/` package (the card's earliest real printing). This file contributes only
+ * the BLC-specific presentation row — set, collector number, art — picked up automatically
+ * by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val TamiyoFieldResearcherReprint = Printing(
+    oracleId = "9cf99129-f51a-4418-a8cc-8ca2992b17fa",
+    name = "Tamiyo, Field Researcher",
+    setCode = "BLC",
+    collectorNumber = "100",
+    artist = "Justin Gerard",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/5899d4c5-e6b8-48e9-9044-b5b34a1284f9.jpg?1783910707",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/TamiyoFieldResearcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/TamiyoFieldResearcher.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Tamiyo, Field Researcher — Eldritch Moon #190
+ * {1}{G}{W}{U} · Legendary Planeswalker — Tamiyo · Starting loyalty 4
+ *
+ * +1: Choose up to two target creatures. Until your next turn, whenever either of those creatures
+ *     deals combat damage, you draw a card.
+ * −2: Tap up to two target nonland permanents. They don't untap during their controller's next
+ *     untap step.
+ * −7: Draw three cards. You get an emblem with "You may cast spells from your hand without paying
+ *     their mana costs."
+ *
+ * Modeling notes:
+ *
+ *  - **"Up to two target …"** is one target requirement taking up to two objects
+ *    (`count = 2, optional = true` → `minCount = 0`, the Smoldering Werewolf idiom), not two
+ *    independent slots — so the picks must be different objects (CR 601.2c) and choosing zero is
+ *    legal. Each payoff is then applied once per chosen object via [ForEachTargetEffect].
+ *  - **The +1 sets up delayed triggers, not granted abilities.** Per the printed rulings the
+ *    watcher "triggers even if Tamiyo has left the battlefield", and *you* draw the card, not the
+ *    creature's controller — so this is Tamiyo's own delayed triggered ability, entity-scoped to
+ *    each chosen creature via `watchedTarget`, and never an ability granted to those creatures.
+ *    One trigger per creature, so two creatures dealing combat damage simultaneously draw two
+ *    cards (also a printed ruling). `fireOnce = false` (the default) is what makes it *whenever*
+ *    rather than *when … next*, and the new [DelayedTriggerExpiry.UntilControllersNextTurn] is the
+ *    "Until your next turn" half — it survives the intervening opponents' turns and wears off on
+ *    the post-untap hook of Tamiyo's controller's next turn, alongside
+ *    [Duration.UntilYourNextTurn] effects.
+ *  - **The −2** is the Crippling Chill pair (tap + [AbilityFlag.DOESNT_UNTAP] for
+ *    [Duration.UntilAfterAffectedControllersNextUntap]) applied per target. The duration keys off
+ *    each affected permanent's *own* controller, which is what "their controller's next untap
+ *    step" means when the two targets are controlled by different players.
+ *  - **The −7 emblem** carries wording that reads on its controller rather than on a group of
+ *    permanents, so it goes in `ownedStaticAbilities` — the emblem *has* Omniscience's
+ *    [MayCastWithoutPayingManaCost] exactly as a permanent printing it would, instead of the
+ *    P/T-and-keyword group grant `CreatePermanentEmblem` otherwise models.
+ */
+val TamiyoFieldResearcher = card("Tamiyo, Field Researcher") {
+    manaCost = "{1}{G}{W}{U}"
+    colorIdentity = "GWU"
+    typeLine = "Legendary Planeswalker — Tamiyo"
+    startingLoyalty = 4
+    oracleText = "+1: Choose up to two target creatures. Until your next turn, whenever either of " +
+        "those creatures deals combat damage, you draw a card.\n" +
+        "−2: Tap up to two target nonland permanents. They don't untap during their controller's " +
+        "next untap step.\n" +
+        "−7: Draw three cards. You get an emblem with \"You may cast spells from your hand " +
+        "without paying their mana costs.\""
+
+    // +1: Choose up to two target creatures. Until your next turn, whenever either of those
+    //     creatures deals combat damage, you draw a card.
+    loyaltyAbility(+1) {
+        target("up to two target creatures", TargetCreature(count = 2, optional = true))
+        effect = ForEachTargetEffect(
+            listOf(
+                CreateDelayedTriggerEffect(
+                    effect = Effects.DrawCards(1),
+                    trigger = Triggers.dealsDamage(damageType = DamageType.Combat),
+                    watchedTarget = EffectTarget.ContextTarget(0),
+                    expiry = DelayedTriggerExpiry.UntilControllersNextTurn
+                )
+            )
+        )
+        description = "Choose up to two target creatures. Until your next turn, whenever either " +
+            "of those creatures deals combat damage, you draw a card."
+    }
+
+    // −2: Tap up to two target nonland permanents. They don't untap during their controller's
+    //     next untap step.
+    loyaltyAbility(-2) {
+        target(
+            "up to two target nonland permanents",
+            TargetPermanent(
+                count = 2,
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.NonlandPermanent)
+            )
+        )
+        effect = ForEachTargetEffect(
+            listOf(
+                Effects.Tap(EffectTarget.ContextTarget(0)),
+                GrantKeywordEffect(
+                    AbilityFlag.DOESNT_UNTAP.name,
+                    EffectTarget.ContextTarget(0),
+                    Duration.UntilAfterAffectedControllersNextUntap
+                )
+            )
+        )
+        description = "Tap up to two target nonland permanents. They don't untap during their " +
+            "controller's next untap step."
+    }
+
+    // −7: Draw three cards. You get an emblem with "You may cast spells from your hand without
+    //     paying their mana costs."
+    loyaltyAbility(-7) {
+        effect = Effects.DrawCards(3) then Effects.CreatePermanentEmblem(
+            ownedStaticAbilities = listOf(MayCastWithoutPayingManaCost(controllerOnly = true)),
+            emblemDescription = "You may cast spells from your hand without paying their mana costs."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "190"
+        artist = "Tianhua X"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f9aced7-9ae9-432f-b8c0-caac9cad098b.jpg?1783937424"
+
+        ruling("2025-01-24", "Tamiyo's first ability can target creatures you don't control. You'll draw a card, not their controller, if they deal combat damage.")
+        ruling("2025-01-24", "Tamiyo's first ability sets up a delayed triggered ability that triggers even if Tamiyo has left the battlefield before those creatures deal combat damage.")
+        ruling("2025-01-24", "If Tamiyo's first ability targets two creatures, and both deal combat damage at the same time, the delayed triggered ability triggers twice.")
+        ruling("2025-01-24", "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. You can, however, pay additional costs. If the spell has any mandatory additional costs, those must be paid to cast the spell.")
+        ruling("2025-01-24", "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/TamiyoFieldResearcherReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/TamiyoFieldResearcherReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tamiyo, Field Researcher reprint in INR.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, loyalty) lives in
+ * EMN's `cards/` package (the card's earliest real printing). This file contributes only
+ * the INR-specific presentation row — set, collector number, art — picked up automatically
+ * by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val TamiyoFieldResearcherReprint = Printing(
+    oracleId = "9cf99129-f51a-4418-a8cc-8ca2992b17fa",
+    name = "Tamiyo, Field Researcher",
+    setCode = "INR",
+    collectorNumber = "249",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/576ba8db-fad9-4c48-96be-a8a7e5f43039.jpg?1783908070",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -3625,6 +3625,175 @@
     ]
 }
 
+// Tamiyo, Field Researcher
+{
+    "name": "Tamiyo, Field Researcher",
+    "manaCost": "{1}{G}{W}{U}",
+    "typeLine": "Legendary Planeswalker — Tamiyo",
+    "oracleText": "+1: Choose up to two target creatures. Until your next turn, whenever either of those creatures deals combat damage, you draw a card.\n−2: Tap up to two target nonland permanents. They don't untap during their controller's next untap step.\n−7: Draw three cards. You get an emblem with \"You may cast spells from your hand without paying their mana costs.\"",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "CreateDelayedTrigger",
+                        "effect": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "trigger": {
+                            "event": {
+                                "type": "DealsDamageEvent",
+                                "damageType": "DamageCombat"
+                            }
+                        },
+                        "watchedTarget": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "expiry": "DelayedTriggerExpiry.UntilControllersNextTurn"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "up to two target creatures"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true,
+                "descriptionOverride": "Choose up to two target creatures. Until your next turn, whenever either of those creatures deals combat damage, you draw a card."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -2
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "TapUntap",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "DOESNT_UNTAP",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "duration": "UntilAfterAffectedControllersNextUntap"
+                            }
+                        ]
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        },
+                        "id": "up to two target nonland permanents"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true,
+                "descriptionOverride": "Tap up to two target nonland permanents. They don't untap during their controller's next untap step."
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -7
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        },
+                        {
+                            "type": "CreatePermanentEmblem",
+                            "ownedStaticAbilities": [
+                                {
+                                    "type": "MayCastWithoutPayingManaCost",
+                                    "controllerOnly": true
+                                }
+                            ],
+                            "emblemDescription": "You may cast spells from your hand without paying their mana costs."
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "MYTHIC",
+        "artist": "Tianhua X",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f9aced7-9ae9-432f-b8c0-caac9cad098b.jpg?1783937424",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "Tamiyo's first ability can target creatures you don't control. You'll draw a card, not their controller, if they deal combat damage."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "Tamiyo's first ability sets up a delayed triggered ability that triggers even if Tamiyo has left the battlefield before those creatures deal combat damage."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If Tamiyo's first ability targets two creatures, and both deal combat damage at the same time, the delayed triggered ability triggers twice."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If you cast a spell \"without paying its mana cost,\" you can't choose to cast it for any alternative costs. You can, however, pay additional costs. If the spell has any mandatory additional costs, those must be paid to cast the spell."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If a spell has {X} in its mana cost, you must choose 0 as the value of X when casting it without paying its mana cost."
+            }
+        ]
+    },
+    "startingLoyalty": 4,
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Thalia, Heretic Cathar
 {
     "name": "Thalia, Heretic Cathar",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -182,6 +182,13 @@ class CleanupPhaseManager(
      * step (to prevent untapping), then removed afterward.
      */
     fun expireUntilYourNextTurnEffects(state: GameState, activePlayer: EntityId): GameState {
+        // Event-based delayed triggers scoped "until your next turn" (Tamiyo, Field Researcher's
+        // +1). Keyed to the delayed trigger's own controller, so an opponent's rider is untouched
+        // by this player's untap step.
+        val remainingDelayed = state.delayedTriggers.filter { delayed ->
+            !(delayed.expiry is DelayedTriggerExpiry.UntilControllersNextTurn &&
+                delayed.controllerId == activePlayer)
+        }
         val remainingFloating = state.floatingEffects.filter { floatingEffect ->
             !(floatingEffect.duration is Duration.UntilYourNextTurn &&
                 floatingEffect.controllerId == activePlayer)
@@ -203,11 +210,13 @@ class CleanupPhaseManager(
         val floatingChanged = remainingFloating.size != state.floatingEffects.size
         val globalChanged = remainingGlobal.size != state.globalGrantedTriggeredAbilities.size
         val grantedActivatedChanged = remainingGrantedActivated.size != state.grantedActivatedAbilities.size
-        var result = if (floatingChanged || globalChanged || grantedActivatedChanged) {
+        val delayedChanged = remainingDelayed.size != state.delayedTriggers.size
+        var result = if (floatingChanged || globalChanged || grantedActivatedChanged || delayedChanged) {
             state.copy(
                 floatingEffects = if (floatingChanged) remainingFloating else state.floatingEffects,
                 globalGrantedTriggeredAbilities = if (globalChanged) remainingGlobal else state.globalGrantedTriggeredAbilities,
-                grantedActivatedAbilities = if (grantedActivatedChanged) remainingGrantedActivated else state.grantedActivatedAbilities
+                grantedActivatedAbilities = if (grantedActivatedChanged) remainingGrantedActivated else state.grantedActivatedAbilities,
+                delayedTriggers = if (delayedChanged) remainingDelayed else state.delayedTriggers
             )
         } else {
             state

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -389,6 +389,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PutIntoGraveyardThisTurnComponent::class)
         subclass(EmblemSourceComponent::class)
         subclass(EmblemActivatedAbilityComponent::class)
+        subclass(EmblemStaticAbilityComponent::class)
         subclass(CommanderComponent::class)
         subclass(RingBearerComponent::class)
         subclass(TheRingComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CreatePermanentEmblemExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/CreatePermanentEmblemExecutor.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.state.components.battlefield.withCastChoice
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.EmblemSourceComponent
 import com.wingedsheep.engine.state.components.identity.EmblemActivatedAbilityComponent
+import com.wingedsheep.engine.state.components.identity.EmblemStaticAbilityComponent
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.CreatePermanentEmblemEffect
@@ -75,6 +76,13 @@ class CreatePermanentEmblemExecutor : EffectExecutor<CreatePermanentEmblemEffect
         if (effect.grantedActivatedAbilities.isNotEmpty()) {
             emblemContainer = emblemContainer.with(
                 EmblemActivatedAbilityComponent(effect.groupFilter, effect.grantedActivatedAbilities)
+            )
+        }
+        // Statics the emblem has itself (Tamiyo's "You may cast spells from your hand without
+        // paying their mana costs") rather than grants to a group.
+        if (effect.ownedStaticAbilities.isNotEmpty()) {
+            emblemContainer = emblemContainer.with(
+                EmblemStaticAbilityComponent(effect.ownedStaticAbilities)
             )
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1280,6 +1280,44 @@ class CostCalculator(
                 return true
             }
         }
+        return hasEmblemFreeCastPermission(state, casterId, spellCardDef, castFromZone)
+    }
+
+    /**
+     * The emblem half of [hasFreeCastPermission] (Tamiyo, Field Researcher's −7). Emblems are
+     * synthetic entities that live outside every zone, so the battlefield scan can't see them;
+     * their statics are read from
+     * [com.wingedsheep.engine.state.components.identity.EmblemStaticAbilityComponent] instead.
+     *
+     * The `firstSpellOfTurnOnly` / `oncePerTurn` gates are deliberately not honored here: those key
+     * off a *battlefield source* being marked used, and no emblem prints them. An emblem carrying
+     * one would silently grant an unlimited permission, so it is rejected outright rather than
+     * approximated.
+     */
+    private fun hasEmblemFreeCastPermission(
+        state: GameState,
+        casterId: EntityId,
+        spellCardDef: CardDefinition?,
+        castFromZone: com.wingedsheep.sdk.core.Zone?
+    ): Boolean {
+        for ((entityId, container) in state.entities) {
+            val statics = container
+                .get<com.wingedsheep.engine.state.components.identity.EmblemStaticAbilityComponent>()
+                ?: continue
+            val emblemController = container
+                .get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                ?.playerId
+            for (ability in statics.abilities) {
+                if (ability !is MayCastWithoutPayingManaCost) continue
+                if (ability.firstSpellOfTurnOnly || ability.oncePerTurn) continue
+                if (ability.fromExileOnly && castFromZone != com.wingedsheep.sdk.core.Zone.EXILE) continue
+                if (ability.controllerOnly && emblemController != casterId) continue
+                if (spellCardDef != null && ability.spellFilter != GameObjectFilter.Any &&
+                    !matchesCardDefinition(spellCardDef, ability.spellFilter, entityId, state, state.projectedState)
+                ) continue
+                return true
+            }
+        }
         return false
     }
 
@@ -1296,6 +1334,9 @@ class CostCalculator(
         spellCardDef: CardDefinition?,
         castFromZone: com.wingedsheep.sdk.core.Zone? = null
     ): EntityId? {
+        // An emblem's permission is always unlimited, so it covers this cast on its own and no
+        // battlefield once-per-turn use should be consumed.
+        if (hasEmblemFreeCastPermission(state, casterId, spellCardDef, castFromZone)) return null
         var oncePerTurnCandidate: EntityId? = null
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/EmblemAbilityComponent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/EmblemAbilityComponent.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.state.components.identity
 
 import com.wingedsheep.engine.state.Component
 import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.StaticAbility
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import kotlinx.serialization.Serializable
 
@@ -10,4 +11,19 @@ import kotlinx.serialization.Serializable
 data class EmblemActivatedAbilityComponent(
     val filter: GroupFilter,
     val abilities: List<ActivatedAbility>,
+) : Component
+
+/**
+ * Static abilities the emblem *itself* has, as though printed on it — for emblem text that reads on
+ * its controller rather than on a group of permanents ("You may cast spells from your hand without
+ * paying their mana costs", Tamiyo, Field Researcher's −7).
+ *
+ * The synthetic emblem entity is never registered in a zone, so scans that walk the battlefield
+ * looking for a printed static won't see it; a scan that should honor an emblem consults this
+ * component alongside the battlefield (see
+ * [com.wingedsheep.engine.mechanics.mana.CostCalculator.hasFreeCastPermission]).
+ */
+@Serializable
+data class EmblemStaticAbilityComponent(
+    val abilities: List<StaticAbility>,
 ) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TamiyoFieldResearcherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TamiyoFieldResearcherScenarioTest.kt
@@ -1,0 +1,259 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.EmblemStaticAbilityComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tamiyo, Field Researcher (EMN #190, {1}{G}{W}{U}, loyalty 4).
+ *
+ *   +1: Choose up to two target creatures. Until your next turn, whenever either of those creatures
+ *       deals combat damage, you draw a card.
+ *   −2: Tap up to two target nonland permanents. They don't untap during their controller's next
+ *       untap step.
+ *   −7: Draw three cards. You get an emblem with "You may cast spells from your hand without paying
+ *       their mana costs."
+ *
+ * The three things that could silently resolve wrong, each with its own test: the +1 draws for
+ * *Tamiyo's controller* even when the watched creature belongs to an opponent (printed ruling) and
+ * lives exactly until that controller's next turn — the new
+ * [com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry.UntilControllersNextTurn]; the −2's
+ * don't-untap rider has to survive the target controller's untap step rather than the caster's; and
+ * the −7 emblem carries a static ability on the emblem itself, so the free cast has to be visible to
+ * a cost scan that otherwise only walks the battlefield.
+ */
+class TamiyoFieldResearcherScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("the +1") {
+
+            test("a watched creature's combat damage draws a card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tamiyo, Field Researcher")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tamiyo = game.findPermanent("Tamiyo, Field Researcher")!!
+                setLoyalty(game, tamiyo, 4)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                activate(game, tamiyo, index = 0, targets = listOf(bears))
+                game.resolveStack()
+
+                withClue("+1 installed one watcher and moved loyalty 4 -> 5") {
+                    game.state.delayedTriggers.size shouldBe 1
+                    loyalty(game, tamiyo) shouldBe 5
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                val libraryBefore = game.librarySize(1)
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("2 combat damage got through and the watcher drew one card") {
+                    game.getLifeTotal(2) shouldBe 18
+                    game.librarySize(1) shouldBe libraryBefore - 1
+                }
+            }
+
+            test("an opponent's creature draws for you, not for them, and stops after your next untap") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tamiyo, Field Researcher")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tamiyo = game.findPermanent("Tamiyo, Field Researcher")!!
+                setLoyalty(game, tamiyo, 4)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                activate(game, tamiyo, index = 0, targets = listOf(bears))
+                game.resolveStack()
+
+                // Out to the opponent's turn — the watcher is not scoped to this turn.
+                advanceToNextTurn(game)
+                withClue("the watcher survived the turn boundary") {
+                    game.state.activePlayerId shouldBe game.player2Id
+                    game.state.delayedTriggers.size shouldBe 1
+                }
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+                val ownerLibraryBefore = game.librarySize(1)
+                val attackerLibraryBefore = game.librarySize(2)
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                withClue("Tamiyo's controller drew, the creature's controller did not") {
+                    game.getLifeTotal(1) shouldBe 18
+                    game.librarySize(1) shouldBe ownerLibraryBefore - 1
+                    game.librarySize(2) shouldBe attackerLibraryBefore
+                }
+
+                // Back around to Tamiyo's controller: the untap step is where it wears off.
+                advanceToNextTurn(game)
+                withClue("\"until your next turn\" expired on the controller's next untap step") {
+                    game.state.activePlayerId shouldBe game.player1Id
+                    game.state.delayedTriggers.size shouldBe 0
+                }
+            }
+        }
+
+        context("the −2") {
+
+            test("taps both targets and holds them down through their controller's untap step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tamiyo, Field Researcher")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    // The test runs out to turn 4; neither player may deck out on the way.
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withCardInLibrary(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tamiyo = game.findPermanent("Tamiyo, Field Researcher")!!
+                setLoyalty(game, tamiyo, 4)
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                activate(game, tamiyo, index = 1, targets = listOf(bears, giant))
+                game.resolveStack()
+
+                withClue("both targets tapped; −2 moved loyalty 4 -> 2") {
+                    isTapped(game, bears) shouldBe true
+                    isTapped(game, giant) shouldBe true
+                    loyalty(game, tamiyo) shouldBe 2
+                }
+
+                advanceToNextTurn(game)
+                withClue("their controller's untap step came and went without untapping them") {
+                    game.state.activePlayerId shouldBe game.player2Id
+                    isTapped(game, bears) shouldBe true
+                    isTapped(game, giant) shouldBe true
+                }
+
+                advanceToNextTurn(game)
+                advanceToNextTurn(game)
+                withClue("the untap step after that is unaffected") {
+                    game.state.activePlayerId shouldBe game.player2Id
+                    isTapped(game, bears) shouldBe false
+                    isTapped(game, giant) shouldBe false
+                }
+            }
+        }
+
+        context("the −7") {
+
+            test("draws three and leaves an emblem that pays for a spell") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Tamiyo, Field Researcher")
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tamiyo = game.findPermanent("Tamiyo, Field Researcher")!!
+                setLoyalty(game, tamiyo, 7)
+                val handBefore = game.handSize(1)
+
+                activate(game, tamiyo, index = 2)
+                game.resolveStack()
+
+                withClue("Tamiyo drew three and died to the 0-loyalty state-based action") {
+                    game.handSize(1) shouldBe handBefore + 3
+                    game.findPermanent("Tamiyo, Field Researcher") shouldBe null
+                }
+                withClue("the emblem outlives her, carrying the static on itself") {
+                    game.state.entities.values.count {
+                        it.get<EmblemStaticAbilityComponent>() != null
+                    } shouldBe 1
+                }
+
+                // No lands, no mana in pool — only the emblem can pay for this.
+                val giant = game.findCardsInHand(1, "Hill Giant").first()
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = giant,
+                        useWithoutPayingManaCost = true,
+                        paymentStrategy = PaymentStrategy.FromPool
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the {4} creature resolved having paid nothing") {
+                    game.state.getBattlefield().contains(giant) shouldBe true
+                }
+            }
+        }
+    }
+
+    /** Step out through the end step so the next [Phase.PRECOMBAT_MAIN] is the *following* turn's. */
+    private fun advanceToNextTurn(game: TestGame) {
+        game.passUntilPhase(Phase.ENDING, Step.END)
+        game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+    }
+
+    private fun activate(
+        game: TestGame,
+        source: EntityId,
+        index: Int,
+        targets: List<EntityId> = emptyList()
+    ) {
+        val ability = cardRegistry.getCard("Tamiyo, Field Researcher")!!.script.activatedAbilities[index]
+        game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = source,
+                abilityId = ability.id,
+                targets = targets.map { ChosenTarget.Permanent(it) }
+            )
+        ).error shouldBe null
+    }
+
+    private fun loyalty(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    private fun setLoyalty(game: TestGame, id: EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { c ->
+            c.with(CountersComponent().withAdded(CounterType.LOYALTY, amount))
+        }
+    }
+
+    private fun isTapped(game: TestGame, id: EntityId): Boolean =
+        game.state.getEntity(id)?.has<TappedComponent>() == true
+}


### PR DESCRIPTION
## What

Adds **Tamiyo, Field Researcher** — canonical `CardDefinition` in EMN (the card's earliest real printing), with `Printing` rows in BLC and INR.

Two reusable SDK/engine additions the card needs:

**`DelayedTriggerExpiry.UntilControllersNextTurn`** — the delayed-trigger analogue of `Duration.UntilYourNextTurn`, swept on the same post-untap hook and keyed to the delayed trigger's own controller. Tamiyo's +1 is a delayed triggered ability entity-scoped to each chosen creature (one per creature, so simultaneous combat damage draws twice), not an ability granted to those creatures — per the printed rulings it fires even after Tamiyo has left the battlefield, and *its* controller draws, not the creature's controller. `EndOfTurn` would have dropped it before the opponent's turn; `Never` would have outlived the wording.

**`CreatePermanentEmblemEffect.ownedStaticAbilities`** — wording an emblem has *itself* rather than grants to a group. Tamiyo's −7 emblem carries the same `MayCastWithoutPayingManaCost` static Omniscience prints. The synthetic emblem entity lives outside every zone, so `CostCalculator`'s free-cast scan consults emblem statics alongside the battlefield. `firstSpellOfTurnOnly` / `oncePerTurn` gates are rejected there rather than approximated, since both key off marking a *battlefield* source used — an emblem carrying one would silently become an unlimited permission.

`docs/card-sdk-language-reference.md` updated for both.

## Why only one card

Innistrad Remastered is at 270/290. Every one of the 19 still-missing cards needs engine work, not just a `cardDef`:

| Blocker | Cards |
|---|---|
| emerge | Abundant Maw, Decimator of the Provinces, Distended Mindbender, Elder Deep-Fiend, It of the Horrid Swarm, Wretched Gryff |
| disturb | Covetous Castaway, Lantern Bearer, Lunarch Veteran, Twinblade Geist |
| soulbond | Deadeye Navigator, Lightning Mauler |
| splice onto Arcane | Through the Breach |
| escalate | Collective Brutality |
| battles | Invasion of Innistrad |
| one-off subsystems | Edgar Markov (eminence / command-zone-active triggers), Garruk Relentless (flip walker + state trigger), Mirrorwing Dragon (copy-for-each with auto-distinct retargeting), Emrakul, the Promised End |

Tamiyo was the one whose engine gaps were small and self-contained enough to land with the card. The highest-value follow-ups are **emerge** (6 cards; alternative base cost + mandatory creature sacrifice + generic reduction by that creature's mana value — likely reusing Harmonize's alternative-payment reduction) and **disturb** (4 cards), each as its own `add-feature` PR.

## Verification

- `just build` — green (SDK, sets, rules-engine, ai, gym, game-server, mtgish-tooling; all test suites).
- `just test-class TamiyoFieldResearcherScenarioTest` — 4/4 passing. Covers each loyalty ability: the +1 drawing off your own attacker; the +1 drawing for *Tamiyo's controller* off an opponent's creature, surviving the turn boundary, and expiring on the controller's next untap step; the −2 tapping both targets and holding them through their own controller's untap step; the −7 drawing three and leaving an emblem that pays for a spell with no lands in play.
- `just check-card-printing "Tamiyo, Field Researcher"` — clean (canonical in EMN, rows in BLC + INR).
- `just rebless-cards` — only `EMN.json` moved, pure insertion of the new card.
- Backlog ticked in `bloomburrow-commander` (cards + Peace Offering deck), header resynced via `just fix-backlog`.

No new decision types or client work: the +1/−2 use existing battlefield targeting, and the emblem's free cast surfaces through the existing `useWithoutPayingManaCost` action variant that Omniscience and Weftwalking already drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)