### PR TITLE
Choose every modal trigger's mode on the stack (CR 603.3c)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7924,9 +7924,10 @@ spell {
 `ModalEffect.chooseOne { mode(...) }` and `ModalEffect.chooseN(n) { ... }` for explicit modal effects.
 
 **Dynamic "choose up to X"** — `ModalEffect.chooseUpToDynamic(dynamicMax, *modes, allowRepeat = false)`
-caps the pick count by a `DynamicAmount` evaluated at resolution time. `minChooseCount` is
+caps the pick count by a `DynamicAmount`, evaluated as the ability goes onto the stack for a
+triggered ability and at resolution for an activated one. `minChooseCount` is
 forced to `0` (the player may always decline); `chooseCount` becomes `min(eval, modes.size)`.
-If the evaluated cap is `0` the effect resolves as a no-op. Used by Riku of Many Paths,
+If the evaluated cap is `0` no mode is chosen and nothing happens. Used by Riku of Many Paths,
 where the cap is `ContextProperty(MODES_CHOSEN_ON_TRIGGERING_SPELL)`. Equivalent raw shape:
 `ModalEffect(modes, chooseCount = modes.size, minChooseCount = 0, dynamicChooseCount = …)`.
 The cap is any `DynamicAmount` — e.g. **Bumi, King of Three Trials** uses
@@ -8024,21 +8025,36 @@ modal(
 ) { /* modes */ }
 ```
 
-**Modal triggered abilities (CR 603.3c).** A modal *triggered* ability with at least one
-**targeting** mode picks its mode **and** that mode's targets as the ability is put onto the
-stack — same moment a modal spell's caster does — not while it resolves. This is what makes the
-choice observable: the chosen targets only "become targets" once the ability is on the stack, and
-that is what ward (CR 702.21), "whenever this becomes the target of a spell or ability", and
-shroud/hexproof checks all key on. Two consequences for authoring and testing:
+**Modal triggered abilities (CR 603.3c / 700.2b).** *Every* modal triggered ability picks its
+mode — and each chosen mode's targets, CR 603.3d — as the ability is put onto the stack, the same
+moment a modal spell's caster does, never while it resolves. Two things depend on that timing:
+
+- The opponent responds to a **known** mode. The ability reaches the stack with `chosenModes`
+  populated, so its chosen mode text and per-mode targets are already in the client view
+  (`ClientCard.chosenModeDescriptions` / `perModeTargets`) while there is still priority to act on.
+- The chosen targets only "become targets" once the ability is on the stack, which is what ward
+  (CR 702.21), "whenever this becomes the target of a spell or ability", and shroud/hexproof key on.
+
+Consequences for authoring and testing:
 
 - A mode whose mandatory target has no legal choice **isn't offered at all** — e.g. Hullbreaker
-  Horror's "target spell you don't control" is absent when the only spell on the stack is your own.
-  If no mode can be chosen, the ability is removed from the stack (both CR 603.3c).
-- In a scenario test the mode / target decisions surface *before* the ability resolves, so the
-  chosen mode's effect needs a further `resolveStack()`.
+  Horror's "target spell you don't control" is absent when the only spell on the stack is your own,
+  and Silent Hallcreeper's "another target creature you control" is absent when it is your only
+  creature. If no mode is chosen, the ability is removed from the stack (CR 603.3c).
+- A `chooseUpToDynamic` cap is evaluated **once**, against the state the ability goes onto the stack
+  in, and then can't drift between picks (CR 601.2c via 603.3d). A cap of `0` means no mode is
+  chosen, so the ability never reaches the stack.
+- The per-source memory of `chooseOneNotYetChosen` / `chooseOneNotYetChosenThisTurn` is written when
+  the ability goes onto the stack, not when it resolves. That is what makes two simultaneous triggers
+  of the same source pick *different* modes (Breeches, Eager Pillager: both attack triggers announce
+  their modes before either resolves).
+- In a scenario test the mode / target decisions surface *before* the ability resolves, so the chosen
+  mode's effect needs a further `resolveStack()`. The decision carries
+  `DecisionPhase.TRIGGER`, not `RESOLUTION`.
 
-Modal triggers whose modes never target keep the simpler resolution-time pick, as do
-`chooseUpToDynamic` (the cap needs the resolving state) and `chooseOneNotYetChosen`.
+`ModalEffectExecutor`'s resolution-time picker still serves modal **activated** abilities and a
+`ModalEffect` **nested inside** another effect (a gated effect, a reflexive trigger, a pipeline step),
+where the mode question isn't the ability's own. See `ModalTriggeredAbilityOnStackTest`.
 
 **"Choose one that hasn't been chosen"** — `ModalEffect.chooseOneNotYetChosen(*modes)` for a
 repeatable modal *ability* whose source remembers which modes it has already chosen across the
@@ -8046,7 +8062,8 @@ game and never offers them again (Gandalf the Grey). Equivalent raw shape:
 `ModalEffect(modes, chooseCount = 1, excludePreviouslyChosenModes = true, countsAsModalSpell =
 false)`. The engine records each chosen mode index in a per-source
 `ChosenModesEverComponent` and excludes it from every later presentation of the effect; once all
-modes have been chosen the ability has no legal mode and resolves as a no-op. The memory is keyed
+modes have been chosen the ability has no legal mode (a triggered ability is removed from the stack,
+CR 603.3c; an activated one resolves as a no-op). The memory is keyed
 to the source object and persists while it remains the same object on the battlefield (CR 700.4) —
 it resets if the permanent leaves and returns as a new object. Intended for triggered/activated
 abilities on a persistent source, not one-shot modal spells.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -152,10 +152,12 @@ data class ModalEffect(
      * result as the effective maximum, clamped to `modes.size`. Two evaluation sites with
      * different floor semantics:
      *
-     * - **Resolution-time** (modal triggered/activated abilities, `ModalEffectExecutor`):
-     *   [minChooseCount] is treated as `0` (always "choose up to"); [chooseCount] is ignored.
-     *   Used for "choose up to X" where X depends on resolution-time data (Riku of Many
-     *   Paths — X is the number of modes the cast modal spell chose). See
+     * - **Put-on-stack / resolution-time** (modal abilities): [minChooseCount] is treated as `0`
+     *   (always "choose up to"); [chooseCount] is ignored. A modal *triggered* ability evaluates it
+     *   as the ability goes onto the stack (CR 603.3c, `TriggerProcessor`) and the result is then
+     *   fixed; a modal *activated* ability evaluates it on resolution (`ModalEffectExecutor`). Used
+     *   for "choose up to X" where X depends on game state rather than the cast (Riku of Many
+     *   Paths — X is the number of modes the triggering modal spell chose). See
      *   [chooseUpToDynamic].
      * - **Cast-time** (modal *spells*, `CastSpellHandler.effectiveModalChooseCounts`): the
      *   [minChooseCount] floor is preserved, so the effective range is
@@ -307,8 +309,9 @@ data class ModalEffect(
             ModalEffect(modes.toList(), 2)
 
         /**
-         * Create a "choose up to X" modal effect where X is evaluated at resolution
-         * time from a [com.wingedsheep.sdk.scripting.values.DynamicAmount]. The player
+         * Create a "choose up to X" modal effect where X is evaluated from a
+         * [com.wingedsheep.sdk.scripting.values.DynamicAmount] — as the ability goes onto the stack
+         * for a triggered ability (CR 603.3c), on resolution for an activated one. The player
          * may decline (pick 0) and may pick at most `min(X, modes.size)` total modes.
          * Mode repetition is not allowed by default (per CR-compliant "choose up to N")
          * — pass `allowRepeat = true` for Spree-style behavior.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/TheRuinousWreckingCrew.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/TheRuinousWreckingCrew.kt
@@ -35,7 +35,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *    time an ETB trigger resolves. `CastX` is the durable, object-scoped reading that rides the
  *    spell's entity onto the battlefield, so the counters and the mode budget are guaranteed to
  *    agree on the same announced X.
- *  - **"Choose up to X"** with a resolution-time cap is [ModalEffect.chooseUpToDynamic] (Riku of
+ *  - **"Choose up to X"** with a runtime cap is [ModalEffect.chooseUpToDynamic] (Riku of
  *    Many Paths / Bumi, King of Three Trials): the minimum is 0, so X = 0 legally chooses nothing
  *    and the Crew simply enters as a 2/2; the effective maximum is `min(X, 4)` since modes can't
  *    repeat (`allowRepeat = false`, matching the printed card's lack of a "you may choose the same

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RikuOfManyPaths.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/otj/cards/RikuOfManyPaths.kt
@@ -40,8 +40,8 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * - X plumbing: the engine's [com.wingedsheep.engine.core.SpellCastEvent] now carries
  *   `chosenModesCount`, which becomes [DynamicAmount.ContextProperty] with key
  *   [ContextPropertyKey.MODES_CHOSEN_ON_TRIGGERING_SPELL] inside this trigger's effect.
- * - "Choose up to X": [ModalEffect.chooseUpToDynamic] resolves the cap at trigger
- *   resolution and uses the standard modal continuation. Rulings: modes can't be
+ * - "Choose up to X": [ModalEffect.chooseUpToDynamic] resolves the cap as the trigger is put onto
+ *   the stack (CR 603.3c), then the modes ride there. Rulings: modes can't be
  *   repeated each time Riku triggers, so [ModalEffect.allowRepeat] stays `false`.
  */
 val RikuOfManyPaths = card("Riku of Many Paths") {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/BumiKingOfThreeTrials.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/BumiKingOfThreeTrials.kt
@@ -30,8 +30,8 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *   Put three +1/+1 counters on it. When it dies or is exiled, return it to the battlefield tapped.)
  *
  * Implementation:
- * - The novelty is a modal "choose up to X" whose cap X is a [DynamicAmount] resolved when the ETB
- *   trigger resolves — not a fixed literal. [ModalEffect.chooseUpToDynamic] already models exactly
+ * - The novelty is a modal "choose up to X" whose cap X is a [DynamicAmount] resolved as the ETB
+ *   trigger goes onto the stack — not a fixed literal. [ModalEffect.chooseUpToDynamic] models exactly
  *   this (Riku of Many Paths): `minChooseCount` is treated as 0 (declining all picks is legal,
  *   matching "up to"), the effective maximum is `min(eval, modes.size)`, and modes can't repeat
  *   (`allowRepeat = false`). Here the cap is `DynamicAmount.Count` of Lesson cards in your graveyard

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalTriggerContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ModalTriggerContinuations.kt
@@ -22,6 +22,9 @@ import kotlinx.serialization.Serializable
  *
  * @property ability The fully built stack component, held until modes/targets are known.
  * @property outerTargets Targets already chosen for the ability's own (non-modal) requirements.
+ * @property chooseCount How many modes to pick. Already resolved: a
+ *   [com.wingedsheep.sdk.scripting.effects.ModalEffect.dynamicChooseCount] cap is evaluated once,
+ *   before the first pick, so the number can't drift between picks (CR 601.2c via 603.3d).
  */
 @Serializable
 data class TriggerModalModeSelectionContinuation(
@@ -37,7 +40,11 @@ data class TriggerModalModeSelectionContinuation(
     val availableIndices: List<Int>? = null,
     val selectedModeIndices: List<Int> = emptyList(),
     val doneOptionOffered: Boolean = false,
-    val causedByAttack: Boolean = false
+    val causedByAttack: Boolean = false,
+    /** See [TriggerModalTargetSelectionContinuation.recordChosenModesOnSource]. */
+    val recordChosenModesOnSource: Boolean = false,
+    /** See [TriggerModalTargetSelectionContinuation.recordChosenModesThisTurn]. */
+    val recordChosenModesThisTurn: Boolean = false
 ) : ContinuationFrame
 
 /**
@@ -58,5 +65,17 @@ data class TriggerModalTargetSelectionContinuation(
     val chosenModeIndices: List<Int>,
     val resolvedModeTargets: List<List<ChosenTarget>>,
     val currentOrdinal: Int,
-    val causedByAttack: Boolean = false
+    val causedByAttack: Boolean = false,
+    /**
+     * "Choose one that hasn't been chosen" (Gandalf the Grey): record every chosen mode in the
+     * source's [com.wingedsheep.engine.state.components.battlefield.ChosenModesEverComponent] once
+     * the ability is on the stack, so later triggers of the same object never offer it again.
+     */
+    val recordChosenModesOnSource: Boolean = false,
+    /**
+     * "…that hasn't been chosen this turn" (Breeches, Eager Pillager): the turn-scoped sibling of
+     * [recordChosenModesOnSource], written to
+     * [com.wingedsheep.engine.state.components.battlefield.ChosenModesThisTurnComponent].
+     */
+    val recordChosenModesThisTurn: Boolean = false
 ) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.mechanics.modal.ChosenModeMemory
 import com.wingedsheep.engine.mechanics.stack.StackResolver
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredEverComponent
@@ -829,11 +830,18 @@ class TriggerProcessor(
         val causedByAttack = isAttackCausedTrigger(trigger)
         val outerRequirements = listOfNotNull(ability.targetRequirement)
 
-        // CR 603.3c — a modal triggered ability's modes and targets are chosen as the ability is
-        // put onto the stack, not while it resolves. Pause here so the choices are locked in
-        // before the ability hits the stack; only then do the chosen targets actually *become*
-        // targets, which is what ward (CR 702.21) and "becomes the target" triggers key on.
-        modalNeedingPutOnStackSelection(abilityComponent.effect)?.let { modal ->
+        // CR 603.3c / 700.2b — a modal triggered ability's modes are announced as the ability is
+        // put onto the stack, and CR 603.3d says its targets follow the same way (601.2c–d). Pause
+        // here so both are locked in *before* the ability hits the stack: that is what lets an
+        // opponent see the chosen mode while the ability is still responded-to, and only then do
+        // the chosen targets actually *become* targets, which is what ward (CR 702.21) and
+        // "becomes the target" triggers key on.
+        //
+        // Only a *top-level* ModalEffect is caught here. A modal nested inside another effect (a
+        // gated effect, a reflexive trigger, a pipeline) isn't the ability's own mode question, so
+        // it stays with the resolution-time picker in
+        // [com.wingedsheep.engine.handlers.effects.composite.ModalEffectExecutor].
+        (abilityComponent.effect as? ModalEffect)?.let { modal ->
             return presentTriggerModalModeDecision(
                 state = state,
                 ability = abilityComponent,
@@ -854,28 +862,43 @@ class TriggerProcessor(
     }
 
     /**
-     * The top-level [ModalEffect] whose modes must be picked *before* the trigger reaches the
-     * stack, or null when the effect can keep the simpler resolution-time mode picking.
+     * How many modes this trigger's controller picks, and the minimum they must pick.
      *
-     * Only modal effects with at least one *targeting* mode need the earlier pick: those are the
-     * ones where a resolution-time choice would silently skip the "becomes the target" step. Modes
-     * that only affect the controller's own board carry no such observable, so they stay on the
-     * resolution-time path ([com.wingedsheep.engine.handlers.effects.composite.ModalEffectExecutor]).
-     *
-     * Three shapes are deliberately excluded because they need state that only exists at resolution:
-     * a `dynamicChooseCount` (evaluated against the resolving game state),
-     * `excludePreviouslyChosenModes` (Gandalf the Grey's per-source memory) and
-     * `excludeModesChosenThisTurn` (Breeches, Eager Pillager's turn-scoped per-source memory),
-     * both recorded by the resolution-time continuation.
+     * A [ModalEffect.dynamicChooseCount] ("choose up to X") is evaluated here, once, against the
+     * state the ability is going onto the stack in — CR 601.2c (reached via 603.3d) fixes the count
+     * at that moment, so it can't drift as the picks are made. The floor drops to 0 because "up to"
+     * always permits picking none; that mirrors the resolution-time evaluation in
+     * [com.wingedsheep.engine.handlers.effects.composite.ModalEffectExecutor], which still serves
+     * modal *activated* abilities and nested modals.
      */
-    private fun modalNeedingPutOnStackSelection(effect: Effect): ModalEffect? {
-        val modal = effect as? ModalEffect ?: return null
-        if (modal.dynamicChooseCount != null) return null
-        if (modal.excludePreviouslyChosenModes) return null
-        if (modal.excludeModesChosenThisTurn) return null
-        if (modal.modes.none { it.targetRequirements.isNotEmpty() }) return null
-        return modal
+    private fun effectiveChooseCounts(
+        state: GameState,
+        ability: TriggeredAbilityOnStackComponent,
+        modal: ModalEffect
+    ): Pair<Int, Int> {
+        val dynamic = modal.dynamicChooseCount
+            ?: return modal.chooseCount to modal.minChooseCount
+        val evaluated = DynamicAmountEvaluator().evaluate(
+            state,
+            dynamic,
+            EffectContext.forTriggeredAbility(ability)
+        )
+        return evaluated.coerceIn(0, modal.modes.size) to 0
     }
+
+    /**
+     * CR 603.3c — "If no mode is chosen, the ability is removed from the stack." Reached when every
+     * mode would be illegal, when a "choose up to X" cap evaluated to 0, and when the player
+     * declined every optional pick.
+     */
+    private fun modalTriggerRemovedFromStack(
+        state: GameState,
+        ability: TriggeredAbilityOnStackComponent,
+        reason: String
+    ): ExecutionResult = ExecutionResult.success(
+        state,
+        listOf(AbilityFizzledEvent(ability.sourceId, ability.description, reason))
+    )
 
     /**
      * Build the next mode-pick decision for a modal triggered ability going on the stack, or move
@@ -895,34 +918,36 @@ class TriggerProcessor(
         availableIndices: List<Int>?,
         causedByAttack: Boolean
     ): ExecutionResult {
-        val candidateIndices = availableIndices ?: modal.modes.indices.toList()
+        val (chooseCount, minChooseCount) = effectiveChooseCounts(state, ability, modal)
+
+        // "Choose one that hasn't been chosen (this turn)" — the source's own memory narrows the
+        // pool before the first pick. Later picks arrive with `availableIndices` already narrowed by
+        // the resumer, so re-applying the memory is a no-op there.
+        val remembered = ChosenModeMemory.excludedFor(state, ability.sourceId, modal)
+        val candidateIndices = (availableIndices ?: modal.modes.indices.toList())
+            .filter { it !in remembered }
         val offerIndices = candidateIndices.filter { index ->
             modeHasLegalTargets(state, ability, modal.modes[index])
         }
 
-        if (offerIndices.isEmpty() && selectedModeIndices.size < modal.minChooseCount) {
-            // No mode can legally be chosen — the ability is removed from the stack (CR 603.3c).
-            return ExecutionResult.success(
-                state,
-                listOf(
-                    AbilityFizzledEvent(
-                        ability.sourceId,
-                        ability.description,
-                        "No legal targets available"
-                    )
+        if (offerIndices.isEmpty() || selectedModeIndices.size >= chooseCount) {
+            if (offerIndices.isEmpty() && selectedModeIndices.size < minChooseCount) {
+                // Every remaining mode is unselectable — no legal target, or already spent by
+                // "…that hasn't been chosen (this turn)".
+                return modalTriggerRemovedFromStack(
+                    state, ability, "No legal mode could be chosen"
                 )
-            )
-        }
-
-        if (offerIndices.isEmpty()) {
+            }
             return presentTriggerModalTargetDecision(
                 state, ability, outerTargets, outerTargetRequirements,
-                modal.modes, selectedModeIndices, emptyList(), currentOrdinal = 0, causedByAttack
+                modal.modes, selectedModeIndices, emptyList(), currentOrdinal = 0, causedByAttack,
+                recordChosenModesOnSource = modal.excludePreviouslyChosenModes,
+                recordChosenModesThisTurn = modal.excludeModesChosenThisTurn
             )
         }
 
-        val doneOffered = selectedModeIndices.size >= modal.minChooseCount &&
-            selectedModeIndices.size < modal.chooseCount
+        val doneOffered = selectedModeIndices.size >= minChooseCount &&
+            selectedModeIndices.size < chooseCount
         // Same decline label the resolution-time modal path uses, so clients (and tests) can
         // recognise "choose up to one"'s opt-out wherever the mode question is raised.
         val optionLabels = offerIndices.map { modal.modes[it].description } +
@@ -934,8 +959,8 @@ class TriggerProcessor(
             "\nAlready picked: ${selectedModeIndices.joinToString("; ") { modal.modes[it].description }}"
         }
         val basePrompt = "Choose a mode for ${ability.sourceName}"
-        val prompt = if (modal.chooseCount > 1) {
-            "$basePrompt ($pickNumber of ${modal.chooseCount})$alreadyPicked"
+        val prompt = if (chooseCount > 1) {
+            "$basePrompt ($pickNumber of $chooseCount)$alreadyPicked"
         } else basePrompt
 
         val decision = ChooseOptionDecision(
@@ -945,9 +970,9 @@ class TriggerProcessor(
             context = DecisionContext(
                 sourceId = ability.sourceId,
                 sourceName = ability.sourceName,
-                // The ability isn't on the stack yet, but from the player's seat this is the
-                // trigger going on the stack, not a spell being cast.
-                phase = DecisionPhase.RESOLUTION
+                // Not a resolution-time question: the ability is on its way to the stack and this
+                // pick is part of putting it there (CR 603.3c).
+                phase = DecisionPhase.TRIGGER
             ),
             options = optionLabels
         )
@@ -958,14 +983,17 @@ class TriggerProcessor(
             outerTargets = outerTargets,
             outerTargetRequirements = outerTargetRequirements,
             modes = modal.modes,
-            chooseCount = modal.chooseCount,
-            minChooseCount = modal.minChooseCount,
+            // The effective counts, so a resolved `dynamicChooseCount` isn't re-evaluated per pick.
+            chooseCount = chooseCount,
+            minChooseCount = minChooseCount,
             allowRepeat = modal.allowRepeat,
             offeredIndices = offerIndices,
-            availableIndices = availableIndices,
+            availableIndices = candidateIndices,
             selectedModeIndices = selectedModeIndices,
             doneOptionOffered = doneOffered,
-            causedByAttack = causedByAttack
+            causedByAttack = causedByAttack,
+            recordChosenModesOnSource = modal.excludePreviouslyChosenModes,
+            recordChosenModesThisTurn = modal.excludeModesChosenThisTurn
         )
 
         return ExecutionResult.paused(
@@ -997,7 +1025,9 @@ class TriggerProcessor(
         chosenModeIndices: List<Int>,
         resolvedModeTargets: List<List<com.wingedsheep.engine.state.components.stack.ChosenTarget>>,
         currentOrdinal: Int,
-        causedByAttack: Boolean
+        causedByAttack: Boolean,
+        recordChosenModesOnSource: Boolean,
+        recordChosenModesThisTurn: Boolean
     ): ExecutionResult {
         var ordinal = currentOrdinal
         var targetsAccum = resolvedModeTargets
@@ -1047,7 +1077,8 @@ class TriggerProcessor(
                 context = DecisionContext(
                     sourceId = ability.sourceId,
                     sourceName = ability.sourceName,
-                    phase = DecisionPhase.RESOLUTION,
+                    // Part of putting the ability on the stack, not of resolving it (CR 603.3d).
+                    phase = DecisionPhase.TRIGGER,
                     effectHint = mode.description
                 ),
                 targetRequirements = requirementInfos,
@@ -1063,7 +1094,9 @@ class TriggerProcessor(
                 chosenModeIndices = chosenModeIndices,
                 resolvedModeTargets = targetsAccum,
                 currentOrdinal = ordinal,
-                causedByAttack = causedByAttack
+                causedByAttack = causedByAttack,
+                recordChosenModesOnSource = recordChosenModesOnSource,
+                recordChosenModesThisTurn = recordChosenModesThisTurn
             )
 
             return ExecutionResult.paused(
@@ -1082,7 +1115,8 @@ class TriggerProcessor(
 
         return finalizeModalTrigger(
             state, ability, outerTargets, outerTargetRequirements,
-            modes, chosenModeIndices, targetsAccum, causedByAttack
+            modes, chosenModeIndices, targetsAccum, causedByAttack,
+            recordChosenModesOnSource, recordChosenModesThisTurn
         )
     }
 
@@ -1101,8 +1135,27 @@ class TriggerProcessor(
         modes: List<com.wingedsheep.sdk.scripting.effects.Mode>,
         chosenModeIndices: List<Int>,
         resolvedModeTargets: List<List<com.wingedsheep.engine.state.components.stack.ChosenTarget>>,
-        causedByAttack: Boolean
+        causedByAttack: Boolean,
+        recordChosenModesOnSource: Boolean,
+        recordChosenModesThisTurn: Boolean
     ): ExecutionResult {
+        if (chosenModeIndices.isEmpty()) {
+            // CR 603.3c — no mode was chosen, so the ability never reaches the stack. Either every
+            // mode was illegal, a "choose up to X" cap evaluated to 0, or the player declined all
+            // of an optional set of picks.
+            return modalTriggerRemovedFromStack(state, ability, "No mode was chosen")
+        }
+
+        // "…that hasn't been chosen (this turn)": commit the picks to the source's memory now that
+        // they're final, so the next trigger of this same object offers what's left.
+        val stateWithMemory = chosenModeIndices.fold(state) { acc, modeIndex ->
+            ChosenModeMemory.record(
+                acc, ability.sourceId, modeIndex,
+                ever = recordChosenModesOnSource,
+                thisTurn = recordChosenModesThisTurn
+            )
+        }
+
         val component = ability.copy(
             chosenModes = chosenModeIndices,
             modeTargetsOrdered = resolvedModeTargets,
@@ -1113,7 +1166,7 @@ class TriggerProcessor(
             chosenModeIndices.flatMap { modes[it].targetRequirements }
 
         return stackResolver.putTriggeredAbility(
-            state, component, flatTargets,
+            stateWithMemory, component, flatTargets,
             targetRequirements = flatRequirements,
             causedByAttack = causedByAttack
         )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.EntitySnapshot
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -486,5 +487,74 @@ data class EffectContext(
             }
             return result
         }
+
+        /**
+         * Build the execution context for a triggered ability sitting on the stack.
+         *
+         * Shared by the two places that need to evaluate the ability's own text against the game
+         * state: [com.wingedsheep.engine.mechanics.stack.StackResolver] when the ability resolves,
+         * and [com.wingedsheep.engine.event.TriggerProcessor] when it resolves a modal
+         * `dynamicChooseCount` as the ability goes onto the stack (CR 603.3c). Both must see the
+         * same trigger payload — an `xValue`, a `MODES_CHOSEN_ON_TRIGGERING_SPELL` count or a
+         * carried pipeline collection that only one of them populated would read as zero/absent.
+         */
+        fun forTriggeredAbility(
+            ability: TriggeredAbilityOnStackComponent,
+            targets: List<ChosenTarget> = emptyList(),
+            targetRequirements: List<TargetRequirement> = emptyList()
+        ): EffectContext = EffectContext(
+            sourceId = ability.sourceId,
+            controllerId = ability.controllerId,
+            granterId = ability.granterId,
+            abilityIdentity = ability.abilityIdentity,
+            targets = targets,
+            triggerDamageAmount = ability.triggerDamageAmount,
+            triggerCounterCount = ability.triggerCounterCount,
+            triggerTotalCounterCount = ability.triggerTotalCounterCount,
+            triggerLastKnownCounters = ability.triggerLastKnownCounters,
+            triggerLastKnownDamageDealtByPlayers = ability.triggerLastKnownDamageDealtByPlayers,
+            triggerLastKnownBlockingOrBlockedByIds = ability.triggerLastKnownBlockingOrBlockedByIds,
+            triggeringEntityId = ability.triggeringEntityId,
+            triggeringPlayerId = ability.triggeringPlayerId,
+            targetingSourceEntityId = ability.targetingSourceEntityId,
+            triggerUnattachedFromEntityId = ability.triggerUnattachedFromEntityId,
+            triggerLastKnownPower = ability.lastKnownPower,
+            triggerLastKnownToughness = ability.lastKnownToughness,
+            triggerDiedBatchTotalPower = ability.diedBatchTotalPower,
+            enchantedCreatureLastKnownPower = ability.enchantedCreatureLastKnownPower,
+            triggerModesChosenCount = ability.triggerModesChosenCount,
+            triggerScryCount = ability.triggerScryCount,
+            triggerDiscardCount = ability.triggerDiscardCount,
+            triggerDiscoverValue = ability.triggerDiscoverValue,
+            triggerExcessDamageAmount = ability.triggerExcessDamageAmount,
+            triggerRecipientToughness = ability.triggerRecipientToughness,
+            triggerManaSpentOnTriggeringSpell = ability.triggerManaSpentOnTriggeringSpell,
+            triggerColorsSpentOnTriggeringSpell = ability.triggerColorsSpentOnTriggeringSpell,
+            triggerManaValueOfTriggeringSpell = ability.triggerManaValueOfTriggeringSpell,
+            triggerXValueOfTriggeringSpell = ability.triggerXValueOfTriggeringSpell,
+            xValue = ability.xValue,
+            damageDistribution = ability.damageDistribution,
+            chosenModes = ability.chosenModes,
+            modeTargetsOrdered = ability.modeTargetsOrdered,
+            modeTargetRequirements = ability.modeTargetRequirements,
+            pipeline = PipelineState(
+                namedTargets = buildNamedTargets(targetRequirements, targets) +
+                    (ability.carriedPipeline?.namedTargets ?: emptyMap()),
+                // Expose a batch trigger's captured permanents (the matching members of a
+                // PermanentsEnteredEvent batch) so a ForEachInCollectionEffect payoff can iterate
+                // them — "for each of them, create a tapped copy of it" (Kambal). The copy executor
+                // reads each entity at resolution, so any that left the battlefield meanwhile no-op.
+                storedCollections = (if (ability.capturedEntityIds.isNotEmpty()) {
+                    mapOf(PipelineState.TRIGGER_CAPTURED_COLLECTION to ability.capturedEntityIds)
+                } else emptyMap()) + (ability.carriedPipeline?.storedCollections ?: emptyMap()),
+                // A `ReflexiveTriggerEffect`'s action half (e.g. `Amass`, a discard) may have stashed
+                // subtype groups or scalar values the reflexive effect reads (CR 603.12) — carried
+                // across the stack round-trip since this ability builds a fresh context on resolve.
+                storedSubtypeGroups = ability.carriedPipeline?.storedSubtypeGroups ?: emptyMap(),
+                chosenValues = ability.carriedPipeline?.chosenValues ?: emptyMap(),
+                storedNumbers = ability.carriedPipeline?.storedNumbers ?: emptyMap(),
+                storedStringLists = ability.carriedPipeline?.storedStringLists ?: emptyMap()
+            )
+        )
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
+import com.wingedsheep.engine.mechanics.modal.ChosenModeMemory
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
@@ -79,15 +80,11 @@ class ModalAndCloneContinuationResumer(
         // on the source so later triggers exclude it. Persists for the source's lifetime.
         // Turn-scoped sibling (Breeches, Eager Pillager): record on a component cleared at end
         // of turn instead, so the exclusion resets next turn.
-        var stateAfterRecord = state
-        if (continuation.sourceId != null) {
-            if (continuation.recordChosenModesOnSource) {
-                stateAfterRecord = recordChosenMode(stateAfterRecord, continuation.sourceId, originalModeIndex)
-            }
-            if (continuation.recordChosenModesThisTurn) {
-                stateAfterRecord = recordChosenModeThisTurn(stateAfterRecord, continuation.sourceId, originalModeIndex)
-            }
-        }
+        val stateAfterRecord = ChosenModeMemory.record(
+            state, continuation.sourceId, originalModeIndex,
+            ever = continuation.recordChosenModesOnSource,
+            thisTurn = continuation.recordChosenModesThisTurn
+        )
 
         // More modes still need to be picked — present the next ChooseOptionDecision.
         if (newSelectedIndices.size < continuation.chooseCount && newAvailableIndices.isNotEmpty()) {
@@ -132,35 +129,6 @@ class ModalAndCloneContinuationResumer(
         }
 
         return resolveChosenModes(stateAfterRecord, continuation, newSelectedIndices, checkForMore)
-    }
-
-    /**
-     * Record a chosen mode index on the source's
-     * [com.wingedsheep.engine.state.components.battlefield.ChosenModesEverComponent]
-     * for "choose one that hasn't been chosen" effects (Gandalf the Grey).
-     */
-    private fun recordChosenMode(state: GameState, sourceId: EntityId, modeIndex: Int): GameState {
-        if (state.getEntity(sourceId) == null) return state
-        return state.updateEntity(sourceId) { c ->
-            val existing = c.get<com.wingedsheep.engine.state.components.battlefield.ChosenModesEverComponent>()
-                ?: com.wingedsheep.engine.state.components.battlefield.ChosenModesEverComponent()
-            c.with(existing.withChosen(modeIndex))
-        }
-    }
-
-    /**
-     * Record a chosen mode index on the source's
-     * [com.wingedsheep.engine.state.components.battlefield.ChosenModesThisTurnComponent]
-     * for "choose one that hasn't been chosen this turn" effects (Breeches, Eager Pillager).
-     * The component is cleared at end of turn by CleanupPhaseManager.
-     */
-    private fun recordChosenModeThisTurn(state: GameState, sourceId: EntityId, modeIndex: Int): GameState {
-        if (state.getEntity(sourceId) == null) return state
-        return state.updateEntity(sourceId) { c ->
-            val existing = c.get<com.wingedsheep.engine.state.components.battlefield.ChosenModesThisTurnComponent>()
-                ?: com.wingedsheep.engine.state.components.battlefield.ChosenModesThisTurnComponent()
-            c.with(existing.withChosen(modeIndex))
-        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ModalTriggerContinuationResumer.kt
@@ -65,11 +65,16 @@ class ModalTriggerContinuationResumer(
                 ability = continuation.ability,
                 outerTargets = continuation.outerTargets,
                 outerTargetRequirements = continuation.outerTargetRequirements,
+                // `chooseCount` / `minChooseCount` are the already-resolved effective counts, so a
+                // "choose up to X" cap is not re-evaluated between picks; `dynamicChooseCount` is
+                // deliberately left null here for that reason.
                 modal = ModalEffect(
                     modes = continuation.modes,
                     chooseCount = continuation.chooseCount,
                     minChooseCount = continuation.minChooseCount,
-                    allowRepeat = continuation.allowRepeat
+                    allowRepeat = continuation.allowRepeat,
+                    excludePreviouslyChosenModes = continuation.recordChosenModesOnSource,
+                    excludeModesChosenThisTurn = continuation.recordChosenModesThisTurn
                 ),
                 selectedModeIndices = newSelected,
                 availableIndices = nextAvailable,
@@ -86,7 +91,9 @@ class ModalTriggerContinuationResumer(
             chosenModeIndices = newSelected,
             resolvedModeTargets = emptyList(),
             currentOrdinal = 0,
-            causedByAttack = continuation.causedByAttack
+            causedByAttack = continuation.causedByAttack,
+            recordChosenModesOnSource = continuation.recordChosenModesOnSource,
+            recordChosenModesThisTurn = continuation.recordChosenModesThisTurn
         ).thenCheckForMore(checkForMore)
     }
 
@@ -114,7 +121,9 @@ class ModalTriggerContinuationResumer(
             chosenModeIndices = continuation.chosenModeIndices,
             resolvedModeTargets = continuation.resolvedModeTargets + listOf(chosenTargets),
             currentOrdinal = continuation.currentOrdinal + 1,
-            causedByAttack = continuation.causedByAttack
+            causedByAttack = continuation.causedByAttack,
+            recordChosenModesOnSource = continuation.recordChosenModesOnSource,
+            recordChosenModesThisTurn = continuation.recordChosenModesThisTurn
         ).thenCheckForMore(checkForMore)
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ModalEffectExecutor.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.mechanics.modal.ChosenModeMemory
 import com.wingedsheep.engine.mechanics.targeting.TargetValidator
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -31,12 +32,18 @@ import kotlin.reflect.KClass
  *   Per-mode Rule 608.2b re-validation is applied against
  *   [SpellOnStackComponent.modeTargetRequirements].
  *
- * - **Resolution-time mode picking** (modal triggered / activated abilities, rule 603.3c):
- *   triggered abilities like Manifold Mouse's BeginCombat trigger and Warren Warleader's
- *   attack trigger don't go through the cast pipeline, so they arrive here with
- *   `chosenModes` empty. The executor presents a [ChooseOptionDecision] inline, pushes
- *   [ModalContinuation], and the modal-and-clone resumer drives target selection via
- *   `processChosenModeQueue`.
+ * - **Resolution-time mode picking**: whatever arrives here with `chosenModes` empty. The executor
+ *   presents a [ChooseOptionDecision] inline, pushes [ModalContinuation], and the modal-and-clone
+ *   resumer drives target selection via `processChosenModeQueue`. Two populations still take this
+ *   path:
+ *   - modal **activated** abilities, which don't go through the cast pipeline; and
+ *   - a [ModalEffect] **nested inside another effect** — inside a gated effect, a reflexive
+ *     trigger, a pipeline step — where the mode question isn't the spell's or ability's own.
+ *
+ *   Modal *triggered* abilities do **not**: their top-level modes and per-mode targets are picked
+ *   as the ability is put onto the stack (CR 603.3c / 700.2b, and 603.3d for the targets) by
+ *   [com.wingedsheep.engine.event.TriggerProcessor], so they reach this executor pre-chosen just
+ *   like a cast spell.
  *
  * @param effectExecutor Function to execute a sub-effect (provided by registry)
  */
@@ -91,16 +98,7 @@ class ModalEffectExecutor(
         // (Breeches, Eager Pillager — turn-scoped): exclude any mode this source has already
         // chosen, recorded in a per-source memory component. If every mode has been chosen, the
         // ability has no legal mode and does nothing.
-        val sourceEntity = context.sourceId?.let { state.getEntity(it) }
-        val alreadyChosenEver: Set<Int> = if (effect.excludePreviouslyChosenModes) {
-            sourceEntity?.get<com.wingedsheep.engine.state.components.battlefield.ChosenModesEverComponent>()
-                ?.modeIndices ?: emptySet()
-        } else emptySet()
-        val alreadyChosenThisTurn: Set<Int> = if (effect.excludeModesChosenThisTurn) {
-            sourceEntity?.get<com.wingedsheep.engine.state.components.battlefield.ChosenModesThisTurnComponent>()
-                ?.modeIndices ?: emptySet()
-        } else emptySet()
-        val alreadyChosen: Set<Int> = alreadyChosenEver + alreadyChosenThisTurn
+        val alreadyChosen = ChosenModeMemory.excludedFor(state, context.sourceId, effect)
 
         val availableIndices = effect.modes.indices.filter { it !in alreadyChosen }
         if (availableIndices.isEmpty()) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/modal/ChosenModeMemory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/modal/ChosenModeMemory.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.mechanics.modal
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ChosenModesEverComponent
+import com.wingedsheep.engine.state.components.battlefield.ChosenModesThisTurnComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+
+/**
+ * Per-source memory of which modes a modal ability has already chosen — the state behind
+ * [ModalEffect.excludePreviouslyChosenModes] ("choose one that hasn't been chosen", game-scoped,
+ * Gandalf the Grey) and [ModalEffect.excludeModesChosenThisTurn] ("…this turn", turn-scoped,
+ * Breeches / Eager Pillager).
+ *
+ * The memory is keyed to the source *object* (CR 700.4 object identity), so two copies of the same
+ * permanent track their choices independently and a permanent that leaves and returns starts fresh.
+ * The turn-scoped component is cleared each cleanup step by
+ * [com.wingedsheep.engine.core.CleanupPhaseManager].
+ *
+ * Two pickers read and write through here so they can never disagree about what a source remembers:
+ * the put-on-stack picker for modal *triggered* abilities
+ * ([com.wingedsheep.engine.event.TriggerProcessor], CR 603.3c) and the resolution-time picker
+ * ([com.wingedsheep.engine.handlers.effects.composite.ModalEffectExecutor]) that still serves modal
+ * activated abilities and modals nested inside another effect.
+ */
+object ChosenModeMemory {
+
+    /**
+     * Mode indices of [modal] that [sourceId] must not be offered again. Empty when [modal] asks
+     * for no memory at all, or when the source is gone.
+     */
+    fun excludedFor(state: GameState, sourceId: EntityId?, modal: ModalEffect): Set<Int> {
+        if (!modal.excludePreviouslyChosenModes && !modal.excludeModesChosenThisTurn) return emptySet()
+        val container = sourceId?.let { state.getEntity(it) } ?: return emptySet()
+        val ever = if (modal.excludePreviouslyChosenModes) {
+            container.get<ChosenModesEverComponent>()?.modeIndices ?: emptySet()
+        } else emptySet()
+        val thisTurn = if (modal.excludeModesChosenThisTurn) {
+            container.get<ChosenModesThisTurnComponent>()?.modeIndices ?: emptySet()
+        } else emptySet()
+        return ever + thisTurn
+    }
+
+    /**
+     * Record [modeIndex] against [sourceId] in whichever memories the caller asked for. A no-op
+     * when neither flag is set or the source has already left the battlefield — the memory only
+     * exists to narrow *that object's* later offers.
+     */
+    fun record(
+        state: GameState,
+        sourceId: EntityId?,
+        modeIndex: Int,
+        ever: Boolean,
+        thisTurn: Boolean
+    ): GameState {
+        if (!ever && !thisTurn) return state
+        if (sourceId == null || state.getEntity(sourceId) == null) return state
+        return state.updateEntity(sourceId) { container ->
+            var updated = container
+            if (ever) {
+                val existing = updated.get<ChosenModesEverComponent>() ?: ChosenModesEverComponent()
+                updated = updated.with(existing.withChosen(modeIndex))
+            }
+            if (thisTurn) {
+                val existing = updated.get<ChosenModesThisTurnComponent>() ?: ChosenModesThisTurnComponent()
+                updated = updated.with(existing.withChosen(modeIndex))
+            }
+            updated
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2477,59 +2477,10 @@ class StackResolver(
         // Execute the effect
         val resolvedTargets2 = targetsComponent?.targets ?: emptyList()
         val targetReqs = targetsComponent?.targetRequirements ?: emptyList()
-        val context = EffectContext(
-            sourceId = abilityComponent.sourceId,
-            controllerId = abilityComponent.controllerId,
-            granterId = abilityComponent.granterId,
-            abilityIdentity = abilityComponent.abilityIdentity,
+        val context = EffectContext.forTriggeredAbility(
+            abilityComponent,
             targets = resolvedTargets2,
-            triggerDamageAmount = abilityComponent.triggerDamageAmount,
-            triggerCounterCount = abilityComponent.triggerCounterCount,
-            triggerTotalCounterCount = abilityComponent.triggerTotalCounterCount,
-            triggerLastKnownCounters = abilityComponent.triggerLastKnownCounters,
-            triggerLastKnownDamageDealtByPlayers = abilityComponent.triggerLastKnownDamageDealtByPlayers,
-            triggerLastKnownBlockingOrBlockedByIds = abilityComponent.triggerLastKnownBlockingOrBlockedByIds,
-            triggeringEntityId = abilityComponent.triggeringEntityId,
-            triggeringPlayerId = abilityComponent.triggeringPlayerId,
-            targetingSourceEntityId = abilityComponent.targetingSourceEntityId,
-            triggerUnattachedFromEntityId = abilityComponent.triggerUnattachedFromEntityId,
-            triggerLastKnownPower = abilityComponent.lastKnownPower,
-            triggerLastKnownToughness = abilityComponent.lastKnownToughness,
-            triggerDiedBatchTotalPower = abilityComponent.diedBatchTotalPower,
-            enchantedCreatureLastKnownPower = abilityComponent.enchantedCreatureLastKnownPower,
-            triggerModesChosenCount = abilityComponent.triggerModesChosenCount,
-            triggerScryCount = abilityComponent.triggerScryCount,
-            triggerDiscardCount = abilityComponent.triggerDiscardCount,
-            triggerDiscoverValue = abilityComponent.triggerDiscoverValue,
-            triggerExcessDamageAmount = abilityComponent.triggerExcessDamageAmount,
-            triggerRecipientToughness = abilityComponent.triggerRecipientToughness,
-            triggerManaSpentOnTriggeringSpell = abilityComponent.triggerManaSpentOnTriggeringSpell,
-            triggerColorsSpentOnTriggeringSpell = abilityComponent.triggerColorsSpentOnTriggeringSpell,
-            triggerManaValueOfTriggeringSpell = abilityComponent.triggerManaValueOfTriggeringSpell,
-            triggerXValueOfTriggeringSpell = abilityComponent.triggerXValueOfTriggeringSpell,
-            xValue = abilityComponent.xValue,
-            damageDistribution = abilityComponent.damageDistribution,
-            chosenModes = abilityComponent.chosenModes,
-            modeTargetsOrdered = abilityComponent.modeTargetsOrdered,
-            modeTargetRequirements = abilityComponent.modeTargetRequirements,
-            pipeline = PipelineState(
-                namedTargets = EffectContext.buildNamedTargets(targetReqs, resolvedTargets2) +
-                    (abilityComponent.carriedPipeline?.namedTargets ?: emptyMap()),
-                // Expose a batch trigger's captured permanents (the matching members of a
-                // PermanentsEnteredEvent batch) so a ForEachInCollectionEffect payoff can iterate
-                // them — "for each of them, create a tapped copy of it" (Kambal). The copy executor
-                // reads each entity at resolution, so any that left the battlefield meanwhile no-op.
-                storedCollections = (if (abilityComponent.capturedEntityIds.isNotEmpty()) {
-                    mapOf(PipelineState.TRIGGER_CAPTURED_COLLECTION to abilityComponent.capturedEntityIds)
-                } else emptyMap()) + (abilityComponent.carriedPipeline?.storedCollections ?: emptyMap()),
-                // A `ReflexiveTriggerEffect`'s action half (e.g. `Amass`, a discard) may have stashed
-                // subtype groups or scalar values the reflexive effect reads (CR 603.12) — carried
-                // across the stack round-trip since this ability builds a fresh context on resolve.
-                storedSubtypeGroups = abilityComponent.carriedPipeline?.storedSubtypeGroups ?: emptyMap(),
-                chosenValues = abilityComponent.carriedPipeline?.chosenValues ?: emptyMap(),
-                storedNumbers = abilityComponent.carriedPipeline?.storedNumbers ?: emptyMap(),
-                storedStringLists = abilityComponent.carriedPipeline?.storedStringLists ?: emptyMap()
-            )
+            targetRequirements = targetReqs
         )
 
         val effectResult = effectHandler.execute(state, abilityComponent.effect, context)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BejeweledWargScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BejeweledWargScenarioTest.kt
@@ -29,10 +29,9 @@ class BejeweledWargScenarioTest : ScenarioTestBase() {
     /**
      * Push through blockers and combat damage until the trigger's mode decision surfaces.
      *
-     * Note the engine picks the mode of a modal *ability* at resolution
-     * ([ChooseOptionDecision], `phase = RESOLUTION`) rather than as the ability is put onto the
-     * stack. That is the shared behaviour of every modal triggered ability here (Kutzil's Flanker,
-     * Breeches), not something this card introduces.
+     * The mode arrives as the ability is put onto the stack (CR 603.3c), so the
+     * [ChooseOptionDecision] carries `phase = TRIGGER` and the ability is not on the stack yet when
+     * it is answered — see `ModalTriggeredAbilityOnStackTest` for the guarantee itself.
      */
     private fun advanceToModeDecision(game: TestGame): ChooseOptionDecision {
         var blockersDeclared = false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreechesEagerPillagerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreechesEagerPillagerScenarioTest.kt
@@ -78,12 +78,10 @@ class BreechesEagerPillagerScenarioTest : ScenarioTestBase() {
             first.options.size shouldBe 3
             first.options shouldContain treasureMode
             game.chooseMode(first, treasureMode)
-            withClue("Treasure mode created a Treasure token") {
-                game.treasureCount() shouldBe 1
-            }
 
-            // Second trigger (the other Pirate): the Treasure mode was already chosen THIS TURN,
-            // so only the remaining two modes are offered.
+            // Second trigger (the other Pirate): both triggers go on the stack before either
+            // resolves, and each announces its mode as it is put there (CR 603.3c), so the Treasure
+            // mode is already spent for this turn and only the remaining two are offered.
             val second = game.resolveToModeChoice()
             second.options.size shouldBe 2
             second.options shouldNotContain treasureMode
@@ -94,7 +92,7 @@ class BreechesEagerPillagerScenarioTest : ScenarioTestBase() {
             game.selectTargets(listOf(bears)).error shouldBe null
             game.resolveStack()
 
-            withClue("still only one Treasure — the second trigger did not re-create one") {
+            withClue("the Treasure mode resolved exactly once — the second trigger took another mode") {
                 game.treasureCount() shouldBe 1
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BumiKingOfThreeTrialsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BumiKingOfThreeTrialsScenarioTest.kt
@@ -111,8 +111,8 @@ class BumiKingOfThreeTrialsScenarioTest : ScenarioTestBase() {
         test("regression: choosing scry then Earthbend — the scry's mid-resolution pause must not drop the Earthbend mode") {
             // The bug: with scry chosen before Earthbend, the scry mode paused mid-resolution for
             // its reorder decision, and the remaining Earthbend mode was silently dropped — the
-            // player never got to target a land. A ModalChosenModeTailContinuation now sits beneath
-            // the scry's pause so the queue resumes afterward.
+            // Earthbend never applied. A ModalPreChosenContinuation now sits beneath the scry's
+            // pause so the mode queue resumes afterward.
             val game = scenario()
                 .withPlayers("Alice", "Bob")
                 .withCardInHand(1, "Bumi, King of Three Trials")
@@ -130,26 +130,27 @@ class BumiKingOfThreeTrialsScenarioTest : ScenarioTestBase() {
             if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
             game.resolveStack()
 
-            // X = 2 → two picks. Choose scry FIRST, then Earthbend.
+            // X = 2 → two picks. Choose scry FIRST, then Earthbend. Modes and per-mode targets are
+            // all settled as the trigger goes on the stack (CR 603.3c–d), so both target decisions
+            // come before anything resolves: the scry mode's player, then Earthbend's land.
             game.chooseModeContaining(scryMode)
             game.chooseModeContaining(earthbendMode)
 
             // Scry mode's player target (two players → an explicit target decision).
             game.selectTargets(listOf(game.player1Id)).error shouldBe null
 
-            // Scry pauses mid-resolution: first choose none of the looked-at cards to put on
-            // the bottom, then keep the remaining cards in their current order on top.
+            val earthbendTarget = game.getPendingDecision()
+            earthbendTarget.shouldNotBeNull()
+            earthbendTarget.shouldBeInstanceOf<ChooseTargetsDecision>()
+            val land = game.findPermanents("Forest").first()
+            game.selectTargets(listOf(land)).error shouldBe null
+
+            // Now the ability resolves. Scry pauses mid-resolution: first choose none of the
+            // looked-at cards to put on the bottom, then keep the remaining cards on top.
+            game.resolveStack()
             game.getPendingDecision().shouldNotBeNull()
             game.skipSelection()
             game.keepLibraryOrder()
-
-            // The Earthbend mode survived the scry pause and now demands its land target.
-            val afterScry = game.getPendingDecision()
-            afterScry.shouldNotBeNull()
-            afterScry.shouldBeInstanceOf<ChooseTargetsDecision>()
-
-            val land = game.findPermanents("Forest").first()
-            game.selectTargets(listOf(land)).error shouldBe null
             game.resolveStack()
 
             // Earthbend applied: the chosen land is now a 3/3 creature-land with haste.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FelidarRetreatScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FelidarRetreatScenarioTest.kt
@@ -39,16 +39,23 @@ class FelidarRetreatScenarioTest : FunSpec({
         return driver
     }
 
-    /** Play a land from hand and pick [modeIndex] on the landfall trigger. */
+    /**
+     * Play a land from hand and pick [modeIndex] on the landfall trigger.
+     *
+     * The mode is announced as the trigger is *put onto the stack* (CR 603.3c), so the decision is
+     * already pending when `playLand` returns — before either player gets priority. Only once it is
+     * answered does passing priority resolve the ability.
+     */
     fun triggerLandfall(driver: GameTestDriver, player: EntityId, modeIndex: Int) {
         val land = driver.putCardInHand(player, "Forest")
         val play = driver.playLand(player, land)
         withClue("playing the land should succeed: ${play.error}") { play.error shouldBe null }
-        driver.bothPass()
 
         val decision = driver.pendingDecision as? ChooseOptionDecision
             ?: error("expected a mode choice for the landfall trigger; got ${driver.pendingDecision}")
         driver.submitDecision(player, OptionChosenResponse(decision.id, optionIndex = modeIndex))
+
+        driver.bothPass()
     }
 
     fun plusOneCounters(driver: GameTestDriver, id: EntityId): Int =

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LordSkittersButcherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LordSkittersButcherScenarioTest.kt
@@ -31,6 +31,13 @@ class LordSkittersButcherScenarioTest : ScenarioTestBase() {
                 .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                 .build()
 
+            /**
+             * Cast the Butcher, answer the ETB's mode question, then let the ability resolve.
+             *
+             * The mode is picked as the trigger goes on the stack (CR 603.3c), so answering it only
+             * gets the ability *onto* the stack — the trailing `resolveStack` is what runs the chosen
+             * mode, and it stops early if that mode needs a decision of its own.
+             */
             fun ScenarioTestBase.TestGame.castAndChooseMode(index: Int) {
                 castSpell(1, "Lord Skitter's Butcher").error shouldBe null
                 if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
@@ -38,12 +45,12 @@ class LordSkittersButcherScenarioTest : ScenarioTestBase() {
                 val modeDecision = getPendingDecision() as? ChooseOptionDecision
                     ?: error("expected a ChooseOptionDecision for the ETB; got ${getPendingDecision()}")
                 submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = index))
+                resolveStack()
             }
 
             test("mode 0 creates a Rat token") {
                 val game = butcherGame()
                 game.castAndChooseMode(0)
-                game.resolveStack()
 
                 game.findAllPermanents("Rat Token").size shouldBe 1
             }
@@ -99,7 +106,6 @@ class LordSkittersButcherScenarioTest : ScenarioTestBase() {
             test("mode 2 gives your creatures menace until end of turn") {
                 val game = butcherGame()
                 game.castAndChooseMode(2)
-                game.resolveStack()
 
                 val bears = game.findPermanent("Grizzly Bears")!!
                 game.state.projectedState.hasKeyword(bears, Keyword.MENACE) shouldBe true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalTriggeredAbilityOnStackTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalTriggeredAbilityOnStackTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * A modal *triggered* ability announces its mode as the ability is put onto the stack
+ * (CR 603.3c / 700.2b), and CR 603.3d sends its per-mode targets the same way (via 601.2c–d) — none
+ * of it waits for resolution.
+ *
+ * That ordering is the point: by the time anybody holds priority the ability is already on the stack
+ * with `chosenModes` filled in, so an opponent decides whether to respond knowing *which* mode they
+ * are responding to. Picking the mode at resolution instead would show them an opaque trigger and
+ * hand them the mode only once it was too late to act on it.
+ *
+ * Per-card behaviour lives in each card's own scenario test (Bumi, King of Three Trials for the
+ * "choose up to X" runtime cap; Breeches, Eager Pillager for "…that hasn't been chosen this turn";
+ * Silent Hallcreeper for a mode that can't be chosen for want of a legal target). This file pins the
+ * shared guarantee, using Lord Skitter's Butcher — three modes, none of which targets, so nothing
+ * but the mode question itself is in play.
+ */
+class ModalTriggeredAbilityOnStackTest : ScenarioTestBase() {
+
+    /** The triggered abilities currently on the stack, innermost component only. */
+    private fun TestGame.triggeredAbilitiesOnStack(): List<TriggeredAbilityOnStackComponent> =
+        state.stack.mapNotNull { state.getEntity(it)?.get<TriggeredAbilityOnStackComponent>() }
+
+    /** Cast the Butcher and stop on its ETB mode question. */
+    private fun butcherAtModeQuestion(): Pair<TestGame, ChooseOptionDecision> {
+        val game = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "Lord Skitter's Butcher")
+            .withLandsOnBattlefield(1, "Swamp", 3)
+            .withCardInLibrary(1, "Swamp")
+            .withCardInLibrary(2, "Forest")
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .build()
+
+        game.castSpell(1, "Lord Skitter's Butcher").error shouldBe null
+        if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+        game.resolveStack()
+
+        val decision = game.getPendingDecision() as? ChooseOptionDecision
+            ?: error("expected the ETB mode question; got ${game.getPendingDecision()}")
+        return game to decision
+    }
+
+    init {
+        context("a modal triggered ability's mode is settled on the way to the stack") {
+
+            test("the mode question is not a resolution-time question") {
+                val (game, decision) = butcherAtModeQuestion()
+
+                withClue("the ability is on its way to the stack, so the decision says so") {
+                    decision.context.phase shouldBe DecisionPhase.TRIGGER
+                }
+                withClue("and it is genuinely not on the stack yet — nothing to respond to") {
+                    game.triggeredAbilitiesOnStack().shouldBeEmpty()
+                }
+            }
+
+            test("answering it puts the ability on the stack with the mode baked in, unresolved") {
+                val (game, decision) = butcherAtModeQuestion()
+                val ratMode = decision.options.indexOfFirst { it.contains("Rat", ignoreCase = true) }
+                check(ratMode >= 0) { "Rat token mode not offered; options=${decision.options}" }
+
+                game.submitDecision(OptionChosenResponse(decision.id, optionIndex = ratMode))
+
+                val onStack = game.triggeredAbilitiesOnStack().single()
+                withClue("the chosen mode rides on the stack object (CR 603.3c)") {
+                    onStack.chosenModes shouldBe listOf(ratMode)
+                }
+                withClue("nothing has resolved — both players still get priority first") {
+                    game.findAllPermanents("Rat Token").shouldBeEmpty()
+                }
+
+                game.resolveStack()
+                withClue("and the chosen mode is what resolves") {
+                    game.findAllPermanents("Rat Token").size shouldBe 1
+                }
+            }
+
+            test("the opponent can read the chosen mode off the stack before responding") {
+                val (game, decision) = butcherAtModeQuestion()
+                val menaceMode = decision.options.indexOfFirst { it.contains("menace", ignoreCase = true) }
+                check(menaceMode >= 0) { "menace mode not offered; options=${decision.options}" }
+
+                game.submitDecision(OptionChosenResponse(decision.id, optionIndex = menaceMode))
+
+                val abilityId = game.state.stack.single()
+                val opponentView = game.getClientState(2).cards[abilityId]
+                    ?: error("the ability should be visible on the opponent's stack")
+                withClue("the opponent sees the mode, not an opaque trigger") {
+                    opponentView.chosenModeDescriptions.size shouldBe 1
+                    opponentView.chosenModeDescriptions.single()
+                        .contains("menace", ignoreCase = true) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SilentHallcreeperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SilentHallcreeperScenarioTest.kt
@@ -58,7 +58,10 @@ class SilentHallcreeperScenarioTest : FunSpec({
         }
         val choice = driver.pendingDecision as? ChooseOptionDecision
             ?: error("expected ChooseOptionDecision for the modal trigger; got ${driver.pendingDecision}")
-        choice.options.size shouldBe 3
+        // Only two of the three modes are offered: the Hallcreeper is the sole creature its
+        // controller has, so "another target creature you control" has no legal target and CR 603.3c
+        // forbids choosing that mode as the ability goes on the stack.
+        choice.options.size shouldBe 2
 
         val counterMode = "Put two +1/+1 counters on this creature"
         choice.options shouldContain counterMode


### PR DESCRIPTION
## What the report said, and what was actually true

> the engine picks the mode of a modal triggered ability at resolution (`ChooseOptionDecision`,
> `phase = RESOLUTION`) rather than as the ability is put onto the stack … This is shared by every
> modal triggered ability in the repo (Kutzil's Flanker, Breeches)

Half right, and the half that was wrong is worth stating plainly: a put-on-stack picker has existed
since `98df433e39`, and both **Bejeweled Warg** and **Kutzil's Flanker** already used it — they have
targeting modes, which was the gate. What made it look otherwise is that the decision it raises was
stamped `DecisionPhase.RESOLUTION`.

The underlying defect is real, though, and broader than the two cards named: the gate was
`modes.any { it.targetRequirements.isNotEmpty() }`, so **every modal trigger whose modes don't target
still picked at resolution** — Felidar Retreat, Lord Skitter's Butcher, Manifold Mouse, Riku, Bumi,
Breeches, Gandalf. CR 603.3c / 700.2b announce the mode as the ability is put onto the stack
regardless of targeting, and the reason matters beyond bookkeeping: an opponent held priority against
an opaque trigger and only learned which mode they'd been responding to once it was too late to act.

## The fix

`TriggerProcessor` now routes **any** top-level `ModalEffect` on a triggered ability through the
put-on-stack picker. That meant taking on the three shapes the old gate excluded as needing
resolution-time state:

- **`dynamicChooseCount`** ("choose up to X" — Riku, Bumi, The Ruinous Wrecking Crew) is evaluated
  once, against the state the ability is going onto the stack in, then fixed for the remaining picks
  (CR 601.2c, reached via 603.3d: the count doesn't drift). A cap of `0` chooses no mode, so the
  ability is removed from the stack — observationally the old no-op.
- **`excludePreviouslyChosenModes` / `excludeModesChosenThisTurn`** (Gandalf the Grey, Breeches) read
  the source's memory when building the offer and write it back once the picks are final. Writing at
  announce time is what makes two *simultaneous* triggers of one source pick different modes:
  Breeches announces both attack triggers' modes before either resolves, which is the card's actual
  ruling and was not achievable from the resolution-time path.
- **Non-targeting modes** simply no longer bail out.

Two supporting corrections:

- `finalizeModalTrigger` removes the ability from the stack when no mode was chosen (CR 603.3c),
  instead of putting it there with empty `chosenModes` — which would have dropped straight back into
  the resolution-time picker and re-asked the question. Latent before; live once `minChooseCount = 0`
  shapes reached this path.
- The mode and per-mode target decisions now carry `DecisionPhase.TRIGGER`. That's the label whose
  absence produced the original report. Only `COMBAT` is branched on client-side, so nothing renders
  differently.

`ModalEffectExecutor`'s resolution-time path stays, and is now documented for what it actually
serves: modal **activated** abilities, and a `ModalEffect` **nested inside** another effect (gated
effect, reflexive trigger, pipeline step) where the mode question isn't the ability's own.

## Refactors carried along

- **`ChosenModeMemory`** — one place reading and writing `ChosenModesEverComponent` /
  `ChosenModesThisTurnComponent`, so the two pickers can't disagree about what a source remembers.
  Replaces a duplicated read in `ModalEffectExecutor` and two private writers in
  `ModalAndCloneContinuationResumer`.
- **`EffectContext.forTriggeredAbility`** — the ~55-line context builder previously inlined in
  `StackResolver`. The dynamic cap has to be evaluated against the same trigger payload
  (`xValue`, `MODES_CHOSEN_ON_TRIGGERING_SPELL`, carried pipeline) the ability will resolve with; a
  hand-rolled partial context would have read those as zero/absent.

## Verification

`just build` — **green**: rules-engine 9646/0, ai 365/0, game-server 483/0, mtg-sets 338/0,
mtg-sdk 363/0. Rule numbers checked against the Comprehensive Rules text (603.3c, 603.3d, 700.2b,
601.2c), not from memory.

New `ModalTriggeredAbilityOnStackTest` pins the shared guarantee on Lord Skitter's Butcher — three
modes, none targeting, so only the mode question is in play: the decision is `phase = TRIGGER`, the
ability is genuinely *not* on the stack when it's asked, answering it puts it there with
`chosenModes` filled in and nothing resolved, and the opponent's client view shows the chosen mode
text before they respond.

Eight existing tests changed, all of it the intended reordering:

| Test | Change |
|---|---|
| Felidar Retreat (×3) | mode answered right after the land is played, before priority |
| Lord Skitter's Butcher (×2) | `resolveStack()` after the mode, since the mode no longer executes inline |
| Breeches | both triggers announce before either resolves; Treasure asserted after resolution |
| Bumi | both per-mode targets picked on the stack, then the scry's mid-resolution pause |
| Silent Hallcreeper | **behaviour change** — 2 modes offered, not 3 |

That last one is a genuine rules improvement rather than a test accommodation: with the Hallcreeper
as its controller's only creature, "another target creature you control" has no legal target, so
CR 603.3c forbids choosing that mode. The old resolution-time picker offered all three and let the
copy mode fizzle.

## Out of scope

Modal **activated** abilities still pick at resolution (CR 601.2b/700.2a want it at activation). Same
class of issue, different pipeline — worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
