### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/backlog/sets/the-hobbit/cards.md
+++ b/backlog/sets/the-hobbit/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 193 cards revealed as of 2026-08-04
 **Release Date:** August 14, 2026
-**Implemented:** 61 / 193
+**Implemented:** 66 / 193
 Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. This list covers only cards revealed as of that date.
 
 - [x] 1. Long-Bodied Grey Dog
@@ -43,7 +43,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 36. Elrond, Moon-Reader
 - [x] 37. Elven Raft-Steerer
 - [x] 38. Elvenking's Harper
-- [ ] 39. Enchanted River's Grasp
+- [x] 39. Enchanted River's Grasp
 - [x] 40. Fateful Discovery
 - [ ] 41. Gandalf, Wandering Wizard
 - [ ] 42. Great Gilded Boat
@@ -52,7 +52,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 45. Long Lake Nuisance
 - [ ] 46. The Lord of the Eagles
 - [ ] 47. Master's Councillors
-- [ ] 48. Mirkwood Meditator
+- [x] 48. Mirkwood Meditator
 - [ ] 49. Most Decrepit Old Bird
 - [ ] 50. Old Fat Spider Can't See Me
 - [ ] 51. Plunder the Trollshaws
@@ -70,7 +70,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [x] 63. Crude Bent Blade
 - [x] 64. Desolation Prowler
 - [ ] 65. Down, Down to Goblin-town
-- [ ] 66. Dreaded Bat-Cloud
+- [x] 66. Dreaded Bat-Cloud
 - [x] 67. Front Porch Sentries
 - [ ] 68. Gathering of Darkness
 - [x] 69. Gnashing of Teeth
@@ -106,7 +106,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 99. Glóin the Mighty
 - [ ] 100. Goblin-town Flunkies
 - [x] 101. Gundabad Opportunist
-- [ ] 102. Iron Hills Stalwart
+- [x] 102. Iron Hills Stalwart
 - [ ] 103. Last Light of Durin's Day
 - [ ] 104. The Misty Mountains Cold
 - [ ] 105. Misty Mountains Raider
@@ -125,7 +125,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 118. Beorn, Reluctant Host
 - [ ] 119. Beorn the Fierce
 - [ ] 120. Beorn's Hospitality
-- [ ] 121. Boughside Wanderers
+- [x] 121. Boughside Wanderers
 - [ ] 122. Cantankerous Keepers
 - [ ] 123. Dancing from Dark to Dawn
 - [ ] 124. Down in the Valley

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4901,6 +4901,10 @@ staticAbility {
   spells you cast cost {X} less to cast, where X is your speed"; "no speed" reads as 0 per CR
   702.179f, so a player who never started their engines simply gets no reduction),
   `CardsInGraveyardMatchingFilter`, `FixedIfAnyTargetMatches`,
+  `FixedIfCreatureDiedThisTurn(amount)` (the morbid discount — "costs {N} less to cast if a creature
+  died this turn", Dreaded Bat-Cloud. Reads the same per-player `CreaturesDiedThisTurnComponent`
+  tallies as `Conditions.CreatureDiedThisTurn`, summed across the table, so an opponent's creature
+  dying counts; turn *history*, so a creature that died and then left the graveyard still counts),
   `GreatestPropertyAmongPermanentsYouControl(property, filter)` — "{X} less, where X is the greatest
   `<property>` among `<filter>` you control", parameterized over `EntityNumericProperty`:
   `ManaValue` (Sunderflock — "greatest mana value among Elementals you control", read from the card

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -589,6 +589,22 @@ sealed interface CostReductionSource {
     }
 
     /**
+     * Reduces cost by a fixed amount if a creature died this turn under *any* player's control —
+     * the morbid family's cost-reduction shape ("This spell costs {3} less to cast if a creature
+     * died this turn", Dreaded Bat-Cloud).
+     *
+     * Reads the same per-player died-this-turn tally as
+     * [com.wingedsheep.sdk.scripting.conditions.CreatureDiedThisTurnCondition], summed across the
+     * table, so an opponent's creature dying counts. Turn history, not a graveyard scan: a creature
+     * that died and was then exiled or reanimated still counts.
+     */
+    @SerialName("FixedIfCreatureDiedThisTurn")
+    @Serializable
+    data class FixedIfCreatureDiedThisTurn(val amount: Int) : CostReductionSource {
+        override val description: String = "$amount if a creature died this turn"
+    }
+
+    /**
      * Reduces cost by a fixed amount if the Void condition is met this turn — i.e.,
      * a nonland permanent left the battlefield this turn or a spell was warped this turn.
      * Used for Edge of Eternities cards like Temporal Intervention

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BoughsideWanderers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BoughsideWanderers.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Boughside Wanderers
+ * {4}{G}{G}
+ * Creature — Elf Scout
+ * 4/4
+ * When this creature enters, look at the top four cards of your library. You may reveal a permanent
+ * card from among them and put it into your hand. Put the rest on the bottom of your library in a
+ * random order.
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * The dig is the Staunch Crewmate idiom: gather the top four, [SelectionMode.ChooseUpTo] one card
+ * matching [CardPredicate.IsPermanent] ("you may reveal" — declining is legal even with hits
+ * present), move the pick to hand `revealed = true`, and bottom the remainder with
+ * [CardOrder.Random] so the leftovers aren't secretly ordered.
+ */
+val BoughsideWanderers = card("Boughside Wanderers") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Scout"
+    oracleText = "When this creature enters, look at the top four cards of your library. You may " +
+        "reveal a permanent card from among them and put it into your hand. Put the rest on the " +
+        "bottom of your library in a random order.\n" +
+        "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(4)), storeAs = "looked"),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter(cardPredicates = listOf(CardPredicate.IsPermanent)),
+                storeSelected = "kept",
+                storeRemainder = "rest",
+                selectedLabel = "Put in hand",
+                remainderLabel = "Put on bottom"
+            ),
+            MoveCollectionEffect(from = "kept", destination = CardDestination.ToZone(Zone.HAND), revealed = true),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Irina Nordsol"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71bec005-2925-4944-be16-2cc5eb30f5d6.jpg?1785497158"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DreadedBatCloud.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DreadedBatCloud.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Dreaded Bat-Cloud
+ * {4}{B}
+ * Creature — Bat
+ * 4/2
+ * This spell costs {3} less to cast if a creature died this turn.
+ * Flying, deathtouch
+ *
+ * The cost reduction is a [SpellCostTarget.SelfCast] static, live from any zone the spell is cast
+ * from, and reads the table-wide died-this-turn tally via
+ * [CostReductionSource.FixedIfCreatureDiedThisTurn] — the oracle text says "a creature", not "a
+ * creature you controlled", so an opponent's creature dying turns this on too.
+ */
+val DreadedBatCloud = card("Dreaded Bat-Cloud") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bat"
+    oracleText = "This spell costs {3} less to cast if a creature died this turn.\nFlying, deathtouch"
+    power = 4
+    toughness = 2
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfCreatureDiedThisTurn(3)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "66"
+        artist = "Andreia Ugrai"
+        flavorText = "Beneath the thunder another blackness whirled forward, so dense that no light could be seen between their wings."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67d52db5-597e-46d5-af39-c3a2de107d30.jpg?1785497085"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/EnchantedRiversGrasp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/EnchantedRiversGrasp.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.LoseAllAbilities
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Enchanted River's Grasp
+ * {2}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, tap enchanted creature and remove all counters from it.
+ * Enchanted creature loses all abilities and doesn't untap during its controller's untap step.
+ *
+ * Frozen in Ice's lock plus a counter wipe: the ETB taps the host and then clears every counter
+ * kind on it via [Effects.RemoveAllCounters] (a one-shot, so counters put on later stick).
+ * The lock itself is the same two Layer 6 statics — [LoseAllAbilities] and the
+ * [AbilityFlag.DOESNT_UNTAP] untap restriction. `DOESNT_UNTAP` is a restriction the Aura imposes
+ * on its host rather than an ability the host has, so losing all abilities doesn't shake it off.
+ */
+val EnchantedRiversGrasp = card("Enchanted River's Grasp") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, tap enchanted creature and remove all counters from it.\n" +
+        "Enchanted creature loses all abilities and doesn't untap during its controller's untap step."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedCreature)
+            .then(Effects.RemoveAllCounters(EffectTarget.EnchantedCreature))
+    }
+
+    staticAbility {
+        ability = LoseAllAbilities()
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Javier Charro"
+        flavorText = "And fast asleep Bombur remained in spite of all they could do."
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad40a4b9-9fab-49c1-8e9f-6e0776966833.jpg?1785497045"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/IronHillsStalwart.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/IronHillsStalwart.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Iron Hills Stalwart
+ * {4}{R}
+ * Creature — Dwarf Warrior
+ * 4/5
+ * Reach, trample
+ * When this creature enters, attach target Equipment you control to up to one target creature you
+ * control.
+ *
+ * Blacksmith's Talent level 2 on an ETB: [Effects.AttachTargetEquipmentToCreature] takes the two
+ * targets explicitly rather than assuming the source is the Equipment. The Equipment target is
+ * mandatory, the creature target is "up to one" (`optional = true`) — choosing no creature makes
+ * the ability unattach nothing and simply do nothing, which is why the Equipment target can't also
+ * be optional.
+ */
+val IronHillsStalwart = card("Iron Hills Stalwart") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf Warrior"
+    oracleText = "Reach, trample\n" +
+        "When this creature enters, attach target Equipment you control to up to one target creature you control."
+    power = 4
+    toughness = 5
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val equipment = target(
+            "Equipment you control",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).youControl())
+            )
+        )
+        val creature = target(
+            "creature you control",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.Creature.youControl()),
+                optional = true
+            )
+        )
+        effect = Effects.AttachTargetEquipmentToCreature(equipment, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Michele Giorgi"
+        flavorText = "Their fires caught the attention of huge bats flapping and whirring round their ears."
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/46daa9ac-0ac7-4df9-b9d2-e03ab5b56c72.jpg?1785497126"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MirkwoodMeditator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MirkwoodMeditator.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mirkwood Meditator
+ * {2}{U}
+ * Creature — Elf Druid
+ * 2/4
+ * Landfall — Whenever a land you control enters, you may have this creature's base power and
+ * toughness become 4/2 until end of turn.
+ *
+ * A base-stat *swap*, not a pump: [Effects.SetBasePowerAndToughness] writes Layer 7b set values, so
+ * the 2/4 body becomes 4/2 and any +1/+1 counters or Layer 7c modifiers still apply on top. The
+ * choice is genuinely the controller's each time a land lands, hence [MayEffect] rather than an
+ * unconditional effect — with the printed body already 2/4, taking the 4/2 is often the wrong call.
+ */
+val MirkwoodMeditator = card("Mirkwood Meditator") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elf Druid"
+    oracleText = "Landfall — Whenever a land you control enters, you may have this creature's base " +
+        "power and toughness become 4/2 until end of turn."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = MayEffect(
+            Effects.SetBasePowerAndToughness(power = 4, toughness = 2, target = EffectTarget.Self),
+            descriptionOverride = "Have Mirkwood Meditator's base power and toughness become 4/2 until end of turn?"
+        )
+        description = "Landfall — Whenever a land you control enters, you may have this creature's " +
+            "base power and toughness become 4/2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Francisco Miyara"
+        flavorText = "Elves always knew what was going on among the peoples of the land—as quick as water flows, or quicker."
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad7ed4e6-3fe2-40f1-909b-a03b2a3c941a.jpg?1785497064"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -85,6 +85,110 @@
     ]
 }
 
+// Boughside Wanderers
+{
+    "name": "Boughside Wanderers",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Elf Scout",
+    "oracleText": "When this creature enters, look at the top four cards of your library. You may reveal a permanent card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nLandfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "permanent",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put on bottom"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Irina Nordsol",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71bec005-2925-4944-be16-2cc5eb30f5d6.jpg?1785497158"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Confusticate and Bebother
 {
     "name": "Confusticate and Bebother",
@@ -343,6 +447,47 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Dreaded Bat-Cloud
+{
+    "name": "Dreaded Bat-Cloud",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Bat",
+    "oracleText": "This spell costs {3} less to cast if a creature died this turn.\nFlying, deathtouch",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfCreatureDiedThisTurn",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "UNCOMMON",
+        "artist": "Andreia Ugrai",
+        "flavorText": "Beneath the thunder another blackness whirled forward, so dense that no light could be seen between their wings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67d52db5-597e-46d5-af39-c3a2de107d30.jpg?1785497085"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -723,6 +868,60 @@
         "artist": "Irina Nordsol",
         "flavorText": "\"Hundreds of torches and many fires must have been lit suddenly and by magic. And hark to the singing and the harps!\"\n—Kíli",
         "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c50656d-c74a-4e90-9ef7-afa237682516.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Enchanted River's Grasp
+{
+    "name": "Enchanted River's Grasp",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, tap enchanted creature and remove all counters from it.\nEnchanted creature loses all abilities and doesn't untap during its controller's untap step.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": "EnchantedCreature"
+                        },
+                        {
+                            "type": "RemoveAllCounters",
+                            "target": "EnchantedCreature"
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            "LoseAllAbilities",
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Javier Charro",
+        "flavorText": "And fast asleep Bombur remained in spite of all they could do.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad40a4b9-9fab-49c1-8e9f-6e0776966833.jpg?1785497045"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -1361,6 +1560,70 @@
     "colorIdentityOverride": []
 }
 
+// Iron Hills Stalwart
+{
+    "name": "Iron Hills Stalwart",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Dwarf Warrior",
+    "oracleText": "Reach, trample\nWhen this creature enters, attach target Equipment you control to up to one target creature you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH",
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AttachTargetEquipmentToCreature",
+                    "equipmentTarget": {
+                        "type": "BoundVariable",
+                        "name": "Equipment you control"
+                    },
+                    "creatureTarget": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact Equipment ctrl:you"
+                    },
+                    "id": "Equipment you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Michele Giorgi",
+        "flavorText": "Their fires caught the attention of huge bats flapping and whirring round their ears.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/46daa9ac-0ac7-4df9-b9d2-e03ab5b56c72.jpg?1785497126"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Large Bear
 {
     "name": "Large Bear",
@@ -1557,6 +1820,59 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Mirkwood Meditator
+{
+    "name": "Mirkwood Meditator",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Landfall — Whenever a land you control enters, you may have this creature's base power and toughness become 4/2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "SetBaseStats",
+                        "target": "Self",
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "duration": "EndOfTurn"
+                    },
+                    "descriptionOverride": "Have Mirkwood Meditator's base power and toughness become 4/2 until end of turn?"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, you may have this creature's base power and toughness become 4/2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Francisco Miyara",
+        "flavorText": "Elves always knew what was going on among the peoples of the land—as quick as water flows, or quicker.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad7ed4e6-3fe2-40f1-909b-a03b2a3c941a.jpg?1785497064"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CommanderComponent
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Color
@@ -442,6 +443,9 @@ class CostCalculator(
             is CostReductionSource.GreatestPropertyAmongPermanentsYouControl -> {
                 greatestPropertyAmongMatching(state, playerId, source.filter, source.property)
             }
+            is CostReductionSource.FixedIfCreatureDiedThisTurn -> {
+                if (anyCreatureDiedThisTurn(state)) source.amount else 0
+            }
             is CostReductionSource.FixedIfVoid -> {
                 if (state.nonlandPermanentLeftBattlefieldThisTurn || state.spellWarpedThisTurn)
                     source.amount
@@ -477,6 +481,18 @@ class CostCalculator(
                 ?.attackerIds
                 ?.size
                 ?: 0
+        }
+
+    /**
+     * Whether a creature died this turn under any player's control. Reads the same per-player
+     * `CreaturesDiedThisTurnComponent` tallies that back
+     * [com.wingedsheep.sdk.scripting.conditions.CreatureDiedThisTurnCondition] — turn history that
+     * `ZoneTransitionService` increments on death and `CleanupPhaseManager` clears at end of turn,
+     * so a creature that died and then left the graveyard still counts.
+     */
+    private fun anyCreatureDiedThisTurn(state: GameState): Boolean =
+        state.turnOrder.any { playerId ->
+            (state.getEntity(playerId)?.get<CreaturesDiedThisTurnComponent>()?.count ?: 0) > 0
         }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadedBatCloudScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadedBatCloudScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dreaded Bat-Cloud — {4}{B} Creature — Bat, 4/2, Flying, Deathtouch
+ *   "This spell costs {3} less to cast if a creature died this turn."
+ *
+ * The discount is `ModifySpellCost(SelfCast, ReduceGenericBy(FixedIfCreatureDiedThisTurn(3)))`,
+ * which reads the same table-wide `CreaturesDiedThisTurnComponent` tallies that back
+ * `Conditions.CreatureDiedThisTurn`. Each test hands the caster *exactly* the mana the expected
+ * cost needs, so a wrong reduction shows up as a failed cast rather than a silently overpaid one:
+ * five black for the full {4}{B}, two black for the discounted {1}{B}.
+ */
+class DreadedBatCloudScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+    }
+
+    test("no creature died this turn — the Bat-Cloud costs the full {4}{B}") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val card = d.putCardInHand(you, "Dreaded Bat-Cloud")
+        d.giveMana(you, Color.BLACK, 5)
+        d.castSpell(you, card).error shouldBe null
+        d.bothPass()
+
+        d.findPermanent(you, "Dreaded Bat-Cloud").shouldNotBeNull()
+    }
+
+    test("no creature died this turn — two black mana is not enough to cast it") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val card = d.putCardInHand(you, "Dreaded Bat-Cloud")
+        d.giveMana(you, Color.BLACK, 2)
+        // {1}{B} of mana against a {4}{B} spell — the cast must be rejected, proving the discount
+        // isn't applied unconditionally.
+        (d.castSpell(you, card).error != null) shouldBe true
+    }
+
+    test("a creature died this turn — {1}{B} is enough") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.addComponent(you, CreaturesDiedThisTurnComponent(1))
+
+        val card = d.putCardInHand(you, "Dreaded Bat-Cloud")
+        d.giveMana(you, Color.BLACK, 2)
+        d.castSpell(you, card).error shouldBe null
+        d.bothPass()
+
+        d.findPermanent(you, "Dreaded Bat-Cloud").shouldNotBeNull()
+    }
+
+    test("an opponent's creature dying also turns on the discount") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // The oracle says "a creature", not "a creature you controlled" — the tally is summed
+        // across the table, so the opponent's loss pays for your Bat-Cloud.
+        d.addComponent(opponent, CreaturesDiedThisTurnComponent(1))
+
+        val card = d.putCardInHand(you, "Dreaded Bat-Cloud")
+        d.giveMana(you, Color.BLACK, 2)
+        d.castSpell(you, card).error shouldBe null
+        d.bothPass()
+
+        d.findPermanent(you, "Dreaded Bat-Cloud").shouldNotBeNull()
+    }
+
+    test("a real death — not a hand-stamped tally — enables the discount") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Kill a creature for real, so ZoneTransitionService credits the tally rather than the test.
+        val victim = d.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val bolt = d.putCardInHand(you, "Lightning Bolt")
+        d.giveMana(you, Color.RED, 1)
+        d.castSpell(you, bolt, targets = listOf(victim)).error shouldBe null
+        d.bothPass()
+        d.findPermanent(you, "Grizzly Bears").shouldBeNull()
+
+        val card = d.putCardInHand(you, "Dreaded Bat-Cloud")
+        d.giveMana(you, Color.BLACK, 2)
+        d.castSpell(you, card).error shouldBe null
+        d.bothPass()
+
+        d.findPermanent(you, "Dreaded Bat-Cloud").shouldNotBeNull()
+    }
+})


### PR DESCRIPTION
Five HOB cards, each canonical in `hob` (first and only printing per Scryfall).

| Card | Cost | Shape |
|---|---|---|
| Enchanted River's Grasp | `{2}{U}` | Aura — tap + wipe counters on ETB, then a Layer 6 lock |
| Mirkwood Meditator | `{2}{U}` | Landfall — optional base-P/T swap to 4/2 |
| Boughside Wanderers | `{4}{G}{G}` | ETB dig for a permanent card + landfall self-pump |
| Iron Hills Stalwart | `{4}{R}` | ETB attaches a target Equipment to a target creature |
| Dreaded Bat-Cloud | `{4}{B}` | Morbid cost reduction, flying + deathtouch |

## Built from existing primitives

- **Enchanted River's Grasp** — Frozen in Ice's lock verbatim (`LoseAllAbilities` + `AbilityFlag.DOESNT_UNTAP`, both Layer 6) with `Effects.RemoveAllCounters` chained onto the ETB tap. `DOESNT_UNTAP` is a restriction the Aura imposes on its host rather than an ability the host has, so losing all abilities doesn't shake it off.
- **Mirkwood Meditator** — `MayEffect` over `Effects.SetBasePowerAndToughness(4, 2)`. A Layer 7b *set* value, not a pump: the printed 2/4 becomes 4/2 and counters/7c modifiers still apply on top. The `descriptionOverride` becomes the yes/no prompt text, so the decision reads clearly each time a land lands — which matters here, since with a 2/4 body taking the 4/2 is often the wrong call.
- **Boughside Wanderers** — the Staunch Crewmate idiom: gather the top four, `ChooseUpTo(1)` filtered to `CardPredicate.IsPermanent` ("you may reveal" — declining stays legal even with hits present), move the pick to hand revealed, bottom the remainder with `CardOrder.Random`.
- **Iron Hills Stalwart** — Blacksmith's Talent level 2's `Effects.AttachTargetEquipmentToCreature` moved onto an ETB. Two explicit targets rather than assuming the source is the Equipment; the Equipment target is mandatory and the creature target is "up to one".

## One new SDK primitive

Dreaded Bat-Cloud needed `CostReductionSource.FixedIfCreatureDiedThisTurn(amount)` — the morbid cost-reduction shape, alongside the existing `FixedIfVoid` / `FixedIfCreatureAttackingYou` siblings.

It reads the same per-player `CreaturesDiedThisTurnComponent` tallies that back `Conditions.CreatureDiedThisTurn`, summed across the table: the oracle text says "a creature", not "a creature you controlled", so an opponent's creature dying counts. Because it's turn history rather than a graveyard scan, a creature that died and was then exiled or reanimated still counts. One new branch in `CostCalculator`; the `when` over `CostReductionSource` is exhaustive, so nothing else enumerating it went unhandled.

`docs/card-sdk-language-reference.md` updated in the same change.

## Tests

`DreadedBatCloudScenarioTest` hands the caster *exactly* the mana the expected cost needs, so a wrong reduction shows up as a failed cast rather than a silently overpaid one:

- no death → full `{4}{B}` casts with five black; two black is **rejected** (proves the discount isn't unconditional)
- after a death → `{1}{B}` is enough
- an opponent's creature dying also turns it on
- a real Lightning Bolt kill, so `ZoneTransitionService` credits the tally instead of the test hand-stamping the component

The other four cards are built purely from existing primitives and are covered by the snapshot and lint nets.

## Verification

- `just build` — green
- `:rules-engine:test` — 9562 tests, 0 failures
- `just rebless-cards` — `HOB.json` diff is 316 insertions, 0 deletions; only these five cards moved
- `just check-card-printing` — clean for all five
- `just check-backlog` — all 14 headers in sync (the-hobbit now 66/193)
- All five `imageUri`s HTTP 200; every mechanical field (mana cost, type line, P/T, rarity, collector number, artist, oracle text, flavor text) re-checked field-by-field against Scryfall

🤖 Generated with [Claude Code](https://claude.com/claude-code)