### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/backlog/sets/the-hobbit/cards.md
+++ b/backlog/sets/the-hobbit/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 193 cards revealed as of 2026-08-04
 **Release Date:** August 14, 2026
-**Implemented:** 66 / 193
+**Implemented:** 71 / 193
 Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. This list covers only cards revealed as of that date.
 
 - [x] 1. Long-Bodied Grey Dog
@@ -23,7 +23,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 16. Iron Hills Blacksmith
 - [ ] 17. Kíli the Resourceful
 - [ ] 18. Lake-town Lookout
-- [ ] 19. Lake-town Toymaker
+- [x] 19. Lake-town Toymaker
 - [x] 20. Magnificent End
 - [ ] 21. Moment of Glory
 - [ ] 22. The Mountain-king's Return
@@ -93,7 +93,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 86. Supper for Spiders
 - [ ] 87. Balin, Loremaster
 - [ ] 88. Bombur, Gentle Dreamer
-- [ ] 89. Bothersome Noisemaker
+- [x] 89. Bothersome Noisemaker
 - [ ] 90. Burn, Burn, Tree and Fern
 - [ ] 91. Dáin Ironfoot
 - [ ] 92. Desert Were-Worm
@@ -104,12 +104,12 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [x] 97. Gandalf, Spark Starter
 - [ ] 98. Getaway Barrel
 - [ ] 99. Glóin the Mighty
-- [ ] 100. Goblin-town Flunkies
+- [x] 100. Goblin-town Flunkies
 - [x] 101. Gundabad Opportunist
 - [x] 102. Iron Hills Stalwart
 - [ ] 103. Last Light of Durin's Day
 - [ ] 104. The Misty Mountains Cold
-- [ ] 105. Misty Mountains Raider
+- [x] 105. Misty Mountains Raider
 - [ ] 106. Óin the Brave
 - [ ] 107. Pinecone Strike
 - [x] 108. Ragged Short Spear
@@ -117,7 +117,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [x] 110. Smaug the Magnificent
 - [x] 111. Smaug's Fury
 - [ ] 112. Snowslope Hunter
-- [ ] 113. Stone-Giant of High Pass
+- [x] 113. Stone-Giant of High Pass
 - [ ] 114. Thorin, Mountain-king
 - [x] 115. Tidings of War
 - [x] 116. Attercop

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BothersomeNoisemaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BothersomeNoisemaker.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bothersome Noisemaker
+ * {1}{R}
+ * Creature — Goblin Bard
+ * 2/2
+ *
+ * Whenever you cast a noncreature spell, amass Goblins 1.
+ */
+val BothersomeNoisemaker = card("Bothersome Noisemaker") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Bard"
+    oracleText = "Whenever you cast a noncreature spell, amass Goblins 1. (Put a +1/+1 counter on " +
+        "an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black " +
+        "Goblin Army creature token first.)"
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.Amass(1, "Goblin")
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Andreia Ugrai"
+        flavorText = "The Goblins began to sing, or croak, keeping time with the flap of their flat feet on the stone."
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb25b11a-6bf5-4a9a-b60f-d4dcac3816d6.jpg?1784894881"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GoblinTownFlunkies.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GoblinTownFlunkies.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin-town Flunkies
+ * {1}{R}
+ * Creature — Goblin Soldier
+ * 1/1
+ *
+ * Haste
+ * When this creature enters, amass Goblins 1.
+ */
+val GoblinTownFlunkies = card("Goblin-town Flunkies") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Soldier"
+    oracleText = "Haste\n" +
+        "When this creature enters, amass Goblins 1. (Put a +1/+1 counter on an Army you control. " +
+        "It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature " +
+        "token first.)"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Amass(1, "Goblin")
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Jason Kang"
+        flavorText = "Goblins made no beautiful things, but they made many clever ones."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/ccff7382-8609-494c-aeee-cd1436456dd0.jpg?1785497117"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LaketownToymaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LaketownToymaker.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lake-town Toymaker
+ * {3}{W}
+ * Creature — Human Artificer
+ * 3/4
+ *
+ * At the beginning of combat on your turn, if you've drawn two or more cards this turn, another
+ * target creature you control gets +3/+0 and gains first strike until end of turn.
+ *
+ * The "if you've drawn two or more cards this turn" clause is an intervening-if (CR 603.4) —
+ * checked both when the trigger would go on the stack and again on resolution — so it's
+ * [triggerCondition], not a [com.wingedsheep.sdk.scripting.effects.ConditionalEffect]. It reads the
+ * controller's `CardsDrawnThisTurnComponent`, which counts every draw this turn regardless of source.
+ */
+val LaketownToymaker = card("Lake-town Toymaker") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Artificer"
+    oracleText = "At the beginning of combat on your turn, if you've drawn two or more cards this " +
+        "turn, another target creature you control gets +3/+0 and gains first strike until end of turn."
+    power = 3
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.YouDrewCardsThisTurn(2)
+        val t = target("another target creature you control", Targets.OtherCreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 0, t),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, t),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Marina Ortega Lorente"
+        flavorText = "In the great days of old, when Dale in the North was rich and prosperous, Lake-town flourished."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67304269-c595-4cf0-8dbf-fcb2e9e01fe2.jpg?1785496951"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MistyMountainsRaider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MistyMountainsRaider.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Misty Mountains Raider
+ * {4}{R}
+ * Creature — Goblin Soldier
+ * 4/4
+ *
+ * Whenever you attack, amass Goblins 2.
+ *
+ * "Whenever you attack" is the once-per-combat declare-attackers trigger
+ * ([Triggers.YouAttack]), not a per-attacker one — it fires once no matter how many creatures
+ * were declared, and it fires even when the Raider itself stays home.
+ */
+val MistyMountainsRaider = card("Misty Mountains Raider") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Soldier"
+    oracleText = "Whenever you attack, amass Goblins 2. (Put two +1/+1 counters on an Army you " +
+        "control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army " +
+        "creature token first.)"
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        effect = Effects.Amass(2, "Goblin")
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "105"
+        artist = "Tomas Duchek"
+        flavorText = "The Wargs and the Goblins often helped one another in wicked deeds."
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6dff14cd-b60b-48f4-9d9f-c9019b55df4c.jpg?1785152178"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StoneGiantOfHighPass.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StoneGiantOfHighPass.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Stone-Giant of High Pass
+ * {5}{R}{R}
+ * Creature — Giant
+ * 7/7
+ *
+ * Whenever this creature enters or attacks, create a 3/1 colorless Wall artifact creature token
+ * with defender named Stone Boulder.
+ * {2}{R}, Sacrifice an artifact: This creature deals 4 damage to any target.
+ *
+ * "Enters or attacks" is two separate triggered abilities on the same card (the printed wording is
+ * a shorthand for both), matching Sentinel of the Nameless City.
+ *
+ * The token carries a printed name that isn't derived from its creature type, so it uses the raw
+ * [CreateTokenEffect] rather than the `Effects.CreateToken` facade — the facade names tokens
+ * "<Type> Token" and can't express "Stone Boulder".
+ */
+private fun stoneBoulderToken() = CreateTokenEffect(
+    power = 3,
+    toughness = 1,
+    colors = emptySet(),
+    creatureTypes = setOf("Wall"),
+    keywords = setOf(Keyword.DEFENDER),
+    name = "Stone Boulder",
+    artifactToken = true,
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/3440e247-a733-4609-9d80-d4a5fc58ae46.jpg?1785502811",
+)
+
+val StoneGiantOfHighPass = card("Stone-Giant of High Pass") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    oracleText = "Whenever this creature enters or attacks, create a 3/1 colorless Wall artifact " +
+        "creature token with defender named Stone Boulder.\n" +
+        "{2}{R}, Sacrifice an artifact: This creature deals 4 damage to any target."
+    power = 7
+    toughness = 7
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = stoneBoulderToken()
+        description = "Whenever this creature enters, create a 3/1 colorless Wall artifact " +
+            "creature token with defender named Stone Boulder."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = stoneBoulderToken()
+        description = "Whenever this creature attacks, create a 3/1 colorless Wall artifact " +
+            "creature token with defender named Stone Boulder."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.Sacrifice(GameObjectFilter.Artifact))
+        val t = target("any target", AnyTarget())
+        effect = Effects.DealDamage(4, t)
+        description = "{2}{R}, Sacrifice an artifact: This creature deals 4 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "113"
+        artist = "Miklós Ligeti"
+        flavorText = "The stone-giants were out and were hurling rocks at one another for a game."
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f4f4683-ffd2-447a-932b-276f7fa17cca.jpg?1785496221"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -85,6 +85,48 @@
     ]
 }
 
+// Bothersome Noisemaker
+{
+    "name": "Bothersome Noisemaker",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Bard",
+    "oracleText": "Whenever you cast a noncreature spell, amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Amass",
+                    "subtype": "Goblin"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Andreia Ugrai",
+        "flavorText": "The Goblins began to sing, or croak, keeping time with the flap of their flat feet on the stone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb25b11a-6bf5-4a9a-b60f-d4dcac3816d6.jpg?1784894881"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Boughside Wanderers
 {
     "name": "Boughside Wanderers",
@@ -1329,6 +1371,45 @@
     ]
 }
 
+// Goblin-town Flunkies
+{
+    "name": "Goblin-town Flunkies",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Soldier",
+    "oracleText": "Haste\nWhen this creature enters, amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Amass",
+                    "subtype": "Goblin"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Jason Kang",
+        "flavorText": "Goblins made no beautiful things, but they made many clever ones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/ccff7382-8609-494c-aeee-cd1436456dd0.jpg?1785497117"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Great Fierce Bee
 {
     "name": "Great Fierce Bee",
@@ -1621,6 +1702,80 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Lake-town Toymaker
+{
+    "name": "Lake-town Toymaker",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "At the beginning of combat on your turn, if you've drawn two or more cards this turn, another target creature you control gets +3/+0 and gains first strike until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "another target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FIRST_STRIKE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "another target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another target creature you control"
+                },
+                "triggerCondition": {
+                    "type": "PlayerDrewCardsThisTurn",
+                    "atLeast": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Marina Ortega Lorente",
+        "flavorText": "In the great days of old, when Dale in the North was rich and prosperous, Lake-town flourished.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67304269-c595-4cf0-8dbf-fcb2e9e01fe2.jpg?1785496951"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1986,6 +2141,45 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Misty Mountains Raider
+{
+    "name": "Misty Mountains Raider",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Goblin Soldier",
+    "oracleText": "Whenever you attack, amass Goblins 2. (Put two +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Amass",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "subtype": "Goblin"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "UNCOMMON",
+        "artist": "Tomas Duchek",
+        "flavorText": "The Wargs and the Goblins often helped one another in wicked deeds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6dff14cd-b60b-48f4-9d9f-c9019b55df4c.jpg?1785152178"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2768,6 +2962,117 @@
         "artist": "Andrea Piparo",
         "flavorText": "The Dwarves had barely time to fly back to the tunnel when Smaug came hurtling from the north, licking the mountainsides with flame, beating his great wings with a noise like a roaring wind.",
         "imageUri": "https://cards.scryfall.io/normal/front/a/1/a16f203a-785e-4c78-9410-fb9f8a0ffa01.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Stone-Giant of High Pass
+{
+    "name": "Stone-Giant of High Pass",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Creature — Giant",
+    "oracleText": "Whenever this creature enters or attacks, create a 3/1 colorless Wall artifact creature token with defender named Stone Boulder.\n{2}{R}, Sacrifice an artifact: This creature deals 4 damage to any target.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Wall"
+                    ],
+                    "keywords": [
+                        "DEFENDER"
+                    ],
+                    "name": "Stone Boulder",
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/4/3440e247-a733-4609-9d80-d4a5fc58ae46.jpg?1785502811",
+                    "artifactToken": true
+                },
+                "descriptionOverride": "Whenever this creature enters, create a 3/1 colorless Wall artifact creature token with defender named Stone Boulder."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Wall"
+                    ],
+                    "keywords": [
+                        "DEFENDER"
+                    ],
+                    "name": "Stone Boulder",
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/4/3440e247-a733-4609-9d80-d4a5fc58ae46.jpg?1785502811",
+                    "artifactToken": true
+                },
+                "descriptionOverride": "Whenever this creature attacks, create a 3/1 colorless Wall artifact creature token with defender named Stone Boulder."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{2}{R}, Sacrifice an artifact: This creature deals 4 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "RARE",
+        "artist": "Miklós Ligeti",
+        "flavorText": "The stone-giants were out and were hurling rocks at one another for a game.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f4f4683-ffd2-447a-932b-276f7fa17cca.jpg?1785496221"
     },
     "colorIdentityOverride": [
         "RED"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BothersomeNoisemakerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BothersomeNoisemakerScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bothersome Noisemaker (HOB) — {1}{R} Creature — Goblin Bard 2/2.
+ *
+ * "Whenever you cast a noncreature spell, amass Goblins 1."
+ *
+ * The trigger is on *casting*, so it fires while the spell is still on the stack — before that
+ * spell resolves. Creature spells must not trigger it, and neither must an opponent's noncreature
+ * spell.
+ */
+class BothersomeNoisemakerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bothersome Noisemaker") {
+
+            test("it is a 2/2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bothersome Noisemaker")
+                    .build()
+
+                val noisemaker = game.findPermanent("Bothersome Noisemaker")!!
+                game.state.projectedState.getPower(noisemaker) shouldBe 2
+                game.state.projectedState.getToughness(noisemaker) shouldBe 2
+            }
+
+            test("casting a noncreature spell amasses Goblins 1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bothersome Noisemaker")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val army = game.findPermanent("Goblin Army")
+                    ?: error("casting a noncreature spell should have amassed")
+                game.state.projectedState.getPower(army) shouldBe 1
+                withClue("the Bolt still resolved") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+            }
+
+            test("casting a creature spell does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bothersome Noisemaker")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the trigger reads 'noncreature spell'") {
+                    game.findAllPermanents("Goblin Army").size shouldBe 0
+                }
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+            }
+
+            test("an opponent's noncreature spell does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bothersome Noisemaker")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the trigger reads 'whenever you cast'") {
+                    game.findAllPermanents("Goblin Army").size shouldBe 0
+                }
+                game.getLifeTotal(1) shouldBe 17
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinTownFlunkiesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinTownFlunkiesScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Goblin-town Flunkies (HOB) — {1}{R} Creature — Goblin Soldier 1/1.
+ *
+ * "Haste
+ *  When this creature enters, amass Goblins 1."
+ *
+ * With no Army in play the amass has to mint the 0/0 black Goblin Army token first and then put
+ * the counter on it, so a fresh board yields a 1/1 Army. A second Flunky amasses onto that same
+ * Army rather than making a second one.
+ */
+class GoblinTownFlunkiesScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Goblin-town Flunkies") {
+
+            test("it is a 1/1 with haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Goblin-town Flunkies")
+                    .build()
+
+                val flunkies = game.findPermanent("Goblin-town Flunkies")!!
+                game.state.projectedState.getPower(flunkies) shouldBe 1
+                game.state.projectedState.getToughness(flunkies) shouldBe 1
+                game.state.projectedState.hasKeyword(flunkies, Keyword.HASTE) shouldBe true
+            }
+
+            test("its ETB amasses Goblins 1, creating a 1/1 Goblin Army from nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Goblin-town Flunkies")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.findAllPermanents("Goblin Army").size shouldBe 0
+
+                game.castSpell(1, "Goblin-town Flunkies").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val army = game.findPermanent("Goblin Army")
+                    ?: error("amass should have created a Goblin Army token")
+                withClue("a 0/0 token plus one +1/+1 counter") {
+                    game.state.projectedState.getPower(army) shouldBe 1
+                    game.state.projectedState.getToughness(army) shouldBe 1
+                }
+            }
+
+            test("a second Flunky amasses onto the existing Army instead of making another") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardsInHand(1, "Goblin-town Flunkies", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                repeat(2) {
+                    game.castSpell(1, "Goblin-town Flunkies").error shouldBe null
+                    if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                    game.resolveStack()
+                }
+
+                withClue("amass never makes a second Army while one is already there") {
+                    game.findAllPermanents("Goblin Army").size shouldBe 1
+                }
+                val army = game.findPermanent("Goblin Army")!!
+                game.state.projectedState.getPower(army) shouldBe 2
+                game.state.projectedState.getToughness(army) shouldBe 2
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LaketownToymakerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LaketownToymakerScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lake-town Toymaker (HOB) — {3}{W} Creature — Human Artificer 3/4.
+ *
+ * "At the beginning of combat on your turn, if you've drawn two or more cards this turn, another
+ *  target creature you control gets +3/+0 and gains first strike until end of turn."
+ *
+ * The draw clause is an intervening-if (CR 603.4), so with fewer than two cards drawn the ability
+ * never goes on the stack at all — no target is even asked for. "Another" excludes the Toymaker
+ * itself, and "you control" excludes the opponent's board.
+ */
+class LaketownToymakerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lake-town Toymaker") {
+
+            test("it is a 3/4") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lake-town Toymaker")
+                    .build()
+
+                val toymaker = game.findPermanent("Lake-town Toymaker")!!
+                game.state.projectedState.getPower(toymaker) shouldBe 3
+                game.state.projectedState.getToughness(toymaker) shouldBe 4
+            }
+
+            test("with two cards drawn it pumps another creature you control and grants first strike") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lake-town Toymaker")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardsDrawnThisTurn(1, 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                val decision = game.getPendingDecision()
+                withClue("the intervening-if is met, so the ability asks for its target") {
+                    (decision is ChooseTargetsDecision) shouldBe true
+                }
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("+3/+0 and first strike until end of turn") {
+                    game.state.projectedState.getPower(bears) shouldBe 5
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                    game.state.projectedState.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+                }
+            }
+
+            test("neither the Toymaker itself nor an opponent's creature is a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lake-town Toymaker")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardsDrawnThisTurn(1, 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val toymaker = game.findPermanent("Lake-town Toymaker")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val theirs = game.findPermanent("Hill Giant")!!
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                val decision = game.getPendingDecision() as ChooseTargetsDecision
+                val legal = decision.legalTargets[0] ?: emptyList()
+                withClue("'another target creature you control'") {
+                    legal shouldContain bears
+                    legal shouldNotContain toymaker
+                    legal shouldNotContain theirs
+                }
+            }
+
+            test("with only one card drawn the ability never triggers") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lake-town Toymaker")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardsDrawnThisTurn(1, 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+                withClue("the intervening-if fails, so nothing goes on the stack") {
+                    game.hasPendingDecision() shouldBe false
+                    game.state.stack.isEmpty() shouldBe true
+                }
+                game.state.projectedState.getPower(bears) shouldBe 2
+                game.state.projectedState.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistyMountainsRaiderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MistyMountainsRaiderScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Misty Mountains Raider (HOB) — {4}{R} Creature — Goblin Soldier 4/4.
+ *
+ * "Whenever you attack, amass Goblins 2."
+ *
+ * "Whenever you attack" is the once-per-declare-attackers trigger: it fires exactly once no matter
+ * how many creatures were declared, and it fires even when the Raider itself stays home.
+ */
+class MistyMountainsRaiderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Misty Mountains Raider") {
+
+            test("it is a 4/4") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Misty Mountains Raider")
+                    .build()
+
+                val raider = game.findPermanent("Misty Mountains Raider")!!
+                game.state.projectedState.getPower(raider) shouldBe 4
+                game.state.projectedState.getToughness(raider) shouldBe 4
+            }
+
+            test("attacking amasses Goblins 2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Misty Mountains Raider", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Misty Mountains Raider" to 2)).error shouldBe null
+                game.resolveStack()
+
+                val army = game.findPermanent("Goblin Army")
+                    ?: error("attacking should have amassed a Goblin Army")
+                withClue("two +1/+1 counters on a fresh 0/0 Army") {
+                    game.state.projectedState.getPower(army) shouldBe 2
+                    game.state.projectedState.getToughness(army) shouldBe 2
+                }
+            }
+
+            test("it fires once for the whole attack, not once per attacker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Misty Mountains Raider", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(
+                    mapOf(
+                        "Misty Mountains Raider" to 2,
+                        "Grizzly Bears" to 2,
+                        "Hill Giant" to 2,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                val army = game.findPermanent("Goblin Army")!!
+                withClue("three attackers, still a single 'whenever you attack' trigger") {
+                    game.findAllPermanents("Goblin Army").size shouldBe 1
+                    game.state.projectedState.getPower(army) shouldBe 2
+                }
+            }
+
+            test("it triggers even when the Raider itself doesn't attack") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Misty Mountains Raider", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("'whenever you attack' is a player trigger, not a self-attack one") {
+                    val army = game.findPermanent("Goblin Army")
+                        ?: error("the Raider should still have amassed")
+                    game.state.projectedState.getPower(army) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StoneGiantOfHighPassScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StoneGiantOfHighPassScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.StoneGiantOfHighPass
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stone-Giant of High Pass (HOB) — {5}{R}{R} Creature — Giant 7/7.
+ *
+ * "Whenever this creature enters or attacks, create a 3/1 colorless Wall artifact creature token
+ *  with defender named Stone Boulder.
+ *  {2}{R}, Sacrifice an artifact: This creature deals 4 damage to any target."
+ *
+ * Enters and attacks are two separate triggers, so a Giant that enters and then attacks in the same
+ * turn ends up with two Boulders. The Boulders are artifacts, which is what feeds the sacrifice cost
+ * on the damage ability.
+ */
+class StoneGiantOfHighPassScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Stone-Giant of High Pass") {
+
+            test("it is a 7/7") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Stone-Giant of High Pass")
+                    .build()
+
+                val giant = game.findPermanent("Stone-Giant of High Pass")!!
+                game.state.projectedState.getPower(giant) shouldBe 7
+                game.state.projectedState.getToughness(giant) shouldBe 7
+            }
+
+            test("entering creates a 3/1 Stone Boulder with defender") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stone-Giant of High Pass")
+                    .withLandsOnBattlefield(1, "Mountain", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Stone-Giant of High Pass").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val boulder = game.findPermanent("Stone Boulder")
+                    ?: error("the enters trigger should have created a Stone Boulder")
+                withClue("a 3/1 artifact creature with defender") {
+                    game.state.projectedState.getPower(boulder) shouldBe 3
+                    game.state.projectedState.getToughness(boulder) shouldBe 1
+                    game.state.projectedState.hasKeyword(boulder, Keyword.DEFENDER) shouldBe true
+                }
+            }
+
+            test("attacking creates another Boulder") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Stone-Giant of High Pass", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("the board starts clean — this Giant was put into play, not cast") {
+                    game.findAllPermanents("Stone Boulder").size shouldBe 0
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Stone-Giant of High Pass" to 2)).error shouldBe null
+                game.resolveStack()
+
+                game.findAllPermanents("Stone Boulder").size shouldBe 1
+            }
+
+            test("{2}{R}, sacrificing the Boulder deals 4 damage to any target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stone-Giant of High Pass")
+                    .withLandsOnBattlefield(1, "Mountain", 10)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Stone-Giant of High Pass").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val giant = game.findPermanent("Stone-Giant of High Pass")!!
+                val boulder = game.findPermanent("Stone Boulder")!!
+                val ability = StoneGiantOfHighPass.activatedAbilities.single().id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = giant,
+                        abilityId = ability,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                    )
+                ).error shouldBe null
+
+                var guard = 0
+                while (guard++ < 10) {
+                    when (game.getPendingDecision()) {
+                        is SelectManaSourcesDecision -> game.submitManaSourcesAutoPay()
+                        is SelectCardsDecision -> game.selectCards(listOf(boulder))
+                        else -> break
+                    }
+                }
+                game.resolveStack()
+
+                withClue("4 damage to the opponent") {
+                    game.getLifeTotal(2) shouldBe 16
+                }
+                withClue("the Boulder was sacrificed to pay the cost") {
+                    game.findAllPermanents("Stone Boulder").size shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five HOB cards, all built on existing SDK vocabulary — no new effects, triggers, or keywords.

| Card | Cost | Text |
|---|---|---|
| Goblin-town Flunkies | {1}{R} | Haste; when it enters, amass Goblins 1 |
| Bothersome Noisemaker | {1}{R} | Whenever you cast a noncreature spell, amass Goblins 1 |
| Misty Mountains Raider | {4}{R} | Whenever you attack, amass Goblins 2 |
| Lake-town Toymaker | {3}{W} | At the beginning of combat on your turn, if you've drawn two or more cards this turn, another target creature you control gets +3/+0 and gains first strike until end of turn |
| Stone-Giant of High Pass | {5}{R}{R} | Whenever it enters or attacks, create a 3/1 colorless Wall artifact creature token with defender named Stone Boulder; {2}{R}, Sacrifice an artifact: 4 damage to any target |

I deliberately skipped every HOB card with `recruit` — that's a new keyword action the engine doesn't
have yet, and faking it would be an `add-feature`, not an `add-card`.

### Notes on the modelling

- **`Triggers.YouAttack`** for Misty Mountains Raider, not `Triggers.Attacks` — "whenever you attack"
  is the once-per-declare-attackers player trigger. Tests pin both halves: it fires once for a
  three-creature attack, and it fires when the Raider itself stays home.
- **Intervening-if (CR 603.4)** for Lake-town Toymaker's draw clause — `triggerCondition`, not a
  `ConditionalEffect`. With one card drawn the ability never reaches the stack, so no target is even
  requested.
- **Raw `CreateTokenEffect` for Stone Boulder** — its printed name isn't derived from its creature
  type, and the `Effects.CreateToken` facade names tokens `"<Type> Token"`. Enters and attacks are two
  separate triggered abilities, matching Sentinel of the Nameless City.

### Verification

- `just build` — green after `just rebless-cards`; the HOB golden diff is pure insertion, only these
  five cards moved.
- `just test-class "*ScenarioTest"` — BUILD SUCCESSFUL, including the 19 new tests across five files
  (one per card).
- `just check-card-printing` clean for all five (each is HOB-exclusive, canonical here).
- `just check-backlog` in sync — The Hobbit now 71 / 193.
- All six image URIs (five cards + the token) verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)