### PR TITLE
Emerge keyword + the six Eldritch Moon emerge Eldrazi (INR 275 → 281)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5848,7 +5848,7 @@ Flying, Menace, Intimidate, Fear, Shadow, Horsemanship, all basic landwalks (Pla
 (`Keyword.NONBASIC_LANDWALK` — unblockable while the defending player controls any non-basic land;
 `LandwalkRule` checks `typeLine.isLand && !isBasicLand`; Trailblazer's Boots), First Strike, Double
 Strike, Trample, Deathtouch, Lifelink, Vigilance, Reach, Provoke, Defender, Indestructible, Hexproof, Shroud, Haste,
-Flash, Prowess, Flurry, Changeling, Convoke, Delve, Affinity, Storm, Flashback, Harmonize, Mayhem, Disturb, Evoke, Sneak, Ninjutsu, Web-slinging, Impending, Conspire, Casualty, Miracle, Hideaway, Cascade, Plot,
+Flash, Prowess, Flurry, Changeling, Convoke, Delve, Affinity, Emerge, Storm, Flashback, Harmonize, Mayhem, Disturb, Evoke, Sneak, Ninjutsu, Web-slinging, Impending, Conspire, Casualty, Miracle, Hideaway, Cascade, Plot,
 Offspring, Persist, Undying, Enduring, Ascend, Start your engines!, Max speed, Wither, Toxic, Eerie, Vivid, Fateful Bite, Exploit, Daybound, Nightbound, … (display-only — engine effect lives in handlers or
 composite abilities).
 
@@ -6242,6 +6242,22 @@ composite abilities).
   `WebSlingingCastEnumerator` and `CastSpellHandler` consult, so a granted web-slinging behaves exactly like a printed
   one. Amazing Spider-Man (back of Peter Parker): "Each legendary spell you cast that's one or more colors has web-slinging
   {G}{W}{U}" → `GrantWebSlingingToSpells({G}{W}{U}, GameObjectFilter(cardPredicates = [IsLegendary, IsColored]))`.
+- `Emerge(cost)` — `card { emerge("{cost}") }` builder helper (CR 702.119, Eldritch Moon). A **hand** alternative
+  cost that bundles a sacrifice *and* a cost reduction derived from it: *"You may cast this spell by paying [cost] and
+  sacrificing a creature rather than paying its mana cost"* plus *"if you chose to pay this spell's emerge cost, its
+  total cost is reduced by an amount of **generic** mana equal to the sacrificed creature's mana value."* Generic-only,
+  so a colored pip is never reduced and mana value beyond the generic portion is wasted (a mana-value-7 creature turns
+  Elder Deep-Fiend's emerge {5}{U}{U} into {U}{U}, not into {0}). Grants **no timing permission** — the spell is cast at
+  its normal timing, which is why Elder Deep-Fiend needs its own flash. All behavior is in the engine, keyed off the
+  `KeywordAbility.Emerge` entry and centralised in `EmergeCasts`: `EmergeCastEnumerator` surfaces a
+  `CastWithAlternativeCost` (`AlternativeCostType.EMERGE`) whose `additionalCostInfo` is an ordinary
+  `SacrificePermanent` selection, filtered to **only the creatures that leave the reduced cost payable** — affordability
+  is per-candidate, so offering an unpayable one would hand the client (and the AI, which takes the first candidate) an
+  action that errors on submission. `CastSpellHandler` prices the cast against the creature actually chosen and
+  sacrifices it **after** the mana payment: CR 601.2f–g activate mana abilities before CR 601.2h pays the total cost, so
+  the creature may legally be tapped for mana toward its own emerge cost before it dies. The chosen creature rides
+  `CastSpell.additionalCostPayment.sacrificedPermanents`, exactly as Sneak's bounce rides `bouncedPermanents`. Printed
+  only — no card grants emerge.
 - `Mayhem(cost)` — `card { mayhem("{cost}") }` builder helper (CR 702.187, Marvel's Spider-Man). A **graveyard**
   alternative cost: *"As long as you discarded this card this turn, you may cast it from your graveyard by paying [cost]
   rather than paying its mana cost."* Grants **no timing permission** (normal timing — sorcery speed unless the card is an

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6257,7 +6257,11 @@ composite abilities).
   sacrifices it **after** the mana payment: CR 601.2f–g activate mana abilities before CR 601.2h pays the total cost, so
   the creature may legally be tapped for mana toward its own emerge cost before it dies. The chosen creature rides
   `CastSpell.additionalCostPayment.sacrificedPermanents`, exactly as Sneak's bounce rides `bouncedPermanents`. Printed
-  only — no card grants emerge.
+  only — no card grants emerge. Because emerge is the one cost whose *mana* half depends on which permanent pays its
+  *non-mana* half, the enumerator also sends `AdditionalCostData.costAfterSacrifice` — the surviving mana cost per
+  candidate — so the client can show `{5}{U} → {2}{U}` live as the player picks and price manual mana-source selection
+  off the chosen entry. The client never re-derives the reduction: the generic-only clamp is a rule, and rules stay
+  server-side.
 - `Mayhem(cost)` — `card { mayhem("{cost}") }` builder helper (CR 702.187, Marvel's Spider-Man). A **graveyard**
   alternative cost: *"As long as you discarded this card this turn, you may cast it from your graveyard by paying [cost]
   rather than paying its mana cost."* Grants **no timing permission** (normal timing — sorcery speed unless the card is an

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -125,6 +125,17 @@ enum class Keyword(val displayName: String) {
     DELVE("Delve"),
     AFFINITY("Affinity"),
 
+    /**
+     * Emerge [cost] (CR 702.119, Eldritch Moon). "You may cast this spell by paying [cost] and
+     * sacrificing a creature rather than paying its mana cost. If you chose to pay this spell's
+     * emerge cost, its total cost is reduced by an amount of generic mana equal to the sacrificed
+     * creature's mana value."
+     *
+     * An alternative cost that bundles a sacrifice *and* a cost reduction derived from what was
+     * sacrificed. See [com.wingedsheep.sdk.scripting.KeywordAbility.Emerge].
+     */
+    EMERGE("Emerge"),
+
     // ── Spell mechanics ─────────────────────────────────────
     STORM("Storm"),
     FLASHBACK("Flashback"),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/EmergeDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/EmergeDsl.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Add Emerge [cost] (Eldritch Moon, CR 702.119).
+ *
+ * "You may cast this spell by paying [cost] and sacrificing a creature rather than paying its mana
+ * cost. If you chose to pay this spell's emerge cost, its total cost is reduced by an amount of
+ * generic mana equal to the sacrificed creature's mana value."
+ *
+ * Display-only at the DSL layer — all behavior lives in the engine's alternative-cost pipeline,
+ * which keys off the [KeywordAbility.Emerge] entry in `cardDef.keywordAbilities`: the legal-action
+ * enumerator offers the cast at the spell's normal timing while a creature the caster controls
+ * makes the reduced cost affordable, and the cast handler charges the reduced emerge mana and
+ * sacrifices the chosen creature as part of paying the total cost.
+ */
+fun CardBuilder.emerge(cost: String) {
+    keywordAbilityList.add(KeywordAbility.emerge(cost))
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -735,6 +735,35 @@ sealed interface KeywordAbility {
     }
 
     // =========================================================================
+    // Emerge
+    // =========================================================================
+
+    /**
+     * Emerge [cost] (CR 702.119, Eldritch Moon).
+     * "You may cast this spell by paying [cost] and sacrificing a creature rather than paying its
+     * mana cost" plus "if you chose to pay this spell's emerge cost, its total cost is reduced by
+     * an amount of generic mana equal to the sacrificed creature's mana value" (CR 702.119a).
+     *
+     * An alternative cost (like [Evoke]) with two extra characteristics:
+     *  - an **additional cost** paid alongside the mana: sacrificing one creature you control,
+     *    chosen as you choose to pay the emerge cost and sacrificed as you pay the total cost
+     *    (CR 702.119c); and
+     *  - a **cost reduction** derived from that choice: the sacrificed creature's mana value comes
+     *    off the *generic* portion only, so it can never reduce a colored pip and any excess is
+     *    simply wasted.
+     *
+     * The sacrifice rides `CastSpell.additionalCostPayment.sacrificedPermanents`, exactly like
+     * [Sneak]'s bounce rides `bouncedPermanents`. Attach via the `emerge("{cost}")` DSL helper on
+     * [com.wingedsheep.sdk.dsl.CardBuilder].
+     */
+    @SerialName("Emerge")
+    @Serializable
+    data class Emerge(val cost: ManaCost) : KeywordAbility {
+        override val keyword: Keyword = Keyword.EMERGE
+        override val description: String = "Emerge $cost"
+    }
+
+    // =========================================================================
     // Gift
     // =========================================================================
 
@@ -1227,6 +1256,12 @@ sealed interface KeywordAbility {
          * Create Evoke with mana cost from string.
          */
         fun evoke(cost: String): KeywordAbility = Evoke(ManaCost.parse(cost))
+
+        /**
+         * Create Emerge with mana cost from string (CR 702.119). Prefer the `emerge(cost)` DSL
+         * helper on [com.wingedsheep.sdk.dsl.CardBuilder].
+         */
+        fun emerge(cost: String): KeywordAbility = Emerge(ManaCost.parse(cost))
 
         /**
          * Create Sneak with mana cost from string. Prefer the `sneak(cost)` DSL helper on

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/ElderDeepFiendReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/ElderDeepFiendReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Elder Deep-Fiend reprint in CMR. Canonical CardDefinition lives in its earliest set (EMN). */
+val ElderDeepFiendReprint = Printing(
+    oracleId = "4eafe717-4ba4-4901-8c67-11757230eb54",
+    name = "Elder Deep-Fiend",
+    setCode = "CMR",
+    collectorNumber = "368",
+    scryfallId = "4cffed4c-4e2b-414a-9b20-90ce21b47d16",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4cffed4c-4e2b-414a-9b20-90ce21b47d16.jpg?1783928734",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/AbundantMaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/AbundantMaw.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Abundant Maw
+ * {8}
+ * Creature — Eldrazi Leech
+ * 6/4
+ *
+ * Emerge {6}{B}
+ * When you cast this spell, target opponent loses 3 life and you gain 3 life.
+ *
+ * Implementation notes:
+ * - Emerge is the engine keyword (CR 702.119) via the `emerge(cost)` helper.
+ * - The drain is a *cast* trigger — it resolves before the creature and still resolves if the
+ *   spell is countered.
+ * - Two independent fixed amounts, not a linked drain: the opponent loses 3 (going below 0 if they
+ *   were at less) and you gain 3 regardless. `DrainLife` would wrongly cap the gain at the life
+ *   actually lost, which is Exsanguinate's wording, not this one's.
+ */
+val AbundantMaw = card("Abundant Maw") {
+    manaCost = "{8}"
+    colorIdentity = "B"
+    typeLine = "Creature — Eldrazi Leech"
+    power = 6
+    toughness = 4
+    oracleText = "Emerge {6}{B} (You may cast this spell by sacrificing a creature and paying the " +
+        "emerge cost reduced by that creature's mana value.)\n" +
+        "When you cast this spell, target opponent loses 3 life and you gain 3 life."
+
+    emerge("{6}{B}")
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        val victim = target("target opponent", TargetOpponent())
+        effect = Effects.Composite(
+            Effects.LoseLife(3, target = victim),
+            Effects.GainLife(3),
+        )
+        description = "When you cast this spell, target opponent loses 3 life and you gain 3 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a4e7ef7-7958-4d7c-b319-4d3db7955002.jpg?1783937529"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/DecimatorOfTheProvinces.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/DecimatorOfTheProvinces.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Decimator of the Provinces
+ * {10}
+ * Creature — Eldrazi Boar
+ * 7/7
+ *
+ * Emerge {6}{G}{G}{G}
+ * When you cast this spell, creatures you control get +2/+2 and gain trample until end of turn.
+ * Trample, haste
+ *
+ * Implementation notes:
+ * - Emerge is the engine keyword (CR 702.119) via the `emerge(cost)` helper.
+ * - The pump is a *cast* trigger: it resolves while this is still on the stack, so the Boar itself
+ *   is NOT among "creatures you control" and doesn't get +2/+2 — it just brings its own trample and
+ *   haste. That's the whole point of the card (swing with the team the turn it lands).
+ */
+val DecimatorOfTheProvinces = card("Decimator of the Provinces") {
+    manaCost = "{10}"
+    colorIdentity = "G"
+    typeLine = "Creature — Eldrazi Boar"
+    power = 7
+    toughness = 7
+    oracleText = "Emerge {6}{G}{G}{G} (You may cast this spell by sacrificing a creature and " +
+        "paying the emerge cost reduced by that creature's mana value.)\n" +
+        "When you cast this spell, creatures you control get +2/+2 and gain trample until end of " +
+        "turn.\nTrample, haste"
+
+    keywords(Keyword.TRAMPLE, Keyword.HASTE)
+
+    emerge("{6}{G}{G}{G}")
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.ModifyStats(2, 2, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self),
+            ),
+        )
+        description = "When you cast this spell, creatures you control get +2/+2 and gain " +
+            "trample until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "2"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/587cb384-db24-4e3d-a338-230e50305d31.jpg?1783937529"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/DistendedMindbender.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/DistendedMindbender.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Distended Mindbender
+ * {8}
+ * Creature — Eldrazi Insect
+ * 5/5
+ *
+ * Emerge {5}{B}{B}
+ * When you cast this spell, target opponent reveals their hand. You choose from it a nonland card
+ * with mana value 3 or less and a card with mana value 4 or greater. That player discards those
+ * cards.
+ *
+ * Implementation notes:
+ * - Emerge is the engine keyword (CR 702.119) via the `emerge(cost)` helper.
+ * - Two selections from one revealed hand, each with its own filter, so it's a gather + two
+ *   `chooseExactly` steps rather than a single restricted selection. The two mana-value bands are
+ *   disjoint, so no card can be picked twice; a hand with nothing in a band simply yields no pick
+ *   for that band (you choose "up to" what exists — CR 608.2 does as much as possible).
+ * - `MoveType.Discard` routes both picks through the discard path so discard triggers and madness
+ *   (CR 702.35a) apply. They go as two moves rather than one simultaneous discard — the only
+ *   observable difference would be an effect that cares about simultaneity, of which there is none
+ *   in this engine.
+ */
+val DistendedMindbender = card("Distended Mindbender") {
+    manaCost = "{8}"
+    colorIdentity = "B"
+    typeLine = "Creature — Eldrazi Insect"
+    power = 5
+    toughness = 5
+    oracleText = "Emerge {5}{B}{B} (You may cast this spell by sacrificing a creature and paying " +
+        "the emerge cost reduced by that creature's mana value.)\n" +
+        "When you cast this spell, target opponent reveals their hand. You choose from it a " +
+        "nonland card with mana value 3 or less and a card with mana value 4 or greater. That " +
+        "player discards those cards."
+
+    emerge("{5}{B}{B}")
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.Pipeline {
+            run(RevealHandEffect(opponent))
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)), name = "hand")
+            val cheap = chooseExactly(
+                1, from = hand,
+                filter = GameObjectFilter.Nonland.manaValueAtMost(3),
+                prompt = "Choose a nonland card with mana value 3 or less",
+                alwaysPrompt = true,
+                showAllCards = true,
+                name = "cheap",
+            )
+            val expensive = chooseExactly(
+                1, from = hand,
+                filter = GameObjectFilter.Any.manaValueAtLeast(4),
+                prompt = "Choose a card with mana value 4 or greater",
+                alwaysPrompt = true,
+                showAllCards = true,
+                name = "expensive",
+            )
+            move(
+                cheap,
+                CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                moveType = MoveType.Discard,
+            )
+            move(
+                expensive,
+                CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                moveType = MoveType.Discard,
+            )
+        }
+        description = "When you cast this spell, target opponent reveals their hand. You choose " +
+            "from it a nonland card with mana value 3 or less and a card with mana value 4 or " +
+            "greater. That player discards those cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "3"
+        artist = "Yohann Schepacz"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b5d1e41-fb0b-4866-912a-2a7d49542428.jpg?1783937528"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ElderDeepFiend.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ElderDeepFiend.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Elder Deep-Fiend
+ * {8}
+ * Creature — Eldrazi Octopus
+ * 5/6
+ *
+ * Flash
+ * Emerge {5}{U}{U}
+ * When you cast this spell, tap up to four target permanents.
+ *
+ * Implementation notes:
+ * - Emerge is the engine keyword (CR 702.119) via the `emerge(cost)` helper. Emerge grants no
+ *   timing permission of its own, so the flash on this card is what makes the emerge cast legal at
+ *   instant speed — the enumerator gates emerge on the spell's normal timing.
+ * - "Tap up to four target permanents" is one requirement with `count = 4, optional = true`
+ *   (a zero-target cast is legal), resolved by `TapEachTarget`.
+ */
+val ElderDeepFiend = card("Elder Deep-Fiend") {
+    manaCost = "{8}"
+    colorIdentity = "U"
+    typeLine = "Creature — Eldrazi Octopus"
+    power = 5
+    toughness = 6
+    oracleText = "Flash\nEmerge {5}{U}{U} (You may cast this spell by sacrificing a creature and " +
+        "paying the emerge cost reduced by that creature's mana value.)\n" +
+        "When you cast this spell, tap up to four target permanents."
+
+    keywords(Keyword.FLASH)
+
+    emerge("{5}{U}{U}")
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        target(
+            "up to four target permanents",
+            TargetPermanent(count = 4, optional = true, filter = TargetFilter.Permanent),
+        )
+        effect = Effects.TapEachTarget()
+        description = "When you cast this spell, tap up to four target permanents."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "5"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c2789fb-a263-4207-8a56-4eeb015a024c.jpg?1783937526"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ItOfTheHorridSwarm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ItOfTheHorridSwarm.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * It of the Horrid Swarm
+ * {8}
+ * Creature — Eldrazi Insect
+ * 4/4
+ *
+ * Emerge {6}{G}
+ * When you cast this spell, create two 1/1 green Insect creature tokens.
+ *
+ * Implementation notes:
+ * - Emerge is the engine keyword (CR 702.119) via the `emerge(cost)` helper.
+ * - The tokens come from a *cast* trigger, so they arrive while the spell is still on the stack —
+ *   and they stay even if the spell is countered.
+ */
+val ItOfTheHorridSwarm = card("It of the Horrid Swarm") {
+    manaCost = "{8}"
+    colorIdentity = "G"
+    typeLine = "Creature — Eldrazi Insect"
+    power = 4
+    toughness = 4
+    oracleText = "Emerge {6}{G} (You may cast this spell by sacrificing a creature and paying the " +
+        "emerge cost reduced by that creature's mana value.)\n" +
+        "When you cast this spell, create two 1/1 green Insect creature tokens."
+
+    emerge("{6}{G}")
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Insect"),
+        )
+        description = "When you cast this spell, create two 1/1 green Insect creature tokens."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Jason Felix"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e9160cb-d3de-49ca-a97d-2cd259cd5447.jpg?1783937526"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/WretchedGryff.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/WretchedGryff.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wretched Gryff
+ * {7}
+ * Creature — Eldrazi Hippogriff
+ * 3/4
+ *
+ * Emerge {5}{U}
+ * When you cast this spell, draw a card.
+ * Flying
+ *
+ * Implementation notes:
+ * - Emerge is the engine keyword (CR 702.119) via the `emerge(cost)` helper; the alternative cost,
+ *   the creature sacrifice, and the generic reduction by that creature's mana value all live in the
+ *   engine's alternative-cost pipeline.
+ * - The draw is a *cast* trigger, not an enters-the-battlefield trigger — it resolves before the
+ *   creature itself, and still resolves if the spell is countered.
+ */
+val WretchedGryff = card("Wretched Gryff") {
+    manaCost = "{7}"
+    colorIdentity = "U"
+    typeLine = "Creature — Eldrazi Hippogriff"
+    power = 3
+    toughness = 4
+    oracleText = "Emerge {5}{U} (You may cast this spell by sacrificing a creature and paying the " +
+        "emerge cost reduced by that creature's mana value.)\n" +
+        "When you cast this spell, draw a card.\nFlying"
+
+    keywords(Keyword.FLYING)
+
+    emerge("{5}{U}")
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        effect = Effects.DrawCards(1)
+        description = "When you cast this spell, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Darek Zabrocki"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d65efec-018f-485c-906c-460379b4af87.jpg?1783937525"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AbundantMawReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/AbundantMawReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Abundant Maw reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val AbundantMawReprint = Printing(
+    oracleId = "3676b745-001d-46e6-880f-2fe26476a38d",
+    name = "Abundant Maw",
+    setCode = "INR",
+    collectorNumber = "1",
+    scryfallId = "c5620c22-910c-4d33-a5e9-4c4eac8c6304",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5620c22-910c-4d33-a5e9-4c4eac8c6304.jpg?1783908190",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DecimatorOfTheProvincesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DecimatorOfTheProvincesReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Decimator of the Provinces reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val DecimatorOfTheProvincesReprint = Printing(
+    oracleId = "7f522ded-09fd-457e-9efe-0a6324925e4c",
+    name = "Decimator of the Provinces",
+    setCode = "INR",
+    collectorNumber = "2",
+    scryfallId = "80fc51aa-64ca-4236-8cdb-670533b75f59",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80fc51aa-64ca-4236-8cdb-670533b75f59.jpg?1783908189",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DistendedMindbenderReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/DistendedMindbenderReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Distended Mindbender reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val DistendedMindbenderReprint = Printing(
+    oracleId = "36d32194-d547-4e2d-894f-f4bf13cf7da6",
+    name = "Distended Mindbender",
+    setCode = "INR",
+    collectorNumber = "3",
+    scryfallId = "7c1980d6-1daa-44f0-a6b5-0458d84894db",
+    artist = "Yohann Schepacz",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c1980d6-1daa-44f0-a6b5-0458d84894db.jpg?1783908188",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ElderDeepFiendReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ElderDeepFiendReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Elder Deep-Fiend reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val ElderDeepFiendReprint = Printing(
+    oracleId = "4eafe717-4ba4-4901-8c67-11757230eb54",
+    name = "Elder Deep-Fiend",
+    setCode = "INR",
+    collectorNumber = "4",
+    scryfallId = "10532d06-94e3-47bc-a036-7535be05be98",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/10532d06-94e3-47bc-a036-7535be05be98.jpg?1783908188",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ItOfTheHorridSwarmReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ItOfTheHorridSwarmReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** It of the Horrid Swarm reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val ItOfTheHorridSwarmReprint = Printing(
+    oracleId = "f4ad190a-6c82-4923-af54-b4cce8d6465f",
+    name = "It of the Horrid Swarm",
+    setCode = "INR",
+    collectorNumber = "6",
+    scryfallId = "ba983caf-72b4-419e-84dc-1ad0215a865c",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba983caf-72b4-419e-84dc-1ad0215a865c.jpg?1783908189",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/WretchedGryffReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/WretchedGryffReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Wretched Gryff reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val WretchedGryffReprint = Printing(
+    oracleId = "83d0c4bc-aab9-4c14-a7dc-a344fcce4fea",
+    name = "Wretched Gryff",
+    setCode = "INR",
+    collectorNumber = "7",
+    scryfallId = "722b519a-715d-4393-9d3c-97f329896ef4",
+    artist = "Darek Zabrocki",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/722b519a-715d-4393-9d3c-97f329896ef4.jpg?1783908187",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -1,3 +1,69 @@
+// Abundant Maw
+{
+    "name": "Abundant Maw",
+    "manaCost": "{8}",
+    "typeLine": "Creature — Eldrazi Leech",
+    "oracleText": "Emerge {6}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, target opponent loses 3 life and you gain 3 life.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "keywords": [
+        "EMERGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Emerge",
+            "cost": "{6}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When you cast this spell, target opponent loses 3 life and you gain 3 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a4e7ef7-7958-4d7c-b319-4d3db7955002.jpg?1783937529"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Alchemist's Greeting
 {
     "name": "Alchemist's Greeting",
@@ -1045,6 +1111,203 @@
     }
 }
 
+// Decimator of the Provinces
+{
+    "name": "Decimator of the Provinces",
+    "manaCost": "{10}",
+    "typeLine": "Creature — Eldrazi Boar",
+    "oracleText": "Emerge {6}{G}{G}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, creatures you control get +2/+2 and gain trample until end of turn.\nTrample, haste",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "TRAMPLE",
+        "HASTE",
+        "EMERGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Emerge",
+            "cost": "{6}{G}{G}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "When you cast this spell, creatures you control get +2/+2 and gain trample until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "MYTHIC",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/587cb384-db24-4e3d-a338-230e50305d31.jpg?1783937529"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Distended Mindbender
+{
+    "name": "Distended Mindbender",
+    "manaCost": "{8}",
+    "typeLine": "Creature — Eldrazi Insect",
+    "oracleText": "Emerge {5}{B}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, target opponent reveals their hand. You choose from it a nonland card with mana value 3 or less and a card with mana value 4 or greater. That player discards those cards.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "EMERGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Emerge",
+            "cost": "{5}{B}{B}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "RevealHand",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "nonland mv<=3",
+                            "storeSelected": "cheap",
+                            "prompt": "Choose a nonland card with mana value 3 or less",
+                            "showAllCards": true,
+                            "alwaysPrompt": true
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "mv>=4",
+                            "storeSelected": "expensive",
+                            "prompt": "Choose a card with mana value 4 or greater",
+                            "showAllCards": true,
+                            "alwaysPrompt": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "cheap",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "expensive",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When you cast this spell, target opponent reveals their hand. You choose from it a nonland card with mana value 3 or less and a card with mana value 4 or greater. That player discards those cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "RARE",
+        "artist": "Yohann Schepacz",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b5d1e41-fb0b-4866-912a-2a7d49542428.jpg?1783937528"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Docent of Perfection
 {
     "name": "Docent of Perfection",
@@ -1278,6 +1541,66 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Elder Deep-Fiend
+{
+    "name": "Elder Deep-Fiend",
+    "manaCost": "{8}",
+    "typeLine": "Creature — Eldrazi Octopus",
+    "oracleText": "Flash\nEmerge {5}{U}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, tap up to four target permanents.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLASH",
+        "EMERGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Emerge",
+            "cost": "{5}{U}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 4,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "up to four target permanents"
+                },
+                "descriptionOverride": "When you cast this spell, tap up to four target permanents."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "RARE",
+        "artist": "Jason Felix",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c2789fb-a263-4207-8a56-4eeb015a024c.jpg?1783937526"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -2359,6 +2682,59 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// It of the Horrid Swarm
+{
+    "name": "It of the Horrid Swarm",
+    "manaCost": "{8}",
+    "typeLine": "Creature — Eldrazi Insect",
+    "oracleText": "Emerge {6}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, create two 1/1 green Insect creature tokens.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "EMERGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Emerge",
+            "cost": "{6}{G}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Insect"
+                    ]
+                },
+                "descriptionOverride": "When you cast this spell, create two 1/1 green Insect creature tokens."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Jason Felix",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e9160cb-d3de-49ca-a97d-2cd259cd5447.jpg?1783937526"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -3982,5 +4358,51 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Wretched Gryff
+{
+    "name": "Wretched Gryff",
+    "manaCost": "{7}",
+    "typeLine": "Creature — Eldrazi Hippogriff",
+    "oracleText": "Emerge {5}{U} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, draw a card.\nFlying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "EMERGE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Emerge",
+            "cost": "{5}{U}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When you cast this spell, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Darek Zabrocki",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d65efec-018f-485c-906c-460379b4af87.jpg?1783937525"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -131,6 +131,14 @@ internal fun BridgeBuilder.keywords() {
     // declines every multi-faced card (the bridge sees only the front face's IR), so these stay
     // SCAFFOLD and get hand-authored — exactly like Daybound/Nightbound above.
     supported("Disturb", "keyword ability: Disturb [cost] -> disturb(\"{cost}\") builder on the DFC front face (CR 702.146)")
+    // Emerge [cost] (CR 702.119) — a PARAMETERIZED keyword ability, so `supported` rather than
+    // `keyword`: `Keyword.EMERGE` exists, so PascalCase→enum auto-resolve would stamp a bare
+    // `keywords(Keyword.EMERGE)` and drop the cost — the Ward/Saddle/Madness trap. Modelled as
+    // `emerge("{cost}")`; the engine owns the whole mechanic (the hand alternative cost, the
+    // creature sacrifice, and the generic-only reduction by the sacrificed creature's mana value).
+    // The emitter's `rname == "Emerge"` branch renders the builder call for the pure-mana shape
+    // (every printed emerge); anything else declines -> SCAFFOLD.
+    supported("Emerge", "keyword ability: Emerge [cost] -> emerge(\"{cost}\") builder (CR 702.119)")
 
     composed("Landwalk", "specific *WALK keywords (SWAMPWALK, FORESTWALK, ...)")
     // Equip is a keyword ability, but the engine has no `Keyword.EQUIP` enum member: `equipAbility(cost)`

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -318,6 +318,15 @@ object Emitter {
                 rname == "Madness" -> block = manaKeywordCost(rule)?.let {
                     listOf(Eval(call("madness", arg("\"$it\""))))
                 }
+                // Emerge [cost] (CR 702.119) carries a `_Cost: PayMana` arg -> the `emerge("{cost}")`
+                // CardBuilder helper. Same trap as Madness/Ward: `Keyword.EMERGE` exists, so falling
+                // through to the bare-keyword case would print the word while dropping the cost that
+                // the whole alternative-cost pipeline (sacrifice + generic reduction by the sacrificed
+                // creature's mana value) keys off. Every printed emerge cost is mana; anything else
+                // declines -> scaffold.
+                rname == "Emerge" -> block = manaKeywordCost(rule)?.let {
+                    listOf(Eval(call("emerge", arg("\"$it\""))))
+                }
                 // Affinity for <group> (cost-reduction keyword, CR 702.41) — "this spell costs {1} less
                 // to cast for each <filter> you control." The engine has no Keyword.AFFINITY card-keyword
                 // path for arbitrary group affinity, so render a self-cast ModifySpellCost whose

--- a/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
@@ -92,6 +92,7 @@ val AbundantGrowth = card("Abundant Growth") {
 package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
 import com.wingedsheep.sdk.model.Rarity
 
 
@@ -110,7 +111,8 @@ val AbundantMaw = card("Abundant Maw") {
     oracleText = "Emerge {6}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, target opponent loses 3 life and you gain 3 life."
     power = 6
     toughness = 4
-    // STRUCTURE needs human wiring: Emerge
+    emerge("{6}{B}")
+    // STRUCTURE needs human wiring: FromStack
     metadata {
         rarity = Rarity.COMMON
         collectorNumber = "1"
@@ -2457,6 +2459,7 @@ package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
 import com.wingedsheep.sdk.model.Rarity
 
 
@@ -2477,7 +2480,8 @@ val DecimatorOfTheProvinces = card("Decimator of the Provinces") {
     power = 7
     toughness = 7
     keywords(Keyword.TRAMPLE, Keyword.HASTE)
-    // STRUCTURE needs human wiring: Emerge
+    emerge("{6}{G}{G}{G}")
+    // STRUCTURE needs human wiring: FromStack
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "2"
@@ -2664,6 +2668,7 @@ val DesertedBeach = card("Deserted Beach") {
 package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
 import com.wingedsheep.sdk.model.Rarity
 
 
@@ -2682,7 +2687,8 @@ val DistendedMindbender = card("Distended Mindbender") {
     oracleText = "Emerge {5}{B}{B} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, target opponent reveals their hand. You choose from it a nonland card with mana value 3 or less and a card with mana value 4 or greater. That player discards those cards."
     power = 5
     toughness = 5
-    // STRUCTURE needs human wiring: Emerge
+    emerge("{5}{B}{B}")
+    // STRUCTURE needs human wiring: FromStack
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "3"
@@ -3045,6 +3051,7 @@ package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
 import com.wingedsheep.sdk.model.Rarity
 
 
@@ -3065,7 +3072,8 @@ val ElderDeepFiend = card("Elder Deep-Fiend") {
     power = 5
     toughness = 6
     keywords(Keyword.FLASH)
-    // STRUCTURE needs human wiring: Emerge
+    emerge("{5}{U}{U}")
+    // STRUCTURE needs human wiring: FromStack
     metadata {
         rarity = Rarity.RARE
         collectorNumber = "4"
@@ -5474,6 +5482,7 @@ val Island = card("Island") {
 package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
 import com.wingedsheep.sdk.model.Rarity
 
 
@@ -5492,7 +5501,8 @@ val ItOfTheHorridSwarm = card("It of the Horrid Swarm") {
     oracleText = "Emerge {6}{G} (You may cast this spell by sacrificing a creature and paying the emerge cost reduced by that creature's mana value.)\nWhen you cast this spell, create two 1/1 green Insect creature tokens."
     power = 4
     toughness = 4
-    // STRUCTURE needs human wiring: Emerge
+    emerge("{6}{G}")
+    // STRUCTURE needs human wiring: FromStack
     metadata {
         rarity = Rarity.COMMON
         collectorNumber = "6"
@@ -10530,6 +10540,7 @@ package com.wingedsheep.mtg.sets.generated.demo.cards
 
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.emerge
 import com.wingedsheep.sdk.model.Rarity
 
 
@@ -10550,7 +10561,8 @@ val WretchedGryff = card("Wretched Gryff") {
     power = 3
     toughness = 4
     keywords(Keyword.FLYING)
-    // STRUCTURE needs human wiring: Emerge
+    emerge("{5}{U}")
+    // STRUCTURE needs human wiring: FromStack
     metadata {
         rarity = Rarity.COMMON
         collectorNumber = "7"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameAction.kt
@@ -227,6 +227,15 @@ enum class AlternativeCostType {
     /** Evoke ([com.wingedsheep.sdk.scripting.KeywordAbility.Evoke]) — hand. */
     EVOKE,
     /**
+     * Emerge ([com.wingedsheep.sdk.scripting.KeywordAbility.Emerge], CR 702.119) — hand, at the
+     * spell's normal timing. Pays the emerge mana *reduced by the sacrificed creature's mana value*
+     * (generic portion only) instead of the mana cost, plus sacrifices that creature
+     * ([CastSpell.additionalCostPayment] `sacrificedPermanents`). Unlike every other alternative
+     * cost here the mana actually charged depends on the non-mana choice, so the enumerator only
+     * offers creatures that leave the reduced cost payable.
+     */
+    EMERGE,
+    /**
      * Sneak ([com.wingedsheep.sdk.scripting.KeywordAbility.Sneak], CR 702.190) — hand,
      * legal only during the active player's declare blockers step. Pays the sneak mana
      * plus returns an unblocked attacker you control to hand

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.engine.core.CardsRevealedEvent
 import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.mechanics.DisturbCasts
+import com.wingedsheep.engine.mechanics.EmergeCasts
 import com.wingedsheep.engine.mechanics.FlashbackGrants
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.mechanics.MayhemGrants
@@ -418,6 +419,25 @@ class CastSpellHandler(
             }
             if (bounced.first() !in WebSlinging.tappedCreaturesYouControl(state, action.playerId)) {
                 return "The chosen creature is not a tapped creature you control"
+            }
+        }
+
+        // Emerge (CR 702.119a/c): the player must sacrifice exactly one creature they control as
+        // the non-mana portion of the alternative cost, chosen as they choose to pay the emerge
+        // cost (CR 601.2b). Timing is the spell's normal timing (checked above) — emerge grants no
+        // extra permission. The chosen creature also fixes the generic reduction, so
+        // computeTotalCastCost prices the cast against exactly this selection.
+        val castingForEmerge = action.useAlternativeCost &&
+            action.altAllows(AlternativeCostType.EMERGE) &&
+            cardDef != null &&
+            EmergeCasts.printedEmerge(cardDef) != null
+        if (castingForEmerge) {
+            val sacrificed = action.additionalCostPayment?.sacrificedPermanents ?: emptyList()
+            if (sacrificed.size != 1) {
+                return "Emerge requires sacrificing exactly one creature you control"
+            }
+            if (sacrificed.first() !in EmergeCasts.sacrificeCandidates(state, action.playerId)) {
+                return "The permanent chosen for emerge is not a creature you control"
             }
         }
 
@@ -916,12 +936,26 @@ class CastSpellHandler(
                     val evokeAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Evoke>().firstOrNull()
                     // Check dash cost (CR 702.109 — hand only, printed only for now).
                     val dashAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Dash>().firstOrNull()
+                    // Check emerge cost (CR 702.119 — mana portion; the sacrifice is paid separately).
+                    val emergeAbility = EmergeCasts.printedEmerge(cardDef)
                     if (action.altAllows(AlternativeCostType.SNEAK) && sneakCost != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, sneakCost, action.playerId)
                     } else if (action.altAllows(AlternativeCostType.WEB_SLINGING) && webSlingingAbility != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, webSlingingAbility.cost, action.playerId)
                     } else if (action.altAllows(AlternativeCostType.EVOKE) && evokeAbility != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, evokeAbility.cost, action.playerId)
+                    } else if (action.altAllows(AlternativeCostType.EMERGE) && emergeAbility != null) {
+                        // CR 702.119a — the emerge cost, then reduced by an amount of *generic*
+                        // mana equal to the sacrificed creature's mana value. The reduction lands
+                        // after the battlefield cost-modifier pipeline because it is a cost
+                        // reduction (CR 601.2f applies increases before reductions), and the
+                        // creature is still on the battlefield here: it is sacrificed only as the
+                        // total cost is paid (CR 601.2h), which execute() does after mana payment.
+                        EmergeCasts.reduceForSacrifice(
+                            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, emergeAbility.cost, action.playerId),
+                            state,
+                            action.additionalCostPayment?.sacrificedPermanents?.firstOrNull()
+                        )
                     } else if (action.altAllows(AlternativeCostType.DASH) && dashAbility != null && zoneResolver.hasDashPermission(state, action.playerId, action.cardId)) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, dashAbility.cost, action.playerId)
                     } else {
@@ -2083,12 +2117,23 @@ class CastSpellHandler(
                     val evokeAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Evoke>().firstOrNull()
                     // Check dash cost (CR 702.109 — hand only, printed only for now).
                     val dashAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Dash>().firstOrNull()
+                    // Check emerge cost (CR 702.119 — mana portion; the sacrifice is paid below,
+                    // after the mana payment, per CR 601.2f–h).
+                    val emergeAbility = EmergeCasts.printedEmerge(cardDef)
                     if (action.altAllows(AlternativeCostType.SNEAK) && sneakCost != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, sneakCost, action.playerId)
                     } else if (action.altAllows(AlternativeCostType.WEB_SLINGING) && webSlingingAbility != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, webSlingingAbility.cost, action.playerId)
                     } else if (action.altAllows(AlternativeCostType.EVOKE) && evokeAbility != null) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, evokeAbility.cost, action.playerId)
+                    } else if (action.altAllows(AlternativeCostType.EMERGE) && emergeAbility != null) {
+                        // CR 702.119a — mirrors validate(): emerge cost reduced by an amount of
+                        // generic mana equal to the sacrificed creature's mana value.
+                        EmergeCasts.reduceForSacrifice(
+                            costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, emergeAbility.cost, action.playerId),
+                            currentState,
+                            action.additionalCostPayment?.sacrificedPermanents?.firstOrNull()
+                        )
                     } else if (action.altAllows(AlternativeCostType.DASH) && dashAbility != null && zoneResolver.hasDashPermission(currentState, action.playerId, action.cardId)) {
                         costCalculator.calculateEffectiveCostWithAlternativeBase(currentState, cardDef, dashAbility.cost, action.playerId)
                     } else {
@@ -2745,6 +2790,25 @@ class CastSpellHandler(
         }
         currentState = paymentResult.state
         events.addAll(paymentResult.events)
+
+        // Emerge (CR 702.119a/c): the chosen creature is sacrificed *as the total cost is paid*
+        // (CR 601.2h), which is why this sits after the mana payment rather than in the additional-
+        // cost block above — mana abilities are activated first (CR 601.2f–g), so the creature can
+        // legally be tapped for mana toward its own emerge cost before it dies. Its mana value was
+        // already taken off the generic portion of `effectiveCost` while it was on the battlefield.
+        // The snapshot feeds "as it last existed on the battlefield" reads (CR 608.2h) exactly like
+        // a scripted sacrifice cost does.
+        if (action.useAlternativeCost && action.altAllows(AlternativeCostType.EMERGE) &&
+            cardDef != null && EmergeCasts.printedEmerge(cardDef) != null
+        ) {
+            val emergeSacrifice = action.additionalCostPayment?.sacrificedPermanents?.firstOrNull()
+            if (emergeSacrifice != null && currentState.getEntity(emergeSacrifice) != null) {
+                sacrificedSnapshots.addAll(
+                    captureEntitySnapshots(listOf(emergeSacrifice), currentState.projectedState)
+                )
+                currentState = sacrificePermanentAsCost(currentState, emergeSacrifice, action.playerId, events)
+            }
+        }
 
         // Track total mana spent on spells this turn (for Expend triggers)
         val manaSpentThisCast = paymentResult.events

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -314,6 +314,20 @@ data class AdditionalCostData(
     val costType: String,
     val validSacrificeTargets: List<EntityId> = emptyList(),
     val sacrificeCount: Int = 1,
+    /**
+     * The spell's remaining mana cost after sacrificing each candidate in [validSacrificeTargets],
+     * keyed by that candidate — emerge (CR 702.119), where the emerge cost is reduced by generic
+     * mana equal to the sacrificed creature's mana value.
+     *
+     * Emerge is the only cost whose *mana* half depends on which permanent pays its *non-mana*
+     * half, so `LegalAction.manaCostString` alone can't tell the player what a given choice will
+     * actually cost, and the client must not re-derive it (the generic-only clamp is a rule, and
+     * rules live server-side). The client shows `manaCostString → costAfterSacrifice[candidate]`
+     * live as the player picks, and prices manual mana-source selection off the chosen entry.
+     *
+     * Empty for every other sacrifice cost, where the mana is fixed regardless of the choice.
+     */
+    val costAfterSacrifice: Map<EntityId, String> = emptyMap(),
     val validTapTargets: List<EntityId> = emptyList(),
     val tapCount: Int = 0,
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalActionEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalActionEnumerator.kt
@@ -34,6 +34,7 @@ class LegalActionEnumerator(
         MorphCastEnumerator(),
         CastSpellEnumerator(),
         SneakCastEnumerator(),
+        EmergeCastEnumerator(),
         WebSlingingCastEnumerator(),
         CyclingEnumerator(),
         PlotEnumerator(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/EmergeCastEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/EmergeCastEnumerator.kt
@@ -9,6 +9,8 @@ import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.mechanics.EmergeCasts
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.EntityId
 
 /**
  * Enumerates the "cast for its emerge cost" legal action (CR 702.119).
@@ -71,14 +73,18 @@ class EmergeCastEnumerator : ActionEnumerator {
 
             // Only creatures whose mana value leaves the reduced cost payable may be offered.
             // Cheapest-first so the AI's "take the first candidate" pick spends the least valuable
-            // body rather than an arbitrary one.
-            val payableCandidates = candidates
-                .sortedBy { EmergeCasts.manaValueOf(state, it) }
-                .filter { creatureId ->
-                    val reduced = EmergeCasts.reduceForSacrifice(baseCost, state, creatureId)
-                    context.manaSolver.canPay(state, playerId, reduced, precomputedSources = cachedSources)
+            // body rather than an arbitrary one. The surviving cost is kept per candidate and sent
+            // along: it is the *only* way the client can tell the player what a given sacrifice
+            // will actually cost, since the generic-only reduction is a rule, not client math.
+            val costByCandidate = LinkedHashMap<EntityId, ManaCost>()
+            for (creatureId in candidates.sortedBy { EmergeCasts.manaValueOf(state, it) }) {
+                val reduced = EmergeCasts.reduceForSacrifice(baseCost, state, creatureId)
+                if (context.manaSolver.canPay(state, playerId, reduced, precomputedSources = cachedSources)) {
+                    costByCandidate[creatureId] = reduced
                 }
-            if (payableCandidates.isEmpty()) continue
+            }
+            if (costByCandidate.isEmpty()) continue
+            val payableCandidates = costByCandidate.keys.toList()
 
             val targetReqs = buildList {
                 addAll(cardDef.script.targetRequirements)
@@ -98,11 +104,12 @@ class EmergeCastEnumerator : ActionEnumerator {
             val firstReq = targetReqs.firstOrNull()
             val firstReqInfo = targetReqInfos.firstOrNull()
 
-            // Preview the cheapest payable line — the same candidate the client pre-selects and the
-            // AI takes. The real solve happens at execute() against the creature actually chosen.
+            // Preview the line for the first candidate — the one the client pre-selects and the AI
+            // takes. The real solve happens at execute() against the creature actually chosen, and
+            // the client re-prices off `costAfterSacrifice` as soon as the player picks.
             val autoTapPreview = if (context.skipAutoTapPreview) null else {
-                val cheapest = EmergeCasts.reduceForSacrifice(baseCost, state, payableCandidates.first())
-                context.manaSolver.solve(state, playerId, cheapest, precomputedSources = cachedSources)
+                context.manaSolver
+                    .solve(state, playerId, costByCandidate.values.first(), precomputedSources = cachedSources)
                     ?.sources?.map { it.entityId }
             }
 
@@ -127,7 +134,8 @@ class EmergeCastEnumerator : ActionEnumerator {
                         description = "a creature to sacrifice (its mana value reduces the emerge cost)",
                         costType = "SacrificePermanent",
                         validSacrificeTargets = payableCandidates,
-                        sacrificeCount = 1
+                        sacrificeCount = 1,
+                        costAfterSacrifice = costByCandidate.mapValues { (_, cost) -> cost.toString() }
                     ),
                     autoTapPreview = autoTapPreview
                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/EmergeCastEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/EmergeCastEnumerator.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.legalactions.enumerators
+
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.ActionEnumerator
+import com.wingedsheep.engine.legalactions.AdditionalCostData
+import com.wingedsheep.engine.legalactions.EnumerationContext
+import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.mechanics.EmergeCasts
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Keyword
+
+/**
+ * Enumerates the "cast for its emerge cost" legal action (CR 702.119).
+ *
+ * Emerge is an alternative cost bundling a sacrifice whose *identity* changes the mana actually
+ * charged: the emerge cost is reduced by an amount of generic mana equal to the sacrificed
+ * creature's mana value (CR 702.119a). That coupling is why emerge gets a dedicated enumerator
+ * rather than another branch in [CastSpellEnumerator] — affordability has to be evaluated once per
+ * candidate creature, and only the creatures that leave the reduced cost payable may be offered.
+ * Handing the client (or the AI, which takes the first candidate) a creature that can't actually
+ * pay would surface an action that errors on submission.
+ *
+ * Emerge grants no timing permission of its own, so the spell is offered at its normal timing —
+ * sorcery speed unless it's an instant or has flash (Elder Deep-Fiend).
+ *
+ * The action emitted is a `CastWithAlternativeCost` carrying [AlternativeCostType.EMERGE]. The
+ * sacrifice is surfaced as a `SacrificePermanent` additional cost the player resolves on the
+ * battlefield, then submits as `CastSpell.additionalCostPayment.sacrificedPermanents`.
+ */
+class EmergeCastEnumerator : ActionEnumerator {
+
+    override fun enumerate(context: EnumerationContext): List<LegalAction> {
+        val state = context.state
+        val playerId = context.playerId
+
+        if (context.cantPlayCardsFromHand) return emptyList()
+
+        // The candidate pool is the same for every emerge card in hand; bail before touching the
+        // hand at all when the player controls no creature to sacrifice.
+        val candidates = EmergeCasts.sacrificeCandidates(state, playerId)
+        if (candidates.isEmpty()) return emptyList()
+
+        val result = mutableListOf<LegalAction>()
+        val cachedSources = context.availableManaSources
+
+        for (cardId in state.getHand(playerId)) {
+            val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: continue
+            if (context.cantCastSpell(cardId)) continue
+
+            val cardDef = context.cardRegistry.getCard(cardComponent.name) ?: continue
+            val emerge = EmergeCasts.printedEmerge(cardDef) ?: continue
+
+            // Normal timing (CR 702.119 adds no permission of its own).
+            val isInstant = cardComponent.typeLine.isInstant
+            val hasFlash = cardDef.keywords.contains(Keyword.FLASH) ||
+                context.castPermissionUtils.hasGrantedFlash(state, cardId)
+            if (!isInstant && !hasFlash && !context.canPlaySorcerySpeed) continue
+
+            // Honor cast restrictions exactly like the normal cast path (CR 601.3).
+            if (!context.castPermissionUtils.checkCastRestrictions(
+                    state, playerId, cardDef.script.castRestrictions
+                )
+            ) continue
+
+            // Base emerge cost through the battlefield cost-modifier pipeline (a Thalia-style tax
+            // applies on top of an alternative cost — CR 601.2f).
+            val baseCost = context.costCalculator.calculateEffectiveCostWithAlternativeBase(
+                state, cardDef, emerge.cost, playerId
+            )
+
+            // Only creatures whose mana value leaves the reduced cost payable may be offered.
+            // Cheapest-first so the AI's "take the first candidate" pick spends the least valuable
+            // body rather than an arbitrary one.
+            val payableCandidates = candidates
+                .sortedBy { EmergeCasts.manaValueOf(state, it) }
+                .filter { creatureId ->
+                    val reduced = EmergeCasts.reduceForSacrifice(baseCost, state, creatureId)
+                    context.manaSolver.canPay(state, playerId, reduced, precomputedSources = cachedSources)
+                }
+            if (payableCandidates.isEmpty()) continue
+
+            val targetReqs = buildList {
+                addAll(cardDef.script.targetRequirements)
+                cardDef.script.auraTarget?.let { add(it) }
+            }
+            val targetReqInfos = if (targetReqs.isEmpty()) {
+                emptyList()
+            } else {
+                context.targetUtils.buildTargetInfos(state, playerId, targetReqs, cardId)
+            }
+            // A targeted emerge spell is only castable if every requirement has a legal target
+            // right now (CR 601.2c).
+            if (targetReqInfos.isNotEmpty() && !context.targetUtils.allRequirementsSatisfied(targetReqInfos)) {
+                continue
+            }
+
+            val firstReq = targetReqs.firstOrNull()
+            val firstReqInfo = targetReqInfos.firstOrNull()
+
+            // Preview the cheapest payable line — the same candidate the client pre-selects and the
+            // AI takes. The real solve happens at execute() against the creature actually chosen.
+            val autoTapPreview = if (context.skipAutoTapPreview) null else {
+                val cheapest = EmergeCasts.reduceForSacrifice(baseCost, state, payableCandidates.first())
+                context.manaSolver.solve(state, playerId, cheapest, precomputedSources = cachedSources)
+                    ?.sources?.map { it.entityId }
+            }
+
+            result.add(
+                LegalAction(
+                    actionType = "CastWithAlternativeCost",
+                    description = "Emerge ${cardComponent.name} ($baseCost minus the sacrificed creature's mana value)",
+                    action = CastSpell(
+                        playerId = playerId,
+                        cardId = cardId,
+                        useAlternativeCost = true,
+                        alternativeCostType = AlternativeCostType.EMERGE
+                    ),
+                    validTargets = firstReqInfo?.validTargets,
+                    requiresTargets = firstReq != null,
+                    targetCount = firstReqInfo?.maxTargets ?: 1,
+                    minTargets = firstReq?.effectiveMinCount ?: (firstReq?.count ?: 1),
+                    targetDescription = firstReq?.description,
+                    targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
+                    manaCostString = baseCost.toString(),
+                    additionalCostInfo = AdditionalCostData(
+                        description = "a creature to sacrifice (its mana value reduces the emerge cost)",
+                        costType = "SacrificePermanent",
+                        validSacrificeTargets = payableCandidates,
+                        sacrificeCount = 1
+                    ),
+                    autoTapPreview = autoTapPreview
+                )
+            )
+        }
+
+        return result
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/EmergeCasts.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/EmergeCasts.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Single source of truth for "can this card be emerge-cast, which creatures can pay for it, and
+ * what does it actually cost?" — used by [com.wingedsheep.engine.legalactions.enumerators.EmergeCastEnumerator]
+ * and by the cast handler's validate/execute paths.
+ *
+ * Emerge (CR 702.119a) is two static abilities that function while the spell is on the stack:
+ * "You may cast this spell by paying [cost] and sacrificing a creature rather than paying its mana
+ * cost", and "if you chose to pay this spell's emerge cost, its total cost is reduced by an amount
+ * of **generic** mana equal to the sacrificed creature's mana value."
+ *
+ * Three consequences shape every read site:
+ *
+ *  - The reduction is generic-only. A creature whose mana value exceeds the generic portion of the
+ *    emerge cost doesn't reduce the colored pips and the excess is simply wasted — so affordability
+ *    has to be recomputed *per candidate creature*, not once for the spell.
+ *  - The creature is chosen as you choose to pay the emerge cost (CR 601.2b) but sacrificed as you
+ *    pay the total cost (CR 601.2h), i.e. *after* mana abilities are activated. It is therefore
+ *    still available to be tapped for mana toward its own emerge cost, and the handler sacrifices
+ *    it only once the mana payment has gone through.
+ *  - Emerge grants no timing permission of its own — the spell is cast at its normal timing, which
+ *    for Elder Deep-Fiend means flash.
+ *
+ * Like [DisturbCasts] there is no runtime-grant source: no card grants emerge to another, so a
+ * printed keyword is the only input.
+ */
+object EmergeCasts {
+
+    /** The printed emerge keyword on [cardDef], or null when it has none. */
+    fun printedEmerge(cardDef: CardDefinition?): KeywordAbility.Emerge? =
+        cardDef?.keywordAbilities?.filterIsInstance<KeywordAbility.Emerge>()?.firstOrNull()
+
+    /**
+     * Creatures [playerId] controls that could be sacrificed to pay an emerge cost (CR 702.119a —
+     * "sacrificing a creature", with no further restriction; tapped and summoning-sick creatures
+     * qualify). Read through projected state so animated lands and type-changing effects count.
+     */
+    fun sacrificeCandidates(state: GameState, playerId: EntityId): List<EntityId> {
+        val projected = state.projectedState
+        return projected.getBattlefieldControlledBy(playerId).filter { projected.isCreature(it) }
+    }
+
+    /**
+     * The mana value the emerge reduction is measured against (CR 702.119a). A permanent's mana
+     * value comes from its own mana cost, so a token or a card with no mana cost contributes 0.
+     */
+    fun manaValueOf(state: GameState, permanentId: EntityId): Int =
+        state.getEntity(permanentId)?.get<CardComponent>()?.manaValue ?: 0
+
+    /**
+     * [cost] with the sacrificed creature's mana value taken off its **generic** portion
+     * (CR 702.119a). Passing a null creature (no selection made yet) leaves the cost untouched.
+     */
+    fun reduceForSacrifice(cost: ManaCost, state: GameState, sacrificedId: EntityId?): ManaCost {
+        val manaValue = sacrificedId?.let { manaValueOf(state, it) } ?: 0
+        return if (manaValue > 0) cost.reduceGeneric(manaValue) else cost
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -203,6 +203,7 @@ class LegalActionEnricher(
         costType = costType,
         validSacrificeTargets = validSacrificeTargets,
         sacrificeCount = sacrificeCount,
+        costAfterSacrifice = costAfterSacrifice,
         validTapTargets = validTapTargets,
         tapCount = tapCount,
         tapBatchMaxActivations = tapBatchMaxActivations,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -215,6 +215,9 @@ data class AdditionalCostInfo(
     val costType: String,
     val validSacrificeTargets: List<EntityId> = emptyList(),
     val sacrificeCount: Int = 1,
+    /** Emerge (CR 702.119): the mana cost left after sacrificing each candidate — see
+     *  [com.wingedsheep.engine.legalactions.AdditionalCostData.costAfterSacrifice]. Empty otherwise. */
+    val costAfterSacrifice: Map<EntityId, String> = emptyMap(),
     val validTapTargets: List<EntityId> = emptyList(),
     val tapCount: Int = 0,
     /** Station-style shortcut: when > 1, up to this many single-creature tap activations may be

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbundantMawScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbundantMawScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Abundant Maw — {8} 6/4 Eldrazi Leech with emerge {6}{B} and
+ * "When you cast this spell, target opponent loses 3 life and you gain 3 life."
+ *
+ * The drain is a cast trigger, so it resolves before the Leech itself.
+ */
+class AbundantMawScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Abundant Maw") {
+
+            test("emerge cast drains the targeted opponent for 3 before the Leech resolves") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Abundant Maw")
+                    .withCardOnBattlefield(1, "Centaur Courser") // {2}{G} → mana value 3
+                    // Emerge {6}{B} reduced by 3 → {3}{B}: four Swamps is exactly enough.
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .build()
+
+                val cast = game.castSpellWithEmerge(
+                    1, "Abundant Maw", "Centaur Courser",
+                    targets = listOf(ChosenTarget.Player(game.player2Id)),
+                )
+                withClue("the emerge cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.isInGraveyard(1, "Centaur Courser") shouldBe true
+
+                game.resolveStack()
+
+                withClue("the opponent lost 3 and the caster gained 3") {
+                    game.getLifeTotal(2) shouldBe 17
+                    game.getLifeTotal(1) shouldBe 23
+                }
+                game.isOnBattlefield("Abundant Maw") shouldBe true
+            }
+
+            test("the two amounts are independent — you gain 3 even if the opponent had less to lose") {
+                val game = scenario()
+                    .withPlayers()
+                    .withLifeTotal(2, 2)
+                    .withCardInHand(1, "Abundant Maw")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .build()
+
+                game.castSpellWithEmerge(
+                    1, "Abundant Maw", "Centaur Courser",
+                    targets = listOf(ChosenTarget.Player(game.player2Id)),
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("an opponent at 2 goes to -1 and you still gain the full 3") {
+                    game.getLifeTotal(2) shouldBe -1
+                    game.getLifeTotal(1) shouldBe 23
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DecimatorOfTheProvincesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DecimatorOfTheProvincesScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Decimator of the Provinces — {10} 7/7 Eldrazi Boar with trample, haste,
+ * emerge {6}{G}{G}{G}, and "When you cast this spell, creatures you control get +2/+2 and gain
+ * trample until end of turn."
+ *
+ * Because the pump is a cast trigger it resolves while the Boar is still on the stack, so the Boar
+ * itself is not among "creatures you control" and stays a 7/7.
+ */
+class DecimatorOfTheProvincesScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Decimator of the Provinces") {
+
+            test("emerge cast pumps the team but not the Boar, which is still on the stack") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Decimator of the Provinces")
+                    .withCardOnBattlefield(1, "Force of Nature") // {3}{G}{G} → mana value 5, 5/5
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2, stays behind to be pumped
+                    // Emerge {6}{G}{G}{G} reduced by 5 → {1}{G}{G}{G}: four Forests.
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .build()
+
+                val cast = game.castSpellWithEmerge(
+                    1, "Decimator of the Provinces", "Force of Nature",
+                )
+                withClue("the emerge cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.isInGraveyard(1, "Force of Nature") shouldBe true
+
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("the surviving creature got +2/+2 and trample") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 4
+                    game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe true
+                }
+
+                val boar = game.findPermanent("Decimator of the Provinces")!!
+                withClue("the Boar was on the stack when the trigger resolved, so it is still 7/7") {
+                    game.state.projectedState.getPower(boar) shouldBe 7
+                    game.state.projectedState.getToughness(boar) shouldBe 7
+                }
+                withClue("it brings its own trample and haste") {
+                    game.state.projectedState.hasKeyword(boar, Keyword.TRAMPLE) shouldBe true
+                    game.state.projectedState.hasKeyword(boar, Keyword.HASTE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DistendedMindbenderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DistendedMindbenderScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Distended Mindbender — {8} 5/5 Eldrazi Insect with emerge {5}{B}{B} and
+ * "When you cast this spell, target opponent reveals their hand. You choose from it a nonland card
+ * with mana value 3 or less and a card with mana value 4 or greater. That player discards those
+ * cards."
+ *
+ * Two selections from one revealed hand, each with its own filter. The two mana-value bands are
+ * disjoint, so a single card can never be picked for both.
+ */
+class DistendedMindbenderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Distended Mindbender") {
+
+            test("emerge cast strips one cheap and one expensive card from the opponent's hand") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Distended Mindbender")
+                    .withCardOnBattlefield(1, "Centaur Courser") // {2}{G} → mana value 3
+                    // Emerge {5}{B}{B} reduced by 3 → {2}{B}{B}: four Swamps.
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInHand(2, "Grizzly Bears") // {1}{G} → mana value 2
+                    .withCardInHand(2, "Force of Nature") // {3}{G}{G} → mana value 5
+                    .withCardInHand(2, "Island") // a land — never a legal pick for either band
+                    .build()
+
+                val cast = game.castSpellWithEmerge(
+                    1, "Distended Mindbender", "Centaur Courser",
+                    targets = listOf(ChosenTarget.Player(game.player2Id)),
+                )
+                withClue("the emerge cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.isInGraveyard(1, "Centaur Courser") shouldBe true
+
+                // Cast trigger: reveal, then two filtered picks by the caster.
+                val cheap = game.findCardsInHand(2, "Grizzly Bears").single()
+                val expensive = game.findCardsInHand(2, "Force of Nature").single()
+                game.resolveStack()
+                game.selectCards(listOf(cheap)).error shouldBe null
+                game.selectCards(listOf(expensive)).error shouldBe null
+                game.resolveStack()
+
+                withClue("both picks were discarded, the land was untouchable") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(2, "Force of Nature") shouldBe true
+                    game.isInHand(2, "Island") shouldBe true
+                }
+                game.isOnBattlefield("Distended Mindbender") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElderDeepFiendScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElderDeepFiendScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Elder Deep-Fiend — {8} 5/6 Eldrazi Octopus with flash, emerge {5}{U}{U}, and
+ * "When you cast this spell, tap up to four target permanents."
+ *
+ * Flash is what makes the emerge cast legal at instant speed: emerge itself grants no timing
+ * permission, so the spell is cast at its normal timing.
+ */
+class ElderDeepFiendScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Elder Deep-Fiend") {
+
+            test("emerge cast taps the chosen permanents via its cast trigger") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Elder Deep-Fiend")
+                    .withCardOnBattlefield(1, "Centaur Courser") // {2}{G} → mana value 3
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    // Emerge {5}{U}{U} reduced by 3 → {2}{U}{U}: four Islands.
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .build()
+
+                val cast = game.castSpellWithEmerge(1, "Elder Deep-Fiend", "Centaur Courser")
+                withClue("the emerge cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.isInGraveyard(1, "Centaur Courser") shouldBe true
+
+                // The cast trigger asks for its "up to four target permanents".
+                val decision = game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val forests = game.findAllPermanents("Forest")
+                val chosen = listOf(bears) + forests.take(2)
+                game.submitDecision(TargetsResponse(decision.id, mapOf(0 to chosen))).error shouldBe null
+
+                game.resolveStack()
+
+                withClue("every chosen permanent is tapped") {
+                    for (permanent in chosen) {
+                        game.state.getEntity(permanent)
+                            ?.has<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() shouldBe true
+                    }
+                }
+                game.isOnBattlefield("Elder Deep-Fiend") shouldBe true
+            }
+
+            test("flash lets the emerge cast happen during the opponent's turn") {
+                val game = scenario()
+                    .withPlayers()
+                    .withActivePlayer(2)
+                    .withPriorityPlayer(1)
+                    .withCardInHand(1, "Elder Deep-Fiend")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .build()
+
+                val cast = game.castSpellWithEmerge(1, "Elder Deep-Fiend", "Centaur Courser")
+                withClue("flash makes the emerge cast legal off-turn: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.isInGraveyard(1, "Centaur Courser") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmergeKeywordTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmergeKeywordTest.kt
@@ -177,6 +177,30 @@ class EmergeKeywordTest : FunSpec({
         candidates shouldNotContain lions
     }
 
+    test("enumeration reports the cost each candidate leaves, so the client can show it") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser") // mana value 3
+        val angler = driver.putCreatureOnBattlefield(player, "Gurmag Angler") // mana value 7
+        repeat(6) { driver.putLandOnBattlefield(player, "Island") }
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+        val emerge = actions.first { la ->
+            (la.action as? CastSpell)?.cardId == gryff &&
+                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+        }
+
+        val costs = emerge.additionalCostInfo!!.costAfterSacrifice
+        // Emerge {5}{U} minus 3 → {2}{U}; minus 7 → the generic is exhausted and {U} survives,
+        // the surplus 4 wasted (CR 702.119a). The client renders these verbatim, so they are the
+        // player-visible contract.
+        costs[courser] shouldBe "{2}{U}"
+        costs[angler] shouldBe "{U}"
+    }
+
     test("no emerge option at all when the reduced cost is unaffordable for every creature") {
         val driver = createDriver()
         val player = driver.activePlayer!!

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmergeKeywordTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmergeKeywordTest.kt
@@ -1,0 +1,272 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AlternativeCostType
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.emn.cards.ElderDeepFiend
+import com.wingedsheep.mtg.sets.definitions.emn.cards.WretchedGryff
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Emerge (CR 702.119, Eldritch Moon) — an alternative cost that bundles a creature sacrifice and a
+ * cost reduction derived from what was sacrificed:
+ *
+ *  - 702.119a "Emerge [cost]" means "You may cast this spell by paying [cost] and sacrificing a
+ *    creature rather than paying its mana cost", plus "if you chose to pay this spell's emerge
+ *    cost, its total cost is reduced by an amount of **generic** mana equal to the sacrificed
+ *    creature's mana value."
+ *  - 702.119c You choose which permanent to sacrifice as you choose to pay the emerge cost
+ *    (CR 601.2b) and sacrifice it as you pay the total cost (CR 601.2h) — i.e. after mana abilities
+ *    have been activated, so it can be tapped for mana toward its own emerge cost first.
+ *  - Emerge grants no timing permission of its own; the spell is cast at its normal timing.
+ *
+ * Cards under test:
+ *   Wretched Gryff    — {7} 3/4 Flying, Emerge {5}{U}, "When you cast this spell, draw a card."
+ *   Elder Deep-Fiend  — {8} 5/6 Flash, Emerge {5}{U}{U}, "When you cast this spell, tap up to four
+ *                       target permanents."
+ */
+class EmergeKeywordTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(WretchedGryff)
+        driver.registerCard(ElderDeepFiend)
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun emergeCast(
+        player: com.wingedsheep.sdk.model.EntityId,
+        cardId: com.wingedsheep.sdk.model.EntityId,
+        sacrifice: com.wingedsheep.sdk.model.EntityId,
+        payment: PaymentStrategy = PaymentStrategy.FromPool,
+    ) = CastSpell(
+        playerId = player,
+        cardId = cardId,
+        useAlternativeCost = true,
+        alternativeCostType = AlternativeCostType.EMERGE,
+        additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(sacrifice)),
+        paymentStrategy = payment,
+    )
+
+    test("emerge pays its cost reduced by the sacrificed creature's mana value") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser") // {2}{G} → mana value 3
+        // Emerge {5}{U} reduced by 3 → {2}{U}, exactly 3 mana.
+        driver.giveMana(player, Color.BLUE, 3)
+
+        val handBefore = driver.getHandSize(player)
+
+        driver.submit(emergeCast(player, gryff, courser)).isSuccess shouldBe true
+
+        // CR 702.119c — the creature is sacrificed as the cost is paid, before anything resolves.
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)) shouldContain courser
+
+        driver.bothPass() // "When you cast this spell, draw a card" resolves first
+        driver.bothPass() // then the creature spell itself
+
+        // Hand: -1 for the Gryff leaving, +1 for the cast trigger's draw.
+        driver.getHandSize(player) shouldBe handBefore
+        driver.findPermanent(player, "Wretched Gryff") shouldNotBe null
+    }
+
+    test("the reduction comes off generic mana only — excess mana value is wasted (CR 702.119a)") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val fiend = driver.putCardInHand(player, "Elder Deep-Fiend")
+        val angler = driver.putCreatureOnBattlefield(player, "Gurmag Angler") // {6}{B} → mana value 7
+        // Emerge {5}{U}{U}: the mana value 7 wipes out the {5} and the surplus 2 is wasted —
+        // {U}{U} still has to be paid.
+        driver.giveMana(player, Color.BLUE, 2)
+
+        // The cast succeeds and then pauses on the cast trigger's "up to four target permanents"
+        // choice, so assert on the absence of an error rather than on `isSuccess`.
+        driver.submit(emergeCast(player, fiend, angler)).error shouldBe null
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)) shouldContain angler
+    }
+
+    test("a colored pip left after the reduction still has to be paid") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val fiend = driver.putCardInHand(player, "Elder Deep-Fiend")
+        val angler = driver.putCreatureOnBattlefield(player, "Gurmag Angler") // mana value 7
+        driver.giveMana(player, Color.BLUE, 1) // one short of the surviving {U}{U}
+
+        driver.submitExpectFailure(emergeCast(player, fiend, angler))
+        // Nothing was paid: the creature is still on the battlefield and the card still in hand.
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)) shouldNotContain angler
+        driver.state.getZone(ZoneKey(player, Zone.HAND)) shouldContain fiend
+    }
+
+    test("emerge without choosing a creature to sacrifice is rejected") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        driver.putCreatureOnBattlefield(player, "Centaur Courser")
+        driver.giveMana(player, Color.BLUE, 8)
+
+        driver.submitExpectFailure(
+            CastSpell(
+                playerId = player,
+                cardId = gryff,
+                useAlternativeCost = true,
+                alternativeCostType = AlternativeCostType.EMERGE,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        driver.state.getZone(ZoneKey(player, Zone.HAND)) shouldContain gryff
+    }
+
+    test("a permanent that isn't a creature you control can't pay the emerge sacrifice") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        driver.giveMana(player, Color.BLUE, 8)
+
+        driver.submitExpectFailure(emergeCast(player, gryff, theirs))
+        driver.state.getZone(ZoneKey(opponent, Zone.GRAVEYARD)) shouldNotContain theirs
+    }
+
+    test("enumeration offers only sacrifices that leave the reduced cost payable") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        val lions = driver.putCreatureOnBattlefield(player, "Savannah Lions") // {W} → mana value 1
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser") // {2}{G} → mana value 3
+        // Four Islands. Sacrificing the Lions leaves {4}{U} (5 mana — unaffordable);
+        // sacrificing the Courser leaves {2}{U} (3 mana — affordable).
+        repeat(4) { driver.putLandOnBattlefield(player, "Island") }
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+
+        val emerge = actions.firstOrNull { la ->
+            (la.action as? CastSpell)?.cardId == gryff &&
+                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+        }
+        emerge shouldNotBe null
+        emerge!!.actionType shouldBe "CastWithAlternativeCost"
+        val candidates = emerge.additionalCostInfo!!.validSacrificeTargets
+        candidates shouldContain courser
+        candidates shouldNotContain lions
+    }
+
+    test("no emerge option at all when the reduced cost is unaffordable for every creature") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        driver.putCreatureOnBattlefield(player, "Savannah Lions") // mana value 1 → leaves {4}{U}
+        repeat(2) { driver.putLandOnBattlefield(player, "Island") }
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+
+        actions.none { la ->
+            (la.action as? CastSpell)?.cardId == gryff &&
+                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+        } shouldBe true
+    }
+
+    test("no emerge option when you control no creature to sacrifice") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        repeat(8) { driver.putLandOnBattlefield(player, "Island") }
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+
+        actions.none { la ->
+            (la.action as? CastSpell)?.cardId == gryff &&
+                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+        } shouldBe true
+    }
+
+    test("emerge grants no timing permission — only a flash spell is offered outside a main phase") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff") // no flash
+        val fiend = driver.putCardInHand(player, "Elder Deep-Fiend") // flash
+        driver.putCreatureOnBattlefield(player, "Gurmag Angler") // mana value 7 — covers both costs
+        repeat(4) { driver.putLandOnBattlefield(player, "Island") }
+        driver.passPriorityUntil(Step.END)
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+        fun emergeFor(cardId: com.wingedsheep.sdk.model.EntityId) = actions.any { la ->
+            (la.action as? CastSpell)?.cardId == cardId &&
+                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+        }
+
+        emergeFor(gryff) shouldBe false
+        emergeFor(fiend) shouldBe true
+    }
+
+    test("the sacrificed creature may be tapped for mana toward its own emerge cost (CR 601.2f-h)") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        val birds = driver.putCreatureOnBattlefield(player, "Birds of Paradise") // {G} → mana value 1
+        driver.removeSummoningSickness(birds)
+        // Emerge {5}{U} reduced by 1 → {4}{U} = 5 mana. Only four Islands are on the battlefield,
+        // so the fifth mana has to come from the Birds — which is then sacrificed to pay the rest
+        // of the cost. CR 601.2f-g put mana abilities before the total cost is paid in 601.2h.
+        repeat(4) { driver.putLandOnBattlefield(player, "Island") }
+
+        driver.submit(emergeCast(player, gryff, birds, payment = PaymentStrategy.AutoPay))
+            .isSuccess shouldBe true
+
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)) shouldContain birds
+        driver.bothPass()
+        driver.bothPass()
+        driver.findPermanent(player, "Wretched Gryff") shouldNotBe null
+    }
+
+    test("a card with emerge cast normally pays its printed cost and sacrifices nothing") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val gryff = driver.putCardInHand(player, "Wretched Gryff")
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+        driver.giveMana(player, Color.BLUE, 7) // the printed {7}
+
+        driver.submit(
+            CastSpell(playerId = player, cardId = gryff, paymentStrategy = PaymentStrategy.FromPool)
+        ).isSuccess shouldBe true
+
+        driver.state.getZone(ZoneKey(player, Zone.GRAVEYARD)) shouldNotContain courser
+        driver.bothPass()
+        driver.bothPass()
+        driver.findPermanent(player, "Wretched Gryff") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ItOfTheHorridSwarmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ItOfTheHorridSwarmScenarioTest.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for It of the Horrid Swarm — {8} 4/4 Eldrazi Insect with emerge {6}{G} and
+ * "When you cast this spell, create two 1/1 green Insect creature tokens."
+ *
+ * The tokens come from a cast trigger, so they arrive while the spell is still on the stack.
+ */
+class ItOfTheHorridSwarmScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("It of the Horrid Swarm") {
+
+            test("emerge cast makes two 1/1 Insect tokens before the body resolves") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "It of the Horrid Swarm")
+                    .withCardOnBattlefield(1, "Force of Nature") // {3}{G}{G} → mana value 5
+                    // Emerge {6}{G} reduced by 5 → {1}{G}: two Forests is exactly enough.
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .build()
+
+                val cast = game.castSpellWithEmerge(1, "It of the Horrid Swarm", "Force of Nature")
+                withClue("the emerge cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.isInGraveyard(1, "Force of Nature") shouldBe true
+
+                game.resolveStack()
+
+                val tokens = game.findAllPermanents("Insect Token")
+                withClue("the cast trigger created two Insect tokens") { tokens.size shouldBe 2 }
+                for (token in tokens) {
+                    game.state.projectedState.getPower(token) shouldBe 1
+                    game.state.projectedState.getToughness(token) shouldBe 1
+                }
+                game.isOnBattlefield("It of the Horrid Swarm") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WretchedGryffScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WretchedGryffScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Wretched Gryff — {7} 3/4 Eldrazi Hippogriff with flying, emerge {5}{U}, and
+ * "When you cast this spell, draw a card."
+ *
+ * The draw is a cast trigger, so it resolves before the Gryff itself.
+ */
+class WretchedGryffScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Wretched Gryff") {
+
+            test("emerge pays {5}{U} minus the sacrificed creature's mana value and draws a card") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Wretched Gryff")
+                    .withCardOnBattlefield(1, "Centaur Courser") // {2}{G} → mana value 3
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    // Emerge {5}{U} reduced by 3 → {2}{U}: three Islands is exactly enough.
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .build()
+
+                val cast = game.castSpellWithEmerge(1, "Wretched Gryff", "Centaur Courser")
+                withClue("the emerge cast should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                withClue("the creature is sacrificed as the cost is paid (CR 702.119c)") {
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe true
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                }
+
+                game.resolveStack()
+
+                withClue("the cast trigger drew a card and the Gryff resolved") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Wretched Gryff") shouldBe true
+                }
+                val gryff = game.findPermanent("Wretched Gryff")!!
+                game.state.projectedState.hasKeyword(gryff, Keyword.FLYING) shouldBe true
+            }
+
+            test("hard cast for {7} draws a card and sacrifices nothing") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Wretched Gryff")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .build()
+
+                val cast = game.castSpell(1, "Wretched Gryff")
+                withClue("the hard cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+                game.isOnBattlefield("Wretched Gryff") shouldBe true
+                withClue("no emerge cost was chosen, so nothing was sacrificed") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
@@ -655,6 +655,48 @@ abstract class ScenarioTestBase : FunSpec() {
         }
 
         /**
+         * Cast a spell for its emerge cost (CR 702.119), sacrificing [sacrificeCreatureName].
+         *
+         * Emerge is an alternative cost whose non-mana portion — sacrificing a creature you
+         * control — also determines the mana actually charged: the emerge cost is reduced by an
+         * amount of generic mana equal to the sacrificed creature's mana value. Both halves ride
+         * one action, so this stamps [AlternativeCostType.EMERGE] and puts the chosen creature in
+         * `additionalCostPayment.sacrificedPermanents`, exactly as the enumerator's
+         * `SacrificePermanent` selection does.
+         */
+        fun castSpellWithEmerge(
+            playerNumber: Int,
+            spellName: String,
+            sacrificeCreatureName: String,
+            targets: List<ChosenTarget> = emptyList()
+        ): ExecutionResult {
+            val playerId = if (playerNumber == 1) player1Id else player2Id
+            val hand = state.getHand(playerId)
+            val cardId = hand.find { entityId ->
+                state.getEntity(entityId)?.get<CardComponent>()?.name == spellName
+            } ?: error("Card '$spellName' not found in player $playerNumber's hand")
+
+            val sacrificeId = state.getBattlefield().find { entityId ->
+                val container = state.getEntity(entityId) ?: return@find false
+                container.get<CardComponent>()?.name == sacrificeCreatureName &&
+                    container.get<ControllerComponent>()?.playerId == playerId
+            } ?: error("Creature '$sacrificeCreatureName' not found on player $playerNumber's battlefield")
+
+            return execute(
+                CastSpell(
+                    playerId = playerId,
+                    cardId = cardId,
+                    targets = targets,
+                    useAlternativeCost = true,
+                    alternativeCostType = com.wingedsheep.engine.core.AlternativeCostType.EMERGE,
+                    additionalCostPayment = com.wingedsheep.sdk.scripting.AdditionalCostPayment(
+                        sacrificedPermanents = listOf(sacrificeId)
+                    )
+                )
+            )
+        }
+
+        /**
          * Cast a spell for its Cleave cost (CR 702.148), optionally targeting a permanent. Cleave
          * is an alternative cost, so this drives [CastSpell.useAlternativeCost] gated on
          * [AlternativeCostType.CLEAVE]; the handler swaps in the brackets-removed

--- a/web-client/src/components/game/overlay/TargetingOverlay.tsx
+++ b/web-client/src/components/game/overlay/TargetingOverlay.tsx
@@ -9,6 +9,8 @@ import { useResponsiveContext, handleImageError } from '../board/shared'
 import { styles } from '../board/styles'
 import { TARGET_COLOR, TARGET_COLOR_BRIGHT } from '@/styles/targetingColors.ts'
 import { CraftMaterialOverlay } from '@/components/decisions/CraftMaterialOverlay'
+import { ManaSymbol } from '@/components/ui/ManaSymbols'
+import { parseManaCost } from '@/utils/manaCost'
 
 /**
  * Cross-zone card targeting overlay — shows when targeting mode requires selecting card(s) from a
@@ -580,6 +582,17 @@ export function TargetingOverlay() {
                 ? `Select ${targetingState.targetDescription} (${targetDisplay})`
                 : `Select targets (${targetDisplay})`
 
+  // Emerge (CR 702.119): the sacrifice is the only cost choice that changes the mana owed, so the
+  // banner shows the server's per-candidate arithmetic live — "{5}{U} → {2}{U}" the moment a
+  // creature is picked. Without it the player has to know the generic-only reduction rule and do
+  // the subtraction in their head against a cost label that never moves.
+  const costBeforeSacrifice = targetingState.costBeforeSacrifice
+  const costAfterMap = targetingState.costAfterSacrifice
+  const chosenSacrifice = targetingState.selectedTargets[0]
+  const costAfterSacrifice =
+    costAfterMap && chosenSacrifice ? costAfterMap[chosenSacrifice] : undefined
+  const showSacrificeCost = !!costBeforeSacrifice && !!costAfterMap
+
   const hintText = hasMaxTargets
     ? isBehold ? 'Card selected' : isDiscard ? 'Card selected' : isReveal ? 'Card selected' : isTapPermanent ? 'Permanents selected' : isBounce ? 'Creature selected' : isSacrifice ? 'Selected' : 'Maximum targets selected'
     : hasEnoughTargets
@@ -643,6 +656,45 @@ export function TargetingOverlay() {
       <div style={{ color: '#aaa', fontSize: responsive.fontSize.small, marginTop: 4 }}>
         {hintText}
       </div>
+      {showSacrificeCost && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            gap: 6,
+            marginTop: 8,
+            padding: '5px 10px',
+            borderRadius: 6,
+            background: 'rgba(255, 255, 255, 0.06)',
+            fontSize: responsive.fontSize.small,
+          }}
+        >
+          <span style={{ color: '#aaa' }}>You pay</span>
+          <span style={{ display: 'inline-flex', gap: 2, opacity: costAfterSacrifice ? 0.45 : 1 }}>
+            {parseManaCost(costBeforeSacrifice!).map((symbol, i) => (
+              <ManaSymbol key={i} symbol={symbol} size={16} />
+            ))}
+          </span>
+          <span style={{ color: '#888' }}>→</span>
+          {costAfterSacrifice !== undefined ? (
+            parseManaCost(costAfterSacrifice).length > 0 ? (
+              <span style={{ display: 'inline-flex', gap: 2 }}>
+                {parseManaCost(costAfterSacrifice).map((symbol, i) => (
+                  <ManaSymbol key={i} symbol={symbol} size={16} />
+                ))}
+              </span>
+            ) : (
+              <span style={{ color: '#86efac', fontWeight: 700 }}>free</span>
+            )
+          ) : (
+            <span style={{ color: '#888', fontStyle: 'italic' }}>
+              pick a creature — its mana value comes off
+            </span>
+          )}
+        </div>
+      )}
       {targetingState.warning && (
         <div
           role="alert"

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -120,6 +120,14 @@ export interface TargetingState {
   totalRequirements?: number
   /** Name of the card that initiated this targeting (shown in overlay header) */
   sourceCardName?: string
+  /**
+   * Emerge (CR 702.119): the spell's mana cost before any reduction, and the cost that remains
+   * after sacrificing each candidate (server-computed, keyed by candidate). Set only for a
+   * sacrifice step whose choice changes the mana owed, so the overlay can show
+   * `{5}{U} → {2}{U}` live instead of leaving the player to do the arithmetic.
+   */
+  costBeforeSacrifice?: string
+  costAfterSacrifice?: Readonly<Record<EntityId, string>>
   /** Transient warning shown when the user tries an illegal toggle (e.g. clicking past max
    * on a multi-target step). Cleared on the next successful add/remove. */
   warning?: string | null

--- a/web-client/src/store/slices/ui/pipelinePhases.test.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.test.ts
@@ -49,3 +49,43 @@ describe('computePhases — choose-N modal', () => {
     expect(computePhases(info)).toEqual([{ type: 'modalModes' }, { type: 'costPayment' }])
   })
 })
+
+describe('computePhases — emerge sacrifice', () => {
+  function emergeAction(): LegalActionInfo {
+    return castAction({
+      actionType: 'CastWithAlternativeCost',
+      action: {
+        type: 'CastSpell',
+        playerId: 'p1',
+        cardId: 'c1',
+        useAlternativeCost: true,
+        alternativeCostType: 'EMERGE',
+      },
+      manaCostString: '{5}{U}',
+      additionalCostInfo: {
+        costType: 'SacrificePermanent',
+        description: 'a creature to sacrifice (its mana value reduces the emerge cost)',
+        validSacrificeTargets: ['bear', 'ogre'],
+        sacrificeCount: 1,
+        costAfterSacrifice: { bear: '{3}{U}', ogre: '{U}' },
+      },
+      availableManaSources: [{ entityId: 'island', producesColors: ['U'] }],
+    })
+  }
+
+  it('picks the sacrifice BEFORE manual mana-source selection, since it changes the cost owed', () => {
+    // With auto-tap off the mana step would otherwise run first and price the cast against the
+    // un-reduced emerge cost — the player would be asked to tap for {5}{U} and then discover the
+    // sacrifice made it {U}.
+    expect(computePhases(emergeAction(), { autoTapEnabled: false })).toEqual([
+      { type: 'costPayment' },
+      { type: 'manaSource' },
+    ])
+  })
+
+  it('runs the sacrifice step exactly once when auto-tap handles the mana', () => {
+    expect(computePhases(emergeAction(), { autoTapEnabled: true })).toEqual([
+      { type: 'costPayment' },
+    ])
+  })
+})

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -162,6 +162,18 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
     phases.push({ type: 'harmonize' })
   }
 
+  // 3c. Emerge sacrifice (CR 702.119). The sacrificed creature's mana value reduces the emerge
+  //     cost, so — like the harmonize creature-tap above — the pick has to happen before any
+  //     manual mana-source selection, which prices what's left to pay. Pushed here instead of in
+  //     the generic cost-payment step below, which runs after mana selection.
+  const isEmergeCast =
+    actionInfo.action.type === 'CastSpell' &&
+    actionInfo.action.alternativeCostType === 'EMERGE' &&
+    (actionInfo.additionalCostInfo?.validSacrificeTargets?.length ?? 0) > 0
+  if (isEmergeCast) {
+    phases.push({ type: 'costPayment' })
+  }
+
   // 4. Mana source selection (skipped when auto-tap is enabled, except for delve/convoke
   //    spells where the player should always confirm land selection after alternative payment)
   const hasAlternativePaymentPhase = phases.some((p) => p.type === 'delve' || p.type === 'convoke' || p.type === 'waterbend')
@@ -172,8 +184,8 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
     phases.push({ type: 'manaSource' })
   }
 
-  // 5. Cost payment (sacrifice/discard/tap/bounce/exile)
-  if (actionInfo.additionalCostInfo?.costType) {
+  // 5. Cost payment (sacrifice/discard/tap/bounce/exile) — emerge already pushed its own above.
+  if (actionInfo.additionalCostInfo?.costType && !isEmergeCast) {
     const costType = actionInfo.additionalCostInfo.costType
     const costTypesNeedingSelection = [
       'SacrificePermanent',

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -706,6 +706,12 @@ export function enterPhase(
           // overlay falls back to hardcoded "creature" wording and misdescribes every
           // non-creature sacrifice cost (Castle Doom's artifact, a land, an enchantment).
           flags.targetDescription = costInfo.description
+          // Emerge (CR 702.119) is the one sacrifice cost where the choice changes the mana owed.
+          // Forward the server's per-candidate costs so the overlay can price each pick.
+          if (costInfo.costAfterSacrifice) {
+            flags.costAfterSacrifice = costInfo.costAfterSacrifice
+            if (actionInfo.manaCostString) flags.costBeforeSacrifice = actionInfo.manaCostString
+          }
           break
         case 'SacrificeForCostReduction':
           validTargets = [...(costInfo.validSacrificeTargets ?? [])]

--- a/web-client/src/store/slices/ui/selectionSlice.ts
+++ b/web-client/src/store/slices/ui/selectionSlice.ts
@@ -568,9 +568,18 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
     const action = actionInfo.action as {
       xValue?: number
       alternativePayment?: { harmonizeCreature?: EntityId | null }
+      additionalCostPayment?: { sacrificedPermanents?: readonly EntityId[] }
     }
     const xValue = action.xValue ?? 0
-    const manaCost = actionInfo.manaCostString ?? ''
+    // Emerge (CR 702.119): the creature chosen in the prior costPayment phase reduces the emerge
+    // cost by its mana value, so the printed `manaCostString` overstates what's owed. The server
+    // sent the resulting cost for every candidate, so price this step off the chosen entry rather
+    // than re-deriving the (generic-only) reduction here — that clamp is a rule, not client math.
+    const emergeSacrifice = action.additionalCostPayment?.sacrificedPermanents?.[0]
+    const emergeCost = emergeSacrifice
+      ? actionInfo.additionalCostInfo?.costAfterSacrifice?.[emergeSacrifice]
+      : undefined
+    const manaCost = emergeCost ?? actionInfo.manaCostString ?? ''
     const xSymbolCount = Math.max(1, (manaCost.match(/\{X\}/g)?.length ?? 0))
 
     // Harmonize creature-tap (chosen in the prior `harmonize` phase) reduces the
@@ -612,8 +621,10 @@ export const createSelectionSlice: SliceCreator<SelectionSlice> = (set, get) => 
     // [autoTapPreview] is null. Once convoke/delve has trimmed the cost we can
     // compute a fresh preview from [availableManaSources] so the player isn't
     // left to hand-pick lands.
+    // An emerge cast's server preview was solved for the *first* candidate; the player may have
+    // picked a different creature, so recompute from the cost that choice actually left.
     const reducedSymbols = parseManaCostUtil(manaCost)
-    const preSelectedIds: EntityId[] = (actionInfo.autoTapPreview && actionInfo.autoTapPreview.length > 0)
+    const preSelectedIds: EntityId[] = (!emergeCost && actionInfo.autoTapPreview && actionInfo.autoTapPreview.length > 0)
       ? [...actionInfo.autoTapPreview]
       : (reducedSymbols.length > 0 ? computeAutoTapPreview(sources, reducedSymbols) : [])
     if (xManaNeeded > 0) {

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -202,6 +202,7 @@ export enum Keyword {
   CONVOKE = 'CONVOKE',
   DELVE = 'DELVE',
   AFFINITY = 'AFFINITY',
+  EMERGE = 'EMERGE',
   // Spell mechanics
   STORM = 'STORM',
   FLASHBACK = 'FLASHBACK',
@@ -293,6 +294,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.CONVOKE]: 'Convoke',
   [Keyword.DELVE]: 'Delve',
   [Keyword.AFFINITY]: 'Affinity',
+  [Keyword.EMERGE]: 'Emerge',
   [Keyword.STORM]: 'Storm',
   [Keyword.FLASHBACK]: 'Flashback',
   [Keyword.EVOKE]: 'Evoke',

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1034,6 +1034,14 @@ export interface AdditionalCostInfo {
   readonly costType: string
   readonly validSacrificeTargets?: readonly EntityId[]
   readonly sacrificeCount?: number
+  /**
+   * Emerge (CR 702.119): the mana cost that remains after sacrificing each candidate, keyed by
+   * that candidate. Emerge is the only cost whose mana half depends on which permanent pays its
+   * non-mana half, so `manaCostString` alone can't say what a given choice costs — and the client
+   * must never re-derive it, since the generic-only reduction is a rule. Absent/empty for every
+   * other sacrifice cost, whose mana is fixed regardless of the choice.
+   */
+  readonly costAfterSacrifice?: Readonly<Record<EntityId, string>>
   readonly validTapTargets?: readonly EntityId[]
   readonly tapCount?: number
   /**


### PR DESCRIPTION
Every card left in Innistrad Remastered needs engine work first — none is a plain `cardDef`. **Emerge** is the highest-value cluster: one keyword unlocks six of the nine remaining cards.

## Emerge (CR 702.119)

> "Emerge [cost]" means "You may cast this spell by paying [cost] and sacrificing a creature rather than paying its mana cost", plus "if you chose to pay this spell's emerge cost, its total cost is reduced by an amount of **generic** mana equal to the sacrificed creature's mana value."

The interesting part is the coupling: the non-mana choice changes the mana actually charged. Three consequences drove the design.

**Affordability is per-candidate, not per-spell.** `EmergeCastEnumerator` evaluates the reduced cost once for each creature you control and offers only the ones that leave it payable, as an ordinary `SacrificePermanent` selection. Listing an unpayable creature would hand the client — and the AI, which takes the first candidate — an action that errors on submission. Candidates are sorted cheapest-mana-value first so that default pick spends the least valuable body.

**The sacrifice happens after the mana payment.** CR 601.2f–g activate mana abilities before CR 601.2h pays the total cost, so the creature may legally be tapped for mana toward its own emerge cost before it dies. `CastSpellHandler` therefore prices the cast against the chosen creature (still on the battlefield) and sacrifices it once `processPayment` has gone through. There's a test for exactly this line.

**Emerge grants no timing permission.** The spell is cast at its normal timing — which is why Elder Deep-Fiend needs its own flash, and why a Wretched Gryff in hand is not offered during the end step.

The reduction is generic-only: a mana-value-7 creature turns Elder Deep-Fiend's emerge `{5}{U}{U}` into `{U}{U}`, not into `{0}`, and the surplus 2 is wasted.

## Layers touched

| Layer | Change |
|---|---|
| SDK | `KeywordAbility.Emerge(cost)`, `Keyword.EMERGE`, `emerge("{cost}")` CardBuilder helper |
| Engine | `EmergeCasts` (single source of truth), `EmergeCastEnumerator`, `AlternativeCostType.EMERGE`, cost + validation + sacrifice in `CastSpellHandler` |
| Client | Keyword display name; the existing on-battlefield `SacrificePermanent` phase, hoisted ahead of manual mana-source selection (same reason harmonize's creature tap is) |
| mtgish | Emitter renders `emerge("{cost}")`; bridge marks the capability supported. The co-occurring cast trigger stays a SCAFFOLD hole rather than being approximated |
| Docs | `card-sdk-language-reference.md` |

No new decision component was needed — emerge's sacrifice is an ordinary additional-cost selection, so it reuses the pipeline that Torgaar and Casualty already drive.

## Cards

Canonical `card(...)` definitions land in **EMN** (their earliest printing); INR gets `Printing` rows. INR goes 275 → 281 of 290.

| Card | Emerge | Cast trigger |
|---|---|---|
| Abundant Maw | `{6}{B}` | target opponent loses 3 life, you gain 3 life |
| Decimator of the Provinces | `{6}{G}{G}{G}` | creatures you control get +2/+2 and gain trample |
| Distended Mindbender | `{5}{B}{B}` | reveal hand; discard one MV≤3 nonland and one MV≥4 |
| Elder Deep-Fiend | `{5}{U}{U}` | tap up to four target permanents |
| It of the Horrid Swarm | `{6}{G}` | create two 1/1 green Insects |
| Wretched Gryff | `{5}{U}` | draw a card |

All six hang their payload off a **"when you cast this spell"** trigger, which resolves while the Eldrazi is still on the stack. That's load-bearing for Decimator: the Boar is not among "creatures you control" when the pump resolves, so it stays a 7/7 and just brings its own trample and haste. There's an explicit test pinning that.

Abundant Maw's two amounts are independent (`LoseLife(3)` + `GainLife(3)`), not a linked drain — an opponent at 2 goes to −1 and you still gain the full 3. `DrainLife` would have capped the gain; a test caught it.

## Verification

- `EmergeKeywordTest` — 11 tests against the CR: the reduction, generic-only clamping, the surviving colored pip, missing/illegal sacrifice, per-candidate enumeration, no-creature and unaffordable boards, the absent timing permission, tapping the fodder for its own cost, and a normal hard cast.
- One scenario test per card (6 files).
- `just build` (full suite), `just check`, `just rebless-cards`, `just coverage-fixtures --rebless`, `npm run typecheck`, `check-card-printing` clean for all six.

Also adds the missing CMR `Printing` row for Elder Deep-Fiend that `check-card-printing` demands.

## Known limitation

In **manual mana mode** (auto-tap off) the mana-source step still displays the *unreduced* emerge cost — the amount genuinely depends on a choice the player hasn't confirmed yet. The sacrifice pick now runs first so the flow is coherent and the server charges correctly; only the label is pessimistic. Auto-tap (the default) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
