### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/backlog/sets/the-hobbit/cards.md
+++ b/backlog/sets/the-hobbit/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 193 cards revealed as of 2026-08-04
 **Release Date:** August 14, 2026
-**Implemented:** 71 / 193
+**Implemented:** 76 / 193
 Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. This list covers only cards revealed as of that date.
 
 - [x] 1. Long-Bodied Grey Dog
@@ -31,7 +31,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 24. The Queen of Dale
 - [ ] 25. Roads Go Ever, Ever On
 - [ ] 26. Settle the Wreckage
-- [ ] 27. Stone by Sunlight
+- [x] 27. Stone by Sunlight
 - [x] 28. Thorin's Last Stand
 - [ ] 29. An Unexpected Party
 - [ ] 30. Velvetwing Butterflies
@@ -72,11 +72,11 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 65. Down, Down to Goblin-town
 - [x] 66. Dreaded Bat-Cloud
 - [x] 67. Front Porch Sentries
-- [ ] 68. Gathering of Darkness
+- [x] 68. Gathering of Darkness
 - [x] 69. Gnashing of Teeth
 - [ ] 70. Gollum, Riddle Master
 - [ ] 71. Gollum, Silent Slinker
-- [ ] 72. Gollum the Abandoned
+- [x] 72. Gollum the Abandoned
 - [x] 73. Great Fierce Bee
 - [ ] 74. Great Ugly-Looking Goblin
 - [ ] 75. Head of the Hunt
@@ -121,7 +121,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 114. Thorin, Mountain-king
 - [x] 115. Tidings of War
 - [x] 116. Attercop
-- [ ] 117. Bejeweled Warg
+- [x] 117. Bejeweled Warg
 - [ ] 118. Beorn, Reluctant Host
 - [ ] 119. Beorn the Fierce
 - [ ] 120. Beorn's Hospitality
@@ -153,7 +153,7 @@ Inventory retrieved from Scryfall on 2026-08-04 while the set was in previews. T
 - [ ] 146. Bard's Company
 - [ ] 147. Bifur, Melodic Rider
 - [ ] 148. Bolg of the North
-- [ ] 149. Bolg's Company
+- [x] 149. Bolg's Company
 - [x] 150. The Chief Warg
 - [ ] 151. Chief Warg's Company
 - [ ] 152. Dáin's Company

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BejeweledWarg.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BejeweledWarg.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bejeweled Warg — The Hobbit #117
+ * {1}{G} · Creature — Wolf · Rare
+ * 3/2
+ *
+ * Trample
+ * Whenever this creature deals combat damage to a player, choose one —
+ * • Put a +1/+1 counter on target Wolf you control.
+ * • Create a Treasure token.
+ *
+ * Modeling notes:
+ *  - The mode is chosen as the trigger goes on the stack, and only the counter mode targets
+ *    (CR 603.3d) — so with no Wolf you control the player is left with the Treasure mode. Bejeweled
+ *    Warg is itself a Wolf, so it is normally its own legal target.
+ *  - `countsAsModalSpell = false`: this is a modal *ability*, not a modal spell, so it must not feed
+ *    `SpellCastEvent.chosenModesCount` / `SpellCastPredicate.IsModal`.
+ */
+val BejeweledWarg = card("Bejeweled Warg") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 3
+    toughness = 2
+    oracleText = "Trample\n" +
+        "Whenever this creature deals combat damage to a player, choose one —\n" +
+        "• Put a +1/+1 counter on target Wolf you control.\n" +
+        "• Create a Treasure token."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)),
+                TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.WOLF)),
+                "Put a +1/+1 counter on target Wolf you control"
+            ),
+            Mode.noTarget(
+                Effects.CreateTreasure(1),
+                "Create a Treasure token"
+            ),
+            countsAsModalSpell = false
+        )
+        description = "Whenever Bejeweled Warg deals combat damage to a player, choose one — " +
+            "put a +1/+1 counter on target Wolf you control; or create a Treasure token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "117"
+        artist = "John Di Giovanni"
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e95eba5c-e0d6-46b4-a0be-8e373b2185ea.jpg?1785496330"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BolgsCompany.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BolgsCompany.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bolg's Company — The Hobbit #149
+ * {B}{R} · Creature — Goblin Soldier · Rare
+ * 2/2
+ *
+ * This creature has haste as long as you control another Goblin.
+ * {T}, Sacrifice another Goblin: Add {B}{R}.
+ *
+ * Modeling notes:
+ *  - The haste clause is a continuous static gated on a *different* Goblin (`excludeSelf`), so it
+ *    goes dark the moment the other Goblin leaves — the Barrow Naughty / Magitek Infantry shape.
+ *    Note the ordering trap this creates: sacrificing your only other Goblin to the mana ability
+ *    turns haste off, which matters if this creature hasn't attacked yet.
+ *  - "Add {B}{R}" is one black *and* one red, not a choice, so it is two `AddMana` effects rather
+ *    than an `AddManaOfChoice`. No targets and no stack — a true mana ability (CR 605.1a).
+ */
+val BolgsCompany = card("Bolg's Company") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Goblin Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "This creature has haste as long as you control another Goblin.\n" +
+        "{T}, Sacrifice another Goblin: Add {B}{R}."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HASTE, GroupFilter.source()),
+            condition = Conditions.YouControl(
+                GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.SacrificeAnother(GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN))
+        )
+        effect = Effects.Composite(
+            Effects.AddMana(Color.BLACK),
+            Effects.AddMana(Color.RED)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}, Sacrifice another Goblin: Add {B}{R}."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "149"
+        artist = "Michele Giorgi"
+        flavorText = "Tidings they had gathered in secret ways; and in all the mountains there was " +
+            "a forging and an arming."
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea3f5644-f7e3-40de-ada5-cea2e9113cfb.jpg?1785497179"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GatheringOfDarkness.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GatheringOfDarkness.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Gathering of Darkness — The Hobbit #68
+ * {3}{B} · Sorcery · Uncommon
+ *
+ * Return up to one target creature card from your graveyard to your hand.
+ * Amass Goblins 3.
+ *
+ * Modeling notes:
+ *  - "Up to one target" is an optional [TargetObject]: casting it with an empty graveyard (or
+ *    declining the target) is legal, and the spell still amasses.
+ *  - Both halves are one resolution, so the recursion happens before the amass — irrelevant here,
+ *    but it is the printed order.
+ */
+val GatheringOfDarkness = card("Gathering of Darkness") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return up to one target creature card from your graveyard to your hand.\n" +
+        "Amass Goblins 3. (Put three +1/+1 counters on an Army you control. It's also a Goblin. " +
+        "If you don't control an Army, create a 0/0 black Goblin Army creature token first.)"
+
+    spell {
+        val creatureCard = target(
+            "creature card in your graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Creature.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+
+        effect = Effects.Move(creatureCard, Zone.HAND) then Effects.Amass(3, "Goblin")
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "68"
+        artist = "Pavel Kolomeyets"
+        flavorText = "\"Alas! Bolg of the North is coming!\"\n—Gandalf"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2ce066be-e5ad-4b93-8245-1b5018990d03.jpg?1784733910"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GollumTheAbandoned.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GollumTheAbandoned.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Gollum the Abandoned — The Hobbit #72
+ * {1}{B} · Legendary Creature — Halfling Horror · Uncommon
+ * 2/2
+ *
+ * Gollum can't block.
+ * When Gollum enters, exile up to one target card from an opponent's graveyard. Each opponent
+ * loses 2 life.
+ * {2}, Sacrifice an artifact or creature: Return this card from your graveyard to your hand.
+ * Activate only as a sorcery.
+ *
+ * Modeling notes:
+ *  - The exile half is "up to one target", so the ETB is castable into an empty board and the
+ *    life loss still happens with no target chosen. It does *not* happen if the one chosen target
+ *    becomes illegal before resolution — the ability is then countered for having no legal targets
+ *    (CR 608.2b), which is the printed behaviour.
+ *  - The recursion ability lives in the graveyard (`activateFromZone`), so the sacrificed artifact
+ *    or creature is never Gollum himself. `TimingRule.SorcerySpeed` carries "activate only as a
+ *    sorcery".
+ */
+val GollumTheAbandoned = card("Gollum the Abandoned") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Halfling Horror"
+    power = 2
+    toughness = 2
+    oracleText = "Gollum can't block.\n" +
+        "When Gollum enters, exile up to one target card from an opponent's graveyard. " +
+        "Each opponent loses 2 life.\n" +
+        "{2}, Sacrifice an artifact or creature: Return this card from your graveyard to your hand. " +
+        "Activate only as a sorcery."
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val exiled = target(
+            "card in an opponent's graveyard",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Any.ownedByOpponent(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = Effects.Move(exiled, Zone.EXILE) then
+            LoseLifeEffect(2, EffectTarget.PlayerRef(Player.EachOpponent))
+        description = "When Gollum the Abandoned enters, exile up to one target card from an " +
+            "opponent's graveyard. Each opponent loses 2 life."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Sacrifice(GameObjectFilter.CreatureOrArtifact)
+        )
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND)
+        activateFromZone = Zone.GRAVEYARD
+        timing = TimingRule.SorcerySpeed
+        description = "{2}, Sacrifice an artifact or creature: Return this card from your " +
+            "graveyard to your hand. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "72"
+        artist = "Andrea Piparo"
+        flavorText = "\"Where iss it? Losst it is, my precious!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50d91ef3-6f5d-4255-8d47-be731b5dad30.jpg?1784733916"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StoneBySunlight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StoneBySunlight.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Stone by Sunlight — The Hobbit #27
+ * {1}{W} · Instant · Uncommon
+ *
+ * Choose one —
+ * • Destroy target creature with power 4 or greater.
+ * • Until end of turn, target creature becomes an artifact in addition to its other types and
+ *   gains indestructible.
+ *
+ * Modeling notes:
+ *  - Each mode carries its own target, so the power-4 restriction only constrains mode 1; mode 2
+ *    can hit any creature (including your own — the intended use, saving a creature from a wrath).
+ *  - "Becomes an artifact **in addition to** its other types" is [Effects.AddCardType], not a
+ *    become-artifact transform: the creature keeps its types, subtypes, abilities, and P/T. Both
+ *    halves of the mode are `Duration.EndOfTurn`.
+ */
+val StoneBySunlight = card("Stone by Sunlight") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Destroy target creature with power 4 or greater.\n" +
+        "• Until end of turn, target creature becomes an artifact in addition to its other types " +
+        "and gains indestructible."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Destroy target creature with power 4 or greater") {
+                val t = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtLeast(4)))
+                effect = Effects.Destroy(t)
+            }
+            mode("Target creature becomes an artifact and gains indestructible until end of turn") {
+                val t = target("target", TargetCreature())
+                effect = Effects.Composite(
+                    Effects.AddCardType("ARTIFACT", t, Duration.EndOfTurn),
+                    Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t, Duration.EndOfTurn)
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "27"
+        artist = "Kamila Szutenberg"
+        flavorText = "\"Dawn take you all, and be stone to you!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5752731-253c-4b41-bdd8-94c26d715206.jpg?1784631953"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -48,6 +48,75 @@
     ]
 }
 
+// Bejeweled Warg
+{
+    "name": "Bejeweled Warg",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Trample\nWhenever this creature deals combat damage to a player, choose one —\n• Put a +1/+1 counter on target Wolf you control.\n• Create a Treasure token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature Wolf ctrl:you"
+                                    }
+                                }
+                            ],
+                            "description": "Put a +1/+1 counter on target Wolf you control"
+                        },
+                        {
+                            "effect": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure"
+                            }
+                        }
+                    ],
+                    "countsAsModalSpell": false
+                },
+                "descriptionOverride": "Whenever Bejeweled Warg deals combat damage to a player, choose one — put a +1/+1 counter on target Wolf you control; or create a Treasure token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "RARE",
+        "artist": "John Di Giovanni",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e95eba5c-e0d6-46b4-a0be-8e373b2185ea.jpg?1785496330"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Bilbo's Deadly Slice
 {
     "name": "Bilbo's Deadly Slice",
@@ -82,6 +151,86 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Bolg's Company
+{
+    "name": "Bolg's Company",
+    "manaCost": "{B}{R}",
+    "typeLine": "Creature — Goblin Soldier",
+    "oracleText": "This creature has haste as long as you control another Goblin.\n{T}, Sacrifice another Goblin: Add {B}{R}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Goblin",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "BLACK"
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "RED"
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}, Sacrifice another Goblin: Add {B}{R}."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Goblin",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "rarity": "RARE",
+        "artist": "Michele Giorgi",
+        "flavorText": "Tidings they had gathered in secret ways; and in all the mountains there was a forging and an arming.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea3f5644-f7e3-40de-ada5-cea2e9113cfb.jpg?1785497179"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -1152,6 +1301,58 @@
     ]
 }
 
+// Gathering of Darkness
+{
+    "name": "Gathering of Darkness",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to one target creature card from your graveyard to your hand.\nAmass Goblins 3. (Put three +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "Amass",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "subtype": "Goblin"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "creature card in your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "rarity": "UNCOMMON",
+        "artist": "Pavel Kolomeyets",
+        "flavorText": "\"Alas! Bolg of the North is coming!\"\n—Gandalf",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2ce066be-e5ad-4b93-8245-1b5018990d03.jpg?1784733910"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Giant's Boulder
 {
     "name": "Giant's Boulder",
@@ -1407,6 +1608,108 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Gollum the Abandoned
+{
+    "name": "Gollum the Abandoned",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Creature — Halfling Horror",
+    "oracleText": "Gollum can't block.\nWhen Gollum enters, exile up to one target card from an opponent's graveyard. Each opponent loses 2 life.\n{2}, Sacrifice an artifact or creature: Return this card from your graveyard to your hand. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "card in an opponent's graveyard"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "own:opponent",
+                        "zone": "Graveyard"
+                    },
+                    "id": "card in an opponent's graveyard"
+                },
+                "descriptionOverride": "When Gollum the Abandoned enters, exile up to one target card from an opponent's graveyard. Each opponent loses 2 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                },
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "{2}, Sacrifice an artifact or creature: Return this card from your graveyard to your hand. Activate only as a sorcery."
+            }
+        ],
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "UNCOMMON",
+        "artist": "Andrea Piparo",
+        "flavorText": "\"Where iss it? Losst it is, my precious!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50d91ef3-6f5d-4255-8d47-be731b5dad30.jpg?1784733916"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -2965,6 +3268,86 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Stone by Sunlight
+{
+    "name": "Stone by Sunlight",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target creature with power 4 or greater.\n• Until end of turn, target creature becomes an artifact in addition to its other types and gains indestructible.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature pow>=4"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target creature with power 4 or greater"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCardType",
+                                "cardType": "ARTIFACT",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                },
+                                "duration": "EndOfTurn"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target creature becomes an artifact and gains indestructible until end of turn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "UNCOMMON",
+        "artist": "Kamila Szutenberg",
+        "flavorText": "\"Dawn take you all, and be stone to you!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5752731-253c-4b41-bdd8-94c26d715206.jpg?1784631953"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BejeweledWargScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BejeweledWargScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AssignDamageDecision
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bejeweled Warg (HOB) — {1}{G} Creature — Wolf 3/2
+ *
+ * Trample
+ * Whenever this creature deals combat damage to a player, choose one —
+ * • Put a +1/+1 counter on target Wolf you control.
+ * • Create a Treasure token.
+ *
+ * Proves the modal *ability* (not a modal spell) reaches a mode decision off combat damage, and
+ * that each mode does what it says.
+ */
+class BejeweledWargScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    /**
+     * Push through blockers and combat damage until the trigger's mode decision surfaces.
+     *
+     * Note the engine picks the mode of a modal *ability* at resolution
+     * ([ChooseOptionDecision], `phase = RESOLUTION`) rather than as the ability is put onto the
+     * stack. That is the shared behaviour of every modal triggered ability here (Kutzil's Flanker,
+     * Breeches), not something this card introduces.
+     */
+    private fun advanceToModeDecision(game: TestGame): ChooseOptionDecision {
+        var blockersDeclared = false
+        var guard = 0
+        while (guard++ < 60) {
+            val pending = game.getPendingDecision()
+            if (pending is ChooseOptionDecision) return pending
+            when {
+                pending is CombatResolutionDecision -> game.submitDefaultCombatDamage()
+                pending is AssignDamageDecision -> game.submitDefaultDamageAssignment()
+                pending != null -> error("unexpected pending decision: $pending")
+                game.state.step == Step.DECLARE_BLOCKERS && !blockersDeclared -> {
+                    blockersDeclared = true
+                    game.declareNoBlockers()
+                }
+                else -> game.passPriority()
+            }
+        }
+        error("no mode decision surfaced; last was ${game.getPendingDecision()}")
+    }
+
+    init {
+        context("Bejeweled Warg") {
+
+            test("mode 1 puts a +1/+1 counter on a Wolf you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bejeweled Warg")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val warg = game.findPermanent("Bejeweled Warg")!!
+                game.declareAttackers(mapOf("Bejeweled Warg" to 2)).error shouldBe null
+
+                val decision = advanceToModeDecision(game)
+                game.submitDecision(OptionChosenResponse(decision.id, optionIndex = 0))
+
+                if (game.getPendingDecision() != null) {
+                    game.selectTargets(listOf(warg))
+                }
+                game.resolveStack()
+
+                withClue("The Warg is the only Wolf, so it counters itself up to 4/3") {
+                    projector.project(game.state).getPower(warg) shouldBe 4
+                }
+            }
+
+            test("mode 2 creates a Treasure token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bejeweled Warg")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Bejeweled Warg" to 2)).error shouldBe null
+
+                val decision = advanceToModeDecision(game)
+                game.submitDecision(OptionChosenResponse(decision.id, optionIndex = 1))
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+                val treasure = game.state.getBattlefield(game.player1Id).firstOrNull { id ->
+                    projected.hasSubtype(id, "Treasure")
+                }
+                withClue("A Treasure token should be on the battlefield") {
+                    (treasure != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BolgsCompanyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BolgsCompanyScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bolg's Company (HOB) — {B}{R} Creature — Goblin Soldier 2/2
+ *
+ * This creature has haste as long as you control another Goblin.
+ * {T}, Sacrifice another Goblin: Add {B}{R}.
+ *
+ * Pins the two halves that could silently misbehave: the conditional keyword must key off a
+ * *different* Goblin (not itself), and the mana ability must be a real mana ability producing one
+ * black and one red — not two of one color.
+ */
+class BolgsCompanyScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Bolg's Company") {
+
+            test("no other Goblin: the haste clause is off") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bolg's Company")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bolg = game.findPermanent("Bolg's Company")!!
+                withClue("A non-Goblin on the battlefield must not switch haste on") {
+                    projector.project(game.state).hasKeyword(bolg, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("another Goblin you control switches haste on") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bolg's Company")
+                    .withCardOnBattlefield(1, "Goblin Guide")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bolg = game.findPermanent("Bolg's Company")!!
+                withClue("Another Goblin you control grants haste") {
+                    projector.project(game.state).hasKeyword(bolg, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("an opponent's Goblin does not switch haste on") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bolg's Company")
+                    .withCardOnBattlefield(2, "Goblin Guide")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bolg = game.findPermanent("Bolg's Company")!!
+                withClue("The clause reads \"you control\", so an opposing Goblin is irrelevant") {
+                    projector.project(game.state).hasKeyword(bolg, Keyword.HASTE) shouldBe false
+                }
+            }
+
+            test("{T}, Sacrifice another Goblin: adds one black and one red") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bolg's Company")
+                    .withCardOnBattlefield(1, "Goblin Guide")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bolg = game.findPermanent("Bolg's Company")!!
+                val fodder = game.findPermanent("Goblin Guide")!!
+                val ability = cardRegistry.getCard("Bolg's Company")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bolg,
+                        abilityId = ability.id,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+                    )
+                )
+                withClue("Activating the mana ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                withClue("The sacrificed Goblin has left the battlefield") {
+                    game.isOnBattlefield("Goblin Guide") shouldBe false
+                }
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Exactly {B}{R} lands in the pool") {
+                    (pool?.black ?: 0) shouldBe 1
+                    (pool?.red ?: 0) shouldBe 1
+                }
+            }
+
+            test("the sacrifice must be another Goblin, not Bolg's Company itself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bolg's Company")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bolg = game.findPermanent("Bolg's Company")!!
+                val ability = cardRegistry.getCard("Bolg's Company")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bolg,
+                        abilityId = ability.id,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bolg))
+                    )
+                )
+                withClue("\"another Goblin\" excludes the source") {
+                    (result.error != null) shouldBe true
+                }
+                withClue("Bolg's Company survives a rejected activation") {
+                    game.isOnBattlefield("Bolg's Company") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GatheringOfDarknessScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GatheringOfDarknessScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gathering of Darkness (HOB) — {3}{B} Sorcery
+ *
+ * Return up to one target creature card from your graveyard to your hand.
+ * Amass Goblins 3.
+ *
+ * The "up to one" target is the interesting half: the amass must still happen when no target is
+ * chosen, and the returned card must be the targeted one.
+ */
+class GatheringOfDarknessScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Gathering of Darkness") {
+
+            test("returns the targeted creature card and amasses Goblins 3") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Gathering of Darkness")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+
+                game.castSpellTargetingGraveyardCard(1, "Gathering of Darkness", listOf(bears))
+                    .error shouldBe null
+                game.resolveStack()
+
+                withClue("The targeted creature card is back in hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+
+                val army = game.findAllPermanents("Army Token").firstOrNull()
+                    ?: game.state.getBattlefield(game.player1Id).firstOrNull { id ->
+                        projector.project(game.state).hasSubtype(id, "Army")
+                    }
+                    ?: error("amass should have created an Army token")
+
+                val projected = projector.project(game.state)
+                withClue("A 0/0 Army with three +1/+1 counters is a 3/3") {
+                    projected.getPower(army) shouldBe 3
+                }
+                withClue("The Army is also a Goblin") {
+                    projected.hasSubtype(army, "Goblin") shouldBe true
+                }
+            }
+
+            test("with no target chosen the spell still amasses") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Gathering of Darkness")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gathering of Darkness").error shouldBe null
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+                val army = game.state.getBattlefield(game.player1Id).firstOrNull { id ->
+                    projected.hasSubtype(id, "Army")
+                } ?: error("amass should have created an Army token even with an empty graveyard")
+
+                withClue("The Army still got its three counters") {
+                    projected.getPower(army) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GollumTheAbandonedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GollumTheAbandonedScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gollum the Abandoned (HOB) — {1}{B} Legendary Creature — Halfling Horror 2/2
+ *
+ * Gollum can't block.
+ * When Gollum enters, exile up to one target card from an opponent's graveyard. Each opponent
+ * loses 2 life.
+ * {2}, Sacrifice an artifact or creature: Return this card from your graveyard to your hand.
+ * Activate only as a sorcery.
+ *
+ * The two shapes worth proving: the ETB still drains with no target chosen ("up to one"), and the
+ * recursion ability is enumerable and payable *from the graveyard*.
+ */
+class GollumTheAbandonedScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Gollum the Abandoned") {
+
+            test("ETB exiles the targeted opposing graveyard card and drains 2") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Gollum the Abandoned")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+                val lifeBefore = game.getLifeTotal(2)
+
+                game.castSpell(1, "Gollum the Abandoned").error shouldBe null
+                game.resolveStack()
+
+                // The ETB trigger targets as it goes on the stack.
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(bears))
+                }
+                game.resolveStack()
+
+                withClue("The targeted card left the opponent's graveyard for exile") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("Each opponent lost 2 life") {
+                    game.getLifeTotal(2) shouldBe lifeBefore - 2
+                }
+            }
+
+            test("ETB still drains when there is nothing to exile") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Gollum the Abandoned")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(2)
+
+                game.castSpell(1, "Gollum the Abandoned").error shouldBe null
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.skipTargets()
+                }
+                game.resolveStack()
+
+                withClue("\"Up to one target\" means an empty opposing graveyard is fine") {
+                    game.getLifeTotal(2) shouldBe lifeBefore - 2
+                }
+                withClue("Gollum is on the battlefield") {
+                    game.isOnBattlefield("Gollum the Abandoned") shouldBe true
+                }
+            }
+
+            test("{2}, Sacrifice an artifact or creature returns Gollum from the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Gollum the Abandoned")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gollum = game.findCardsInGraveyard(1, "Gollum the Abandoned").single()
+                val fodder = game.findPermanent("Grizzly Bears")!!
+                val ability = cardRegistry.getCard("Gollum the Abandoned")!!
+                    .script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = gollum,
+                        abilityId = ability.id,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+                    )
+                )
+                withClue("The graveyard ability should activate: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The sacrificed creature is gone") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("Gollum is back in hand") {
+                    game.isInHand(1, "Gollum the Abandoned") shouldBe true
+                    game.isInGraveyard(1, "Gollum the Abandoned") shouldBe false
+                }
+            }
+
+            test("the graveyard ability can't be activated at instant speed") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInGraveyard(1, "Gollum the Abandoned")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                    .build()
+
+                val gollum = game.findCardsInGraveyard(1, "Gollum the Abandoned").single()
+                val fodder = game.findPermanent("Grizzly Bears")!!
+                val ability = cardRegistry.getCard("Gollum the Abandoned")!!
+                    .script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = gollum,
+                        abilityId = ability.id,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+                    )
+                )
+                withClue("\"Activate only as a sorcery\" blocks it outside a main phase") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("Gollum can't block") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Gollum the Abandoned")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+
+                val result = game.declareBlockers(
+                    mapOf("Gollum the Abandoned" to listOf("Grizzly Bears"))
+                )
+                withClue("The can't-block static must reject the block") {
+                    (result.error != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StoneBySunlightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StoneBySunlightScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Stone by Sunlight (HOB) — {1}{W} Instant
+ *
+ * Choose one —
+ * • Destroy target creature with power 4 or greater.
+ * • Until end of turn, target creature becomes an artifact in addition to its other types and
+ *   gains indestructible.
+ *
+ * Mode 1 pins the power restriction; mode 2 pins that the creature *keeps* its other types
+ * (in addition to, not instead of) and actually survives destruction.
+ */
+class StoneBySunlightScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Stone by Sunlight") {
+
+            test("mode 1 destroys a creature with power 4 or greater") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Stone by Sunlight")
+                    .withCardOnBattlefield(2, "Charging Rhino")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rhino = game.findPermanent("Charging Rhino")!!
+
+                game.castSpellWithMode(1, "Stone by Sunlight", modeIndex = 0, targetId = rhino)
+                    .error shouldBe null
+                game.resolveStack()
+
+                withClue("The 4/4 Rhino is a legal mode-1 target and is destroyed") {
+                    game.isOnBattlefield("Charging Rhino") shouldBe false
+                    game.isInGraveyard(2, "Charging Rhino") shouldBe true
+                }
+            }
+
+            test("mode 1 can't target a creature with power 3 or less") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Stone by Sunlight")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.castSpellWithMode(
+                    1,
+                    "Stone by Sunlight",
+                    modeIndex = 0,
+                    targetId = bears
+                )
+                withClue("A 2/2 is below the power-4 threshold") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("mode 2 adds the artifact type and indestructible without removing creature-ness") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Stone by Sunlight")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpellWithMode(1, "Stone by Sunlight", modeIndex = 1, targetId = bears)
+                    .error shouldBe null
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+                withClue("It gained the artifact type") {
+                    projected.hasType(bears, "ARTIFACT") shouldBe true
+                }
+                withClue("\"in addition to its other types\" — it is still a creature") {
+                    projected.isCreature(bears) shouldBe true
+                }
+                withClue("It gained indestructible") {
+                    projected.hasKeyword(bears, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+                withClue("Its printed stats are untouched") {
+                    projected.getPower(bears) shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five HOB cards, each composed entirely from existing SDK vocabulary — no new effects, triggers, keywords, or executors.

## Cards

| Card | Shape |
|---|---|
| **Bolg's Company** {B}{R} | `ConditionalStaticAbility(GrantKeyword(HASTE, GroupFilter.source()), YouControl(Goblin, excludeSelf))` + a `{T}`, sacrifice-another-Goblin mana ability adding `{B}{R}` (two `AddMana` effects, not a color choice) |
| **Gathering of Darkness** {3}{B} | Optional ("up to one target") graveyard-recursion `TargetObject` then `Effects.Amass(3, "Goblin")` |
| **Stone by Sunlight** {1}{W} | Modal instant with per-mode targets; mode 2 uses `AddCardType("ARTIFACT", …, EndOfTurn)` so "in addition to its other types" is literal, plus an until-EOT indestructible grant |
| **Gollum the Abandoned** {1}{B} | `CantBlock()`, an "up to one target" opposing-graveyard exile + drain 2, and a sorcery-speed recursion ability with `activateFromZone = Zone.GRAVEYARD` |
| **Bejeweled Warg** {1}{G} | Trample + a modal combat-damage trigger (`ModalEffect.chooseOne(..., countsAsModalSpell = false)`) |

## Card selection

The obvious remaining HOB cards are gated on mechanics the SDK doesn't have yet — **recruit**, **hone counters**, and **storied / enduring story** are all absent, and each is `add-feature` work rather than `add-card`. These five need none of them.

## Tests

One scenario test file per card, 14 tests, all passing. They target the edges rather than the happy path:

- Bolg's haste going dark with no *other* Goblin, and staying dark for an *opponent's* Goblin
- "Sacrifice another Goblin" rejecting Bolg's Company itself as the sacrifice
- Gathering of Darkness still amassing when no target is chosen (empty graveyard)
- Stone by Sunlight's power-4 restriction rejecting a 2/2, and mode 2 leaving the creature a creature
- Gollum draining with an empty opposing graveyard, his graveyard ability being blocked in the declare-blockers step, and his can't-block static rejecting a block
- Both Bejeweled Warg modes off real combat damage

## Notes

- All five canonical placements verified with `just check-card-printing` — HOB is the earliest real printing for each.
- HOB snapshot golden re-blessed; the diff is 383 pure insertions and only these five cards moved.
- Backlog ticked, header resynced to 76/193.
- `just build` green.

**Pre-existing behaviour worth flagging (not introduced here):** the engine picks the mode of a modal *triggered ability* at resolution (`ChooseOptionDecision`, `phase = RESOLUTION`) rather than as the ability is put onto the stack. Under CR 603.3d the mode and its target should be locked in on the stack so opponents can respond. This is shared by every modal triggered ability in the repo (Kutzil's Flanker, Breeches), so Bejeweled Warg follows the house shape; fixing it is a separate engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
