### PR TITLE
Local testing mode: inspect and steer the engine AI

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.ai.engine.evaluation.*
 import com.wingedsheep.ai.engine.knowledge.IntentCatalog
 import com.wingedsheep.ai.engine.hidden.Determinizer
 import com.wingedsheep.ai.engine.hidden.OpponentModel
+import com.wingedsheep.ai.insight.AiInsightSink
 import com.wingedsheep.ai.engine.rollout.CandidateEvaluator
 import com.wingedsheep.ai.engine.rollout.FastDecisionResponder
 import com.wingedsheep.ai.engine.rollout.PlayoutEngine
@@ -180,6 +181,11 @@ class AIPlayer(
             playerId: EntityId,
             profile: AiProfile,
             opponentModels: Map<EntityId, OpponentModel> = emptyMap(),
+            /**
+             * Local testing mode: where the [Strategist]'s per-candidate scores are published
+             * instead of being discarded. Null (the default) is production — no recording.
+             */
+            insightSink: AiInsightSink? = null,
         ): AIPlayer {
             val advisorRegistry = CardAdvisorRegistry()
             profile.advisorModules.forEach { it.register(advisorRegistry) }
@@ -238,6 +244,7 @@ class AIPlayer(
                     } else {
                         null
                     },
+                    insightSink = insightSink,
                 ),
                 responder = responder,
                 useMeaningfulFilter = profile.useMeaningfulFilter,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.ai.engine
 import com.wingedsheep.ai.engine.advisor.CardAdvisorRegistry
 import com.wingedsheep.ai.engine.budget.DecisionBudget
 import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
+import com.wingedsheep.ai.insight.CombatPlanTrace
 import com.wingedsheep.engine.core.DeclareAttackers
 import com.wingedsheep.engine.core.DeclareBlockers
 import com.wingedsheep.engine.core.GameAction
@@ -78,6 +79,8 @@ class CombatAdvisor(
         legalAction: LegalAction,
         playerId: EntityId,
         budget: DecisionBudget = DecisionBudget.legacy(),
+        /** Local testing mode: collects the plans local search simulated. Null in production. */
+        trace: CombatPlanTrace? = null,
     ): GameAction {
         val projected = state.projectedState
         val validAttackers = legalAction.validAttackers ?: emptyList()
@@ -105,7 +108,7 @@ class CombatAdvisor(
         }
         if (state.step == Step.DECLARE_ATTACKERS && enemyControlsCreature) {
             improveAttackViaLocalSearch(
-                state, playerId, opponentId, validAttackers, mandatory.toSet(), seedMap, budget
+                state, playerId, opponentId, validAttackers, mandatory.toSet(), seedMap, budget, trace
             )
         }
 
@@ -133,6 +136,8 @@ class CombatAdvisor(
         playerId: EntityId,
         useSimulation: Boolean = false,
         budget: DecisionBudget = DecisionBudget.legacy(),
+        /** Local testing mode: collects the plans local search simulated. Null in production. */
+        trace: CombatPlanTrace? = null,
     ): GameAction {
         val projected = state.projectedState
         val validBlockers = legalAction.validBlockers ?: emptyList()
@@ -173,7 +178,7 @@ class CombatAdvisor(
         val bestMap = if (useSimulation) {
             improveViaLocalSearch(
                 state, projected, playerId, attackers, validBlockers,
-                mandatoryBlockerIds, seedMap, budget
+                mandatoryBlockerIds, seedMap, budget, trace
             )
         } else {
             seedMap
@@ -331,9 +336,11 @@ class CombatAdvisor(
         mandatoryBlockerIds: Set<EntityId>,
         seedMap: MutableMap<EntityId, List<EntityId>>,
         budget: DecisionBudget,
+        trace: CombatPlanTrace? = null,
     ): MutableMap<EntityId, List<EntityId>> {
         var currentPlan = seedMap.toMutableMap()
         var currentScore = evaluateBlockingPlan(state, playerId, currentPlan) ?: return currentPlan
+        trace?.recordBlock(currentPlan, currentScore)
         var simulationsLeft = budget.allowances.blockSimulations
         val deadline = budget.combatDeadlineNanos
 
@@ -353,6 +360,7 @@ class CombatAdvisor(
                 if (simulationsLeft <= 0 || System.nanoTime() > deadline) break
                 simulationsLeft--
                 val score = evaluateBlockingPlan(state, playerId, mutation) ?: continue
+                trace?.recordBlock(mutation, score)
                 if (score > bestScore) {
                     bestScore = score
                     bestMutation = mutation
@@ -948,16 +956,19 @@ class CombatAdvisor(
         mandatoryAttackers: Set<EntityId>,
         attackerMap: MutableMap<EntityId, EntityId>,
         budget: DecisionBudget,
+        trace: CombatPlanTrace? = null,
     ) {
         val deadline = budget.combatDeadlineNanos
         // Baseline: use current board evaluation. Attack plans must beat this.
         val noAttackScore = evaluateAttackPlan(state, playerId, opponentId, emptyMap())
             ?: evaluator.evaluate(state, state.projectedState, playerId)
+        trace?.recordAttack(emptyMap(), noAttackScore)
         var currentScore = if (attackerMap.isEmpty()) {
             noAttackScore
         } else {
             evaluateAttackPlan(state, playerId, opponentId, attackerMap) ?: return
         }
+        trace?.recordAttack(attackerMap, currentScore)
 
         // If seed plan is worse than not attacking, start from empty
         if (currentScore < noAttackScore && mandatoryAttackers.isEmpty()) {
@@ -978,6 +989,7 @@ class CombatAdvisor(
                 val mutation = attackerMap.toMutableMap()
                 mutation[attacker] = opponentId
                 val score = evaluateAttackPlan(state, playerId, opponentId, mutation) ?: continue
+                trace?.recordAttack(mutation, score)
                 if (score > bestScore) {
                     bestScore = score
                     bestMutation = mutation
@@ -996,6 +1008,7 @@ class CombatAdvisor(
                 } else {
                     evaluateAttackPlan(state, playerId, opponentId, mutation) ?: continue
                 }
+                trace?.recordAttack(mutation, score)
                 if (score > bestScore) {
                     bestScore = score
                     bestMutation = mutation

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.ai.engine
 
 import com.wingedsheep.ai.ActionResponse
 import com.wingedsheep.ai.AiPlayerController
+import com.wingedsheep.ai.insight.AiInsightSink
 import com.wingedsheep.ai.llm.BottomCardsInfo
 import com.wingedsheep.ai.llm.CardSummary
 import com.wingedsheep.ai.llm.MulliganInfo
@@ -29,10 +30,15 @@ private val logger = LoggerFactory.getLogger(EngineAiPlayerController::class.jav
 class EngineAiPlayerController(
     private val cardRegistry: CardRegistry,
     private val playerId: EntityId,
-    private val gameStateProvider: () -> GameState?
+    private val gameStateProvider: () -> GameState?,
+    /**
+     * Local testing mode: publishes the scores the [Strategist] assigned each candidate, so a human
+     * can browse what the AI weighed. Null in normal play.
+     */
+    insightSink: AiInsightSink? = null,
 ) : AiPlayerController {
 
-    private val aiPlayer = AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION)
+    private val aiPlayer = AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION, insightSink = insightSink)
 
     override fun chooseAction(
         state: ClientGameState,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -14,8 +14,17 @@ import com.wingedsheep.ai.engine.rollout.CandidateEvaluator
 import com.wingedsheep.ai.engine.rollout.PlayoutPolicy
 import com.wingedsheep.ai.engine.rollout.RolloutCandidateEvaluator
 import com.wingedsheep.ai.engine.rollout.StaticCandidateEvaluator
+import com.wingedsheep.ai.insight.AiActionOption
+import com.wingedsheep.ai.insight.AiDecisionInsight
+import com.wingedsheep.ai.insight.AiDecisionKind
+import com.wingedsheep.ai.insight.AiInsightLabels
+import com.wingedsheep.ai.insight.AiInsightSink
+import com.wingedsheep.ai.insight.CombatPlan
+import com.wingedsheep.ai.insight.CombatPlanTrace
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
 import com.wingedsheep.engine.core.GameAction
 import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.legalactions.MeaningfulActionFilter
@@ -83,6 +92,12 @@ class Strategist(
     private val candidateEvaluator: CandidateEvaluator = StaticCandidateEvaluator(evaluator),
     /** Phase 8: a fair complete world, sampled once before any candidate simulation. */
     private val stateSampler: ((GameState, EntityId) -> GameState)? = null,
+    /**
+     * Local testing mode: where the per-candidate scores this class computes go, instead of being
+     * dropped once the winner is picked. Null in production, and the only thing that reads it is a
+     * null check — the numbers are already being computed either way, so recording adds no search.
+     */
+    private val insightSink: AiInsightSink? = null,
 ) {
     private val holdPolicy = HoldPolicy(intents)
 
@@ -99,6 +114,7 @@ class Strategist(
         legalActions: List<LegalAction>,
         playerId: EntityId
     ): LegalAction {
+        val startNanos = if (insightSink != null) System.nanoTime() else 0L
         val evaluationState = stateSampler?.invoke(state, playerId) ?: state
         // Combat declaration steps need the CombatAdvisor to fill in attacker/blocker maps
         // even when there's only one legal action (which is the common case — the enumerator
@@ -106,7 +122,7 @@ class Strategist(
         val combatAction = legalActions.find { it.actionType == "DeclareAttackers" || it.actionType == "DeclareBlockers" }
         if (combatAction != null) {
             val budget = budgetPolicy.budgetFor(state, playerId, listOf(combatAction))
-            return handleCombatDeclaration(evaluationState, combatAction, playerId, budget)
+            return handleCombatDeclaration(evaluationState, combatAction, playerId, budget, startNanos)
         }
 
         if (legalActions.size == 1) {
@@ -131,11 +147,16 @@ class Strategist(
         // the real option it is rather than as a separately-computed threshold.
         val leaves = mutableListOf<LegalAction>()
         val leafStates = mutableListOf<GameState>()
+        // Local testing mode only: the candidates that never reached scoring. Reading the panel
+        // without them makes the AI look like it never considered a play it in fact discarded.
+        val dropped = if (insightSink != null) mutableListOf<AiActionOption>() else null
+        var searched = 0
         if (pass != null) {
             leaves += pass
             leafStates += simulator.simulate(evaluationState, pass.action).state
         }
         for (action in affordable) {
+            searched++
             val (materialized, simulation) = materialize(evaluationState, action, playerId, budget, here)
             val usable = when {
                 // LegalAction affordability is necessarily a preview for costs such as convoke and
@@ -154,11 +175,35 @@ class Strategist(
             if (usable) {
                 leaves += action.copy(action = materialized)
                 leafStates += simulation.state
+            } else {
+                val illegal = simulation is SimulationResult.Illegal
+                dropped?.add(
+                    droppedOption(
+                        evaluationState, action, materialized,
+                        note = if (illegal) {
+                            "dropped — illegal once materialized"
+                        } else {
+                            "dropped — leads back to a position already acted from"
+                        },
+                        submittable = !illegal,
+                    )
+                )
             }
             // Every candidate cost a simulation whether or not it survived those filters, so the
             // anytime cut is taken on all of them. Checking only after a survivor was recorded
             // would let a board full of inert candidates run straight past the budget.
             if (budget.expired()) break
+        }
+        if (dropped != null) {
+            for (action in affordable.drop(searched)) {
+                dropped += droppedOption(
+                    evaluationState, action, action.action,
+                    note = "not searched — decision budget expired",
+                    // Never materialized, so its targets are unfilled — not something to hand the
+                    // processor. Listed so the panel can say the budget, not the AI, ruled it out.
+                    submittable = false,
+                )
+            }
         }
 
         // ── Pass 2: score every leaf at once ──
@@ -172,9 +217,10 @@ class Strategist(
 
         // ── Pass 3: per-card timing and advisor adjustments, in raw evaluator units ──
         val firstCandidate = if (pass != null) 1 else 0
-        val scored = (firstCandidate until leaves.size).map { i ->
-            leaves[i] to adjustScore(evaluationState, leaves[i], playerId, leafScores[i], passScore)
+        val adjusted = (firstCandidate until leaves.size).map { i ->
+            Triple(leaves[i], leafScores[i], adjustScore(evaluationState, leaves[i], playerId, leafScores[i], passScore))
         }
+        val scored = adjusted.map { (action, _, adjustment) -> action to adjustment.score }
 
         // On the opponent's end step, unspent mana is about to be wasted. Reduce the pass threshold
         // so the AI is more willing to use instants rather than letting mana evaporate.
@@ -191,16 +237,119 @@ class Strategist(
             }
 
         val best = scored.maxByOrNull { it.second }
-        return if (best != null && best.second > adjustedPassScore) {
+        val takeAction = best != null && best.second > adjustedPassScore
+        val chosen = if (takeAction) {
             remember(here)
             // Fill in targets on the returned action so the processor can execute it.
             // The committed target is chosen by simulation (not just the heuristic) so the
             // AI sees the real resolved board, including effects already on the stack.
-            best.first
+            best!!.first
         } else {
             pass ?: legalActions.first()
         }
+
+        if (insightSink != null) {
+            recordPriorityInsight(
+                state, evaluationState, playerId, startNanos,
+                pass = pass, passScore = passScore, adjustedPassScore = adjustedPassScore,
+                adjusted = adjusted, dropped = dropped.orEmpty(),
+                chosenAction = if (takeAction) best!!.first else null,
+            )
+        }
+        return chosen
     }
+
+    /**
+     * Hand the scores this decision produced to [insightSink], best-first, with passing sitting in
+     * the ranking at its own score so the waterline every option had to clear is visible.
+     */
+    private fun recordPriorityInsight(
+        state: GameState,
+        evaluationState: GameState,
+        playerId: EntityId,
+        startNanos: Long,
+        pass: LegalAction?,
+        passScore: Double,
+        adjustedPassScore: Double,
+        adjusted: List<Triple<LegalAction, Double, AdjustedScore>>,
+        dropped: List<AiActionOption>,
+        chosenAction: LegalAction?,
+    ) {
+        val sink = insightSink ?: return
+        val options = mutableListOf<AiActionOption>()
+        if (pass != null) {
+            options += AiActionOption(
+                label = "Pass priority",
+                actionType = "PassPriority",
+                score = adjustedPassScore,
+                rawScore = passScore.takeIf { it != adjustedPassScore },
+                advantage = 0.0,
+                chosen = chosenAction == null,
+                baseline = true,
+                note = if (adjustedPassScore != passScore) {
+                    "opponent's end step — pass discounted so unspent mana isn't wasted"
+                } else {
+                    null
+                },
+                action = pass.action,
+            )
+        }
+        for ((action, leafScore, adjustment) in adjusted) {
+            options += AiActionOption(
+                label = AiInsightLabels.describe(evaluationState, action, action.action),
+                actionType = action.actionType,
+                cardName = AiInsightLabels.cardName(evaluationState, action.action),
+                targets = AiInsightLabels.targetNames(evaluationState, action.action),
+                score = adjustment.score,
+                rawScore = leafScore.takeIf { it != adjustment.score },
+                advantage = adjustment.score - adjustedPassScore,
+                chosen = action === chosenAction,
+                note = adjustment.note,
+                action = action.action,
+            )
+        }
+        options.sortByDescending { it.score }
+        options += dropped
+
+        sink.record(
+            evaluationState,
+            AiDecisionInsight(
+                kind = AiDecisionKind.PRIORITY,
+                playerId = playerId,
+                turnNumber = state.turnNumber,
+                step = state.step.name,
+                activePlayerId = state.activePlayerId,
+                onOwnTurn = state.activePlayerId == playerId,
+                baselineLabel = "Pass priority",
+                baselineScore = adjustedPassScore,
+                chosenLabel = options.firstOrNull { it.chosen }?.label ?: "Pass priority",
+                thinkTimeMs = (System.nanoTime() - startNanos) / 1_000_000,
+                options = options,
+            ),
+        )
+    }
+
+    /**
+     * An option that never reached scoring, so the panel can say what happened to it.
+     *
+     * [submittable] is false for a candidate the processor already rejected — it stays visible (the
+     * AI did consider it) but carries no action, so the local testing mode can't offer to play a
+     * line the engine would refuse.
+     */
+    private fun droppedOption(
+        state: GameState,
+        action: LegalAction,
+        materialized: GameAction,
+        note: String,
+        submittable: Boolean,
+    ): AiActionOption = AiActionOption(
+        label = AiInsightLabels.describe(state, action, materialized),
+        actionType = action.actionType,
+        cardName = AiInsightLabels.cardName(state, materialized),
+        targets = AiInsightLabels.targetNames(state, materialized),
+        note = note,
+        action = materialized.takeIf { submittable },
+    )
 
     /**
      * The concrete action the AI would submit for [action], and the position it leads to.
@@ -273,14 +422,117 @@ class Strategist(
         legalAction: LegalAction,
         playerId: EntityId,
         budget: DecisionBudget,
+        startNanos: Long,
     ): LegalAction {
+        val trace = if (insightSink != null) CombatPlanTrace() else null
         val action = when (legalAction.actionType) {
-            "DeclareAttackers" -> combatAdvisor.chooseAttackers(state, legalAction, playerId, budget)
-            "DeclareBlockers" ->
-                combatAdvisor.chooseBlockers(state, legalAction, playerId, useSimulation = true, budget = budget)
+            "DeclareAttackers" -> combatAdvisor.chooseAttackers(state, legalAction, playerId, budget, trace)
+            "DeclareBlockers" -> combatAdvisor.chooseBlockers(
+                state, legalAction, playerId, useSimulation = true, budget = budget, trace = trace
+            )
             else -> legalAction.action
         }
+        if (trace != null) recordCombatInsight(state, legalAction, playerId, action, trace, startNanos)
         return legalAction.copy(action = action)
+    }
+
+    /**
+     * Hand the combat plans local search simulated to [insightSink], measured against declaring
+     * nothing.
+     *
+     * The trace is empty on the paths that skip local search altogether — a lethal alpha strike, an
+     * opponent with no creatures to block with, no legal blockers — so the submitted plan is
+     * recorded on its own with that said plainly, rather than as an unexplained single row.
+     */
+    private fun recordCombatInsight(
+        state: GameState,
+        legalAction: LegalAction,
+        playerId: EntityId,
+        action: GameAction,
+        trace: CombatPlanTrace,
+        startNanos: Long,
+    ) {
+        val sink = insightSink ?: return
+        val attacking = legalAction.actionType == "DeclareAttackers"
+        val chosenPlan: Any = when (action) {
+            is DeclareAttackers -> action.attackers
+            is DeclareBlockers -> action.blockers.filterValues { it.isNotEmpty() }
+            else -> emptyMap<EntityId, EntityId>()
+        }
+        val describe: (CombatPlan) -> String = { plan ->
+            when (plan) {
+                is CombatPlan.Attack -> AiInsightLabels.describeAttackPlan(state, plan.attackers)
+                is CombatPlan.Block -> AiInsightLabels.describeBlockPlan(state, plan.blockers)
+            }
+        }
+        val planOf: (CombatPlan) -> Any = { plan ->
+            when (plan) {
+                is CombatPlan.Attack -> plan.attackers
+                is CombatPlan.Block -> plan.blockers
+            }
+        }
+        val actionOf: (CombatPlan) -> GameAction = { plan ->
+            when (plan) {
+                is CombatPlan.Attack -> DeclareAttackers(playerId, plan.attackers)
+                is CombatPlan.Block -> DeclareBlockers(playerId, plan.blockers)
+            }
+        }
+        val baselineLabel = if (attacking) "No attacks" else "No blocks"
+        val baselineScore = trace.plans
+            .firstOrNull { describe(it) == baselineLabel }
+            ?.score
+            ?: trace.plans.minOfOrNull { it.score }
+            ?: 0.0
+
+        val options = trace.plans
+            .map { plan ->
+                AiActionOption(
+                    label = describe(plan),
+                    actionType = legalAction.actionType,
+                    score = plan.score,
+                    advantage = plan.score - baselineScore,
+                    chosen = planOf(plan) == chosenPlan,
+                    baseline = describe(plan) == baselineLabel,
+                    action = actionOf(plan),
+                )
+            }
+            .sortedByDescending { it.score }
+            .toMutableList()
+
+        val chosenLabel = if (attacking) {
+            AiInsightLabels.describeAttackPlan(state, (action as? DeclareAttackers)?.attackers.orEmpty())
+        } else {
+            AiInsightLabels.describeBlockPlan(state, (action as? DeclareBlockers)?.blockers.orEmpty())
+        }
+        if (options.none { it.chosen }) {
+            options.add(
+                0,
+                AiActionOption(
+                    label = chosenLabel,
+                    actionType = legalAction.actionType,
+                    chosen = true,
+                    note = "heuristic seed — local search did not run for this declaration",
+                    action = action,
+                ),
+            )
+        }
+
+        sink.record(
+            state,
+            AiDecisionInsight(
+                kind = if (attacking) AiDecisionKind.DECLARE_ATTACKERS else AiDecisionKind.DECLARE_BLOCKERS,
+                playerId = playerId,
+                turnNumber = state.turnNumber,
+                step = state.step.name,
+                activePlayerId = state.activePlayerId,
+                onOwnTurn = state.activePlayerId == playerId,
+                baselineLabel = baselineLabel,
+                baselineScore = baselineScore,
+                chosenLabel = chosenLabel,
+                thinkTimeMs = (System.nanoTime() - startNanos) / 1_000_000,
+                options = options,
+            ),
+        )
     }
 
     /**
@@ -296,8 +548,8 @@ class Strategist(
         playerId: EntityId,
         leafScore: Double,
         passScore: Double,
-    ): Double {
-        val cardName = resolveCardName(state, action) ?: return leafScore
+    ): AdjustedScore {
+        val cardName = resolveCardName(state, action) ?: return AdjustedScore(leafScore)
 
         // Phase 6: what the board looks like after this resolves is only half the question; the
         // other half is whether this was the window.
@@ -305,14 +557,16 @@ class Strategist(
         if (timing is TimingVerdict.NoWindow) {
             // The card does nothing here, so nothing the simulation reports should make it beat
             // passing. See [TimingVerdict.NoWindow] for why this is a floor and not a penalty.
-            return passScore - 1.0
+            return AdjustedScore(passScore - 1.0, "hold policy: wrong window — floored below passing")
         }
         val timingDelta = (timing as? TimingVerdict.Adjust)?.delta ?: 0.0
+        val timingNote = if (timingDelta != 0.0) "hold policy timing %+.2f".format(timingDelta) else null
 
         // Check for card-specific advisor override. Timing is applied outside it, so a per-card
         // advisor still sees the pure board score as its `defaultScore` and a card with both
         // keeps both.
-        val advisor = advisorRegistry.getAdvisor(cardName) ?: return leafScore + timingDelta
+        val advisor = advisorRegistry.getAdvisor(cardName)
+            ?: return AdjustedScore(leafScore + timingDelta, timingNote)
         val context = CastContext(
             state = state,
             projected = state.projectedState,
@@ -323,8 +577,21 @@ class Strategist(
             evaluator = evaluator,
             simulator = simulator
         )
-        return (advisor.evaluateCast(context) ?: leafScore) + timingDelta
+        val override = advisor.evaluateCast(context)
+        val advisorNote = override?.let { "${advisor::class.simpleName} replaced the board score" }
+        return AdjustedScore(
+            (override ?: leafScore) + timingDelta,
+            listOfNotNull(advisorNote, timingNote).joinToString("; ").ifEmpty { null },
+        )
     }
+
+    /**
+     * A leaf score after per-card adjustment, plus what did the adjusting.
+     *
+     * The [note] exists for the local testing mode: a candidate the AI passed over despite a strong
+     * board score is only explicable if the panel can say *which* policy floored it.
+     */
+    private data class AdjustedScore(val score: Double, val note: String? = null)
 
     /**
      * Pick the targets the AI actually commits to for a chosen targeted action, by simulation

--- a/ai/src/main/kotlin/com/wingedsheep/ai/insight/AiDecisionInsight.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/insight/AiDecisionInsight.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.ai.insight
+
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.Serializable
+
+/**
+ * A record of one choice the engine AI actually made, with the preference it assigned to every
+ * option it weighed.
+ *
+ * The AI already computes all of this — [com.wingedsheep.ai.engine.Strategist] scores each candidate
+ * against passing, and [com.wingedsheep.ai.engine.CombatAdvisor] scores each attack/block plan
+ * against not attacking — and then throws the numbers away and returns the winner. This is that
+ * discarded workings, captured on the *real* decision path rather than re-derived: what the panel
+ * shows is exactly what drove the move, not a second opinion computed for display.
+ *
+ * Recording is opt-in ([AiInsightSink] is null in production) because a sink also pins the
+ * [GameState] each decision was made from, which is the half of a training example the scores alone
+ * can't reconstruct.
+ */
+@Serializable
+data class AiDecisionInsight(
+    val kind: AiDecisionKind,
+    /** The AI seat that made this choice. */
+    val playerId: EntityId,
+    val turnNumber: Int,
+    /** [com.wingedsheep.sdk.core.Step] name, e.g. `PRECOMBAT_MAIN`. */
+    val step: String,
+    /** Null in the window before the first turn begins. */
+    val activePlayerId: EntityId?,
+    /** True when it was the AI's own turn. */
+    val onOwnTurn: Boolean,
+    /**
+     * The "do nothing" reference every option is measured against — passing priority, or declaring
+     * no attackers/blockers. An option only wins by beating it.
+     */
+    val baselineLabel: String,
+    val baselineScore: Double,
+    /** Label of the option in [options] the AI submitted. */
+    val chosenLabel: String,
+    val thinkTimeMs: Long,
+    /** Scored options best-first, then the ones dropped before scoring. */
+    val options: List<AiActionOption>,
+)
+
+@Serializable
+enum class AiDecisionKind {
+    /** A normal priority window: cast, activate, play a land, or pass. */
+    PRIORITY,
+    DECLARE_ATTACKERS,
+    DECLARE_BLOCKERS,
+}
+
+/**
+ * One option the AI weighed, and how much it wanted it.
+ *
+ * Scores are **raw board-evaluator units** — the same scale the AI compares internally. They are
+ * only meaningful relative to each other and to [AiDecisionInsight.baselineScore], which is what
+ * [advantage] expresses; there is no absolute "good score".
+ */
+@Serializable
+data class AiActionOption(
+    /** Human-readable, e.g. `Cast Lightning Bolt → Grizzly Bears`. */
+    val label: String,
+    /** [com.wingedsheep.engine.legalactions.LegalAction.actionType], e.g. `CastSpell`. */
+    val actionType: String,
+    val cardName: String? = null,
+    /** Names of the targets the AI committed to, when it had a choice to make. */
+    val targets: List<String> = emptyList(),
+    /** Preference in evaluator units, or null when the option was dropped before it was scored. */
+    val score: Double? = null,
+    /**
+     * The leaf score before per-card timing and advisor adjustment. Null when nothing adjusted it,
+     * so a populated value is exactly the set of options where card knowledge changed the AI's mind.
+     */
+    val rawScore: Double? = null,
+    /** [score] minus the baseline. Positive means the AI preferred this to doing nothing. */
+    val advantage: Double? = null,
+    val chosen: Boolean = false,
+    /** True for the "pass priority" / "no attacks" row, so the UI can draw the waterline. */
+    val baseline: Boolean = false,
+    /** Why an option was dropped, or what adjusted its score. */
+    val note: String? = null,
+    /**
+     * The exact action the AI would submit for this option — already materialized, already
+     * simulated against the real processor.
+     *
+     * This is what makes an option *playable*. Held at a decision, the local testing mode can submit
+     * this instead of the AI's own pick, so "what would have happened if it took the second-best
+     * line?" is answered by the engine rather than argued about. Null only when the option cannot be
+     * submitted (it failed materialization), which is also how the UI knows not to offer it.
+     */
+    val action: GameAction? = null,
+)
+
+/**
+ * Where captured decisions go. Implemented by the host (the game server's local testing mode);
+ * null everywhere else, which is what keeps recording off the production decision path.
+ *
+ * [state] is the position the decision was made from — the AI's own view of it, so a profile that
+ * determinizes hidden information hands over the sampled world it actually searched.
+ */
+fun interface AiInsightSink {
+    fun record(state: GameState, insight: AiDecisionInsight)
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/insight/AiInsightLabels.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/insight/AiInsightLabels.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.ai.insight
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Names for the things an [AiActionOption] talks about.
+ *
+ * Read off the state the decision was made from, at capture time: an entity id means nothing to a
+ * reader, and by the time anyone opens the panel the permanent it referred to may be gone.
+ */
+object AiInsightLabels {
+
+    /** A card, permanent or player name for [id], falling back to the raw id. */
+    fun nameOf(state: GameState, id: EntityId): String {
+        val entity = state.getEntity(id) ?: return id.value
+        entity.get<CardComponent>()?.name?.let { return it }
+        entity.get<PlayerComponent>()?.name?.let { return it }
+        return id.value
+    }
+
+    /** Names of the targets [action] commits to, in submission order. */
+    fun targetNames(state: GameState, action: GameAction): List<String> {
+        val targets = when (action) {
+            is CastSpell -> action.targets
+            is ActivateAbility -> action.targets
+            else -> return emptyList()
+        }
+        return targets.map { target ->
+            when (target) {
+                is ChosenTarget.Player -> nameOf(state, target.playerId)
+                is ChosenTarget.Permanent -> nameOf(state, target.entityId)
+                is ChosenTarget.Card -> nameOf(state, target.cardId)
+                is ChosenTarget.Spell -> nameOf(state, target.spellEntityId)
+            }
+        }
+    }
+
+    /** The card [action] is cast from / activated from / played, if any. */
+    fun cardName(state: GameState, action: GameAction): String? {
+        val id = when (action) {
+            is CastSpell -> action.cardId
+            is ActivateAbility -> action.sourceId
+            is PlayLand -> action.cardId
+            else -> return null
+        }
+        return state.getEntity(id)?.get<CardComponent>()?.name
+    }
+
+    /**
+     * The enumerator's description, plus the chosen targets and X.
+     *
+     * The description alone is what the *player* would see on a button ("Cast Lightning Bolt"), and
+     * two candidates for the same card differ only in what the AI aimed it at — which is exactly the
+     * thing worth reading here.
+     */
+    fun describe(state: GameState, legalAction: LegalAction, action: GameAction): String {
+        val x = when (action) {
+            is CastSpell -> action.xValue
+            is ActivateAbility -> action.xValue
+            else -> null
+        }
+        val base = if (x != null && legalAction.hasXCost) "${legalAction.description} (X=$x)" else legalAction.description
+        val targets = targetNames(state, action)
+        return if (targets.isEmpty()) base else "$base → ${targets.joinToString(", ")}"
+    }
+
+    /** `Grizzly Bears, Llanowar Elves → Opponent`, or "No attacks" for an empty plan. */
+    fun describeAttackPlan(state: GameState, attackers: Map<EntityId, EntityId>): String {
+        if (attackers.isEmpty()) return "No attacks"
+        return attackers.entries
+            .groupBy({ it.value }, { it.key })
+            .entries
+            .joinToString("; ") { (defender, ids) ->
+                "${ids.joinToString(", ") { nameOf(state, it) }} → ${nameOf(state, defender)}"
+            }
+    }
+
+    /** `Grizzly Bears blocks Shivan Dragon`, or "No blocks" for an empty plan. */
+    fun describeBlockPlan(state: GameState, blockers: Map<EntityId, List<EntityId>>): String {
+        val real = blockers.filterValues { it.isNotEmpty() }
+        if (real.isEmpty()) return "No blocks"
+        return real.entries.joinToString("; ") { (blocker, attackers) ->
+            "${nameOf(state, blocker)} blocks ${attackers.joinToString(", ") { nameOf(state, it) }}"
+        }
+    }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/insight/CombatPlanTrace.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/insight/CombatPlanTrace.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.ai.insight
+
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Collects the combat plans [com.wingedsheep.ai.engine.CombatAdvisor]'s local search actually
+ * simulated, so the ones it rejected are visible next to the one it kept.
+ *
+ * A fresh instance is created per decision and threaded down the call stack, never shared — the
+ * advisor is also driven from inside rollout playouts, and a shared collector would mix a
+ * hypothetical combat into the real one's trace. Null (the default everywhere) means no recording.
+ *
+ * Plans are deduplicated on the assignment map: local search re-evaluates a plan across iterations,
+ * and scoring is deterministic, so the first score is the only one.
+ */
+class CombatPlanTrace {
+    private val entries = LinkedHashMap<Any, CombatPlan>()
+
+    val plans: List<CombatPlan> get() = entries.values.toList()
+
+    fun recordAttack(attackers: Map<EntityId, EntityId>, score: Double) {
+        entries.putIfAbsent(attackers, CombatPlan.Attack(attackers.toMap(), score))
+    }
+
+    fun recordBlock(blockers: Map<EntityId, List<EntityId>>, score: Double) {
+        val normalized = blockers.filterValues { it.isNotEmpty() }
+        entries.putIfAbsent(normalized, CombatPlan.Block(normalized, score))
+    }
+}
+
+/** One evaluated combat assignment and the board score it simulated to. */
+sealed interface CombatPlan {
+    val score: Double
+
+    data class Attack(val attackers: Map<EntityId, EntityId>, override val score: Double) : CombatPlan
+
+    data class Block(val blockers: Map<EntityId, List<EntityId>>, override val score: Double) : CombatPlan
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/EngineAiMomirMulliganTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/EngineAiMomirMulliganTest.kt
@@ -37,7 +37,7 @@ class EngineAiMomirMulliganTest : ScenarioTestBase() {
     init {
         test("engine AI keeps an all-lands opening hand in Momir Basic") {
             val game = scenario().withPlayers().withFormat(Format.MomirBasic()).build()
-            val controller = EngineAiPlayerController(aiRegistry, game.player1Id) { game.state }
+            val controller = EngineAiPlayerController(aiRegistry, game.player1Id, gameStateProvider = { game.state })
 
             controller.decideMulligan(sevenBasicLandHand()) shouldBe true
         }
@@ -45,7 +45,7 @@ class EngineAiMomirMulliganTest : ScenarioTestBase() {
         test("engine AI still mulligans a 7-land flood outside Momir Basic") {
             // Standard format: a seven-land opener is a genuine flood, so the heuristic mulligans.
             val game = scenario().withPlayers().build()
-            val controller = EngineAiPlayerController(aiRegistry, game.player1Id) { game.state }
+            val controller = EngineAiPlayerController(aiRegistry, game.player1Id, gameStateProvider = { game.state })
 
             controller.decideMulligan(sevenBasicLandHand()) shouldBe false
         }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/insight/AiInsightCaptureTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/insight/AiInsightCaptureTest.kt
@@ -1,0 +1,289 @@
+package com.wingedsheep.ai.insight
+
+import com.wingedsheep.ai.engine.AIPlayer
+import com.wingedsheep.ai.engine.AiProfile
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * The local testing mode's contract: what the panel shows is the AI's *actual* workings.
+ *
+ * The value of this feature depends entirely on the captured ratings being the ones that drove the
+ * move — a display recomputed on the side would be a second opinion, and would quietly disagree with
+ * the AI exactly when someone is trying to work out why it blundered. So the assertions here are all
+ * agreement assertions: the option marked chosen is the action the AI returned, and its score is the
+ * highest one recorded.
+ */
+class AiInsightCaptureTest : FunSpec({
+
+    val bear = CardDefinition.creature(
+        name = "Grizzly Bears",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2, toughness = 2,
+    )
+    val hillGiant = CardDefinition.creature(
+        name = "Hill Giant",
+        manaCost = ManaCost.parse("{3}{R}"),
+        subtypes = setOf(Subtype("Giant")),
+        power = 3, toughness = 3,
+    )
+    val cadet = CardDefinition.creature(
+        name = "Eager Cadet",
+        manaCost = ManaCost.parse("{W}"),
+        subtypes = setOf(Subtype("Human"), Subtype("Soldier")),
+        power = 1, toughness = 1,
+    )
+    val drake = CardDefinition.creature(
+        name = "Wind Drake",
+        manaCost = ManaCost.parse("{2}{U}"),
+        subtypes = setOf(Subtype("Drake")),
+        power = 2, toughness = 2,
+        keywords = setOf(Keyword.FLYING),
+    )
+    val cards = listOf(bear, hillGiant, cadet, drake)
+
+    fun setup(): Triple<CardRegistry, GameTestDriver, MutableList<Pair<GameState, AiDecisionInsight>>> {
+        val registry = CardRegistry().apply {
+            register(cards)
+            register(TestCards.all)
+        }
+        val driver = GameTestDriver().apply {
+            registerCards(cards)
+            registerCards(TestCards.all)
+            initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+        }
+        return Triple(registry, driver, mutableListOf())
+    }
+
+    fun aiWithSink(
+        registry: CardRegistry,
+        playerId: EntityId,
+        captured: MutableList<Pair<GameState, AiDecisionInsight>>,
+    ): AIPlayer = AIPlayer.create(
+        registry, playerId, AiProfile.PRODUCTION,
+        insightSink = { state, insight -> captured += state to insight },
+    )
+
+    test("a priority decision records every candidate, ranked, with passing as the baseline") {
+        val (registry, driver, captured) = setup()
+        val p1 = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two castable creatures — a real choice, so the Strategist scores rather than short-circuits.
+        driver.putCardInHand(p1, "Grizzly Bears")
+        driver.putCardInHand(p1, "Hill Giant")
+        driver.giveMana(p1, Color.GREEN, 1)
+        driver.giveMana(p1, Color.RED, 1)
+        driver.giveColorlessMana(p1, 3)
+
+        val action = aiWithSink(registry, p1, captured).chooseAction(driver.state)
+
+        captured.shouldNotBeEmpty()
+        val insight = captured.last().second
+        insight.kind shouldBe AiDecisionKind.PRIORITY
+        insight.playerId shouldBe p1
+        insight.baselineLabel shouldBe "Pass priority"
+
+        // Both spells were weighed, not just the one that won.
+        val labels = insight.options.map { it.label }
+        labels.any { it.contains("Grizzly Bears") }.shouldBeTrue()
+        labels.any { it.contains("Hill Giant") }.shouldBeTrue()
+        insight.options.count { it.baseline } shouldBe 1
+
+        // The captured ranking is the ranking that produced the move.
+        val chosen = insight.options.single { it.chosen }
+        chosen.label shouldBe insight.chosenLabel
+        val scored = insight.options.mapNotNull { it.score }
+        chosen.score.shouldNotBeNull() shouldBe scored.max()
+        if (action is CastSpell) {
+            chosen.baseline shouldBe false
+            chosen.score.shouldNotBeNull().shouldBeGreaterThan(insight.baselineScore)
+            chosen.cardName shouldNotBe null
+        } else {
+            chosen.baseline shouldBe true
+        }
+    }
+
+    test("plan labels name the creatures involved rather than their entity ids") {
+        val (_, driver, _) = setup()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val giant = driver.putCreatureOnBattlefield(p1, "Hill Giant")
+        val cadetId = driver.putCreatureOnBattlefield(p2, "Eager Cadet")
+        val state = driver.state
+
+        AiInsightLabels.nameOf(state, giant) shouldBe "Hill Giant"
+        AiInsightLabels.describeAttackPlan(state, mapOf(giant to p2)) shouldContain "Hill Giant"
+        AiInsightLabels.describeAttackPlan(state, emptyMap()) shouldBe "No attacks"
+        AiInsightLabels.describeBlockPlan(state, mapOf(cadetId to listOf(giant))) shouldBe
+            "Eager Cadet blocks Hill Giant"
+        // An entry with no assignment is not a block — it must not read as one.
+        AiInsightLabels.describeBlockPlan(state, mapOf(cadetId to emptyList())) shouldBe "No blocks"
+    }
+
+    test("declaring attackers records the plans local search compared against not attacking") {
+        val (registry, driver, captured) = setup()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(p1, "Hill Giant")
+        driver.removeSummoningSickness(attacker)
+        // An opponent creature is what makes the advisor run its simulation-backed search at all.
+        driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val action = aiWithSink(registry, p1, captured).chooseAction(driver.state)
+
+        captured.shouldNotBeEmpty()
+        val insight = captured.last().second
+        insight.kind shouldBe AiDecisionKind.DECLARE_ATTACKERS
+        insight.baselineLabel shouldBe "No attacks"
+
+        val chosen = insight.options.single { it.chosen }
+        chosen.label shouldBe insight.chosenLabel
+        val declared = (action as DeclareAttackers).attackers
+        chosen.label shouldBe AiInsightLabels.describeAttackPlan(driver.state, declared)
+    }
+
+    test("the sink sees the position the decision was made from, not a later one") {
+        val (registry, driver, captured) = setup()
+        val p1 = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardInHand(p1, "Grizzly Bears")
+        driver.putCardInHand(p1, "Hill Giant")
+        driver.giveMana(p1, Color.GREEN, 1)
+        driver.giveMana(p1, Color.RED, 1)
+        driver.giveColorlessMana(p1, 3)
+
+        val before = driver.state
+        aiWithSink(registry, p1, captured).chooseAction(before)
+
+        val (recordedState, insight) = captured.last()
+        // Same turn/step as the live position — an export has to reproduce the decision, so a state
+        // captured after the action would make the whole bundle useless as training input.
+        recordedState.turnNumber shouldBe before.turnNumber
+        recordedState.step shouldBe before.step
+        insight.turnNumber shouldBe before.turnNumber
+        insight.step shouldBe before.step.name
+    }
+
+    test("every scored option carries an action the engine actually accepts") {
+        val (registry, driver, captured) = setup()
+        val p1 = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardInHand(p1, "Grizzly Bears")
+        driver.putCardInHand(p1, "Hill Giant")
+        driver.putCardInHand(p1, "Wind Drake")
+        driver.giveMana(p1, Color.GREEN, 1)
+        driver.giveMana(p1, Color.RED, 1)
+        driver.giveMana(p1, Color.BLUE, 1)
+        driver.giveColorlessMana(p1, 4)
+
+        aiWithSink(registry, p1, captured).chooseAction(driver.state)
+        val (state, insight) = captured.last()
+
+        val scored = insight.options.filter { it.score != null }
+        scored.size shouldBeGreaterThan 2
+
+        // This is the whole contract behind "play this option instead": the local testing mode
+        // submits the recorded action verbatim, so an option the panel offers must be one the
+        // processor takes. Anything less and overriding would wedge the game on a rejected move.
+        val processor = ActionProcessor(registry)
+        scored.forEach { option ->
+            val action = option.action.shouldNotBeNull()
+            withClue("option '${'$'}{option.label}' should be submittable") {
+                processor.process(state, action).result.error shouldBe null
+            }
+        }
+    }
+
+    test("an option the processor already rejected is listed but never offered as playable") {
+        val (registry, driver, captured) = setup()
+        val p1 = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardInHand(p1, "Grizzly Bears")
+        driver.putCardInHand(p1, "Hill Giant")
+        driver.giveMana(p1, Color.GREEN, 1)
+        driver.giveMana(p1, Color.RED, 1)
+        driver.giveColorlessMana(p1, 3)
+
+        aiWithSink(registry, p1, captured).chooseAction(driver.state)
+        val insight = captured.last().second
+
+        // A note explaining an engine refusal must never come with an action attached — that pairing
+        // is exactly what would let the panel offer a move the processor will reject.
+        insight.options.forEach { option ->
+            if (option.note?.contains("illegal") == true) option.action shouldBe null
+        }
+    }
+
+    test("combat plans carry the declaration that would play them") {
+        val (registry, driver, captured) = setup()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(p1, "Hill Giant")
+        driver.removeSummoningSickness(attacker)
+        driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        aiWithSink(registry, p1, captured).chooseAction(driver.state)
+
+        val (state, insight) = captured.last()
+        val processor = ActionProcessor(registry)
+        insight.options.forEach { option ->
+            val action = option.action.shouldNotBeNull()
+            (action is DeclareAttackers).shouldBeTrue()
+            withClue("plan '${'$'}{option.label}' should be submittable") {
+                processor.process(state, action).result.error shouldBe null
+            }
+        }
+    }
+
+    test("no sink means no recording — the production path is untouched") {
+        val (registry, driver, captured) = setup()
+        val p1 = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCardInHand(p1, "Grizzly Bears")
+        driver.putCardInHand(p1, "Hill Giant")
+        driver.giveMana(p1, Color.GREEN, 1)
+        driver.giveMana(p1, Color.RED, 1)
+        driver.giveColorlessMana(p1, 3)
+
+        AIPlayer.create(registry, p1, AiProfile.PRODUCTION).chooseAction(driver.state)
+
+        captured.size shouldBe 0
+    }
+})

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -210,3 +210,73 @@ sampling reveals the tempo it cannot see. `SearchAllowances.NORMAL_PLAYOUTS` the
 That ladder is also Phase 7's safety net, the analogue of `ArenaBudgetScalingTest` one level down:
 strength must never *fall* with more playouts, or the search is generating noise rather than signal.
 Saturation is fine; inversion is the alarm.
+
+---
+
+## Watching a decision happen (local testing mode)
+
+Everything above is invisible from inside a game: `Strategist` computes a
+`List<Pair<LegalAction, Double>>`, takes the max, returns the winner, and the numbers go out of
+scope. When the AI makes a move that looks wrong, "wrong" is all you can observe.
+
+`AiInsightSink` (in `ai/insight/`) is the one place those numbers escape. `Strategist` publishes the
+options it scored, `CombatAdvisor` publishes the attack/block plans its local search simulated, and
+each record carries the `GameState` the decision was made from:
+
+```
+Strategist.chooseAction ──┐
+                          ├── AiInsightSink.record(state, AiDecisionInsight)
+CombatAdvisor local search ┘
+```
+
+Three properties are load-bearing:
+
+- **It is the real decision, not a re-run.** The sink is fed from the same locals the choice was made
+  from, so a captured ranking cannot disagree with the move — which is exactly what a
+  recompute-for-display would eventually do, and only under the conditions you were investigating.
+- **It is free when off.** The sink is null in production and every recording site is behind a null
+  check. No extra simulation, no extra scoring; `AiProfile` is untouched.
+- **The dropped candidates are in it too.** An action that failed materialization, walked back into a
+  position already acted from (`StateProgress`), or fell off the end of the budget is recorded with
+  the reason. Without them the panel silently implies the AI never considered a line it in fact
+  discarded — the most misleading thing a debugging view can do.
+
+Scores are raw evaluator units (see above), so an option is reported as an **advantage over the
+baseline** — passing priority, or declaring no attackers — which is the threshold it actually had to
+clear. `AdjustedScore.note` says when a hold-policy verdict or a `CardAdvisor` override, rather than
+the board score, is what decided it.
+
+The game server records into `AiInsightService` and serves `/api/dev/ai-insight/{playerId}`, mounted
+only under `game.ai.insight-enabled` (on in `application-local.yml`). The web client's `AiInsightPanel`
+browses it live and exports `(board state, ratings)` bundles; the `state` in an export is a full
+`GameState`, so a position that produced a bad rating also re-opens through
+`POST /api/scenarios/from-state`. The export is unmasked by design — which is why the flag is separate
+from `game.dev-endpoints.enabled` and off by default.
+
+### Stepping and overriding
+
+Reading a ranking after the fact answers "what did it think?". **Step mode** answers the more useful
+question, "what if it had done something else?".
+
+Each `AiActionOption` carries the concrete `GameAction` the AI would submit for it — already
+materialized, already simulated — so an option is not merely a label but a *playable* move. With step
+mode on, `AiActionGate` holds the AI between choosing and submitting, and the panel can hand the
+engine any option's action in place of the AI's own. The line then plays out for real rather than
+being argued about.
+
+Three constraints shape it:
+
+- **The gate runs after the decision is recorded**, so a held game is showing a finished ranking, not
+  a blank panel.
+- **Only submittable options are offered.** A candidate the processor already rejected is still
+  listed (the AI did consider it) but carries no action, so the panel can never offer a move the
+  engine would refuse. `AiInsightCaptureTest` pins this by submitting every offered option through a
+  real `ActionProcessor`.
+- **It can never wedge a game.** Every path that isn't an explicit human choice — timeout, no
+  recorded decision, seat mismatch, step mode toggled off, history cleared — falls back to the AI's
+  own pick. Step mode is also keyed by *seat* and gated on a recent poll: a closed tab reads as
+  "nobody is watching" and the game plays on at full speed.
+
+An override is stamped on the recorded decision and travels into the export as `humanOverride`, which
+is the pair actually worth training on: the position, what the AI ranked highest, and what a human
+played instead.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -167,6 +167,38 @@ class AiGameManager(
     )
 
     /**
+     * The only place an [AiWebSocketSession] is constructed.
+     *
+     * There are four bring-up paths (fresh opponent, placeholder identity, rehydrated identity,
+     * re-wire at match start), and per-seat wiring added later has twice been attached to some of
+     * them and not the rest — the local testing mode's step gate went in at [registerAiSession] and
+     * was silently absent from [wireAiForGame], which is the path a normal game against the AI
+     * actually takes. Funnelling every construction through here is what stops the next addition
+     * from repeating that.
+     *
+     * A null [gameSession] means a placeholder seat that is not attached to a game yet: no
+     * callbacks, and no step gate to hang one on.
+     */
+    private fun buildAiSession(
+        aiPlayerId: EntityId,
+        controller: AiPlayerController,
+        gameSession: GameSession?,
+        onActionReady: (EntityId, GameAction) -> Unit = { _, _ -> },
+        onMulliganKeep: (EntityId) -> Unit = { _ -> },
+        onMulliganTake: (EntityId) -> Unit = { _ -> },
+        onBottomCards: (EntityId, List<EntityId>) -> Unit = { _, _ -> },
+    ): AiWebSocketSession = AiWebSocketSession(
+        aiPlayerId = aiPlayerId,
+        controller = controller,
+        thinkingDelayMs = gameProperties.ai.thinkingDelayMs,
+        onActionReady = onActionReady,
+        onMulliganKeep = onMulliganKeep,
+        onMulliganTake = onMulliganTake,
+        onBottomCards = onBottomCards,
+        actionGate = gameSession?.let { aiInsightService.gateFor(it.sessionId) },
+    )
+
+    /**
      * Wire the AI plumbing common to every bring-up path: synthetic [AiWebSocketSession],
      * its [PlayerSession]/[PlayerIdentity], registration with [SessionRegistry] +
      * [activeSessions] + [aiPlayerIds].
@@ -185,15 +217,14 @@ class AiGameManager(
         onMulliganTake: (EntityId) -> Unit,
         onBottomCards: (EntityId, List<EntityId>) -> Unit,
     ): Pair<PlayerSession, PlayerIdentity> {
-        val aiSession = AiWebSocketSession(
+        val aiSession = buildAiSession(
             aiPlayerId = aiPlayerId,
             controller = controller,
-            thinkingDelayMs = gameProperties.ai.thinkingDelayMs,
+            gameSession = gameSession,
             onActionReady = onActionReady,
             onMulliganKeep = onMulliganKeep,
             onMulliganTake = onMulliganTake,
             onBottomCards = onBottomCards,
-            actionGate = aiInsightService.gateFor(gameSession.sessionId),
         )
 
         val playerSession = PlayerSession(
@@ -355,16 +386,9 @@ class AiGameManager(
         // Use a placeholder controller — will be replaced when match starts
         val controller = createController(aiPlayerId, modelOverride = modelOverride)
 
-        val aiSession = AiWebSocketSession(
-            aiPlayerId = aiPlayerId,
-            controller = controller,
-            thinkingDelayMs = aiProperties.thinkingDelayMs,
-            // No-op callbacks — will be replaced when match starts
-            onActionReady = { _, _ -> },
-            onMulliganKeep = { _ -> },
-            onMulliganTake = { _ -> },
-            onBottomCards = { _, _ -> }
-        )
+        // No game yet, so no callbacks and no step gate — [wireAiForGame] replaces this session
+        // wholesale once a match starts.
+        val aiSession = buildAiSession(aiPlayerId, controller, gameSession = null)
 
         val effectiveModel = modelOverride ?: if (gameProperties.ai.isLlmMode) gameProperties.ai.model else null
         val modelSuffix = effectiveModel?.substringAfterLast('/')?.let { " ($it)" } ?: ""
@@ -415,16 +439,8 @@ class AiGameManager(
         val aiProperties = gameProperties.ai
 
         val controller = createController(aiPlayerId, modelOverride = identity.aiModelOverride)
-        val aiSession = AiWebSocketSession(
-            aiPlayerId = aiPlayerId,
-            controller = controller,
-            thinkingDelayMs = aiProperties.thinkingDelayMs,
-            // No-op callbacks — replaced when a match (or draft) wires this AI.
-            onActionReady = { _, _ -> },
-            onMulliganKeep = { _ -> },
-            onMulliganTake = { _ -> },
-            onBottomCards = { _, _ -> }
-        )
+        // Replaced when a match (or draft) wires this AI, so no callbacks and no step gate here.
+        val aiSession = buildAiSession(aiPlayerId, controller, gameSession = null)
 
         identity.webSocketSession = aiSession
         val playerSession = PlayerSession(
@@ -468,14 +484,14 @@ class AiGameManager(
             controller.setDeckList(deckList)
         }
 
-        val newSession = AiWebSocketSession(
+        val newSession = buildAiSession(
             aiPlayerId = aiPlayerId,
             controller = controller,
-            thinkingDelayMs = aiProperties.thinkingDelayMs,
+            gameSession = gameSession,
             onActionReady = onActionReady,
             onMulliganKeep = onMulliganKeep,
             onMulliganTake = onMulliganTake,
-            onBottomCards = onBottomCards
+            onBottomCards = onBottomCards,
         )
 
         // Update identity and registry to use the new session

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiGameManager.kt
@@ -34,7 +34,8 @@ class AiGameManager(
     private val sessionRegistry: SessionRegistry,
     private val deckGenerator: SealedDeckGenerator,
     private val cardRegistry: CardRegistry,
-    private val llmCostTracker: com.wingedsheep.gameserver.tournament.llm.LlmCostTracker
+    private val llmCostTracker: com.wingedsheep.gameserver.tournament.llm.LlmCostTracker,
+    private val aiInsightService: AiInsightService,
 ) {
     /**
      * The live AI sessions of each game, keyed game → AI player. A multiplayer pod seats more than
@@ -130,17 +131,22 @@ class AiGameManager(
         val aiConfig = ai.toAiConfig().let { cfg ->
             if (modelOverride != null) cfg.copy(model = modelOverride, mode = "llm") else cfg
         }
+        // Local testing mode only, and null everywhere else: the LLM controller's engine fallback
+        // gets one too, so a fallback decision doesn't silently vanish from the panel.
+        val insightSink = gameSession?.sessionId?.let { aiInsightService.sinkFor(it, aiPlayerId) }
         return if (aiConfig.isEngineMode) {
             EngineAiPlayerController(
                 cardRegistry = cardRegistry,
                 playerId = aiPlayerId,
-                gameStateProvider = { gameSession?.getStateSnapshot() }
+                gameStateProvider = { gameSession?.getStateSnapshot() },
+                insightSink = insightSink,
             )
         } else {
             val engineFallback = EngineAiPlayerController(
                 cardRegistry = cardRegistry,
                 playerId = aiPlayerId,
-                gameStateProvider = { gameSession?.getStateSnapshot() }
+                gameStateProvider = { gameSession?.getStateSnapshot() },
+                insightSink = insightSink,
             )
             // Attribute in-game LLM token usage + cost to this game session, so the LLM-tournament
             // can report cost per game. No-op when there's no game (e.g. placeholder identities).
@@ -186,7 +192,8 @@ class AiGameManager(
             onActionReady = onActionReady,
             onMulliganKeep = onMulliganKeep,
             onMulliganTake = onMulliganTake,
-            onBottomCards = onBottomCards
+            onBottomCards = onBottomCards,
+            actionGate = aiInsightService.gateFor(gameSession.sessionId),
         )
 
         val playerSession = PlayerSession(
@@ -304,7 +311,10 @@ class AiGameManager(
         val controller = EngineAiPlayerController(
             cardRegistry = cardRegistry,
             playerId = aiPlayerId,
-            gameStateProvider = { gameSession.getStateSnapshot() }
+            gameStateProvider = { gameSession.getStateSnapshot() },
+            // Scenarios are the sharpest use of the local testing mode — a hand-built position is
+            // exactly where you want to read what the AI made of it.
+            insightSink = aiInsightService.sinkFor(gameSession.sessionId, aiPlayerId),
         )
 
         val (playerSession, identity) = registerAiSession(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiInsightService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiInsightService.kt
@@ -1,0 +1,259 @@
+package com.wingedsheep.gameserver.ai
+
+import com.wingedsheep.ai.insight.AiDecisionInsight
+import com.wingedsheep.ai.insight.AiInsightSink
+import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+private val logger = LoggerFactory.getLogger(AiInsightService::class.java)
+
+/**
+ * The local testing mode's store and its step control: every choice the engine AI made in a live
+ * game with the scores it assigned each option, and — when step mode is on — the ability to hold the
+ * AI at a decision and hand it a different move than the one it picked.
+ *
+ * Off unless `game.ai.insight-enabled` is set (`application-local.yml` turns it on). While off,
+ * [sinkFor] and [gateFor] return null, no AI is given either, and the `Strategist` skips the
+ * recording branch entirely — a production server pays nothing for this.
+ *
+ * The retained [GameState]s are what make an entry exportable as AI training input: the scores alone
+ * say what the AI preferred, not what it was looking at. They cost little to *hold* (states are
+ * immutable and structurally shared with the live game), so the ring buffer is sized by how much
+ * history is useful to browse rather than by memory.
+ */
+@Service
+class AiInsightService(gameProperties: GameProperties) {
+
+    val enabled: Boolean = gameProperties.ai.insightEnabled
+
+    /** Decisions per game session, oldest first. */
+    private val byGame = ConcurrentHashMap<String, ArrayDeque<AiInsightEntry>>()
+
+    /**
+     * Seat → game session, so the client can ask for "my game" using the only id it has, its own
+     * player id. Rebuilt from each recorded state's turn order, which keeps it correct across
+     * reconnects and never needs its own teardown path beyond [clearGame].
+     */
+    private val gameByPlayer = ConcurrentHashMap<EntityId, String>()
+
+    /**
+     * Seats whose human asked to approve each AI move before it is submitted.
+     *
+     * Keyed by **player**, not game, because the toggle has to work before the AI has ever moved —
+     * and [gameByPlayer] only learns the mapping from a recorded decision. Keying this by game made
+     * arming step mode at the start of a game a silent no-op.
+     */
+    private val stepModeByPlayer = ConcurrentHashMap<EntityId, Boolean>()
+
+    /** Last time each client polled — the watchdog behind [stepModeActive]. */
+    private val lastPolledAtByPlayer = ConcurrentHashMap<EntityId, Long>()
+
+    /** The decision an AI is currently held at, per game. At most one: only one seat acts at a time. */
+    private val pendingByGame = ConcurrentHashMap<String, PendingAiDecision>()
+
+    private val nextId = AtomicLong(1)
+
+    /**
+     * The sink for one AI seat, or null when the mode is off — which is exactly what the AI wiring
+     * passes through to `EngineAiPlayerController`, so "off" needs no second check anywhere.
+     */
+    fun sinkFor(gameSessionId: String, aiPlayerId: EntityId): AiInsightSink? {
+        if (!enabled) return null
+        logger.info("AI insight recording enabled for game {} seat {}", gameSessionId, aiPlayerId.value)
+        return AiInsightSink { state, insight -> record(gameSessionId, state, insight) }
+    }
+
+    /**
+     * The step gate for a game's AI seats, or null when the mode is off.
+     *
+     * Returned as a lambda rather than a service reference so `AiWebSocketSession` — which knows
+     * nothing about insight — depends only on "given the move you were about to make, what should I
+     * actually submit?".
+     */
+    fun gateFor(gameSessionId: String): AiActionGate? {
+        if (!enabled) return null
+        return AiActionGate { aiPlayerId, proposed -> awaitApproval(gameSessionId, aiPlayerId, proposed) }
+    }
+
+    private fun record(gameSessionId: String, state: GameState, insight: AiDecisionInsight) {
+        val entry = AiInsightEntry(nextId.getAndIncrement(), Instant.now(), insight, state)
+        val entries = byGame.computeIfAbsent(gameSessionId) { ArrayDeque() }
+        synchronized(entries) {
+            entries.addLast(entry)
+            while (entries.size > MAX_DECISIONS_PER_GAME) entries.removeFirst()
+        }
+        state.turnOrder.forEach { gameByPlayer[it] = gameSessionId }
+    }
+
+    // ── Browsing ──────────────────────────────────────────────────────────────
+
+    /** The game session [playerId] is seated in, or null if no AI in it has recorded anything yet. */
+    fun gameForPlayer(playerId: EntityId): String? = gameByPlayer[playerId]
+
+    /** Recorded decisions for [gameSessionId], newest first. */
+    fun decisions(gameSessionId: String, limit: Int = MAX_DECISIONS_PER_GAME): List<AiInsightEntry> {
+        val entries = byGame[gameSessionId] ?: return emptyList()
+        return synchronized(entries) { entries.toList() }.asReversed().take(limit)
+    }
+
+    fun decision(gameSessionId: String, id: Long): AiInsightEntry? =
+        decisions(gameSessionId).firstOrNull { it.id == id }
+
+    fun clearGame(gameSessionId: String) {
+        byGame.remove(gameSessionId)
+        gameByPlayer.entries.removeIf { it.value == gameSessionId }
+        // Releasing first: a held AI whose history is being wiped must not be stranded.
+        pendingByGame[gameSessionId]?.let { it.deferred.complete(it.proposed) }
+        pendingByGame.remove(gameSessionId)
+    }
+
+    // ── Step mode ─────────────────────────────────────────────────────────────
+
+    /** Note that [playerId]'s client is watching. See [stepModeActive]. */
+    fun markPolled(playerId: EntityId) {
+        lastPolledAtByPlayer[playerId] = System.currentTimeMillis()
+    }
+
+    fun setStepMode(playerId: EntityId, on: Boolean) {
+        stepModeByPlayer[playerId] = on
+        logger.info("AI step mode {} for seat {}", if (on) "ON" else "OFF", playerId.value)
+        // Turning it off must release whatever is already held, or the AI sits there until the
+        // watchdog fires — the click that disables the mode is also "stop holding my game".
+        if (!on) gameForPlayer(playerId)?.let { resume(it, optionIndex = null) }
+    }
+
+    fun isStepMode(playerId: EntityId): Boolean = stepModeByPlayer[playerId] == true
+
+    /**
+     * Step mode only holds the AI while a client is actually watching.
+     *
+     * The only thing that can release a held decision is a human clicking in the panel. If the tab
+     * is closed with step mode left on, every AI move would stall for the full
+     * [APPROVAL_TIMEOUT_MS] — so a stale poll is treated as "nobody is there", and the game plays on
+     * at full speed. The seats are read off the recorded position rather than tracked separately,
+     * which keeps this correct for a pod where only one player is watching.
+     */
+    private fun stepModeActive(seats: List<EntityId>): Boolean {
+        val now = System.currentTimeMillis()
+        return seats.any { seat ->
+            stepModeByPlayer[seat] == true &&
+                (lastPolledAtByPlayer[seat]?.let { now - it < WATCHER_TIMEOUT_MS } ?: false)
+        }
+    }
+
+    /** The decision currently held for [gameSessionId], if any. */
+    fun pending(gameSessionId: String): PendingAiDecision? = pendingByGame[gameSessionId]
+
+    /**
+     * Hold [proposed] until a human approves it or swaps it, and return whatever should actually be
+     * submitted.
+     *
+     * Only decisions the AI genuinely weighed are held: a window with a single legal action has no
+     * insight to show, and stopping on it would be a click with nothing to read. Falls back to
+     * [proposed] on every path that isn't an explicit human choice — a timeout, a game with no
+     * recorded decision, a seat mismatch — because a debugging aid must never be able to wedge a
+     * game.
+     */
+    private suspend fun awaitApproval(
+        gameSessionId: String,
+        aiPlayerId: EntityId,
+        proposed: GameAction,
+    ): GameAction {
+        val latest = decisions(gameSessionId, 1).firstOrNull() ?: return proposed
+        if (latest.insight.playerId != aiPlayerId) return proposed
+        if (!stepModeActive(latest.state.turnOrder)) return proposed
+
+        val held = PendingAiDecision(latest.id, aiPlayerId, proposed, CompletableDeferred())
+        pendingByGame[gameSessionId] = held
+        logger.info("AI held at decision {} in game {}: {}", latest.id, gameSessionId, latest.insight.chosenLabel)
+        return try {
+            withTimeoutOrNull(APPROVAL_TIMEOUT_MS) { held.deferred.await() } ?: proposed
+        } finally {
+            pendingByGame.remove(gameSessionId, held)
+        }
+    }
+
+    /**
+     * Release a held AI. [optionIndex] swaps in that option's action instead of the AI's own pick;
+     * null lets the AI play what it chose.
+     *
+     * An override is stamped on the recorded entry, so the timeline shows which decisions a human
+     * disagreed with and the export carries "the AI wanted A, the human played B" — which is the
+     * pair worth training on.
+     */
+    fun resume(gameSessionId: String, optionIndex: Int?): Boolean {
+        val held = pendingByGame[gameSessionId] ?: return false
+        val entry = decision(gameSessionId, held.decisionId)
+        val option = optionIndex?.let { entry?.insight?.options?.getOrNull(it) }
+        val override = option?.action
+        if (option != null && override == null) return false
+        if (option != null && override != null) {
+            entry?.humanOverride = AiHumanOverride(optionIndex, option.label)
+            logger.info("Human overrode AI decision {}: {} → {}", held.decisionId, entry?.insight?.chosenLabel, option.label)
+        }
+        return held.deferred.complete(override ?: held.proposed)
+    }
+
+    private companion object {
+        /**
+         * Ring-buffer depth per game. The AI decides on most priority windows, so a long game
+         * produces hundreds; this is roughly "the last few turns", which is the window anyone
+         * actually scrolls back through when a play looks wrong.
+         */
+        const val MAX_DECISIONS_PER_GAME = 200
+
+        /** Longest a held AI waits for a human before playing its own pick. */
+        const val APPROVAL_TIMEOUT_MS = 10 * 60 * 1000L
+
+        /** How stale the last poll may be before step mode is treated as unattended. */
+        const val WATCHER_TIMEOUT_MS = 15_000L
+    }
+}
+
+/**
+ * Given the move an AI is about to submit, the move it should actually submit.
+ *
+ * Suspends while step mode holds the decision. `AiWebSocketSession` calls this from its existing IO
+ * coroutine, so a hold is the game sitting quietly at the AI's turn, not a blocked thread.
+ */
+fun interface AiActionGate {
+    suspend fun approve(aiPlayerId: EntityId, proposed: GameAction): GameAction
+}
+
+/** An AI decision held for human approval. */
+class PendingAiDecision(
+    val decisionId: Long,
+    val aiPlayerId: EntityId,
+    /** What the AI chose on its own. */
+    val proposed: GameAction,
+    internal val deferred: CompletableDeferred<GameAction>,
+)
+
+/** A move a human substituted for the AI's pick. */
+data class AiHumanOverride(val optionIndex: Int, val label: String)
+
+/**
+ * One recorded decision: what the AI weighed, and the position it weighed it in.
+ *
+ * [state] is the AI's own view — unmasked, and already determinized if the profile samples hidden
+ * information — which is what makes an export reproduce the decision rather than approximate it.
+ */
+class AiInsightEntry(
+    val id: Long,
+    val recordedAt: Instant,
+    val insight: AiDecisionInsight,
+    val state: GameState,
+) {
+    /** Set when a human played something other than the AI's pick at this decision. */
+    @Volatile
+    var humanOverride: AiHumanOverride? = null
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/ai/AiWebSocketSession.kt
@@ -50,7 +50,13 @@ class AiWebSocketSession(
     private val onActionReady: (EntityId, GameAction) -> Unit,
     private val onMulliganKeep: (EntityId) -> Unit,
     private val onMulliganTake: (EntityId) -> Unit,
-    private val onBottomCards: (EntityId, List<EntityId>) -> Unit
+    private val onBottomCards: (EntityId, List<EntityId>) -> Unit,
+    /**
+     * Local testing mode: the last word on what this seat submits. Given the move the AI chose, it
+     * may hold the decision until a human approves it and may hand back a different move entirely
+     * (see [AiInsightService]). Null in normal play, where the AI's own pick goes straight through.
+     */
+    private val actionGate: AiActionGate? = null,
 ) : WebSocketSession {
 
     // =========================================================================
@@ -294,7 +300,14 @@ class AiWebSocketSession(
             delay(thinkingDelayMs * 4)
         }
 
-        submitResponse(response)
+        // The gate runs *after* the AI has chosen and therefore after the decision was recorded, so
+        // a human holding the game is looking at the finished ranking rather than a blank panel.
+        val gated = if (response is ActionResponse.SubmitAction && actionGate != null) {
+            ActionResponse.SubmitAction(actionGate.approve(aiPlayerId, response.action))
+        } else {
+            response
+        }
+        submitResponse(gated)
     }
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameProperties.kt
@@ -77,7 +77,17 @@ data class AiProperties(
      * When true, AI sealed decks are always built with the deterministic heuristic builder,
      * skipping the LLM regardless of per-request flags. Useful for fully local play vs AI.
      */
-    val heuristicDeckbuilding: Boolean = false
+    val heuristicDeckbuilding: Boolean = false,
+    /**
+     * Local testing mode: record what the engine AI considered on every decision and expose it over
+     * `/api/dev/ai-insight`, so a human can browse the AI's options with the scores it gave them and
+     * export a position plus its ratings as AI-training input.
+     *
+     * Off by default and deliberately separate from `game.dev-endpoints.enabled`: recording pins a
+     * `GameState` per decision, and that is opt-in even on a box where the other dev endpoints are
+     * already open. `application-local.yml` turns it on.
+     */
+    val insightEnabled: Boolean = false
 ) {
     /** Returns the model to use for deckbuilding — falls back to the gameplay model if not set. */
     val effectiveDeckbuildingModel: String get() = deckbuildingModel.ifBlank { model }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AiInsightController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AiInsightController.kt
@@ -1,0 +1,239 @@
+package com.wingedsheep.gameserver.controller
+
+import com.wingedsheep.ai.insight.AiDecisionInsight
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.gameserver.ai.AiHumanOverride
+import com.wingedsheep.gameserver.ai.AiInsightEntry
+import com.wingedsheep.gameserver.ai.AiInsightService
+import com.wingedsheep.gameserver.persistence.persistenceJson
+import com.wingedsheep.sdk.model.EntityId
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+/**
+ * Local testing mode over a game against the AI: browse the actions the AI weighed and how strongly
+ * it preferred each, hold it at a decision and play a different option than the one it picked, and
+ * export a position together with those ratings as AI-training input.
+ *
+ * Mounted only when `game.ai.insight-enabled` is set (see
+ * [com.wingedsheep.gameserver.config.AiProperties.insightEnabled]). When it isn't, every route here
+ * 404s, which is also how the client decides whether to offer the panel at all — no extra config
+ * round-trip, and no way to leave the UI advertising a mode the server isn't running.
+ *
+ * Everything is keyed by **any seat's player id** rather than a game id, because the player id is
+ * the only identifier the web client holds for its own game
+ * ([com.wingedsheep.engine.view.ClientGameState.viewingPlayerId]).
+ *
+ * These responses carry the AI's *unmasked* view of the board — that is the entire point of the
+ * export, and the reason this stays behind an opt-in local flag rather than shipping with the other
+ * dev endpoints.
+ *
+ * - `GET /api/dev/ai-insight/{playerId}` → recent decisions, plus whether one is held right now
+ * - `POST /api/dev/ai-insight/{playerId}/step?enabled=true` → hold the AI before each move
+ * - `POST /api/dev/ai-insight/{playerId}/resume[?optionIndex=N]` → let it play, or play N instead
+ * - `GET /api/dev/ai-insight/{playerId}/export[?decision=N]` → a decision + its board state
+ * - `DELETE /api/dev/ai-insight/{playerId}` → drop the recorded history for this game
+ */
+@RestController
+@RequestMapping("/api/dev/ai-insight")
+@ConditionalOnProperty(name = ["game.ai.insight-enabled"], havingValue = "true")
+class AiInsightController(private val service: AiInsightService) {
+
+    @GetMapping("/{playerId}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun list(
+        @PathVariable playerId: String,
+        @RequestParam(defaultValue = "60") limit: Int,
+    ): ResponseEntity<String> {
+        val seat = EntityId(playerId)
+        // Doubles as the watchdog heartbeat: step mode only holds the AI while someone is watching.
+        // Unconditional, and before the game lookup — a client that armed step mode on its very first
+        // poll must count as present even though no decision has been recorded yet.
+        service.markPolled(seat)
+        val stepMode = service.isStepMode(seat)
+
+        val gameSessionId = service.gameForPlayer(seat) ?: return json(
+            AiInsightListResponse(gameSessionId = null, decisions = emptyList(), stepMode = stepMode)
+        )
+
+        val decisions = service.decisions(gameSessionId, limit.coerceIn(1, 200)).map { it.toDto() }
+        val held = service.pending(gameSessionId)
+        return json(
+            AiInsightListResponse(
+                gameSessionId = gameSessionId,
+                decisions = decisions,
+                stepMode = stepMode,
+                pending = held?.let {
+                    AiPendingApproval(
+                        decisionId = it.decisionId,
+                        proposedLabel = service.decision(gameSessionId, it.decisionId)
+                            ?.insight?.chosenLabel ?: "its chosen move",
+                    )
+                },
+            )
+        )
+    }
+
+    /**
+     * Turn "hold the AI before each move it actually weighed" on or off for this seat.
+     *
+     * Deliberately does *not* require the game to be known yet: arming step mode at the start of a
+     * game, before the AI has recorded anything, is the normal case.
+     */
+    @PostMapping("/{playerId}/step")
+    fun step(
+        @PathVariable playerId: String,
+        @RequestParam enabled: Boolean,
+    ): ResponseEntity<Void> {
+        val seat = EntityId(playerId)
+        service.markPolled(seat)
+        service.setStepMode(seat, enabled)
+        return ResponseEntity.noContent().build()
+    }
+
+    /**
+     * Release a held AI. Without [optionIndex] it plays its own pick; with one, that option's action
+     * is submitted instead and the disagreement is stamped on the recorded decision.
+     *
+     * 409 rather than 404 when the option can't be played: the decision is real and the index is
+     * real, but that row is one the engine already rejected, so there is nothing to submit.
+     */
+    @PostMapping("/{playerId}/resume")
+    fun resume(
+        @PathVariable playerId: String,
+        @RequestParam(required = false) optionIndex: Int?,
+    ): ResponseEntity<Void> {
+        val seat = EntityId(playerId)
+        service.markPolled(seat)
+        val gameSessionId = service.gameForPlayer(seat) ?: return ResponseEntity.notFound().build()
+        if (service.pending(gameSessionId) == null) return ResponseEntity.notFound().build()
+        return if (service.resume(gameSessionId, optionIndex)) {
+            ResponseEntity.noContent().build()
+        } else {
+            ResponseEntity.status(409).build()
+        }
+    }
+
+    /**
+     * The export the panel's button produces: the board state the AI was looking at, paired with the
+     * rating it gave every option and — when a human overrode it — the move played instead.
+     *
+     * `state` is a full [GameState] and so also round-trips through
+     * `POST /api/scenarios/from-state`, which means a position that produced a bad rating can be
+     * re-opened and replayed rather than only read about.
+     */
+    @GetMapping("/{playerId}/export", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun export(
+        @PathVariable playerId: String,
+        @RequestParam(required = false) decision: Long?,
+    ): ResponseEntity<String> {
+        val gameSessionId = service.gameForPlayer(EntityId(playerId))
+            ?: return ResponseEntity.notFound().build()
+        val entry = if (decision != null) {
+            service.decision(gameSessionId, decision)
+        } else {
+            service.decisions(gameSessionId, 1).firstOrNull()
+        } ?: return ResponseEntity.notFound().build()
+
+        val payload = AiInsightExport(
+            exportedAt = Instant.now().toString(),
+            gameSessionId = gameSessionId,
+            sample = AiInsightSample(
+                id = entry.id,
+                recordedAt = entry.recordedAt.toString(),
+                insight = entry.insight,
+                humanOverride = entry.humanOverride?.toDto(),
+                state = entry.state,
+            ),
+        )
+        return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(
+                HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename=\"ai-insight-$gameSessionId-${entry.id}.json\"",
+            )
+            .body(persistenceJson.encodeToString(AiInsightExport.serializer(), payload))
+    }
+
+    @DeleteMapping("/{playerId}")
+    fun clear(@PathVariable playerId: String): ResponseEntity<Void> {
+        val gameSessionId = service.gameForPlayer(EntityId(playerId))
+            ?: return ResponseEntity.notFound().build()
+        service.clearGame(gameSessionId)
+        return ResponseEntity.noContent().build()
+    }
+
+    private fun AiInsightEntry.toDto() =
+        AiInsightDecision(id, recordedAt.toString(), insight, humanOverride?.toDto())
+
+    private fun AiHumanOverride.toDto() = AiHumanOverrideDto(optionIndex, label)
+
+    /**
+     * kotlinx rather than Spring's Jackson converter: these payloads are built from engine types —
+     * [EntityId] is a value class and [GameState] a large polymorphic tree — that only round-trip
+     * correctly through the engine's own serializers module.
+     */
+    private inline fun <reified T> json(body: T): ResponseEntity<String> =
+        ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(persistenceJson.encodeToString(body))
+}
+
+@Serializable
+data class AiInsightListResponse(
+    /** Null when no AI in this player's game has recorded a decision yet. */
+    val gameSessionId: String?,
+    /** Newest first. */
+    val decisions: List<AiInsightDecision>,
+    val stepMode: Boolean = false,
+    /** Set while the AI is held waiting for a human to approve or replace its move. */
+    val pending: AiPendingApproval? = null,
+)
+
+@Serializable
+data class AiInsightDecision(
+    val id: Long,
+    val recordedAt: String,
+    val insight: AiDecisionInsight,
+    val humanOverride: AiHumanOverrideDto? = null,
+)
+
+@Serializable
+data class AiPendingApproval(val decisionId: Long, val proposedLabel: String)
+
+@Serializable
+data class AiHumanOverrideDto(val optionIndex: Int, val label: String)
+
+/**
+ * Self-describing bundle: one board state, what the AI thought of every option in it, and the move
+ * actually played if a human disagreed.
+ */
+@Serializable
+data class AiInsightExport(
+    val formatVersion: Int = 2,
+    val exportedAt: String,
+    val gameSessionId: String,
+    val sample: AiInsightSample,
+)
+
+@Serializable
+data class AiInsightSample(
+    val id: Long,
+    val recordedAt: String,
+    val insight: AiDecisionInsight,
+    /** What a human played instead, when they overrode the AI here. The label half of a training pair. */
+    val humanOverride: AiHumanOverrideDto? = null,
+    /** The AI's unmasked view of the position this decision was made from. */
+    val state: GameState,
+)

--- a/game-server/src/main/resources/application-local.yml
+++ b/game-server/src/main/resources/application-local.yml
@@ -16,3 +16,5 @@ game:
     timeout-ms: ${GAME_AI_TIMEOUT_MS:120000}
     # Always build AI sealed decks with the deterministic heuristic builder (skips the LLM).
     heuristic-deckbuilding: ${GAME_AI_HEURISTIC_DECKBUILDING:true}
+    # Browse what the AI considered, and export a position + its ratings, while playing against it.
+    insight-enabled: ${GAME_AI_INSIGHT_ENABLED:true}

--- a/game-server/src/main/resources/application.yml
+++ b/game-server/src/main/resources/application.yml
@@ -122,6 +122,9 @@ game:
     open-router-api-key: ${OPENROUTER_API_KEY:}
     # When true, AI sealed decks always use the deterministic heuristic builder (skips the LLM).
     heuristic-deckbuilding: ${GAME_AI_HEURISTIC_DECKBUILDING:false}
+    # Local testing mode: record the engine AI's candidate actions + scores and serve them from
+    # /api/dev/ai-insight. Off in production — recording retains a GameState per decision.
+    insight-enabled: ${GAME_AI_INSIGHT_ENABLED:false}
 
 # Swagger UI - only enabled when dev endpoints are enabled
 springdoc:

--- a/web-client/src/api/aiInsight.ts
+++ b/web-client/src/api/aiInsight.ts
@@ -1,0 +1,152 @@
+/**
+ * Local testing mode: read what the engine AI considered on each decision, hold it before it moves
+ * so you can play a different option than the one it picked, and export a position together with
+ * those ratings as AI-training input.
+ *
+ * Served by the game server's `AiInsightController`, which is mounted only when
+ * `game.ai.insight-enabled` is set. On any other server these routes 404 — which is the signal the
+ * UI uses to hide itself, so nothing here needs a separate feature-flag fetch.
+ */
+
+export type AiDecisionKind = 'PRIORITY' | 'DECLARE_ATTACKERS' | 'DECLARE_BLOCKERS'
+
+/** One option the AI weighed. Scores are raw evaluator units — only relative values mean anything. */
+export interface AiActionOption {
+  readonly label: string
+  readonly actionType: string
+  readonly cardName?: string | null
+  readonly targets: readonly string[]
+  /** Null when the option was dropped before it was ever scored. */
+  readonly score: number | null
+  /** The board score before per-card timing/advisor adjustment; null when nothing adjusted it. */
+  readonly rawScore: number | null
+  /** `score` minus the baseline. Positive means the AI preferred this to doing nothing. */
+  readonly advantage: number | null
+  readonly chosen: boolean
+  /** The "pass priority" / "no attacks" row — the waterline every other option had to clear. */
+  readonly baseline: boolean
+  readonly note?: string | null
+  /**
+   * Present when this option can actually be submitted. Its shape is engine-internal — the client
+   * never reads it, it just means "this row is playable", and plays it back by index.
+   */
+  readonly action?: unknown
+}
+
+export interface AiDecisionInsight {
+  readonly kind: AiDecisionKind
+  readonly playerId: string
+  readonly turnNumber: number
+  readonly step: string
+  readonly activePlayerId: string | null
+  readonly onOwnTurn: boolean
+  readonly baselineLabel: string
+  readonly baselineScore: number
+  readonly chosenLabel: string
+  readonly thinkTimeMs: number
+  /** Scored options best-first, then the ones dropped before scoring. */
+  readonly options: readonly AiActionOption[]
+}
+
+/** A move a human substituted for the AI's pick. */
+export interface AiHumanOverride {
+  readonly optionIndex: number
+  readonly label: string
+}
+
+export interface AiInsightDecision {
+  readonly id: number
+  readonly recordedAt: string
+  readonly insight: AiDecisionInsight
+  readonly humanOverride?: AiHumanOverride | null
+}
+
+/** The AI is held at this decision, waiting for the human to approve or replace its move. */
+export interface AiPendingApproval {
+  readonly decisionId: number
+  readonly proposedLabel: string
+}
+
+export interface AiInsightListResponse {
+  readonly gameSessionId: string | null
+  /** Newest first. */
+  readonly decisions: readonly AiInsightDecision[]
+  readonly stepMode: boolean
+  readonly pending?: AiPendingApproval | null
+}
+
+/** The route isn't mounted: this server doesn't run the local testing mode, and never will. */
+export const AI_INSIGHT_UNAVAILABLE = Symbol('ai-insight-unavailable')
+
+/** A request that failed for some other reason — retryable, and says nothing about the server. */
+export const AI_INSIGHT_ERROR = Symbol('ai-insight-error')
+
+/**
+ * Fetch the AI's recent decisions for the game `playerId` is seated in.
+ *
+ * The two failure symbols are deliberately distinct: {@link AI_INSIGHT_UNAVAILABLE} (a 404) means
+ * the caller should hide the panel and stop asking, while {@link AI_INSIGHT_ERROR} is a blip worth
+ * retrying. Collapsing them would let one dropped request hide the panel for the rest of the game.
+ */
+export async function fetchAiInsight(
+  playerId: string,
+  limit = 60,
+): Promise<AiInsightListResponse | typeof AI_INSIGHT_UNAVAILABLE | typeof AI_INSIGHT_ERROR> {
+  let res: Response
+  try {
+    res = await fetch(`/api/dev/ai-insight/${encodeURIComponent(playerId)}?limit=${limit}`)
+  } catch {
+    return AI_INSIGHT_ERROR
+  }
+  if (res.status === 404) return AI_INSIGHT_UNAVAILABLE
+  if (!res.ok) return AI_INSIGHT_ERROR
+  return (await res.json()) as AiInsightListResponse
+}
+
+/** Hold the AI before each move it actually weighed, or let it run again. */
+export async function setAiStepMode(playerId: string, enabled: boolean): Promise<void> {
+  const res = await fetch(
+    `/api/dev/ai-insight/${encodeURIComponent(playerId)}/step?enabled=${enabled}`,
+    { method: 'POST' },
+  )
+  // Surfaced rather than swallowed: a toggle that silently fails leaves the button showing one
+  // thing and the server doing another, which is the worst possible state for a debugging tool.
+  if (!res.ok) throw new Error(`Could not change step mode (${res.status})`)
+}
+
+/**
+ * Release a held AI. Without `optionIndex` it plays its own pick; with one, that option is submitted
+ * instead — which is how you ask "what would have happened if it took the second-best line?".
+ */
+export async function resumeAi(playerId: string, optionIndex?: number): Promise<void> {
+  const query = optionIndex === undefined ? '' : `?optionIndex=${optionIndex}`
+  const res = await fetch(
+    `/api/dev/ai-insight/${encodeURIComponent(playerId)}/resume${query}`,
+    { method: 'POST' },
+  )
+  if (!res.ok) throw new Error(`The AI could not play that option (${res.status})`)
+}
+
+/** Download one decision's board state plus every rating the AI gave it. */
+export async function downloadAiInsightExport(playerId: string, decisionId?: number): Promise<void> {
+  const query = decisionId === undefined ? '' : `?decision=${decisionId}`
+  const res = await fetch(`/api/dev/ai-insight/${encodeURIComponent(playerId)}/export${query}`)
+  if (!res.ok) throw new Error(`Export failed (${res.status})`)
+  const text = await res.text()
+
+  const blob = new Blob([text], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `ai-insight-decision-${decisionId ?? 'latest'}.json`
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  // Revoking synchronously cancels the download in some browsers — see DeckBuilderOverlay.
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+/** Drop the recorded history for this game, so a fresh sequence is easier to read. */
+export async function clearAiInsight(playerId: string): Promise<void> {
+  await fetch(`/api/dev/ai-insight/${encodeURIComponent(playerId)}`, { method: 'DELETE' })
+}

--- a/web-client/src/components/game/AiInsightPanel.tsx
+++ b/web-client/src/components/game/AiInsightPanel.tsx
@@ -1,0 +1,675 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useGameStore } from '@/store/gameStore.ts'
+import {
+  AI_INSIGHT_ERROR,
+  AI_INSIGHT_UNAVAILABLE,
+  clearAiInsight,
+  downloadAiInsightExport,
+  fetchAiInsight,
+  resumeAi,
+  setAiStepMode,
+  type AiActionOption,
+  type AiInsightDecision,
+  type AiInsightListResponse,
+} from '@/api/aiInsight'
+
+/**
+ * Local testing mode: browse the actions the AI weighed on each decision ranked by how strongly it
+ * preferred them, hold it before it moves so you can play a different option, and export a position
+ * plus its ratings as AI-training input.
+ *
+ * Renders nothing unless the server runs the mode (`game.ai.insight-enabled`) — the route 404s
+ * otherwise and the component stays invisible for the rest of the game. It polls slowly while
+ * closed (so the button's count is honest) and quickly while open.
+ *
+ * Scores are the AI's raw board-evaluator units. They have no absolute meaning; what's readable is
+ * the ordering and the distance from the baseline row (passing / not attacking), which is the
+ * threshold an option had to clear to be taken at all.
+ */
+export function AiInsightPanel() {
+  const playerId = useGameStore((state) => state.playerId)
+  const [available, setAvailable] = useState<boolean | null>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [data, setData] = useState<AiInsightListResponse | null>(null)
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // Tracked in state because the rows are inline-styled buttons, and Chrome's default button hover
+  // is a near-white fill that makes the dark panel unreadable under the pointer.
+  const [hoveredId, setHoveredId] = useState<number | null>(null)
+
+  const decisions = data?.decisions ?? []
+  const pending = data?.pending ?? null
+  const stepMode = data?.stepMode ?? false
+  const pendingId = pending?.decisionId ?? null
+
+  // Requests are issued from a 700ms poll *and* from every button, so they overlap and can resolve
+  // out of order. Without this, a poll that left before you toggled step mode can answer after it
+  // and paint the old value back — the toggle appears to bounce, and the panel disagrees with the
+  // server. Only the newest request may write.
+  const requestSeq = useRef(0)
+
+  const refresh = useCallback(async () => {
+    if (!playerId) return
+    const seq = ++requestSeq.current
+    const result = await fetchAiInsight(playerId)
+    if (seq !== requestSeq.current) return
+    // A blip leaves `available` alone: one dropped request must not hide the panel for the game.
+    if (result === AI_INSIGHT_ERROR) return
+    if (result === AI_INSIGHT_UNAVAILABLE) {
+      setAvailable(false)
+      return
+    }
+    setAvailable(true)
+    setData(result)
+  }, [playerId])
+
+  useEffect(() => {
+    if (!playerId || available === false) return
+    void refresh()
+    // The poll doubles as the server's watchdog heartbeat: step mode only holds the AI while a
+    // client is demonstrably watching, so a closed tab can never strand a game at the AI's turn.
+    const timer = window.setInterval(() => void refresh(), expanded ? 700 : 5000)
+    return () => window.clearInterval(timer)
+  }, [playerId, expanded, available, refresh])
+
+  // A held AI is the one thing worth looking at, so it takes the detail pane whatever was pinned.
+  useEffect(() => {
+    if (pendingId !== null) setSelectedId(pendingId)
+  }, [pendingId])
+
+  const latest = decisions[0] ?? null
+  const selected =
+    selectedId === null ? latest : decisions.find((d) => d.id === selectedId) ?? latest
+  const isHeld = pendingId !== null && selected?.id === pendingId
+
+  const run = useCallback(
+    async (work: () => Promise<void>) => {
+      setBusy(true)
+      setError(null)
+      try {
+        await work()
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Something went wrong')
+      } finally {
+        setBusy(false)
+      }
+      await refresh()
+    },
+    [refresh],
+  )
+
+  if (!playerId || available !== true) return null
+
+  if (!expanded) {
+    return (
+      <button
+        onClick={() => setExpanded(true)}
+        style={{ ...styles.toggleButton, ...(pending ? styles.toggleButtonHeld : null) }}
+        title={pending ? 'The AI is waiting for you' : 'Browse what the AI considered'}
+      >
+        {pending ? '⏸ AI waiting' : `AI Insight (${decisions.length})`}
+      </button>
+    )
+  }
+
+  return (
+    <div style={styles.panel}>
+      <div style={styles.header}>
+        <span style={styles.headerTitle}>AI Insight</span>
+        <div style={styles.headerActions}>
+          <button
+            style={{ ...styles.actionButton, ...(stepMode ? styles.actionButtonOn : null) }}
+            disabled={busy}
+            onClick={() => void run(() => setAiStepMode(playerId, !stepMode))}
+            title={
+              stepMode
+                ? 'The AI stops before each move it weighed. Click to let it play freely.'
+                : 'Stop the AI before each move it weighed, so you can inspect or replace it.'
+            }
+          >
+            {stepMode ? '⏸ Stepping' : '▶ Playing'}
+          </button>
+          <button
+            style={styles.actionButton}
+            disabled={busy || !selected}
+            onClick={() => void run(() => downloadAiInsightExport(playerId, selected?.id))}
+            title="Download this position and every rating the AI gave it"
+          >
+            Export
+          </button>
+          <button
+            style={styles.actionButton}
+            disabled={busy || decisions.length === 0}
+            onClick={() =>
+              void run(async () => {
+                await clearAiInsight(playerId)
+                setSelectedId(null)
+              })
+            }
+            title="Drop the recorded history for this game"
+          >
+            Clear
+          </button>
+          <button onClick={() => setExpanded(false)} style={styles.closeButton} title="Close">
+            &times;
+          </button>
+        </div>
+      </div>
+
+      {error && <div style={styles.error}>{error}</div>}
+
+      {pending && (
+        <div style={styles.heldBanner}>
+          <div style={styles.heldTitle}>
+            Holding — the AI wants to play <strong>{pending.proposedLabel}</strong>
+          </div>
+          <div style={styles.heldHint}>
+            Let it through, or play any option below to see what that line does instead.
+          </div>
+          <button
+            style={styles.heldButton}
+            disabled={busy}
+            onClick={() => void run(() => resumeAi(playerId))}
+          >
+            Let the AI play it
+          </button>
+        </div>
+      )}
+
+      {decisions.length === 0 ? (
+        <div style={styles.empty}>
+          Nothing recorded yet. Decisions appear once the AI has a real choice to make — a window
+          with only one legal action is taken without weighing anything.
+        </div>
+      ) : (
+        <>
+          <div style={styles.timeline}>
+            {decisions.map((decision) => {
+              const isSelected = decision.id === selected?.id
+              const held = pendingId === decision.id
+              return (
+                <button
+                  key={decision.id}
+                  // Clicking the pinned row unpins it and resumes following the latest decision.
+                  onClick={() =>
+                    setSelectedId(selectedId !== null && isSelected ? null : decision.id)
+                  }
+                  onMouseEnter={() => setHoveredId(decision.id)}
+                  onMouseLeave={() =>
+                    setHoveredId((current) => (current === decision.id ? null : current))
+                  }
+                  style={{
+                    ...styles.timelineRow,
+                    ...(isSelected ? styles.timelineRowSelected : null),
+                    ...(hoveredId === decision.id ? styles.timelineRowHovered : null),
+                  }}
+                >
+                  <span style={styles.timelineTurn}>
+                    {held && <span style={styles.heldDot}>⏸ </span>}
+                    T{decision.insight.turnNumber} {kindTag(decision.insight.kind)}
+                  </span>
+                  <span style={styles.timelineChoice}>
+                    {decision.humanOverride?.label ?? decision.insight.chosenLabel}
+                  </span>
+                  {decision.humanOverride && <span style={styles.overrideTag}>yours</span>}
+                </button>
+              )
+            })}
+          </div>
+
+          {selected && (
+            <DecisionDetail
+              decision={selected}
+              pinned={selectedId !== null && !isHeld}
+              held={isHeld}
+              busy={busy}
+              onPlay={(index) => void run(() => resumeAi(playerId, index))}
+            />
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function DecisionDetail({
+  decision,
+  pinned,
+  held,
+  busy,
+  onPlay,
+}: {
+  decision: AiInsightDecision
+  pinned: boolean
+  held: boolean
+  busy: boolean
+  onPlay: (optionIndex: number) => void
+}) {
+  const { insight } = decision
+  // Bar width is relative to the biggest swing in this decision: the interesting question is
+  // "how much better than the alternatives", and a fixed scale flattens every close call.
+  const maxMagnitude = useMemo(() => {
+    const values = insight.options
+      .map((option) => option.advantage)
+      .filter((value): value is number => value !== null)
+      .map(Math.abs)
+    return Math.max(0.01, ...values)
+  }, [insight.options])
+
+  return (
+    <div style={styles.detail}>
+      <div style={styles.detailMeta}>
+        Turn {insight.turnNumber} · {formatStep(insight.step)} ·{' '}
+        {insight.onOwnTurn ? "AI's turn" : 'your turn'} · {insight.thinkTimeMs}ms
+        {pinned && <span style={styles.pinned}> · pinned</span>}
+      </div>
+      <div style={styles.detailMeta}>
+        Baseline: {insight.baselineLabel} at {insight.baselineScore.toFixed(2)} — an option is only
+        taken if it scores above this.
+      </div>
+      {decision.humanOverride && (
+        <div style={styles.overrideNote}>
+          You played <strong>{decision.humanOverride.label}</strong> instead of the AI's{' '}
+          <strong>{insight.chosenLabel}</strong>.
+        </div>
+      )}
+      <div style={styles.options}>
+        {insight.options.map((option, index) => (
+          <OptionRow
+            key={`${option.label}-${index}`}
+            option={option}
+            optionIndex={index}
+            maxMagnitude={maxMagnitude}
+            playedByHuman={decision.humanOverride?.optionIndex === index}
+            canPlay={held && option.action !== undefined && option.action !== null}
+            busy={busy}
+            onPlay={() => onPlay(index)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function OptionRow({
+  option,
+  optionIndex,
+  maxMagnitude,
+  playedByHuman,
+  canPlay,
+  busy,
+  onPlay,
+}: {
+  option: AiActionOption
+  optionIndex: number
+  maxMagnitude: number
+  playedByHuman: boolean
+  canPlay: boolean
+  busy: boolean
+  onPlay: () => void
+}) {
+  const unscored = option.score === null
+  const advantage = option.advantage ?? 0
+  const barWidth = unscored ? 0 : Math.min(100, (Math.abs(advantage) / maxMagnitude) * 100)
+  const positive = advantage >= 0
+
+  return (
+    <div
+      data-testid={`ai-insight-option-${optionIndex}`}
+      style={{
+        ...styles.option,
+        ...(option.chosen ? styles.optionChosen : null),
+        ...(option.baseline ? styles.optionBaseline : null),
+        ...(playedByHuman ? styles.optionPlayed : null),
+        ...(unscored ? styles.optionUnscored : null),
+      }}
+    >
+      <div style={styles.optionTop}>
+        <span style={styles.optionRank}>{unscored ? '·' : optionIndex + 1}</span>
+        <span style={styles.optionLabel} title={option.label}>
+          {option.label}
+        </span>
+        {option.chosen && <span style={styles.aiPickTag}>AI pick</span>}
+        {playedByHuman && <span style={styles.playedTag}>played</span>}
+        <span
+          style={{
+            ...styles.optionScore,
+            color: unscored ? '#666' : positive ? '#6ec98b' : '#d08a7a',
+          }}
+        >
+          {unscored ? '—' : `${advantage >= 0 ? '+' : ''}${advantage.toFixed(2)}`}
+        </span>
+        {canPlay && (
+          <button
+            data-testid={`ai-insight-play-${optionIndex}`}
+            style={styles.playButton}
+            disabled={busy}
+            onClick={onPlay}
+            title="Submit this move instead of the AI's"
+          >
+            Play
+          </button>
+        )}
+      </div>
+      {!unscored && (
+        <div style={styles.barTrack}>
+          <div
+            style={{
+              ...styles.barFill,
+              // Zero sits at the track's midpoint: the baseline row is the reference, and a
+              // rejected option reads as "below the line" rather than as a short green bar.
+              width: `${barWidth / 2}%`,
+              marginLeft: positive ? '50%' : `${50 - barWidth / 2}%`,
+              backgroundColor: positive ? 'rgba(110, 201, 139, 0.55)' : 'rgba(208, 138, 122, 0.55)',
+            }}
+          />
+        </div>
+      )}
+      {(option.note || option.rawScore !== null) && (
+        <div style={styles.optionNote}>
+          {option.rawScore !== null && `board score ${option.rawScore.toFixed(2)}`}
+          {option.rawScore !== null && option.note ? ' · ' : ''}
+          {option.note}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function kindTag(kind: string): string {
+  switch (kind) {
+    case 'DECLARE_ATTACKERS':
+      return 'attacks'
+    case 'DECLARE_BLOCKERS':
+      return 'blocks'
+    default:
+      return 'priority'
+  }
+}
+
+function formatStep(step: string): string {
+  return step.toLowerCase().replace(/_/g, ' ')
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  toggleButton: {
+    position: 'fixed',
+    bottom: 12,
+    left: 92,
+    zIndex: 500,
+    padding: '6px 12px',
+    fontSize: 12,
+    backgroundColor: 'rgba(20, 20, 40, 0.85)',
+    color: '#aaa',
+    border: '1px solid #444',
+    borderRadius: 6,
+    cursor: 'pointer',
+  },
+  toggleButtonHeld: {
+    backgroundColor: 'rgba(224, 168, 64, 0.22)',
+    borderColor: 'rgba(224, 168, 64, 0.6)',
+    color: '#f0c473',
+  },
+  panel: {
+    position: 'fixed',
+    bottom: 48,
+    left: 12,
+    zIndex: 501,
+    width: 'min(520px, calc(100vw - 24px))',
+    maxHeight: '72vh',
+    display: 'flex',
+    flexDirection: 'column',
+    backgroundColor: 'rgba(10, 10, 25, 0.96)',
+    border: '1px solid #333',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '6px 10px',
+    borderBottom: '1px solid #333',
+    gap: 8,
+    flexShrink: 0,
+  },
+  headerTitle: {
+    color: '#aaa',
+    fontSize: 12,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    whiteSpace: 'nowrap',
+  },
+  headerActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+  },
+  actionButton: {
+    padding: '3px 8px',
+    fontSize: 11,
+    backgroundColor: 'rgba(60, 60, 90, 0.6)',
+    color: '#bbb',
+    border: '1px solid #444',
+    borderRadius: 4,
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+  },
+  actionButtonOn: {
+    backgroundColor: 'rgba(224, 168, 64, 0.22)',
+    borderColor: 'rgba(224, 168, 64, 0.55)',
+    color: '#f0c473',
+  },
+  closeButton: {
+    background: 'none',
+    border: 'none',
+    color: '#888',
+    fontSize: 18,
+    cursor: 'pointer',
+    padding: '0 4px',
+    lineHeight: 1,
+  },
+  error: {
+    padding: '4px 10px',
+    fontSize: 11,
+    color: '#d08a7a',
+    flexShrink: 0,
+  },
+  heldBanner: {
+    padding: '8px 10px',
+    borderBottom: '1px solid #333',
+    backgroundColor: 'rgba(224, 168, 64, 0.10)',
+    flexShrink: 0,
+  },
+  heldTitle: {
+    fontSize: 12,
+    color: '#f0c473',
+    lineHeight: 1.5,
+  },
+  heldHint: {
+    fontSize: 11,
+    color: '#8a8a99',
+    lineHeight: 1.5,
+    paddingTop: 2,
+  },
+  heldButton: {
+    marginTop: 6,
+    padding: '4px 10px',
+    fontSize: 11,
+    backgroundColor: 'rgba(224, 168, 64, 0.2)',
+    color: '#f0c473',
+    border: '1px solid rgba(224, 168, 64, 0.5)',
+    borderRadius: 4,
+    cursor: 'pointer',
+  },
+  empty: {
+    color: '#666',
+    fontSize: 12,
+    padding: 12,
+    lineHeight: 1.5,
+  },
+  timeline: {
+    maxHeight: 110,
+    overflowY: 'auto',
+    borderBottom: '1px solid #333',
+    flexShrink: 0,
+  },
+  timelineRow: {
+    display: 'flex',
+    gap: 8,
+    alignItems: 'baseline',
+    width: '100%',
+    textAlign: 'left',
+    padding: '3px 10px',
+    fontSize: 11,
+    background: 'none',
+    border: 'none',
+    borderBottom: '1px solid rgba(255,255,255,0.04)',
+    color: '#999',
+    cursor: 'pointer',
+  },
+  timelineRowSelected: {
+    backgroundColor: 'rgba(91, 192, 222, 0.12)',
+    color: '#cfe8f2',
+  },
+  timelineRowHovered: {
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+    color: '#ddd',
+  },
+  timelineTurn: {
+    flexShrink: 0,
+    width: 100,
+    color: '#777',
+  },
+  heldDot: {
+    color: '#f0c473',
+  },
+  timelineChoice: {
+    flex: 1,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  overrideTag: {
+    flexShrink: 0,
+    fontSize: 9,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    color: '#7fb3d5',
+  },
+  detail: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: '6px 10px 10px',
+  },
+  detailMeta: {
+    fontSize: 11,
+    color: '#777',
+    lineHeight: 1.5,
+    paddingBottom: 2,
+  },
+  pinned: {
+    color: '#5bc0de',
+  },
+  overrideNote: {
+    fontSize: 11,
+    color: '#7fb3d5',
+    lineHeight: 1.5,
+    paddingTop: 2,
+  },
+  options: {
+    paddingTop: 6,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+  },
+  option: {
+    padding: '4px 6px',
+    borderRadius: 4,
+    border: '1px solid transparent',
+  },
+  optionChosen: {
+    backgroundColor: 'rgba(110, 201, 139, 0.10)',
+    borderColor: 'rgba(110, 201, 139, 0.35)',
+  },
+  optionBaseline: {
+    backgroundColor: 'rgba(255, 255, 255, 0.04)',
+  },
+  optionPlayed: {
+    backgroundColor: 'rgba(127, 179, 213, 0.12)',
+    borderColor: 'rgba(127, 179, 213, 0.45)',
+  },
+  optionUnscored: {
+    opacity: 0.55,
+  },
+  optionTop: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: 6,
+    fontSize: 12,
+  },
+  optionRank: {
+    width: 12,
+    flexShrink: 0,
+    color: '#666',
+    fontSize: 10,
+    fontVariantNumeric: 'tabular-nums',
+  },
+  optionLabel: {
+    flex: 1,
+    color: '#ddd',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  aiPickTag: {
+    flexShrink: 0,
+    fontSize: 9,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    color: '#6ec98b',
+  },
+  playedTag: {
+    flexShrink: 0,
+    fontSize: 9,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    color: '#7fb3d5',
+  },
+  optionScore: {
+    flexShrink: 0,
+    fontVariantNumeric: 'tabular-nums',
+    fontSize: 12,
+  },
+  playButton: {
+    flexShrink: 0,
+    padding: '1px 7px',
+    fontSize: 10,
+    backgroundColor: 'rgba(224, 168, 64, 0.18)',
+    color: '#f0c473',
+    border: '1px solid rgba(224, 168, 64, 0.45)',
+    borderRadius: 3,
+    cursor: 'pointer',
+  },
+  barTrack: {
+    height: 3,
+    marginTop: 3,
+    marginLeft: 18,
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderRadius: 2,
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: '100%',
+    borderRadius: 2,
+  },
+  optionNote: {
+    marginLeft: 18,
+    marginTop: 2,
+    fontSize: 10,
+    color: '#6b6b7a',
+    fontStyle: 'italic',
+  },
+}

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -14,6 +14,7 @@ import { TargetingArrows } from '../targeting/TargetingArrows'
 import { DraggedCardOverlay } from './DraggedCardOverlay'
 import { GameLog } from './GameLog'
 import { ActiveYieldsPanel } from './ActiveYieldsPanel'
+import { AiInsightPanel } from './AiInsightPanel'
 import { DrawAnimations } from '../animations/DrawAnimations'
 import { DamageAnimations } from '../animations/DamageAnimations'
 import { RevealAnimations } from '../animations/RevealAnimations'
@@ -1974,6 +1975,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
           that size anyway. */}
       {!spectatorMode && !responsive.isMobile && <GameLog />}
       {!spectatorMode && <ActiveYieldsPanel />}
+      {!spectatorMode && <AiInsightPanel />}
 
       {/* Draw animations */}
       <DrawAnimations />


### PR DESCRIPTION
The engine AI already scores every candidate it weighs and then throws the numbers away: `Strategist` builds a `List<Pair<LegalAction, Double>>`, takes the max, returns the winner. When it makes a move that looks wrong, "wrong" is all you can observe.

This adds a local-only mode that surfaces those numbers, lets you hold the AI and play a different option, and exports a position plus its ratings as AI-training input.

## What it does

**Browse.** An "AI Insight" panel (bottom-left, next to the game log) lists every decision the AI actually weighed. Each shows its options ranked, with the **advantage over the baseline** — passing priority, or declaring no attackers — which is the threshold an option had to clear to be taken at all. Options the AI *dropped* are listed too, with why (illegal once materialized / walks back into a position already acted from / budget expired); without them the panel would imply the AI never considered a line it in fact discarded. Where a hold-policy verdict or a `CardAdvisor` override rather than the board score decided it, the row says so.

**Step and override.** Toggle `⏸ Stepping` and `AiActionGate` holds the AI between choosing and submitting — so you see the finished ranking, not a blank panel. Let its pick through, or hit `Play` on any row and the engine executes that line instead.

**Export.** One decision's board state plus every rating, as JSON. `state` is a full `GameState`, so a position that produced a bad rating also re-opens through `POST /api/scenarios/from-state`. An override rides along as `humanOverride` — position, what the AI ranked highest, what a human played instead.

## Design notes

- **It is the real decision, not a re-run.** The sink is fed from the same locals the choice was made from, so a captured ranking cannot disagree with the move — which is exactly what a recompute-for-display would eventually do, and only under the conditions you were investigating.
- **Free when off.** The sink is null in production and every recording site sits behind a null check. No extra simulation, no extra scoring; `AiProfile` untouched.
- **Options are playable, not just readable.** Each carries the concrete `GameAction` the AI would submit, already materialized and simulated. A candidate the processor already rejected stays listed but carries no action, so the panel can never offer a move the engine would refuse.
- **It cannot wedge a game.** Every path that isn't an explicit human choice — timeout, no recorded decision, seat mismatch, step mode off, history cleared — falls back to the AI's own pick. Step mode is keyed by seat and gated on a recent poll, so a closed tab reads as "nobody is watching" and the game runs at full speed.

Gated on `game.ai.insight-enabled` (on in `application-local.yml`), deliberately separate from `game.dev-endpoints.enabled`: the export is unmasked, so it stays opt-in even where the other dev endpoints are already open. The routes 404 when off, which is how the client decides whether to offer the panel at all.

## Second commit

`AiGameManager` builds an `AiWebSocketSession` in four places and the gate went in at one. `wireAiForGame` — the path a normal game against the AI takes at match start — built its own ungated session and replaced the gated one, so step mode looked armed and never held. All four now funnel through `buildAiSession`; per-seat wiring has been missed twice in this file already.

## Verification

- `just build` green (full suite). Client typecheck clean.
- 8 new tests in `AiInsightCaptureTest`. The load-bearing one pushes **every offered option through a real `ActionProcessor`** — if the panel can offer it, the engine takes it.
- Driven end to end in Chrome on both paths: a dev scenario, and a real solo vs-AI Momir game (10 ranked options, all playable). Held at `Cast Lightning Bolt → Wind Drake (+17.60)`, played `Pass priority (+0.00)` instead; the Drake survived and the turn moved on.

Screenshots of the panel (browsing, held, post-override) are captured and can be attached on request — I did not push them to a side branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
