### PR TITLE
Add Collective Brutality with non-mana escalate support

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/TargetSelection.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/TargetSelection.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.GameAction
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.legalactions.ModalLegalEnumeration
 import com.wingedsheep.engine.legalactions.TargetInfo
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -15,6 +16,7 @@ import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 
 /**
  * Picking targets for a spell or ability without simulating anything.
@@ -167,11 +169,56 @@ object TargetSelection {
             }
             orderedTargets += chosen
         }
-        return cast.copy(
+        val withModes = cast.copy(
             chosenModes = modes.map { it.index },
             modeTargetsOrdered = orderedTargets,
             targets = orderedTargets.flatten(),
         )
+        return payEscalateCost(state, withModes, modal, modes.size)
+    }
+
+    /**
+     * Pay a non-mana escalate cost (CR 702.120a) for the modes just chosen — one cost per mode
+     * beyond the first, so three modes on Collective Brutality discard two cards.
+     *
+     * The enumeration's cost data is for **one** extra mode; the cast handler validates the scaled
+     * total, so the count has to be multiplied here. `modalEnumeration.chooseCount` is already
+     * capped by what the caster can pay, so the candidate pool always covers the picks.
+     */
+    private fun payEscalateCost(
+        state: GameState,
+        cast: CastSpell,
+        modal: ModalLegalEnumeration,
+        chosenModeCount: Int,
+    ): CastSpell {
+        val info = modal.additionalCostPerExtraMode ?: return cast
+        val extraModes = chosenModeCount - 1
+        if (extraModes <= 0) return cast
+        val existing = cast.additionalCostPayment ?: AdditionalCostPayment()
+        val payment = when (info.costType) {
+            // Prefer lands as discard fodder, mirroring the activated-ability discard heuristic.
+            "DiscardCard" -> existing.copy(
+                discardedCards = info.validDiscardTargets
+                    .sortedByDescending { state.getEntity(it)?.get<CardComponent>()?.isLand == true }
+                    .take(info.discardCount * extraModes)
+            )
+            "TapPermanents" -> existing.copy(
+                tappedPermanents = info.validTapTargets.take(info.tapCount * extraModes)
+            )
+            "SacrificePermanent" -> existing.copy(
+                sacrificedPermanents = info.validSacrificeTargets.take(info.sacrificeCount * extraModes)
+            )
+            "BouncePermanent" -> existing.copy(
+                bouncedPermanents = info.validBounceTargets.take(info.bounceCount * extraModes)
+            )
+            "ExileFromGraveyard" -> existing.copy(
+                exiledCards = info.validExileTargets.take(info.exileMinCount * extraModes)
+            )
+            // A cost shape with no picker never reaches here: the enumerator caps chooseCount at 1
+            // for one, so extraModes is 0.
+            else -> return cast
+        }
+        return cast.copy(additionalCostPayment = payment)
     }
 
     /**

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7989,6 +7989,33 @@ spell {
 }
 ```
 
+**Escalate with a non-mana cost.** *"Escalate—Discard a card"* (Collective Brutality),
+*"Escalate—Tap an untapped creature you control"* (Collective Effort). Pass the payable thing as a
+`CostAtom` to `additionalCostPerExtraMode` instead:
+
+```kotlin
+spell {
+    modal(chooseCount = 3, minChooseCount = 1, additionalCostPerExtraMode = CostAtom.Discard(1)) {
+        mode("First mode") { effect = firstEffect }
+        …
+    }
+}
+```
+
+The engine charges it as **one scaled cost** — `atom.repeated(chosenModes.size - 1)`, so three modes
+owe `Discard(2)` — because every additional-cost payment channel is a flat list and two `Discard(1)`
+entries would both be satisfied by the same card. `CostAtom.repeated(times)` is the general
+"pay this cost N times over" operation (`scripting/costs/CostAtoms.kt`); it is exhaustive over the
+atom vocabulary, so a new atom is a compile error rather than a silent no-op.
+
+The cast surface follows: `CastSpellEnumerator` caps the offered `chooseCount` at
+`1 + (candidates / per-mode selection)` — one spare card in hand means at most two modes — and puts
+the per-extra-mode cost on `modalEnumeration.additionalCostPerExtraMode`. The client's mode panel
+names it, then an injected `escalateCost` pipeline phase opens the ordinary picker for that cost
+type with the count scaled by the modes just chosen. Supported cost shapes are the selection-bearing
+ones (`SelectionCostPresentation`): sacrifice, discard, tap, bounce, exile from graveyard; any other
+atom caps the spell at one mode rather than offering a mode that can never be paid for.
+
 **Tiered (CR 702.183) — `spell { tiered { } }`.** *"Tiered (Choose one additional cost.)"* is a
 choose-**one** modal spell where each tier carries its own additional mana cost, paid as you cast
 the spell (702.183a: *"Choose one. As an additional cost to cast this spell, pay the cost associated

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1186,6 +1186,7 @@ class SpellBuilder {
         minChooseCount: Int = chooseCount,
         allowRepeat: Boolean = false,
         additionalManaCostPerExtraMode: String? = null,
+        additionalCostPerExtraMode: com.wingedsheep.sdk.scripting.costs.CostAtom? = null,
         chooseAllIfBlightPaid: Boolean = false,
         dynamicChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null,
         init: ModalBuilder.() -> Unit
@@ -1195,6 +1196,7 @@ class SpellBuilder {
             minChooseCount,
             allowRepeat,
             additionalManaCostPerExtraMode,
+            additionalCostPerExtraMode,
             chooseAllIfBlightPaid,
             dynamicChooseCount
         )
@@ -1253,6 +1255,7 @@ class ModalBuilder(
     private val minChooseCount: Int = chooseCount,
     private val allowRepeat: Boolean = false,
     private val additionalManaCostPerExtraMode: String? = null,
+    private val additionalCostPerExtraMode: com.wingedsheep.sdk.scripting.costs.CostAtom? = null,
     private val chooseAllIfBlightPaid: Boolean = false,
     private val dynamicChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null
 ) {
@@ -1281,6 +1284,7 @@ class ModalBuilder(
             minChooseCount = minChooseCount,
             allowRepeat = allowRepeat,
             additionalManaCostPerExtraMode = additionalManaCostPerExtraMode,
+            additionalCostPerExtraMode = additionalCostPerExtraMode,
             chooseAllIfBlightPaid = chooseAllIfBlightPaid,
             dynamicChooseCount = dynamicChooseCount
         )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtoms.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/costs/CostAtoms.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.sdk.scripting.costs
+
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Operations over the shared [CostAtom] vocabulary.
+ */
+
+/**
+ * This atom as it reads when the same cost has to be paid [times] times over — "discard a card"
+ * paid twice is "discard two cards".
+ *
+ * Magic never asks for the same cost twice as two separate payments: CR 601.2f folds repeated
+ * costs into one total the player pays once, and every selection channel the engine carries a
+ * payment through ([com.wingedsheep.sdk.scripting.AdditionalCostPayment.discardedCards] and its
+ * siblings) is a single flat list. Two copies of `Discard(1)` in a cost list would therefore both
+ * be satisfied by one discarded card; one `Discard(2)` is the shape that validates and charges
+ * correctly.
+ *
+ * The caller with a repeated cost today is **escalate** (CR 702.120a) with a non-mana cost —
+ * `ModalEffect.additionalCostPerExtraMode`, paid once for each mode chosen beyond the first.
+ *
+ * `times = 0` yields a cost with nothing to pay, and `times = 1` returns the atom unchanged.
+ *
+ * @throws IllegalArgumentException for a [CostAtom.RemoveCounters] whose count is a runtime
+ *   [DynamicAmount] — a variable amount has no fixed number to multiply. No printed repeated cost
+ *   removes a variable number of counters.
+ */
+fun CostAtom.repeated(times: Int): CostAtom {
+    require(times >= 0) { "Cannot repeat a cost a negative number of times: $times" }
+    if (times == 1) return this
+    return when (this) {
+        is CostAtom.Mana -> copy(cost = cost * times)
+        is CostAtom.PayLife -> copy(amount = amount * times)
+        is CostAtom.Mill -> copy(count = count * times)
+        is CostAtom.Sacrifice -> copy(count = count * times)
+        is CostAtom.VariablePermanents -> copy(minCount = minCount * times)
+        is CostAtom.Discard -> copy(count = count * times)
+        is CostAtom.ExileFrom -> copy(count = count * times)
+        is CostAtom.TapPermanents -> copy(count = count * times)
+        is CostAtom.ReturnToHand -> copy(count = count * times)
+        is CostAtom.RemoveCounters -> {
+            val fixed = count as? DynamicAmount.Fixed
+                ?: throw IllegalArgumentException(
+                    "Cannot repeat a counter-removal cost with a variable count: $count"
+                )
+            copy(count = DynamicAmount.Fixed(fixed.amount * times))
+        }
+        is CostAtom.PutCountersOnSelf -> copy(count = count * times)
+        is CostAtom.RevealFromHand -> copy(count = count * times)
+    }
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -129,6 +129,13 @@ data class Mode(
  *           (rules 700.2d — Escalate/Spree-style).
  * @property additionalManaCostPerExtraMode Additional cost paid for each chosen mode beyond the
  *           first. Models escalate without assigning a cost to any particular printed mode.
+ * @property additionalCostPerExtraMode The non-mana sibling of [additionalManaCostPerExtraMode] —
+ *           escalate whose cost is a payable thing rather than mana ("Escalate—Discard a card",
+ *           Collective Brutality; "Escalate—Tap an untapped creature you control", Collective
+ *           Effort). Paid once for each mode chosen beyond the first, so with three modes chosen
+ *           the caster discards two cards. The engine charges it as a single scaled cost
+ *           (`atom.repeated(extraModes)`), which is what the flat payment channels can validate.
+ *           A card may carry both this and [additionalManaCostPerExtraMode]; no printed card does.
  */
 @SerialName("Modal")
 @Serializable
@@ -138,6 +145,7 @@ data class ModalEffect(
     val minChooseCount: Int = chooseCount,
     val allowRepeat: Boolean = false,
     val additionalManaCostPerExtraMode: String? = null,
+    val additionalCostPerExtraMode: com.wingedsheep.sdk.scripting.costs.CostAtom? = null,
     /**
      * If true, when this spell's `AdditionalCost.BlightOrPay` cost was paid via the
      * blight path, the effective number of modes the player must choose becomes

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/CollectiveBrutality.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/CollectiveBrutality.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Collective Brutality — Eldritch Moon #85.
+ *
+ * The escalate cost is a discard rather than mana, so it rides
+ * [com.wingedsheep.sdk.scripting.effects.ModalEffect.additionalCostPerExtraMode]: choosing two
+ * modes discards one card, choosing three discards two.
+ *
+ * The third mode is *not* a drain — the 2 life gained is independent of the life actually lost, so
+ * it stays a composite of a loss and a gain rather than `Effects.DrainLife`.
+ */
+val CollectiveBrutality = card("Collective Brutality") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Escalate—Discard a card. (Pay this cost for each mode chosen beyond the first.)\n" +
+        "Choose one or more —\n" +
+        "• Target opponent reveals their hand. You choose an instant or sorcery card from it. " +
+        "That player discards that card.\n" +
+        "• Target creature gets -2/-2 until end of turn.\n" +
+        "• Target opponent loses 2 life and you gain 2 life."
+
+    spell {
+        modal(
+            chooseCount = 3,
+            minChooseCount = 1,
+            additionalCostPerExtraMode = CostAtom.Discard(1),
+        ) {
+            mode("Target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card.") {
+                val opponent = target("reveal opponent", TargetOpponent())
+                effect = Effects.Composite(
+                    listOf(
+                        RevealHandEffect(opponent),
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                            storeAs = "opponentHand"
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "opponentHand",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                            chooser = Chooser.Controller,
+                            filter = GameObjectFilter.InstantOrSorcery,
+                            storeSelected = "toDiscard",
+                            prompt = "Choose an instant or sorcery card to discard",
+                            alwaysPrompt = true,
+                            showAllCards = true
+                        ),
+                        MoveCollectionEffect(
+                            from = "toDiscard",
+                            destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                            moveType = MoveType.Discard
+                        )
+                    )
+                )
+            }
+            mode("Target creature gets -2/-2 until end of turn.") {
+                val creature = target("weakened creature", TargetCreature())
+                effect = Effects.ModifyStats(-2, -2, creature)
+            }
+            mode("Target opponent loses 2 life and you gain 2 life.") {
+                val opponent = target("drained opponent", TargetOpponent())
+                effect = Effects.Composite(
+                    Effects.LoseLife(2, opponent),
+                    Effects.GainLife(2),
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "85"
+        artist = "Johann Bodin"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb94a02f-4660-45b6-8a39-941b710cf8f3.jpg?1783937489"
+        ruling("2016-07-13", "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes.")
+        ruling("2016-07-13", "You can't choose any one mode multiple times.")
+        ruling("2016-07-13", "If one target of an escalate spell becomes illegal, the other targets will still be affected. If all of the targets become illegal, the spell won't resolve.")
+        ruling("2016-07-13", "Effects that reduce the cost of spells reduce the total cost, including any escalate costs added.")
+        ruling("2016-07-13", "If an effect allows you to cast a spell that has escalate without paying its mana cost, you pay escalate costs for that spell if you choose more than one mode.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CollectiveBrutalityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CollectiveBrutalityReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Collective Brutality reprint in INR. Canonical CardDefinition lives in its earliest set (EMN). */
+val CollectiveBrutalityReprint = Printing(
+    oracleId = "22a78443-db21-4656-b38a-e3e3186fd94b",
+    name = "Collective Brutality",
+    setCode = "INR",
+    collectorNumber = "101",
+    scryfallId = "ae35b6c5-3bfd-483e-9c85-58629b717d7f",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/ae35b6c5-3bfd-483e-9c85-58629b717d7f.jpg?1783908148",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -756,6 +756,176 @@
     ]
 }
 
+// Collective Brutality
+{
+    "name": "Collective Brutality",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Escalate—Discard a card. (Pay this cost for each mode chosen beyond the first.)\nChoose one or more —\n• Target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card.\n• Target creature gets -2/-2 until end of turn.\n• Target opponent loses 2 life and you gain 2 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "RevealHand",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "reveal opponent"
+                                }
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "opponentHand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "opponentHand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "filter": "instant|sorcery",
+                                "storeSelected": "toDiscard",
+                                "prompt": "Choose an instant or sorcery card to discard",
+                                "showAllCards": true,
+                                "alwaysPrompt": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toDiscard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponent",
+                            "id": "reveal opponent"
+                        }
+                    ],
+                    "description": "Target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card."
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "weakened creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "weakened creature"
+                        }
+                    ],
+                    "description": "Target creature gets -2/-2 until end of turn."
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "drained opponent"
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponent",
+                            "id": "drained opponent"
+                        }
+                    ],
+                    "description": "Target opponent loses 2 life and you gain 2 life."
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1,
+            "additionalCostPerExtraMode": "AtomDiscard"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "rarity": "RARE",
+        "artist": "Johann Bodin",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb94a02f-4660-45b6-8a39-941b710cf8f3.jpg?1783937489",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "You choose all of your modes at once. You can't wait to perform one mode's actions and then decide to choose more modes."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "You can't choose any one mode multiple times."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "If one target of an escalate spell becomes illegal, the other targets will still be affected. If all of the targets become illegal, the spell won't resolve."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "Effects that reduce the cost of spells reduce the total cost, including any escalate costs added."
+            },
+            {
+                "date": "2016-07-13",
+                "text": "If an effect allows you to cast a spell that has escalate without paying its mana cost, you pay escalate costs for that spell if you choose more than one mode."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Collective Defiance
 {
     "name": "Collective Defiance",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.core.ManaSpentEvent
 import com.wingedsheep.engine.mechanics.DisturbCasts
 import com.wingedsheep.engine.mechanics.EmergeCasts
+import com.wingedsheep.engine.mechanics.EscalateCosts
 import com.wingedsheep.engine.mechanics.FlashbackGrants
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.mechanics.MayhemGrants
@@ -1487,6 +1488,11 @@ class CastSpellHandler(
         return payment.distributedCounterRemovals
     }
 
+    /**
+     * The additional costs a modal spell owes for the modes it chose: per-mode overrides where the
+     * chosen modes declare them (rule 700.2h — they stack), card-level costs otherwise, plus the
+     * non-mana escalate cost when the card has one ([EscalateCosts.additionalCostFor]).
+     */
     private fun resolveAdditionalCostsForMode(
         cardDef: com.wingedsheep.sdk.model.CardDefinition,
         action: CastSpell
@@ -1497,8 +1503,9 @@ class CastSpellHandler(
         val perModeOverrides = action.chosenModes.mapNotNull { modeIndex ->
             modalEffect.modes.getOrNull(modeIndex)?.additionalCosts
         }
-        if (perModeOverrides.isEmpty()) return cardDef.script.additionalCosts
-        return perModeOverrides.flatten()
+        val base = if (perModeOverrides.isEmpty()) cardDef.script.additionalCosts else perModeOverrides.flatten()
+        val escalate = EscalateCosts.additionalCostFor(modalEffect, action.chosenModes.size)
+        return if (escalate == null) base else base + escalate
     }
 
     /**
@@ -3712,6 +3719,18 @@ class CastSpellHandler(
         modalEffect: ModalEffect,
         chosenIndices: List<Int>
     ): Boolean {
+        // Escalate with a non-mana cost (CR 702.120a): each mode beyond the first owes another
+        // discard / tap / …, so a pick can run the caster out of cards to pay with just as it can
+        // run them out of mana.
+        val escalatePayability = EscalateCosts.payability(
+            state, action.playerId, action.cardId, modalEffect, costEnumerationUtils, predicateEvaluator
+        )
+        if (escalatePayability != null &&
+            (chosenIndices.size - 1).coerceAtLeast(0) > escalatePayability.maxExtraModes
+        ) {
+            return false
+        }
+
         val extraCosts = buildList {
             addAll(chosenIndices.mapNotNull { modalEffect.modes.getOrNull(it)?.additionalManaCost })
             modalEffect.additionalManaCostPerExtraMode?.let { perExtraMode ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -185,6 +185,10 @@ data class LegalAction(
  *           "choose one or both" / "choose one or more").
  * @property allowRepeat When true, the same mode index may be chosen more than
  *           once (rules 700.2d — Escalate / Spree).
+ * @property additionalCostPerExtraMode Non-mana escalate (CR 702.120a — Collective Brutality's
+ *           "discard a card"): the cost of **one** extra mode. The client scales it by the number
+ *           of modes chosen beyond the first and drives the matching picker. [chooseCount] is
+ *           already capped by what the caster can pay, so the picker can never run dry.
  * @property modes One entry per declared mode, in printed order.
  * @property unavailableIndices Convenience list of mode indices flagged
  *           unavailable. Equal to `modes.filterNot { it.available }.map { it.index }`.
@@ -194,6 +198,7 @@ data class ModalLegalEnumeration(
     val minChooseCount: Int,
     val allowRepeat: Boolean,
     val additionalManaCostPerExtraMode: String? = null,
+    val additionalCostPerExtraMode: AdditionalCostData? = null,
     val modes: List<ModalEnumerationMode>,
     val unavailableIndices: List<Int>
 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -9,6 +9,8 @@ import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.legalactions.ModalEnumerationMode
 import com.wingedsheep.engine.legalactions.ModalLegalEnumeration
 import com.wingedsheep.engine.legalactions.TargetInfo
+import com.wingedsheep.engine.legalactions.utils.SelectionCostPresentation
+import com.wingedsheep.engine.mechanics.EscalateCosts
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
@@ -350,7 +352,9 @@ class CastSpellEnumerator : ActionEnumerator {
                         // Always payable: the player can always choose the "pay mana" path.
                         // Surface the candidates for the leg path, whichever cost it carries.
                         orPayCost = cost
-                        orPayTargets = orPayLegCandidates(context, playerId, cardId, cost.cost)
+                        orPayTargets = SelectionCostPresentation.candidates(
+                            state, playerId, cardId, cost.cost, context.costUtils, context.predicateEvaluator
+                        )
                     }
                     is AdditionalCost.ChooseEntity -> {
                         // Search each (zone, filter) pair in `cost.zoneFilters`. Battlefield
@@ -559,7 +563,7 @@ class CastSpellEnumerator : ActionEnumerator {
             // enough candidates for the leg cost's own selection — permanents to sacrifice, cards to
             // discard/exile/behold, …).
             val canAffordOrPayPath = if (orPayCost != null &&
-                orPayTargets.size >= orPayLegSelectionCount(orPayCost.cost)
+                orPayTargets.size >= SelectionCostPresentation.selectionCount(orPayCost.cost)
             ) {
                 context.manaSolver.canPay(state, playerId, orPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
@@ -631,7 +635,7 @@ class CastSpellEnumerator : ActionEnumerator {
             // "Behold", …), so a plain sacrifice/discard/exile/behold cost and the or-pay variant
             // drive the exact same selection UI.
             val orPayPathInfo = if (canAffordOrPayPath && orPayCost != null) {
-                orPayLegCostData(orPayCost.cost, orPayTargets)?.let { (label, legCostInfo) ->
+                SelectionCostPresentation.costData(orPayCost.cost, orPayTargets)?.let { (label, legCostInfo) ->
                     orPayPath(label = label, baseCost = orPayBaseCost, legCostInfo = legCostInfo)
                 }
             } else null
@@ -969,6 +973,17 @@ class CastSpellEnumerator : ActionEnumerator {
                         .filterNot { it.available }
                         .map { it.index }
 
+                    // Escalate with a non-mana cost (CR 702.120a): the caster can only reach as
+                    // many modes as they can pay for — three modes on Collective Brutality wants
+                    // two cards in hand to discard. Cap the offered maximum the same way the mana
+                    // escalate is capped by [canPayModeSelection], and hand the client the cost
+                    // data so it can prompt for one extra mode's payment per mode chosen.
+                    val escalatePayability = EscalateCosts.payability(
+                        state, playerId, cardId, variantEffect, context.costUtils, context.predicateEvaluator
+                    )
+                    val effectiveChooseCount = if (escalatePayability == null) variantEffect.chooseCount
+                        else minOf(variantEffect.chooseCount, 1 + escalatePayability.maxExtraModes)
+
                     // If every mode is unavailable, the spell can't legally be cast —
                     // drop the action entirely rather than offering an unplayable UI.
                     val hasAnyAvailable = enumerationModes.any { it.available }
@@ -988,10 +1003,11 @@ class CastSpellEnumerator : ActionEnumerator {
                             manaCostString = variant.manaCostString,
                             autoTapPreview = variant.autoTapPreview,
                             modalEnumeration = ModalLegalEnumeration(
-                                chooseCount = variantEffect.chooseCount,
-                                minChooseCount = variantEffect.minChooseCount,
+                                chooseCount = effectiveChooseCount,
+                                minChooseCount = minOf(variantEffect.minChooseCount, effectiveChooseCount),
                                 allowRepeat = variantEffect.allowRepeat,
                                 additionalManaCostPerExtraMode = variantEffect.additionalManaCostPerExtraMode,
+                                additionalCostPerExtraMode = escalatePayability?.costData,
                                 modes = enumerationModes,
                                 unavailableIndices = unavailableIndices
                             )
@@ -2246,123 +2262,6 @@ class CastSpellEnumerator : ActionEnumerator {
         val autoTapPreview: List<EntityId>?,
         val costInfo: AdditionalCostData,
     )
-
-    /**
-     * Candidates the caster could pick to pay [leg] as the non-mana leg of an
-     * [AdditionalCost.OrPay], excluding the spell being cast ([cardId]) — it is on the stack, not in
-     * the zone the cost draws from.
-     *
-     * Covers exactly the selection-carrying costs the cast-time payment machinery can tell apart by
-     * payment field (see [AdditionalCost.OrPay]); anything else returns no candidates, so only the
-     * pay path is offered.
-     */
-    private fun orPayLegCandidates(
-        context: EnumerationContext,
-        playerId: EntityId,
-        cardId: EntityId,
-        leg: AdditionalCost,
-    ): List<EntityId> {
-        val state = context.state
-        val predicateContext = PredicateContext(controllerId = playerId)
-        return when (leg) {
-            // Behold spans battlefield *and* hand in one candidate pool.
-            is AdditionalCost.Behold -> {
-                val projected = state.projectedState
-                val battlefieldMatches = projected.getBattlefieldControlledBy(playerId).filter { permId ->
-                    context.predicateEvaluator.matches(state, projected, permId, leg.filter, predicateContext)
-                }
-                val handMatches = state.getZone(ZoneKey(playerId, Zone.HAND))
-                    .filter { it != cardId }
-                    .filter { context.predicateEvaluator.matches(state, projected, it, leg.filter, predicateContext) }
-                battlefieldMatches + handMatches
-            }
-            is AdditionalCost.Atom -> when (val atom = leg.atom) {
-                is CostAtom.Sacrifice -> context.costUtils.findSacrificeTargets(state, playerId, atom)
-                is CostAtom.ExileFrom -> context.costUtils.findExileTargets(state, playerId, atom.filter, atom.zone)
-                    .filter { it != cardId }
-                is CostAtom.Discard -> {
-                    val handCards = state.getZone(ZoneKey(playerId, Zone.HAND)).filter { it != cardId }
-                    if (atom.filter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any) handCards
-                    else handCards.filter {
-                        context.predicateEvaluator.matches(state, state.projectedState, it, atom.filter, predicateContext)
-                    }
-                }
-                is CostAtom.TapPermanents -> context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
-                    .let { if (atom.excludeSelf) it.filter { id -> id != cardId } else it }
-                is CostAtom.ReturnToHand -> context.costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
-                else -> emptyList()
-            }
-            else -> emptyList()
-        }
-    }
-
-    /** How many entities the caster must pick to pay [leg] — 0 when it carries no selection. */
-    private fun orPayLegSelectionCount(leg: AdditionalCost): Int = when (leg) {
-        is AdditionalCost.Behold -> leg.count
-        is AdditionalCost.Atom -> leg.atom.selectionCount
-        else -> 0
-    }
-
-    /**
-     * The action-description label and client cost data for paying [leg] as an or-pay leg, or null
-     * when [leg] carries no selection the client could drive (so the leg isn't offered).
-     *
-     * Deliberately reuses the same `costType`s the leg cost emits when it stands alone, so the
-     * or-pay leg drives the existing pickers with no client-side changes. `"ExileFromGraveyard"`
-     * pins the client's picker to the graveyard, so a non-graveyard exile leg is declined rather
-     * than shown against the wrong zone.
-     */
-    private fun orPayLegCostData(
-        leg: AdditionalCost,
-        candidates: List<EntityId>,
-    ): Pair<String, AdditionalCostData>? = when (leg) {
-        is AdditionalCost.Behold -> "Behold" to AdditionalCostData(
-            description = leg.description,
-            costType = "Behold",
-            validBeholdTargets = candidates,
-            beholdCount = leg.count,
-        )
-        is AdditionalCost.Atom -> {
-            val description = leg.description
-            when (val atom = leg.atom) {
-                is CostAtom.Sacrifice -> "Sacrifice" to AdditionalCostData(
-                    description = description,
-                    costType = "SacrificePermanent",
-                    validSacrificeTargets = candidates,
-                    sacrificeCount = atom.count,
-                )
-                is CostAtom.Discard -> "Discard" to AdditionalCostData(
-                    description = description,
-                    costType = "DiscardCard",
-                    validDiscardTargets = candidates,
-                    discardCount = atom.count,
-                )
-                is CostAtom.ExileFrom -> if (atom.zone != Zone.GRAVEYARD) null else {
-                    "Exile from graveyard" to AdditionalCostData(
-                        description = description,
-                        costType = "ExileFromGraveyard",
-                        validExileTargets = candidates,
-                        exileMinCount = atom.count,
-                        exileMaxCount = atom.count,
-                    )
-                }
-                is CostAtom.TapPermanents -> "Tap" to AdditionalCostData(
-                    description = description,
-                    costType = "TapPermanents",
-                    validTapTargets = candidates,
-                    tapCount = atom.count,
-                )
-                is CostAtom.ReturnToHand -> "Return to hand" to AdditionalCostData(
-                    description = description,
-                    costType = "BouncePermanent",
-                    validBounceTargets = candidates,
-                    bounceCount = atom.count,
-                )
-                else -> null
-            }
-        }
-        else -> null
-    }
 
     /**
      * Internal data holder for self-alternative cost computation results.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/SelectionCostPresentation.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.legalactions.utils
+
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.legalactions.AdditionalCostData
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+
+/**
+ * Candidate pools and client cost data for an additional cost that the caster pays by **selecting
+ * objects** — sacrifice, discard, tap, bounce, exile from a zone, behold.
+ *
+ * Two cast-time shapes need exactly this, off the same cost vocabulary: the non-mana leg of an
+ * "… or pay {N}" cost ([AdditionalCost.OrPay]), and escalate whose cost isn't mana
+ * ([com.wingedsheep.sdk.scripting.effects.ModalEffect.additionalCostPerExtraMode]). Both have to
+ * answer "which objects could pay this, and which client picker drives the choice?" before the
+ * cost is committed to, and both are declined outright when the answer is "none".
+ *
+ * The emitted `costType`s are deliberately the ones each cost already emits when it stands alone,
+ * so these paths drive the existing pickers with no client-side special-casing.
+ */
+object SelectionCostPresentation {
+
+    /**
+     * Objects the caster could pick to pay [cost], excluding the spell being cast ([castCardId]) —
+     * it is on the stack, not in the zone the cost draws from.
+     *
+     * Empty for a cost that carries no selection (pay life, mill) or one no picker covers; callers
+     * treat that as "not payable this way" and decline the path rather than offering a dead UI.
+     */
+    fun candidates(
+        state: GameState,
+        playerId: EntityId,
+        castCardId: EntityId,
+        cost: AdditionalCost,
+        costUtils: CostEnumerationUtils,
+        predicateEvaluator: PredicateEvaluator,
+    ): List<EntityId> {
+        val predicateContext = PredicateContext(controllerId = playerId)
+        return when (cost) {
+            // Behold spans battlefield *and* hand in one candidate pool.
+            is AdditionalCost.Behold -> {
+                val projected = state.projectedState
+                val battlefieldMatches = projected.getBattlefieldControlledBy(playerId).filter { permId ->
+                    predicateEvaluator.matches(state, projected, permId, cost.filter, predicateContext)
+                }
+                val handMatches = state.getZone(ZoneKey(playerId, Zone.HAND))
+                    .filter { it != castCardId }
+                    .filter { predicateEvaluator.matches(state, projected, it, cost.filter, predicateContext) }
+                battlefieldMatches + handMatches
+            }
+            is AdditionalCost.Atom -> when (val atom = cost.atom) {
+                is CostAtom.Sacrifice -> costUtils.findSacrificeTargets(state, playerId, atom)
+                is CostAtom.ExileFrom -> costUtils.findExileTargets(state, playerId, atom.filter, atom.zone)
+                    .filter { it != castCardId }
+                is CostAtom.Discard -> handCandidates(state, playerId, castCardId, atom.filter, predicateEvaluator)
+                is CostAtom.RevealFromHand -> handCandidates(state, playerId, castCardId, atom.filter, predicateEvaluator)
+                is CostAtom.TapPermanents -> costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                    .let { if (atom.excludeSelf) it.filter { id -> id != castCardId } else it }
+                is CostAtom.ReturnToHand -> costUtils.findAbilityBounceTargets(state, playerId, atom.filter)
+                else -> emptyList()
+            }
+            else -> emptyList()
+        }
+    }
+
+    /** How many objects the caster must pick to pay [cost] — 0 when it carries no selection. */
+    fun selectionCount(cost: AdditionalCost): Int = when (cost) {
+        is AdditionalCost.Behold -> cost.count
+        is AdditionalCost.Atom -> cost.atom.selectionCount
+        else -> 0
+    }
+
+    /**
+     * A short label for the cast action's description ("Discard", "Sacrifice", …) paired with the
+     * client cost data for paying [cost] from [candidates], or null when [cost] carries no
+     * selection a picker could drive.
+     *
+     * `"ExileFromGraveyard"` pins the client's picker to the graveyard, so a non-graveyard exile
+     * cost is declined rather than shown against the wrong zone.
+     */
+    fun costData(
+        cost: AdditionalCost,
+        candidates: List<EntityId>,
+    ): Pair<String, AdditionalCostData>? = when (cost) {
+        is AdditionalCost.Behold -> "Behold" to AdditionalCostData(
+            description = cost.description,
+            costType = "Behold",
+            validBeholdTargets = candidates,
+            beholdCount = cost.count,
+        )
+        is AdditionalCost.Atom -> {
+            val description = cost.description
+            when (val atom = cost.atom) {
+                is CostAtom.Sacrifice -> "Sacrifice" to AdditionalCostData(
+                    description = description,
+                    costType = "SacrificePermanent",
+                    validSacrificeTargets = candidates,
+                    sacrificeCount = atom.count,
+                )
+                is CostAtom.Discard -> "Discard" to AdditionalCostData(
+                    description = description,
+                    costType = "DiscardCard",
+                    validDiscardTargets = candidates,
+                    discardCount = atom.count,
+                )
+                is CostAtom.ExileFrom -> if (atom.zone != Zone.GRAVEYARD) null else {
+                    "Exile from graveyard" to AdditionalCostData(
+                        description = description,
+                        costType = "ExileFromGraveyard",
+                        validExileTargets = candidates,
+                        exileMinCount = atom.count,
+                        exileMaxCount = atom.count,
+                    )
+                }
+                is CostAtom.TapPermanents -> "Tap" to AdditionalCostData(
+                    description = description,
+                    costType = "TapPermanents",
+                    validTapTargets = candidates,
+                    tapCount = atom.count,
+                )
+                is CostAtom.ReturnToHand -> "Return to hand" to AdditionalCostData(
+                    description = description,
+                    costType = "BouncePermanent",
+                    validBounceTargets = candidates,
+                    bounceCount = atom.count,
+                )
+                else -> null
+            }
+        }
+        else -> null
+    }
+
+    private fun handCandidates(
+        state: GameState,
+        playerId: EntityId,
+        castCardId: EntityId,
+        filter: GameObjectFilter,
+        predicateEvaluator: PredicateEvaluator,
+    ): List<EntityId> {
+        val handCards = state.getZone(ZoneKey(playerId, Zone.HAND)).filter { it != castCardId }
+        if (filter == GameObjectFilter.Any) return handCards
+        val predicateContext = PredicateContext(controllerId = playerId)
+        return handCards.filter {
+            predicateEvaluator.matches(state, state.projectedState, it, filter, predicateContext)
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/EscalateCosts.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/EscalateCosts.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.legalactions.AdditionalCostData
+import com.wingedsheep.engine.legalactions.utils.CostEnumerationUtils
+import com.wingedsheep.engine.legalactions.utils.SelectionCostPresentation
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.costs.repeated
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+
+/**
+ * Escalate (CR 702.120a) — "Pay this cost for each mode chosen beyond the first."
+ *
+ * The mana form rides [ModalEffect.additionalManaCostPerExtraMode] and is folded straight into the
+ * spell's mana cost. The non-mana form ([ModalEffect.additionalCostPerExtraMode] — Collective
+ * Brutality's "discard a card", Collective Effort's "tap an untapped creature you control") has to
+ * become a real [AdditionalCost] the cast pipeline can enumerate, validate, and charge.
+ *
+ * It is charged as **one scaled cost**, not as N repeats: every additional-cost payment channel is
+ * a single flat list (`discardedCards`, `tappedPermanents`, …), so two `Discard(1)` entries would
+ * both be satisfied by the same one discarded card. `Discard(2)` is the shape that validates and
+ * charges the two cards escalate actually owes.
+ */
+object EscalateCosts {
+
+    /**
+     * The escalate cost owed for a cast that chose [chosenModeCount] modes, or null when the card
+     * has no non-mana escalate cost or when only one mode was chosen (escalate charges nothing for
+     * the first mode).
+     */
+    fun additionalCostFor(modalEffect: ModalEffect, chosenModeCount: Int): AdditionalCost? {
+        val atom = modalEffect.additionalCostPerExtraMode ?: return null
+        val extraModes = chosenModeCount - 1
+        if (extraModes <= 0) return null
+        return AdditionalCost.Atom(atom.repeated(extraModes))
+    }
+
+    /**
+     * How the caster would pay one extra mode's worth of [modalEffect]'s non-mana escalate cost:
+     * the candidate objects, the client cost data driving the picker, and the resulting cap on how
+     * many modes beyond the first they can afford. Null when the card has no such cost.
+     *
+     * The cap exists because escalating past what you can pay dead-ends at payment, where the only
+     * way out is cancelling the whole cast — the same reason mode selection is already gated on
+     * mana affordability (rule 700.2h). A cost shape no picker covers caps the spell at one mode
+     * rather than offering modes that can never be paid for.
+     */
+    fun payability(
+        state: GameState,
+        playerId: EntityId,
+        castCardId: EntityId,
+        modalEffect: ModalEffect,
+        costUtils: CostEnumerationUtils,
+        predicateEvaluator: PredicateEvaluator,
+    ): Payability? {
+        val atom = modalEffect.additionalCostPerExtraMode ?: return null
+        val cost = AdditionalCost.Atom(atom)
+        val candidates = SelectionCostPresentation.candidates(
+            state, playerId, castCardId, cost, costUtils, predicateEvaluator
+        )
+        val costData = SelectionCostPresentation.costData(cost, candidates)?.second
+        val perModeSelection = SelectionCostPresentation.selectionCount(cost)
+        val maxExtraModes = when {
+            costData == null -> 0
+            perModeSelection <= 0 -> 0
+            else -> candidates.size / perModeSelection
+        }
+        return Payability(costData, maxExtraModes)
+    }
+
+    /**
+     * @property costData Client cost data for **one** extra mode's payment — the picker multiplies
+     *   its count by the number of modes chosen beyond the first. Null when no picker covers the
+     *   cost.
+     * @property maxExtraModes Cap on modes chosen beyond the first, from what is available to pay.
+     */
+    data class Payability(
+        val costData: AdditionalCostData?,
+        val maxExtraModes: Int,
+    )
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -143,6 +143,7 @@ class LegalActionEnricher(
         minChooseCount = minChooseCount,
         allowRepeat = allowRepeat,
         additionalManaCostPerExtraMode = additionalManaCostPerExtraMode,
+        additionalCostPerExtraMode = additionalCostPerExtraMode?.toDto(),
         modes = modes.map { it.toDto() },
         unavailableIndices = unavailableIndices
     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -160,6 +160,9 @@ data class ModalLegalEnumerationInfo(
     val minChooseCount: Int,
     val allowRepeat: Boolean,
     val additionalManaCostPerExtraMode: String? = null,
+    /** Non-mana escalate (CR 702.120a): the cost of one extra mode — see
+     *  [com.wingedsheep.engine.legalactions.ModalLegalEnumeration.additionalCostPerExtraMode]. */
+    val additionalCostPerExtraMode: AdditionalCostInfo? = null,
     val modes: List<ModalEnumerationModeInfo>,
     val unavailableIndices: List<Int>
 )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CollectiveBrutalityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CollectiveBrutalityScenarioTest.kt
@@ -1,0 +1,235 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Scenario test for Collective Brutality (EMN #85) — {1}{B} sorcery, "Escalate—Discard a card",
+ * three modes.
+ *
+ * It is the first card whose escalate cost isn't mana (CR 702.120a), so these pin the cost scaling
+ * the engine does for it: one mode owes nothing, two modes owe one discard, three modes owe two.
+ * Mode 1's "-2/-2" and mode 2's "loses 2 life and you gain 2 life" ride along.
+ */
+class CollectiveBrutalityScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Collective Brutality") {
+
+            /** Cast Collective Brutality with an explicit mode subset, per-mode targets, and discards. */
+            fun ScenarioTestBase.TestGame.castBrutality(
+                modes: List<Int>,
+                modeTargets: List<List<ChosenTarget>>,
+                discards: List<EntityId> = emptyList(),
+            ) = execute(
+                CastSpell(
+                    playerId = player1Id,
+                    cardId = state.getHand(player1Id).first {
+                        state.getEntity(it)?.get<CardComponent>()?.name == "Collective Brutality"
+                    },
+                    targets = modeTargets.flatten(),
+                    chosenModes = modes,
+                    modeTargetsOrdered = modeTargets,
+                    additionalCostPayment = AdditionalCostPayment(discardedCards = discards),
+                )
+            )
+
+            fun ScenarioTestBase.TestGame.cardInHand(playerNumber: Int, name: String): EntityId =
+                findCardsInHand(playerNumber, name).first()
+
+            test("one mode owes no escalate cost — the drain resolves and nothing is discarded") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Collective Brutality")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lifeBefore = game.getLifeTotal(1)
+                val opponentLifeBefore = game.getLifeTotal(2)
+
+                val cast = game.castBrutality(
+                    modes = listOf(2),
+                    modeTargets = listOf(listOf(ChosenTarget.Player(game.player2Id))),
+                )
+                withClue("a single-mode cast pays no escalate cost: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                withClue("nothing was discarded") { game.isInHand(1, "Grizzly Bears") shouldBe true }
+
+                game.resolveStack()
+                game.getLifeTotal(2) shouldBe (opponentLifeBefore - 2)
+                game.getLifeTotal(1) shouldBe (lifeBefore + 2)
+            }
+
+            test("two modes discard one card and both modes resolve") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Collective Brutality")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser") // 3/3 — survives -2/-2
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val opponentLifeBefore = game.getLifeTotal(2)
+
+                val cast = game.castBrutality(
+                    modes = listOf(1, 2),
+                    modeTargets = listOf(
+                        listOf(ChosenTarget.Permanent(courser)),
+                        listOf(ChosenTarget.Player(game.player2Id)),
+                    ),
+                    discards = listOf(game.cardInHand(1, "Grizzly Bears")),
+                )
+                withClue("two modes owe exactly one discard: ${cast.error}") { cast.error shouldBe null }
+
+                withClue("the escalate cost is paid as the spell is cast, before it goes on the stack") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+
+                game.resolveStack()
+                withClue("-2/-2 shrinks the 3/3 to a 1/1 rather than killing it") {
+                    game.findPermanent("Centaur Courser") shouldNotBe null
+                }
+                game.getLifeTotal(2) shouldBe (opponentLifeBefore - 2)
+            }
+
+            test("three modes discard two cards and every mode resolves") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Collective Brutality")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Centaur Courser")
+                    .withCardInHand(2, "Lightning Bolt") // the only instant/sorcery to take
+                    .withCardInHand(2, "Forest")
+                    .withCardOnBattlefield(2, "Runeclaw Bear") // 2/2 — dies to -2/-2
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Runeclaw Bear")!!
+                val opponentLifeBefore = game.getLifeTotal(2)
+                val lifeBefore = game.getLifeTotal(1)
+
+                val cast = game.castBrutality(
+                    modes = listOf(0, 1, 2),
+                    modeTargets = listOf(
+                        listOf(ChosenTarget.Player(game.player2Id)),
+                        listOf(ChosenTarget.Permanent(bear)),
+                        listOf(ChosenTarget.Player(game.player2Id)),
+                    ),
+                    discards = listOf(
+                        game.cardInHand(1, "Grizzly Bears"),
+                        game.cardInHand(1, "Centaur Courser"),
+                    ),
+                )
+                withClue("three modes owe two discards: ${cast.error}") { cast.error shouldBe null }
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                game.isInGraveyard(1, "Centaur Courser") shouldBe true
+
+                game.resolveStack()
+
+                // Mode 0 pauses for the caster to pick a card out of the revealed hand.
+                game.selectCards(listOf(game.cardInHand(2, "Lightning Bolt")))
+                game.resolveStack()
+
+                withClue("mode 0 took the opponent's only instant") {
+                    game.isInGraveyard(2, "Lightning Bolt") shouldBe true
+                }
+                withClue("the land was never an eligible choice") {
+                    game.isInHand(2, "Forest") shouldBe true
+                }
+                withClue("-2/-2 killed the 2/2") { game.findPermanent("Runeclaw Bear") shouldBe null }
+                game.getLifeTotal(2) shouldBe (opponentLifeBefore - 2)
+                game.getLifeTotal(1) shouldBe (lifeBefore + 2)
+            }
+
+            test("a second mode without its discard is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Collective Brutality")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val cast = game.castBrutality(
+                    modes = listOf(1, 2),
+                    modeTargets = listOf(
+                        listOf(ChosenTarget.Permanent(courser)),
+                        listOf(ChosenTarget.Player(game.player2Id)),
+                    ),
+                )
+                withClue("the escalate cost is mandatory once a second mode is chosen") {
+                    cast.error shouldNotBe null
+                }
+                cast.error!!.lowercase() shouldContain "discard"
+            }
+
+            test("three modes are unpayable with only one spare card in hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Collective Brutality")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val cast = game.castBrutality(
+                    modes = listOf(0, 1, 2),
+                    modeTargets = listOf(
+                        listOf(ChosenTarget.Player(game.player2Id)),
+                        listOf(ChosenTarget.Permanent(courser)),
+                        listOf(ChosenTarget.Player(game.player2Id)),
+                    ),
+                    discards = listOf(game.cardInHand(1, "Grizzly Bears")),
+                )
+                withClue("one card can't pay for two extra modes") { cast.error shouldNotBe null }
+            }
+
+            test("the offered mode count is capped by the cards available to escalate with") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Collective Brutality")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val modal = game.getLegalActions(1)
+                    .first { it.description.contains("Collective Brutality") }
+                    .modalEnumeration
+                withClue("one spare card pays for exactly one extra mode") {
+                    modal?.chooseCount shouldBe 2
+                }
+                withClue("the client is told what each extra mode costs") {
+                    modal?.additionalCostPerExtraMode?.costType shouldBe "DiscardCard"
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CollectiveBrutalityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CollectiveBrutalityScenarioTest.kt
@@ -117,13 +117,13 @@ class CollectiveBrutalityScenarioTest : ScenarioTestBase() {
                     .withCardInHand(1, "Centaur Courser")
                     .withCardInHand(2, "Lightning Bolt") // the only instant/sorcery to take
                     .withCardInHand(2, "Forest")
-                    .withCardOnBattlefield(2, "Runeclaw Bear") // 2/2 — dies to -2/-2
+                    .withCardOnBattlefield(2, "Savannah Lions") // 1/1 — dies to -2/-2
                     .withLandsOnBattlefield(1, "Swamp", 2)
                     .withActivePlayer(1)
                     .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                     .build()
 
-                val bear = game.findPermanent("Runeclaw Bear")!!
+                val lions = game.findPermanent("Savannah Lions")!!
                 val opponentLifeBefore = game.getLifeTotal(2)
                 val lifeBefore = game.getLifeTotal(1)
 
@@ -131,7 +131,7 @@ class CollectiveBrutalityScenarioTest : ScenarioTestBase() {
                     modes = listOf(0, 1, 2),
                     modeTargets = listOf(
                         listOf(ChosenTarget.Player(game.player2Id)),
-                        listOf(ChosenTarget.Permanent(bear)),
+                        listOf(ChosenTarget.Permanent(lions)),
                         listOf(ChosenTarget.Player(game.player2Id)),
                     ),
                     discards = listOf(
@@ -155,7 +155,7 @@ class CollectiveBrutalityScenarioTest : ScenarioTestBase() {
                 withClue("the land was never an eligible choice") {
                     game.isInHand(2, "Forest") shouldBe true
                 }
-                withClue("-2/-2 killed the 2/2") { game.findPermanent("Runeclaw Bear") shouldBe null }
+                withClue("-2/-2 killed the 1/1") { game.findPermanent("Savannah Lions") shouldBe null }
                 game.getLifeTotal(2) shouldBe (opponentLifeBefore - 2)
                 game.getLifeTotal(1) shouldBe (lifeBefore + 2)
             }

--- a/web-client/src/components/ui/ModalModeSelector.tsx
+++ b/web-client/src/components/ui/ModalModeSelector.tsx
@@ -56,7 +56,14 @@ function ModalModePanel({ state }: { state: ModalModeSelectionState }) {
   const responsive = useResponsive()
 
   const { enumeration, cardName, baseManaCost } = state
-  const { modes, minChooseCount, chooseCount, allowRepeat, additionalManaCostPerExtraMode } = enumeration
+  const {
+    modes,
+    minChooseCount,
+    chooseCount,
+    allowRepeat,
+    additionalManaCostPerExtraMode,
+    additionalCostPerExtraMode,
+  } = enumeration
 
   const [counts, setCounts] = useState<number[]>(() => new Array(modes.length).fill(0) as number[])
   const [minimized, setMinimized] = useState(false)
@@ -85,6 +92,14 @@ function ModalModePanel({ state }: { state: ModalModeSelectionState }) {
     ),
   ])
   const totalCost = combineManaCosts([baseManaCost, additionalCost])
+
+  // Non-mana escalate is paid after this panel closes, so name what the current selection owes.
+  const extraModes = Math.max(0, totalChosen - 1)
+  const escalateCostLabel = additionalCostPerExtraMode
+    ? extraModes > 0
+      ? `${additionalCostPerExtraMode.description} ×${extraModes}`
+      : `${additionalCostPerExtraMode.description} for each mode beyond the first`
+    : null
 
   const withinRange = totalChosen >= minChooseCount && totalChosen <= chooseCount
   const rangeLabel = minChooseCount === chooseCount
@@ -120,7 +135,10 @@ function ModalModePanel({ state }: { state: ModalModeSelectionState }) {
 
       <h2 className={decisionStyles.title}>{cardName}</h2>
       <p className={decisionStyles.sourceLabel}>
-        {rangeLabel}{additionalManaCostPerExtraMode ? ' — escalate for each mode beyond the first' : ' — pay for each chosen mode'}
+        {rangeLabel}
+        {additionalManaCostPerExtraMode || additionalCostPerExtraMode
+          ? ' — escalate for each mode beyond the first'
+          : ' — pay for each chosen mode'}
       </p>
 
       {/* Mode list */}
@@ -208,6 +226,14 @@ function ModalModePanel({ state }: { state: ModalModeSelectionState }) {
           Total: <ManaCost cost={totalCost} size={15} />
         </span>
       </div>
+
+      {/* Non-mana escalate (Collective Brutality's "discard a card"): say up front what confirming
+          will ask for, since the picker only opens afterwards. */}
+      {additionalCostPerExtraMode && escalateCostLabel && (
+        <p style={{ margin: 0, fontSize: 'var(--font-sm)', color: 'var(--text-secondary)' }}>
+          Escalate: {escalateCostLabel}
+        </p>
+      )}
 
       {isHoveringSource && !responsive.isMobile && (
         <DecisionCardPreview cardName={cardName} imageUri={sourceCard?.imageUri} />

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -778,6 +778,13 @@ export type PipelinePhase =
   | { type: 'harmonize' }
   | { type: 'manaSource' }
   | { type: 'costPayment' }
+  /**
+   * Non-mana escalate (CR 702.120a): pay the escalate cost once for each mode chosen beyond the
+   * first. Its own phase rather than a plain `costPayment` because the cost and its count come
+   * from `modalEnumeration.additionalCostPerExtraMode` scaled by the modes just picked, not from
+   * the action's card-level `additionalCostInfo`. Injected after `modalModes` resolves.
+   */
+  | { type: 'escalateCost' }
   | { type: 'blightVariable' }
   | { type: 'payXLife' }
   | { type: 'manaColorChoice' }

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -686,6 +686,66 @@ export function enterPhase(
       break
     }
 
+    // Escalate (CR 702.120a) with a non-mana cost: pay it once per mode chosen beyond the first.
+    // The enumeration advertises one extra mode's cost, so the counts scale by the modes picked in
+    // the preceding modalModes phase; the server capped chooseCount at what the caster can pay, so
+    // the candidate pool always covers them.
+    case 'escalateCost': {
+      const costInfo = actionInfo.modalEnumeration?.additionalCostPerExtraMode
+      const extraModes =
+        action.type === 'CastSpell' ? Math.max(0, (action.chosenModes?.length ?? 0) - 1) : 0
+      if (!costInfo || extraModes === 0) return
+
+      const scaled = (perMode: number | undefined) => (perMode ?? 1) * extraModes
+      const flags: Partial<TargetingState> = { targetDescription: costInfo.description }
+      let validTargets: EntityId[]
+      let count: number
+
+      switch (costInfo.costType) {
+        case 'DiscardCard':
+          validTargets = [...costInfo.validDiscardTargets!]
+          count = scaled(costInfo.discardCount)
+          flags.isSacrificeSelection = true
+          flags.isDiscardSelection = true
+          break
+        case 'TapPermanents':
+          validTargets = [...costInfo.validTapTargets!]
+          count = scaled(costInfo.tapCount)
+          flags.isSacrificeSelection = true
+          flags.isTapPermanentSelection = true
+          break
+        case 'SacrificePermanent':
+          validTargets = [...costInfo.validSacrificeTargets!]
+          count = scaled(costInfo.sacrificeCount)
+          flags.isSacrificeSelection = true
+          break
+        case 'BouncePermanent':
+          validTargets = [...costInfo.validBounceTargets!]
+          count = scaled(costInfo.bounceCount)
+          flags.isSacrificeSelection = true
+          flags.isBounceSelection = true
+          break
+        case 'ExileFromGraveyard':
+          validTargets = [...costInfo.validExileTargets!]
+          count = scaled(costInfo.exileMinCount)
+          flags.isSacrificeSelection = true
+          flags.targetZone = 'Graveyard'
+          break
+        default:
+          return
+      }
+
+      store.startTargeting({
+        action,
+        validTargets,
+        selectedTargets: [],
+        minTargets: count,
+        maxTargets: count,
+        ...flags,
+      })
+      break
+    }
+
     case 'costPayment': {
       const costInfo = actionInfo.additionalCostInfo!
       const costType = costInfo.costType!

--- a/web-client/src/store/slices/ui/pipelineSlice.ts
+++ b/web-client/src/store/slices/ui/pipelineSlice.ts
@@ -211,6 +211,17 @@ export const createPipelineSlice: SliceCreator<PipelineSlice> = (set, get) => ({
       nextPhases = [{ type: 'costPayment' }, ...nextPhases]
     }
 
+    // Dynamic phase injection: a non-mana escalate cost (CR 702.120a) is owed once per mode
+    // chosen beyond the first, so how much there is to pay — and whether anything is owed at
+    // all — is only known once the modal panel has confirmed its picks.
+    if (
+      result.type === 'modalModes' &&
+      actionInfo.modalEnumeration?.additionalCostPerExtraMode &&
+      result.chosenModes.length > 1
+    ) {
+      nextPhases = [{ type: 'escalateCost' }, ...nextPhases]
+    }
+
     // Dynamic phase injection: damage distribution after targeting with >1 targets
     if (
       result.type === 'targeting' &&

--- a/web-client/src/store/slices/ui/targetingSlice.ts
+++ b/web-client/src/store/slices/ui/targetingSlice.ts
@@ -105,10 +105,14 @@ export const createTargetingSlice: SliceCreator<TargetingSlice> = (set, get) => 
 
     const currentPhase = pipelineState.remainingPhases[0]
 
-    // Cost payment phase (sacrifice/discard/tap/bounce/exile/blight selection)
-    if (currentPhase?.type === 'costPayment') {
-      const costType =
-        pipelineState.actionInfo.additionalCostInfo?.costType ?? 'SacrificePermanent'
+    // Cost payment phase (sacrifice/discard/tap/bounce/exile/blight selection). Escalate pays a
+    // different cost from the same pickers, so it reads its costType off the modal enumeration.
+    if (currentPhase?.type === 'costPayment' || currentPhase?.type === 'escalateCost') {
+      const costInfo =
+        currentPhase.type === 'escalateCost'
+          ? pipelineState.actionInfo.modalEnumeration?.additionalCostPerExtraMode
+          : pipelineState.actionInfo.additionalCostInfo
+      const costType = costInfo?.costType ?? 'SacrificePermanent'
       set({ targetingState: null })
       get().advancePipeline({
         type: 'costPayment',

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -953,6 +953,12 @@ export interface ModalLegalEnumerationInfo {
   readonly allowRepeat: boolean
   /** Additional mana paid for every selected mode beyond the first (Escalate). */
   readonly additionalManaCostPerExtraMode?: string
+  /**
+   * Non-mana escalate (CR 702.120a — Collective Brutality's "discard a card"): the cost of **one**
+   * extra mode. Its counts are per extra mode, so the picker multiplies them by
+   * `chosenModes.length - 1`. `chooseCount` is already capped by what the caster can pay.
+   */
+  readonly additionalCostPerExtraMode?: AdditionalCostInfo
   /** One entry per declared mode, in printed order. */
   readonly modes: readonly ModalEnumerationModeInfo[]
   /** Mode indices that cannot currently be chosen (no legal target / unaffordable). */


### PR DESCRIPTION
## What

Adds **Collective Brutality** (EMN #85, reprinted in INR #101) — the first card whose escalate cost isn't mana.

Innistrad Remastered is at 281/290 and **no remaining card is a plain `cardDef`**; each needs an engine subsystem first. Escalate with a non-mana cost is the one that unblocks Collective Brutality, so this PR is one card plus the mechanic behind it.

## Escalate (CR 702.120a) with a non-mana cost

`ModalEffect.additionalManaCostPerExtraMode` already handles the mana form. Collective Brutality's is *"Escalate—Discard a card"*, so `ModalEffect.additionalCostPerExtraMode` carries a `CostAtom` for the payable-thing form (Collective Effort's "tap an untapped creature you control" is the other printed shape).

```kotlin
modal(chooseCount = 3, minChooseCount = 1, additionalCostPerExtraMode = CostAtom.Discard(1)) { … }
```

The engine charges it as **one scaled cost** — `atom.repeated(chosenModes.size - 1)`, so three modes owe `Discard(2)` — not as N repeats. Every additional-cost payment channel is a flat list (`discardedCards`, `tappedPermanents`, …), so two `Discard(1)` entries in a cost list would both be satisfied by the *same* one discarded card. `CostAtom.repeated(times)` is exhaustive over the atom vocabulary, so adding an atom is a compile error rather than a silent no-op.

Across the cast surface:

| Layer | Change |
|---|---|
| `CastSpellHandler.resolveAdditionalCostsForMode` | appends the scaled cost — the single chokepoint both validation and payment read |
| `CastSpellHandler.canPayModeSelection` | caps the server-driven sequential picker (AI / free casts) at what the caster can pay |
| `CastSpellEnumerator` | caps the offered `chooseCount` at `1 + candidates / per-mode selection`; publishes the per-extra-mode cost on `modalEnumeration` |
| `SelectionCostPresentation` (new) | the or-pay leg's candidate-pool / cost-data helpers, lifted out of `CastSpellEnumerator` and now shared with escalate instead of duplicated |
| web client | the mode panel names the escalate cost; confirming injects an `escalateCost` pipeline phase that opens the ordinary picker for that cost type with the count scaled by the modes just chosen |
| AI | `fillModalHeuristically` pays for the modes it picked (prefers lands as discard fodder) |

Reused rather than rebuilt: the client's existing `DiscardCard` / `TapPermanents` / … pickers, and the `costPayment` merge branch that writes them into `AdditionalCostPayment`.

## The card

Canonical `CardDefinition` in **EMN** (its earliest real printing); INR gets a `Printing` row.

Mode 3 is deliberately *not* `Effects.DrainLife` — "loses 2 life **and** you gain 2 life" gains 2 regardless of the life actually lost, so it stays a composite of a loss and a gain.

## Verification

- `just build` — green, with every change in place (SDK, rules-engine, AI, web-client, card, snapshot).
- `just test-class CollectiveBrutalityScenarioTest` — 6/6 pass: 1 / 2 / 3 modes, the two unpayable-cast rejections, and the enumerator's `chooseCount` cap.
- `just rebless-cards` — run; the EMN golden gained `Collective Brutality` and nothing else (170 insertions, 0 deletions).
- `npm run typecheck` (web-client) — clean.

Not exercised: the client's `escalateCost` pipeline phase has no test of its own and hasn't been driven in the running app — the picker it opens is the existing `DiscardCard` flow, but the injection and count scaling are only covered by reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
