### PR TITLE
Fix two stale SerialNames in the mtgish bridge; add a non-interactive cross-set index

### DIFF
--- a/backlog/mtgish-tooling-engine-gaps.md
+++ b/backlog/mtgish-tooling-engine-gaps.md
@@ -1,0 +1,491 @@
+# mtgish Tooling — Engine Capability Gap Analysis
+
+Cross-reference of the **engine/SDK's actual capability surface** against the two mtgish dictionaries
+(`mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/`):
+
+| Dictionary | Question it answers | Lives in |
+|------------|---------------------|----------|
+| **Capability** (`bridge/`) | *Can* Argentum express this tag? | `coverage/bridge/*` |
+| **Rendering** (`emitter/`) | *What Kotlin DSL* does it emit? | `coverage/emitter/*Handlers.kt` |
+
+This is the **inverse** of the usual coverage question. The dashboard's feature leaderboard answers
+"what engine work unlocks the most cards?"; this document answers "what has the engine already
+shipped that the tooling doesn't know about?" — capability we've paid for but aren't scoring.
+
+Generated 2026-08-07 by scanning `mtg-sdk` source against a word-boundary match over both
+dictionaries. See [Method & caveats](#8-method--caveats).
+
+---
+
+## Index
+
+1. [Bottom line](#1-bottom-line)
+1b. [**Ranked by cards unlocked** — the cross-set capability index](#1b-ranked-by-cards-unlocked)
+2. [Effects in neither dictionary (188)](#2-effects-in-neither-dictionary-188)
+   - [2.1 Counters & growth](#21-counters--growth)
+   - [2.2 Explore, transform, phasing, animation](#22-explore-transform-phasing-animation)
+   - [2.3 Life totals & game-ending](#23-life-totals--game-ending)
+   - [2.4 Stack manipulation](#24-stack-manipulation)
+   - [2.5 Combat](#25-combat)
+   - [2.6 Types & colors](#26-types--colors)
+   - [2.7 Protection & hexproof scoping](#27-protection--hexproof-scoping)
+   - [2.8 Player-scoped statics & emblems](#28-player-scoped-statics--emblems)
+   - [2.9 Tokens & copies](#29-tokens--copies)
+   - [2.10 Granted alternative-cast keywords](#210-granted-alternative-cast-keywords)
+   - [2.11 Zones, exile & removal riders](#211-zones-exile--removal-riders)
+   - [2.12 Mana](#212-mana)
+   - [2.13 Choice, pipeline & misc](#213-choice-pipeline--misc)
+   - [2.14 Internal plumbing — do NOT map](#214-internal-plumbing--do-not-map)
+3. [Bridge-only effects — always SCAFFOLD (27)](#3-bridge-only-effects--always-scaffold-27)
+4. [Parameterized keyword abilities with no emitter branch (~35)](#4-parameterized-keyword-abilities-with-no-emitter-branch-35)
+5. [Mechanic DSLs invisible to the tooling (16)](#5-mechanic-dsls-invisible-to-the-tooling-16)
+6. [CostAtom variants (3)](#6-costatom-variants-3)
+7. [Suggested order of attack](#7-suggested-order-of-attack)
+8. [Method & caveats](#8-method--caveats)
+
+---
+
+## 1. Bottom line
+
+| Axis | Engine has | Tooling knows | Gap |
+|---|---|---|---|
+| `Effect` SerialNames | 308 | 120 | **188 in neither dictionary** |
+| Effects bridged but unrendered | — | — | **27** (forced `SCAFFOLD`) |
+| `KeywordAbility` factories | ~70 | ~22 | **~35 unrendered** |
+| `dsl/mechanics/*Dsl.kt` helpers | 29 | 13 | **16 unknown** |
+| `CostAtom` variants | 12 | 9 | **3** |
+
+**61% of the engine's `Effect` vocabulary is invisible to the coverage probe.** Roughly 25 of those
+188 are internal plumbing that should never be mapped (§2.14), so the real actionable figure is
+**~163 effects**.
+
+Two distinct failure modes, with different consequences:
+
+- **Unmapped in `bridge/`** — the probe reports the card `BLOCKED`/`UNMAPPED`. This *understates*
+  our coverage and distorts the cross-set feature leaderboard: engine work already done shows up as
+  work still to do. Fixing these is cheap (one line per tag) and changes the numbers immediately.
+- **Bridged but unrendered in `emitter/`** — the card scores as covered but never auto-generates.
+  This is why some sets show high `implemented/total` yet low `gN`. Fixing these is a handler, not
+  a one-liner.
+
+Keyword *capability* is less bad than the raw counts suggest: the probe's PascalCase→enum
+auto-resolve (`Bridge.resolve`) covers bare keywords for free. The gaps in §4 are **rendering**
+gaps, not coverage gaps — `keywordLines` correctly refuses to stamp a parameterized keyword bare
+(it skips any rule carrying `args`), so those cards scaffold rather than mis-render. That guard is
+working as designed; the missing piece is the explicit `rname ==` branch.
+
+---
+
+## 1b. Ranked by cards unlocked
+
+Source: `just coverage-cross` (the non-interactive dump of the same `Analyzer.crossSet` roll-up the
+TUI's `c` view shows) over **185 sets**, cross-referenced by hand against the SDK registry to
+separate "the engine already has this" from "this is real engine work".
+
+**Headline: ~6,000 of the 11,317 blocked card-instances — 53% of the entire "blocked on engine
+work" backlog — are blocked on capability the engine already ships.** They're blocked by a missing
+or wrong line in `bridge/`, not by missing engine code.
+
+Counts are per-set instances (a reprint counts once per set), matching how the dashboard reports.
+`SETS` is how many sets the capability appears in — a high number means the fix generalizes.
+
+### Tier 0 — outright bugs in `bridge/` (self-caught, unfixed)
+
+Both are `GAP` (kind = `MISSING`), meaning the bridge names a SerialName that isn't in the registry.
+This is the anti-rot mechanism described in `bridge/Bridge.kt` working exactly as designed — it
+caught the drift, nobody acted on it.
+
+| Cards | Sets | Tag | Problem | Fix |
+|------:|-----:|-----|---------|-----|
+| 387 | 121 | `_LayerEffect = SetPT` | `ManaCountersAndState.kt:43` maps to `SetBasePowerToughness`; the actual SerialName is **`SetBaseStats`** | one word |
+| 91 | 53 | `_StaticLayerEffect = SetPT` | same entry | — |
+| 108 | 14 | `_Action = Investigate` | `DamageLifeAndCards.kt:99` maps to a SerialName `Investigate` that **does not exist** | re-file as `composed(...)` over the Clue-token primitives |
+
+**586 card-instances on a one-word typo and one mis-filed entry.**
+
+### Tier 1 — engine has it, bridge has no entry at all
+
+Every row verified against the scanned registry (SerialName present) or a `KeywordAbility` factory /
+`CardBuilder` helper.
+
+| Cards | Sets | Tag | Engine capability |
+|------:|-----:|-----|-------------------|
+| **1674** | 145 | `_Action = PutACounterOfTypeOnPermanent` | `AddCounters` ✅ |
+| **1336** | 147 | `_Trigger = WhenACreatureOrPlaneswalkerDies` | dies triggers ✅ (`WhenAPermanentDies` is already `supported`) |
+| 372 | 118 | `_Action = PutNumberCountersOfTypeOnPermanent` | `AddCounters` ✅ |
+| 282 | 104 | `_LayerEffect = AddCardtype` | `AddCardType` ✅ |
+| 238 | 93 | `_Action = PutACounterOfTypeOnEachPermanent` | `AddCounters` ✅ |
+| 169 | 48 | `_Action = ChooseADamageSource` | `ChosenSource` (`PreventionSourceFilter`) ✅ |
+| 119 | 17 | `_Rule = Kicker` | `KeywordAbility.kicker` ✅ |
+| 105 | 45 | `_LayerEffect = AddColor` | `AddColor` ✅ |
+| 101 | 52 | `_LayerEffect = LosesAbility` | `RemoveAllAbilities` ✅ (partial — "loses *a* named ability" is narrower) |
+| 98 | 19 | `_Rule = SpellActions_Kicker` | `KeywordAbility.kicker` ✅ |
+| 94 | 46 | `_Action = GetAnEmblem` | `CreatePermanentEmblem` ✅ |
+| 94 | 13 | `_Action = Proliferate` | `Proliferate` ✅ |
+| 87 | 49 | `_Action = HaveCreaturesFight` | `Fight` ✅ |
+| 80 | 11 | `_Rule = Morph` | `KeywordAbility.morph` ✅ (emitter already has the branch) |
+| 79 | 44 | `_StaticLayerEffect = AddCardtype` | `AddCardType` ✅ |
+| 72 | 10 | `_Rule = SagaChapters` | `CardBuilder.sagaChapter` ✅ |
+| 52 | 35 | `_Action = WinTheGame` | `WinGame` ✅ |
+| 48 | 5 | `_Rule = LevelUp` | `LevelUpClass` / `CardBuilder.classLevel` ✅ |
+| 43 | 14 | `_Rule = Multikicker` | `KeywordAbility.multikicker` ✅ |
+| 40 | 30 | `_Action = SetLifeTotal` | `SetLifeTotal` ✅ |
+| 37 | 25 | `_StaticLayerEffect = SetLandType` | `SetLandType` ✅ |
+| 33 | 15 | `_Action = ReturnSpellToOwnersHand` | `ReturnSpellToOwnersHand` ✅ |
+| 31 | 22 | `_Action = PutNumberCountersOfTypeOnEachPermanent` | `AddCounters` ✅ |
+| 29 | 24 | `_LayerEffect = SetLandType` | `SetLandType` ✅ |
+| 29 | 4 | `_Action = Amass` | `Amass` ✅ |
+| 28 | 20 | `_StaticLayerEffect = LosesAbility` | `RemoveAllAbilities` ✅ |
+| 27 | 12 | `_Action = PhaseOutPermanent` | `PhaseOut` ✅ |
+| 27 | 6 | `_Action = ExploreWithPermanent` | `Explore` ✅ |
+| 26 | 7 | `_Rule = Dash` | `KeywordAbility.dash` ✅ |
+
+**Subtotal ≈ 5,450 card-instances.** The top two rows alone are 3,010 — over a quarter of the entire
+blocked backlog, on two tags whose capability is unambiguous.
+
+> The two counter tags are worth understanding before fixing: `ManaCountersAndState.kt:52` already
+> maps `ACounterOfTypeOnPermanent` / `NumberCountersOfTypeOnPermanent` — the *nested* variants under
+> the `PutCounters` envelope. The IR also emits a **direct `_Action` form** with a `Put` prefix, and
+> that key was never added. Same capability, different node shape.
+
+### Tier 2 — structural envelopes
+
+Not effects — mtgish wrappers whose children carry the real capability. Each is a candidate
+`envelope(...)` row, but each needs a look at what the IR actually nests before pinning.
+
+| Cards | Sets | Tag |
+|------:|-----:|-----|
+| 299 | 105 | `_Rule = EachPermanentRuleEffect` |
+| 234 | 34 | `_Rule = DeckConstruction` (not a gameplay capability at all — deck rules; should probably be `envelope`/ignored) |
+| 202 | 69 | `_Rule = FromStack` |
+| 100 | 55 | `_Rule = ThisSpellEffect` |
+| 79 | 27 | `_Rule = FromAnyZone` |
+| 39 | 37 | `_Rule = ActivatedAbilityEffect` |
+| 28 | 13 | `_Rule = FromExile` |
+
+**Subtotal ≈ 981.** `FromStack` / `FromAnyZone` / `FromExile` already have emitter `rname` branches —
+only the bridge pin is missing.
+
+### Tier 3 — genuine engine work (the honest backlog)
+
+These rank high but the engine does **not** have them. This is what the leaderboard is *supposed* to
+be telling us, now that the noise above is separated out.
+
+| Cards | Sets | Tag | Note |
+|------:|-----:|-----|------|
+| 279 | 87 | `_Cost = RemoveACounterOfTypeFromPermanent` | counter-removal as a cost |
+| 246 | 102 | `_Cost = PayManaX` | the extra-costs / chosen-X area the creator's note flags |
+| 145 | 9 | `_Rule = CDA_Color` | characteristic-defining color |
+| 142 | 67 | `_Action = RevealTopCardOfLibrary` | |
+| 134 | 56 | `_Cost = RemoveNumberCountersOfTypeFromPermanent` | |
+| 133 | 74 | `_Action = RevealTheTopNumberCardsOfLibrary` | |
+| 127 | 63 | `_Action = PermanentDoesntUntapDuringControllersNextUntap` | |
+| 124 | 75 | `_Action = PlayerActions` | |
+| 120 | 62 | `_Cost = TapAPermanent` | |
+| 118 | 63 | `_Trigger = WhenAPermanentDealsDamageToAPlayer` | |
+| 116 | 68 | `_Action = DiscardHand` | |
+| 115 | 65 | `_Action = CopySpellAndMayChooseNewTargets` | |
+| 113 | 18 | `_Rule = CDA_Types` | |
+| 111 | 65 | `_Trigger = WhenACreatureBlocksACreature` | block triggers — a whole family (`WhenACreatureBecomesBlocked` 94, `…BecomesBlockedByACreature` 98) |
+| 97 | 8 | `_Rule = CumulativeUpkeep` | |
+| 53 | 22 | `_Rule = Intimidate` | **already pinned** `unsupported` in `bridge/Keywords.kt` — correctly blocking |
+
+Mechanics with no engine support that show up further down: Bestow (54), Buyback (53), Monstrosity
+(53), Echo (74), Unearth (68), Exalted (47), Megamorph (44), Infect (71), Soulbond (37), Escape (34),
+Splice onto Arcane (34), Mutate (33), Extort (30), Retrace (30), Improvise (29), Split Second (29),
+Bloodthirst (28), Mentor (28), Living Weapon (27), Soulshift (30), Disguise (38), Overload (42),
+Bolster (26), Support (34), Adapt (32), Clash (36), Monarch (55), Venture/dungeon (34), Roll a d20
+(49). Each is a real `add-feature` unit.
+
+### What this changes about §7
+
+The original suggested order was written from engine structure. The data says otherwise — **fix the
+bridge before writing any engine code.** Revised order is in [§7](#7-suggested-order-of-attack).
+
+---
+
+## 2. Effects in neither dictionary (188)
+
+Grouped by theme. Each name is an `Effect` `@SerialName` from
+`mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/`.
+
+### 2.1 Counters & growth
+
+`AddCountersToCollection`, `Amass`, `ConvertCountersToTokens`, `DistributeCountersAmongFiltered`,
+`DistributeCountersFromSelf`, `MoveChosenCountersToTarget`, `MoveCounters`,
+`MoveCountersEachKindMissing`, `Proliferate`, `RemoveAllCounters`
+
+> `Proliferate` alone is an evergreen-adjacent mechanic spanning Scars of Mirrodin through
+> Phyrexia: All Will Be One. Its absence blocks every card that references it.
+
+### 2.2 Explore, transform, phasing, animation
+
+`Explore`, `Transform`, `ExileAndReturnTransformed`, `ReturnSelfFromExileTransformed`,
+`ReturnSelfFromZoneTransformed`, `PhaseOut`, `PhaseOutUntilLeaves`, `PhaseInLinkedToSource`,
+`TurnFaceDown`, `MassAnimate`, `BecomeArtifact`, `BecomeSaddled`, `TapUntapCollection`
+
+### 2.3 Life totals & game-ending
+
+`DrainLife`, `ExchangeLifeTotals`, `ExchangeLifeAndStat`, `SetLifeTotal`, `PayDynamicLife`,
+`WinGame`, `EndTheTurn`, `SkipNextTurn`, `SkipNextDrawStep`, `HijackNextTurn`,
+`AddAdditionalUpkeepSteps`, `AddAdditionalEndSteps`
+
+### 2.4 Stack manipulation
+
+The single largest untouched cluster — 19 effects, none mapped.
+
+`ChangeSpellTarget`, `ChangeTriggeringObjectTargets`, `CopyEachSpellCast`, `CopyEachTargetSpell`,
+`CopyTargetTriggeredAbility`, `CounterAllOnStack`, `DestroySourceOfTargetedAbility`,
+`ExileSpellsOnStack`, `GrantKeywordToSpell`, `GrantNextSpellAffinity`, `MakeNextSpellUncounterable`,
+`MarkSpellExileWithCounters`, `ReduceSpellCostsThisTurn`,
+`RemoveAbilitiesFromSourceOfTargetedAbility`, `ReselectTargetRandomly`,
+`ReturnSpellOrPermanentToOwnersHand`, `ReturnSpellToOwnersHand`, `StormCopy`, `WardCounter`
+
+### 2.5 Combat
+
+`CanAttackDespiteDefenderThisTurn`, `CantAttackGroup`, `CantBlockGroup`, `ForceBlock`,
+`GrantAttackBlockTaxPerCreatureType`, `GrantCantBeBlockedByChosenColor`,
+`GrantKeywordToAttackersBlockedBy`, `MarkMustAttackThisTurn`, `Provoke`,
+`RedirectCombatDamageToController`, `SetSuspected`
+
+Plus from removal/damage: `CantBeRegenerated`, `AmplifyNoncombatDamageThisTurn`,
+`DealDamagePerEntityInZone`, `DoubleDamageToPlayer`, `RemoveDamageShield`
+
+### 2.6 Types & colors
+
+All 13 effects in `TypeAndColorEffects.kt` are unmapped:
+
+`AddCardType`, `AddColor`, `AddSubtype`, `BecomeChosenManaColor`, `ChangeColor`,
+`ChangeColorToChosen`, `ChangeCreatureTypeText`, `ChangeGroupColor`, `ChangeWordInText`,
+`ChooseColorForTarget`, `LoseAllCreatureTypes`, `SetCreatureSubtypes`, `SetGroupCreatureSubtypes`
+
+### 2.7 Protection & hexproof scoping
+
+`ChooseColorThen`, `GrantHexproofFromChosenColor`, `GrantPlayerProtection`,
+`GrantProtectionFromChosenCardType`, `GrantProtectionFromChosenColor`
+
+### 2.8 Player-scoped statics & emblems
+
+`CantActivateLoyaltyAbilities`, `CantCastSpellsFromNonHandZones`, `CreatePermanentEmblem`,
+`GainCitysBlessing`, `GiftGiven`, `GrantCastCreaturesFromGraveyardWithForage`, `GrantDamageBonus`,
+`GrantEvasionKeyword`, `GrantFlashToSpells`, `GrantSpellKeyword`, `GrantSpellsCantBeCountered`,
+`LockLifeGain`, `PreventLandPlaysThisTurn`, `TheRingTemptsYou`
+
+### 2.9 Tokens & copies
+
+`CreateRandomCreatureTokenWithManaValue`, `CreateRoleToken`, `CreateTokenCopyOfChosenPermanent`,
+`CreateTokenCopyOfEquippedCreature`, `CreateTokenCopyOfSource`, `BecomeCopyOfLinkedExile`,
+`CopyCardIntoCollection`, `CopyCollectionIntoCollection`, `ChainCopy`,
+`EachPermanentBecomesCopyOfTarget` *(bridged — see §3)*
+
+### 2.10 Granted alternative-cast keywords
+
+`GrantEmbalm`, `GrantFlashback`, `GrantHarmonize`, `GrantSuspend`, `GrantReplacementEffect`,
+`GrantActivatedAbilityToGroup`, `RemoveAllAbilities`, `GrantFreeCastTargetFromExile`,
+`GrantPlayWithAdditionalCost`, `GrantPlayWithCostIncrease`, `GrantExileOnLeave`,
+`CastAnyNumberFromCollectionWithoutPayingCost`
+
+### 2.11 Zones, exile & removal riders
+
+`DestroyAllEquipmentOnTarget`, `ExileAndGrantOwnerPlayPermission`, `ExileOpponentsGraveyards`,
+`ExileWithAurasNotingCounters`, `ExileFromTopRepeating`, `ForceExileMultiZone`,
+`MoveTrackedBattlefieldObject`, `ReturnCreaturesPutInGraveyardThisTurn`,
+`ReturnNotedExileTappedWithAuras`, `ReturnOneFromLinkedExile`, `ReturnSelfToBattlefieldAttached`,
+`ReturnSameNamedFromGraveyard`, `WarpExile`, `AttachTargetEquipmentToCreature`,
+`UnattachEquipment`, `GainControlByActivePlayer`, `GainControlByMost`
+
+### 2.12 Mana
+
+`AddAnyColorManaSpendOnChosenType`, `AddDynamicMana`, `AddOneManaOfEachColorAmong`,
+`PayDynamicManaCost`, `RetainUnspentMana`
+
+### 2.13 Choice, pipeline & misc
+
+`AnyPlayerMayPay`, `Behold`, `BudgetModal`, `FlipCoins`, `FlipTwoCoins`, `SecretBid`, `OpenLifeBid`,
+`LevelUpClass`, `LockDoor`, `UnlockDoor`, `CaptureControllers`, `ChooseCreatureType`,
+`ChooseOption`, `ChoosePile`, `ConditionalOnCollection`, `EachPlayerChoosesCreatureType`,
+`ForEachCapturedController`, `GatherSubtypes`, `ChooseCardTypeForSource`, `ChooseNumberForSource`,
+`ChooseNumberThen`, `ChooseOpponentForSource`, `EachPlayerDiscardsOrLoseLife`,
+`EachPlayerDrawsForDamageDealtToSource`, `LookAtFaceDown`, `MayRevealCardFromHand`,
+`OpponentGuessesTopCardKindEffect`
+
+> ⚠ Several of these sit squarely in the **extra-costs / chosen-value** area the creator's note in
+> `mtgish-tooling/README.md` flags as engine-sloppy (`ChooseNumberThen`, `ChooseCardTypeForSource`,
+> `AnyPlayerMayPay`, `PayDynamicManaCost`). Map the **capability** in `bridge/` so the leaderboard is
+> honest, but the emitter should keep declining → `SCAFFOLD`.
+
+### 2.14 Internal plumbing — do NOT map
+
+These are engine-internal markers with no mtgish IR counterpart. Listed for completeness so a
+future sweep doesn't mistake them for gaps.
+
+`EmitBendEvent`, `EmitDiscoveredEvent`, `EmitExploitedEvent`, `EmitExploredEvent`,
+`EmitLibrarySearchedEvent`, `EmitManifestedDreadEvent`, `EmitScriedEvent`, `EmitSurveiledEvent`,
+`EmitTrainedEvent`, `IncrementAbilityResolutionCount`, `MarkEnduringReturn`,
+`MarkExileControllerGraveyardOnDeath`, `NoteCreatureType`, `RecordChosenLinkedExile`,
+`StoreCardName`, `StoreNumber`
+
+---
+
+## 3. Bridge-only effects — always SCAFFOLD (27)
+
+Capability is mapped, so the probe scores these as covered — but no emitter handler exists, so the
+card never auto-generates. These are the reason a set can show high coverage and low `gN`.
+
+`AddCountersUpTo`, `AnimateLand`, `CantBlockTargetCreatures`, `CantPlayCardsFromHand`,
+`ChangeSpeed`, `ChooseOnePerCategory`, `CreateGlobalTriggeredAbility`,
+`DistributeCountersAmongTargets`, `DrawUpTo`, `EachPermanentBecomesCopyOfTarget`,
+`EachPlayerReturnsPermanentToHand`, `ExileTargetSpell`, `FilterCollection`, `Gated`, `LoseGame`,
+`MarkSpellPlotOnResolve`, `PayCounters`, `PayFixedCounters`, `PreventDamageShield`,
+`PutOnLibraryPositionOfChoice`, `RedirectNextDamage`, `ReduceMaximumHandSize`,
+`RemoveAnyNumberOfCounters`, `RepeatDynamicTimes`, `RepeatWhile`, `ReplaceNextDrawWith`, `TapUntap`
+
+Note that some of these are *correctly* unrendered per the fidelity policy — `Gated`,
+`RepeatWhile`, and `FilterCollection` are structural and their payload is a per-card read. The
+straightforwardly renderable ones are `DrawUpTo`, `AddCountersUpTo`, `TapUntap`,
+`RemoveAnyNumberOfCounters`, `ExileTargetSpell`, `LoseGame`, `ReduceMaximumHandSize`.
+
+---
+
+## 4. Parameterized keyword abilities with no emitter branch (~35)
+
+The engine models all of these via `KeywordAbility` factories
+(`mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt`). `keywordLines` in
+`emitter/Shells.kt` correctly skips any rule with `args`, so they scaffold instead of dropping their
+parameter. Each needs an explicit `rname == "X"` branch alongside the existing Ward / Saddle /
+Madness / Impending / Firebending ones.
+
+### Numeric (`KeywordAbility.Numeric`)
+
+`absorb`, `afflict`, `annihilator`, `bushido`, `casualty`, `devour` / `devourLand`, `fabricate`,
+`fading`, `hideaway`, `mobilize`, `modular`, `rampage`, `renown`, `toxic`, `tribute`, `vanishing`
+
+These are the cheapest wins in the whole document — the shape is identical to the already-rendered
+`saddle(N)` / `firebending(N)`, just a different factory name.
+
+### Cost-carrying
+
+`basicLandcycling`, `cleave`, `dash`, `evoke`, `foretell`, `harmonize`, `mayhem`, `miracle`,
+`morphPayLife`, `ninjutsu`, `offspring`, `sneak`, `suspend`, `warp`, `webSlinging`
+
+### Kicker family
+
+`kicker`, `multikicker`, `flashKicker` — `kicker` is mentioned in `bridge/` but has no emitter
+render.
+
+### Scoped protection / ward variants
+
+`hexproofFrom`, `protectionFromSubtype`, `protectionFromSupertype`, `wardComposite`,
+`wardWaterbend`
+
+### No-arg but unbranched
+
+`conspire`
+
+---
+
+## 5. Mechanic DSLs invisible to the tooling (16)
+
+`mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/` ships 29 helpers. These 16 appear in
+**neither** dictionary:
+
+`BeginGameOnBattlefield`, `Converge`¹, `Craft`, `Decayed`, `Embalm`, `Enduring`, `Flurry`,
+`JobSelect`, `Mayhem`, `Mobilize`, `Ninjutsu`, `Renew`, `Riot`, `Sneak`, `Vivid`, `WebSlinging`
+
+¹ `Converge` is referenced in `emitter/` but has no `bridge/` pin, so it can't score as a
+capability.
+
+**Partially covered** — bridge pin exists, emitter declines:
+
+| Mechanic | Status |
+|---|---|
+| `Disturb` | Deliberate — every disturb card is a transforming DFC and the emitter declines all multi-faced cards |
+| `Gift` | Deliberate — which `GiftKind` is listed is a per-card read |
+| `Exploit` | **Looks like a genuine miss** — worth a handler |
+
+---
+
+## 6. CostAtom variants (3)
+
+`CostAtom` is nearly complete. Unknown to the tooling:
+
+`ExileFrom`, `PutCountersOnSelf`, `RevealFromHand`
+
+---
+
+## 7. Suggested order of attack
+
+Ordered by measured cards-unlocked from [§1b](#1b-ranked-by-cards-unlocked), not by intuition.
+
+1. **Fix the two `GAP` bridge entries** — `SetPT` → `SetBaseStats` (one word) and re-file
+   `Investigate` as `composed`. **586 card-instances**, minutes of work. Add a test that asserts
+   every `effect(...)`/`keyword(...)` tag resolves against the registry so `GAP` can't sit unfixed
+   again — the mechanism already detects this, it just has no alarm.
+2. **Add the Tier 1 bridge rows** — ~29 lines. **≈5,450 card-instances.** Start with
+   `PutACounterOfTypeOnPermanent` and `WhenACreatureOrPlaneswalkerDies`: 3,010 between them.
+3. **Pin the Tier 2 structural envelopes** — ~981 more, and `FromStack`/`FromAnyZone`/`FromExile`
+   already have emitter branches waiting.
+4. **Re-run `just coverage-cross`** — steps 1–3 will reshuffle the ranking substantially. Do not
+   plan engine work off the current numbers; more than half the list is noise until the bridge is
+   honest.
+5. **Numeric keyword branches (§4)** — a mechanical copy of the `saddle(N)` branch, ~16 keywords,
+   converts a tail of old-set creatures from `SCAFFOLD` to `WHOLE`. Emitter work, so it raises `gN`
+   rather than unblocking cards.
+6. **Then, and only then, real engine work** — Tier 3. The block-trigger family
+   (`WhenACreatureBlocksACreature` + `…BecomesBlocked` + `…BecomesBlockedByACreature` ≈ 303 across
+   ~65 sets) is the largest single coherent unit and is plain `add-feature` territory.
+
+Two caveats on the counts. They're **per-set instances** — a reprint counts once per set, so the
+unique-card figure is lower (`autogen --all --gaps --unique` collapses it). And a bridge row moves a
+card from `BLOCKED` to `SCAFFOLD`, not necessarily to `AUTOGEN`: it makes our *coverage reporting*
+honest, which is the point, but only an emitter handler makes the card auto-generate.
+
+---
+
+## 8. Method & caveats
+
+**How this was produced.** For each axis, the SDK source was scanned for the capability's canonical
+identifier, then word-boundary matched against the concatenated text of `bridge/*.kt` and
+`emitter/*.kt`:
+
+- **Effects** — `@SerialName("X")` in `scripting/effects/`, filtered to declarations whose supertype
+  is `Effect` (this correctly excludes the 90 co-located `CollectionFilter`, `ManaRestriction`,
+  `CardSource`, `SelectionMode`, `PreventionSourceFilter`, `MayPlayExpiry`, `RepeatCondition`,
+  `FeasibilityCheck`, `PlayerRankMetric`, `ManaSpellRider`, and `CardDestination` variants). Matched
+  on both the SerialName and the Kotlin class name.
+- **Keywords** — `Keyword` enum members, matched on both `UPPER_SNAKE` and the `PascalCase` form the
+  bridge's auto-resolve would produce.
+- **Keyword abilities** — `fun` factories in `KeywordAbility.kt`'s companion.
+- **Mechanics** — filenames under `dsl/mechanics/`.
+- **CostAtom** — `data class` / `object` declarations in `costs/CostAtom.kt`.
+
+**Caveats.**
+
+- Word-boundary matching is a heuristic. A handful of entries may already be reachable indirectly
+  through a `composed` / `envelope` bridge entry filed under a different mtgish tag name — verify
+  before adding a row (`BridgeBuilder.add` rejects duplicate keys loudly, so a collision fails fast).
+- The counts assume every `Effect` has a working executor. `add-feature`'s executor-coverage
+  guarantee makes a missing Static/Replacement executor a compile error, so this is safe for those
+  two families; a leaf resolution effect that exists but is engine-inert would need the
+  `unsupported(...)` treatment `Intimidate` gets in `bridge/Keywords.kt`.
+- Adding a bridge row makes the probe score a card as coverable. If the emitter can't render it
+  exactly, that's correct and expected — the card lands in `SCAFFOLD`, not `BLOCKED`. Per the
+  fidelity policy, **a confidently wrong generated card is worse than no generated card**: return
+  `null` from the handler rather than widen a filter to make something emit.
+
+**Regenerating this.** §2–§6 come from a ~40-line script over the two source trees; nothing there is
+committed tooling. If that becomes a recurring check, the natural home is a `probe --unmapped-sdk`
+subcommand in `coverage/Main.kt` reusing `Registry.loadEffectSerialNames()` and `Bridge.entry(...)`,
+which would also make it a test-able invariant instead of a point-in-time document.
+
+§1b **is** reproducible: `just coverage-cross` (added for this analysis) dumps the cross-set index
+non-interactively. The tier classification on top of it is hand-verified against the registry and
+will need redoing as the bridge changes — but the ranking underneath regenerates in ~90s.
+
+**On the §1b counts specifically.** Every ✅ in Tier 1 was checked against
+`Registry.loadEffectSerialNames()` output or a concrete `KeywordAbility` / `CardBuilder` factory —
+none are inferred from the tag name. What is *not* verified is whether each tag's **arguments** are
+recoverable; a bridge row asserts the capability exists, which is the honest claim, and the emitter
+independently decides whether it can render exactly. Two rows are marked partial (`LosesAbility` →
+`RemoveAllAbilities`) because the engine primitive is broader than the tag; those need a closer read
+before pinning.

--- a/justfile
+++ b/justfile
@@ -200,6 +200,15 @@ coverage *ARGS: _coverage-tool
 coverage-dashboard *ARGS: _coverage-tool
     @mtgish-tooling/build/install/mtgish-tooling/bin/mtgish-tooling dashboard {{ARGS}}
 
+# Cross-set capability index, non-interactively — the same ranking as the dashboard's `c` view
+# ("what engine work unlocks the most cards everywhere"), printed as a plain table so it can be
+# piped, diffed, or pasted into a backlog doc. Use the TUI when you want to DRILL into the cards.
+#   just coverage-cross              # every capability, ranked by blocked cards it would unlock
+#   just coverage-cross --top 50     # just the head of the ranking
+[group: 'build']
+coverage-cross *ARGS: _coverage-tool
+    @mtgish-tooling/build/install/mtgish-tooling/bin/mtgish-tooling dashboard --cross {{ARGS}}
+
 # Generation fidelity — could we AUTO-AUTHOR a card from mtgish? Diffs the bridge's output
 # against each card's compiled golden snapshot, tiering AUTO / SCAFFOLD / MISS.
 # Whole set:  just coverage-fidelity --set POR

--- a/mtgish-tooling/README.md
+++ b/mtgish-tooling/README.md
@@ -9,6 +9,7 @@ Run through `just` from the repo root:
 
 ```bash
 just coverage-dashboard          # interactive TUI over everything below
+just coverage-cross              # cross-set capability ranking, non-interactively (dashboard `c`)
 just coverage --set POR
 just coverage-fidelity --set POR
 just coverage-verify POR
@@ -91,6 +92,12 @@ rather than re-implementing coverage logic, and memoizes per-set results so a ke
   it unlocks → detail) · `←`/`esc` back · `tab` Kotlin/capabilities · `/` search/filter · `s` sort ·
   `f` scan-all · `r` fetch a set from Scryfall · `c` cross-set · `q` quit.
   Needs an interactive terminal (drives `/dev/tty` via `stty`).
+
+`just coverage-cross` (`dashboard --cross [--top N]`) prints the **`c` view's ranking only**, without
+raw mode — the same `Analyzer.crossSet` roll-up, as a plain table for piping or pasting into a
+backlog doc. It reads each set's *full* leaderboard, so unlike aggregating `probe --set` output (which
+truncates to a top-20 per set) the counts are exact. Use the TUI when you want to drill from a row
+into the cards it would unlock.
 
 The dashboard adds no runtime dependency — it uses raw ANSI escapes and `stty` raw mode
 (`dashboard/Tui.kt`), keeping the module dependency-light. `dashboard --render` prints static frames

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -95,8 +95,12 @@ internal fun BridgeBuilder.damageLifeAndCards() {
     // (Impractical Joke); other game effects scaffold in the emitter.
     effect("CreateGameEffect", "DamageCantBePreventedThisTurn")
     effect("Shuffle", "ShuffleLibrary")
-    // Investigate (CR 701.36) — create a Clue token (Effects.Investigate() / Effects.CreateClue()).
-    effect("Investigate", "Investigate")
+    // Investigate (CR 701.36) — create a Clue token. `Effects.Investigate(n)` is a NAMED FACADE, not
+    // its own Effect type: it returns `CreatePredefinedTokenEffect("Clue", n)`, so the leaf SerialName
+    // is `CreatePredefinedToken`. The entry used to name a SerialName "Investigate" that has never
+    // existed, which the registry validation correctly reported as a MISSING gap — blocking every
+    // investigate card in the corpus rather than scoring the capability we do have.
+    effect("Investigate", "CreatePredefinedToken", "investigate -> Effects.Investigate(n) = a Clue predefined token (CR 701.36)")
     effect("RevealHand", "RevealHand")
     effect("LookAtPlayersHand", "LookAtTargetHand")
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -40,7 +40,7 @@ internal fun BridgeBuilder.manaCountersAndState() {
     // trample" cycle — but every corpus card with this tag also carries SetPT / activated-ability /
     // until-EOT riders the shape doesn't cover, so there is no calibrated card to render and the
     // emitter keeps declining.)
-    effect("SetPT", "SetBasePowerToughness", "set base power/toughness via an enters-with layer effect (Ghost Vacuum)")
+    effect("SetPT", "SetBaseStats", "set base power/toughness via an enters-with layer effect (Ghost Vacuum)")
     effect("AddCreatureType", "AddCreatureType", "add a creature subtype in addition to other types (Ghost Vacuum)")
     // The mtgish IR routes every put-counter action through a `PutCounters` envelope whose nested
     // `_PutCountersAction` variants carry the real shape (the old top-level `PutACounterOfType…` /

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Dashboard.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/dashboard/Dashboard.kt
@@ -51,6 +51,7 @@ object Dashboard {
             return 1
         }
         if ("--render" in args) return selfRender()
+        if ("--cross" in args) return dumpCrossSet(args)
         if (!RawTerminal.available()) {
             System.err.println("coverage-dashboard needs an interactive terminal (no /dev/tty available).")
             return 1
@@ -62,6 +63,34 @@ object Dashboard {
         } finally {
             tty.exit()
         }
+        return 0
+    }
+
+    /**
+     * Non-interactive dump of the cross-set capability index (`dashboard --cross [--top N]`) — the same
+     * [Analyzer.crossSet] roll-up the TUI's `c` view shows, printed as a plain ranked table so it can be
+     * piped, diffed, or pasted into a backlog doc. The interactive view stays the place to DRILL from a
+     * row into the cards it unlocks; this is the ranking only.
+     *
+     * Deliberately not folded into `probe`: `probe --set` prints its own per-set leaderboard truncated to
+     * the top 20, so aggregating those would undercount any capability sitting in a set's long tail. The
+     * roll-up here reads each set's FULL leaderboard, so the counts are exact.
+     */
+    private fun dumpCrossSet(args: List<String>): Int {
+        val top = args.indexOf("--top").takeIf { it >= 0 }?.let { args.getOrNull(it + 1)?.toIntOrNull() } ?: Int.MAX_VALUE
+        System.err.print("analyzing ${sets.size} sets")
+        val rows = Analyzer.crossSet { done, total -> if (done % 20 == 0 || done == total) System.err.print(" $done/$total") }
+        System.err.println()
+        println("== cross-set capability index — ${rows.size} unmapped/missing capabilities across ${sets.size} sets ==")
+        println("   (count = blocked unimplemented cards this capability would unlock; sets = how many sets it appears in)")
+        println()
+        println("  %-6s %-7s %-6s %s".format("CARDS", "SETS", "KIND", "CAPABILITY"))
+        println("  " + "-".repeat(84))
+        for (r in rows.take(top)) {
+            val kind = if (r.verdict == "MISSING") "GAP" else "??"
+            println("  %-6d %-7d %-6s %s = %s".format(r.count, r.sets, kind, r.disc, r.value))
+        }
+        if (rows.size > top) println("  … ${rows.size - top} more (raise --top)")
         return 0
     }
 


### PR DESCRIPTION
## What

Two `bridge/` entries named an Effect `@SerialName` that does not exist. `Bridge.resolve` validates
every `effect(...)`/`keyword(...)` tag against a live scan of the SDK, so both resolved to `MISSING`
and **blocked every card that used them**.

The mechanism worked exactly as its docstring promises — *"a wrong guess surfaces as a MISSING gap =
the mechanism catching its own error."* It caught them. Nothing alarmed, so they sat.

| File | Was | Is |
|---|---|---|
| `bridge/ManaCountersAndState.kt:43` | `effect("SetPT", "SetBasePowerToughness")` | `effect("SetPT", "SetBaseStats")` |
| `bridge/DamageLifeAndCards.kt:99` | `effect("Investigate", "Investigate")` | `effect("Investigate", "CreatePredefinedToken")` |

`Effects.Investigate(n)` is a **named facade**, not its own Effect type — it returns
`CreatePredefinedTokenEffect("Clue", n)` (CR 701.36), so the leaf SerialName is
`CreatePredefinedToken`. The old entry assumed the facade name was the tag. Comment expanded so the
next reader doesn't repeat it.

## Impact

**586 card-instances unblocked**, verified by diffing the cross-set index before/after:

| Cards | Sets | Tag |
|------:|-----:|-----|
| 387 | 121 | `_LayerEffect = SetPT` |
| 91 | 53 | `_StaticLayerEffect = SetPT` |
| 108 | 14 | `_Action = Investigate` |

All three are gone from the ranking after the fix. Counts are per-set instances (a reprint counts
once per set), matching how the dashboard reports.

Note these move cards `BLOCKED` → `SCAFFOLD`, not necessarily to `AUTOGEN`. That makes our coverage
*reporting* honest, which is the point; only an emitter handler makes a card auto-generate.

## Also: `just coverage-cross`

Measuring the above needed the cross-set capability index, which was reachable only by pressing `c`
in the TUI — it requires `/dev/tty`. Added `dashboard --cross [--top N]` next to the existing
`--render` smoke path: same `Analyzer.crossSet` roll-up, printed as a plain table.

Deliberately *not* folded into `probe`: `probe --set` truncates its leaderboard to a top-20 per set,
so aggregating that output would undercount any capability sitting in a set's long tail. This reads
each set's full leaderboard, so the counts are exact.

## Context

`backlog/mtgish-tooling-engine-gaps.md` (added here) is the analysis these two bugs fell out of — a
cross-reference of the engine's capability surface against both dictionaries. Headline: **~6,000 of
the 11,317 blocked card-instances are blocked on capability the engine already ships**, not on
missing engine code. This PR fixes the two outright bugs; the rest is left as documented backlog.

### Three follow-ups found while verifying, deliberately NOT in this PR

1. **The comment at `ManaCountersAndState.kt:45-49` is stale, and it matters.** It claims the
   top-level `PutACounterOfType…` actions "are gone", replaced by a `PutCounters` envelope with
   nested `_PutCountersAction` variants. Against the actual corpus:

   ```
   PutACounterOfTypeOnPermanent   1835 occurrences
   _PutCountersAction                0 occurrences
   ```

   Exactly backwards — the bridge is keyed for a shape the IR doesn't emit and unkeyed for the one it
   does. That is why `_Action = PutACounterOfTypeOnPermanent` tops the ranking at **1,674 blocked
   cards / 145 sets**. I left the comment alone because correcting it properly means adding the
   mapping, which is a scoring change beyond this PR — but as written it would actively discourage
   the fix.

2. **Three remaining `GAP` rows are a different bug class — the validator is too narrow, not the
   entries.** `ReplaceWouldPutIntoGraveyard` (43/28), `ReplaceWouldDiscard` (19/18) and
   `AbilitiesTriggerAnAdditionalTime` (6/6) map to `RedirectZoneChange` and
   `AdditionalSourceTriggers`, both of which **do exist** — in `scripting/ReplacementEffect.kt` and
   `scripting/MiscStaticAbilities.kt`. `Registry.loadEffectSerialNames()` only scans
   `scripting/effects/`, so it reports false MISSING. Widening the scan unblocks 68 more and stops
   future replacement-effect entries looking broken.

3. **No guard test.** A `GAP` row is currently only visible to someone who goes looking. A test
   asserting every `effect(...)`/`keyword(...)` tag resolves against the registry would have caught
   both of these at commit time. (The 4th `GAP`, `Intimidate`, is the deliberate `unsupported` pin
   and would need to stay exempt.)

## Verification

- `:mtgish-tooling:test` — **142 tests, 0 failures**, confirmed via the JUnit XML rather than a
  possibly up-to-date Gradle task. `EmitterGoldenTest` (the per-card emitter regression net across
  9 vendored sets) and `BridgeResolveTest` both executed clean, so no emitted card shifted.
- `just coverage-cross` re-run end-to-end over 185 sets before and after; the three rows above are
  the only ones that moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
