### PR TITLE
Promote the rollout AI to production, with two targeted evaluation fixes

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -194,7 +194,10 @@ class AIPlayer(
             // pre-Phase-6 behaviour — so a profile that doesn't opt in is untouched.
             val intents = if (profile.useCardIntent) IntentCatalog.of(cardRegistry) else IntentCatalog.NONE
 
-            val simulator = GameSimulator(cardRegistry)
+            val simulator = GameSimulator(
+                cardRegistry,
+                resolveThroughCombatDamage = profile.resolveThroughCombatDamage,
+            )
             // Raw Phase 9 vectors contain CardIntent-derived facts even when the surrounding
             // legacy-based arena profile deliberately keeps Phase 6 timing/targeting behavior off.
             // Give only the evaluator the full catalog so the fitted training schema and runtime
@@ -205,7 +208,11 @@ class AIPlayer(
                 intents
             }
             val evaluator = EvalWeights.resolveEvaluator(profile.evalWeightsId, evaluationIntents)
-            val combatAdvisor = CombatAdvisor(simulator, evaluator, cardRegistry, advisorRegistry)
+            val combatAdvisor = CombatAdvisor(
+                simulator, evaluator, cardRegistry, advisorRegistry,
+                priceCrackBackAsLife = profile.priceCrackBackAsLife,
+                lifeWeight = EvalWeights.resolve(profile.evalWeightsId).life,
+            )
             val responder = DecisionResponder(
                 simulator, evaluator,
                 advisorRegistry = advisorRegistry,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -78,6 +78,30 @@ data class AiProfile(
      * Off preserves the historical full-information agents used as arena controls.
      */
     val determinizeHiddenInformation: Boolean = false,
+    /**
+     * Carry a candidate simulation through the combat damage step once blockers are declared,
+     * instead of stopping at the empty stack that sits one step before it.
+     *
+     * The cheap half of what Phase 7's rollouts were bought for. Three of the suite's six
+     * remaining failures pay mana now for a payoff that only lands at damage — a Fog, a
+     * regeneration shield, a firebreathing pump — and a one-ply evaluator that stops at the empty
+     * stack sees only the cost. Unlike a rollout this adds no sampling and no horizon *beyond*
+     * combat, so it cannot manufacture the tempo blindness that made `v0-rollout` lose
+     * `respond-02`.
+     *
+     * See [GameSimulator]'s constructor for why it starts at declare-blockers rather than
+     * declare-attackers.
+     */
+    val resolveThroughCombatDamage: Boolean = false,
+    /**
+     * Charge an attack plan's estimated crack-back as the life it would actually cost, rather
+     * than a flat −3.0 that only fires when the crack-back is exactly lethal.
+     *
+     * See [CombatAdvisor]'s constructor. The target is `race-03` — "keep the ground creature home
+     * to block the 3/3" — which is the one attack-vs-hold position the evaluator owns rather than
+     * `CombatSeed`, and which the rollouts do not close either.
+     */
+    val priceCrackBackAsLife: Boolean = false,
     /** Non-null profiles may only be selected automatically for this set. Arena selection stays explicit. */
     val restrictedToSet: String? = null,
 ) {
@@ -96,18 +120,133 @@ data class AiProfile(
         val CURRENT = AiProfile(id = "current")
 
         /**
-         * What a player actually faces in a real game — see [EngineAiPlayerController]. Naming it
-         * here makes the production configuration arena-runnable instead of a literal buried in a
-         * controller constructor.
+         * What a player faced in a real game **up to 2026-08-07**, when
+         * [PRODUCTION_CANDIDATE_TUNED] replaced it in [EngineAiPlayerController].
          *
-         * Card intent is **on** here: Phase 6's exit criterion is measured on this profile (it is
-         * what `PuzzleSuiteTest` runs), and shipping the analyzer to everything except the AI
-         * players actually face would be pointless.
+         * Kept, unchanged, as the baseline every promotion is measured against — the same job
+         * [LEGACY_V0] does for the plan's phases, one level up. A candidate has to beat *this*,
+         * not `v0`, because `v0` carries neither the card advisors nor `CardIntent` that shipped
+         * long ago. It is still what `PuzzleSuiteTest` runs, so `KNOWN_FAILURES` keeps describing
+         * a fixed agent rather than drifting with whatever is live.
          */
         val PRODUCTION = AiProfile(
             id = "production",
             advisorModules = listOf(BloomburrowAdvisorModule(), OnslaughtAdvisorModule()),
             useCardIntent = true,
+        )
+
+        /**
+         * What [PRODUCTION] would become if Phases 4, 7 and 8 were switched on for real players:
+         * the shipped card advisors and `CardIntent`, plus the meaningful-action filter, the
+         * four-tier budget, the rollout evaluator and fair play. The arena agent
+         * `production-candidate`.
+         *
+         * **This is the only profile that answers the promotion question**, and until it existed
+         * nothing did. Every number the plan publishes is quoted against [LEGACY_V0], which carries
+         * neither advisors nor `CardIntent` — so "the rollouts are worth +6%" is a statement about
+         * an agent nobody plays against. The gate is `just arena production production-candidate`;
+         * the compounding check is `just arena v0 production-candidate`.
+         *
+         * [TieredBudgetPolicy] is not optional here, unlike in the phase-isolating profiles.
+         * [LegacyBudgetPolicy] has no global deadline, so rollouts under it are a search a real
+         * player waits on with nothing to stop it — acceptable in an arena that spends its budget
+         * as a simulation count, not in a session with a human on the other end.
+         */
+        val PRODUCTION_CANDIDATE = PRODUCTION.copy(
+            id = "production-candidate",
+            useMeaningfulFilter = true,
+            budgetPolicy = TieredBudgetPolicy(),
+            rollouts = RolloutSettings.DEFAULT,
+            determinizeHiddenInformation = true,
+        )
+
+        /**
+         * The two targeted fixes for the suite's remaining failures, without rollouts:
+         * the combat-damage horizon and the concave hand curve, on top of what already ships.
+         *
+         * Between them they aim at four of `PuzzleSuiteTest.KNOWN_FAILURES` — `instants-05` and
+         * `activate-05` from the horizon, `sequencing-02` and `noncreature-02` from the curve —
+         * and they cost essentially nothing: one extra step of simulation inside combat, and a
+         * different constant. That makes this the control that says whether
+         * [PRODUCTION_CANDIDATE]'s rollouts are still paying for themselves once the cheap fixes
+         * are in, rather than being credited for what a constant would have bought.
+         */
+        val PRODUCTION_TUNED = PRODUCTION.copy(
+            id = "production-tuned",
+            useMeaningfulFilter = true,
+            budgetPolicy = TieredBudgetPolicy(),
+            evalWeightsId = "concave-hand",
+            resolveThroughCombatDamage = true,
+        )
+
+        /**
+         * Attribution controls for [PRODUCTION_TUNED], which moves four things at once. Each of
+         * these moves exactly one, so a puzzle that changes can be blamed on something.
+         */
+        val PRODUCTION_HORIZON = PRODUCTION.copy(
+            id = "production-horizon",
+            resolveThroughCombatDamage = true,
+        )
+        val PRODUCTION_CONCAVE = PRODUCTION.copy(
+            id = "production-concave",
+            evalWeightsId = "concave-hand",
+        )
+
+        /** The same curve fix at half strength: empty hand at −2.0 rather than −1.0. */
+        val PRODUCTION_CONCAVE_2 = PRODUCTION.copy(
+            id = "production-concave-2",
+            evalWeightsId = "concave-hand-2",
+        )
+
+        /** The crack-back pricing on its own, so `race-03` moving can be attributed to it. */
+        val PRODUCTION_CRACKBACK = PRODUCTION.copy(
+            id = "production-crackback",
+            priceCrackBackAsLife = true,
+        )
+
+        /** All three targeted fixes. The best the suite can be pushed to without curve-fitting. */
+        val PRODUCTION_TARGETED = PRODUCTION.copy(
+            id = "production-targeted",
+            evalWeightsId = "concave-hand-2",
+            resolveThroughCombatDamage = true,
+            priceCrackBackAsLife = true,
+        )
+
+        /** Horizon plus each curve value, to pick the pair that costs nothing. */
+        val PRODUCTION_HORIZON_CONCAVE = PRODUCTION.copy(
+            id = "production-horizon-concave",
+            evalWeightsId = "concave-hand",
+            resolveThroughCombatDamage = true,
+        )
+        val PRODUCTION_HORIZON_CONCAVE_2 = PRODUCTION.copy(
+            id = "production-horizon-concave-2",
+            evalWeightsId = "concave-hand-2",
+            resolveThroughCombatDamage = true,
+        )
+
+        /**
+         * **What a player faces in a real game as of 2026-08-07** — see [EngineAiPlayerController].
+         *
+         * [PRODUCTION_CANDIDATE] with the two cheap fixes on top. The two scoreboards turned out
+         * to measure nearly orthogonal things, which is why this is a combination rather than a
+         * choice. The rollouts win the arena (**+7.3%** against `production` over 300 paired
+         * games) and *cost* four puzzles; the combat-damage horizon and the concave hand curve win
+         * three puzzles and are arena-neutral (49.7%, CI [48.7%, 50.7%]). Neither result argues
+         * against the other, so this takes both — measured together at **+6.7%**
+         * (`production` 43.3%, CI [39.3%, 47.0%]) and 60/66 on the suite, level with `production`.
+         *
+         * `concave-hand-2` rather than `concave-hand`: −1.0 also closes `sequencing-02`, but it
+         * starts spending the last Counterspell on a 2/2 with seven lands open, and `respond-02`
+         * is the negative control that exists to catch exactly that.
+         *
+         * The id stays `production-candidate-tuned` after promotion on purpose — every arena
+         * report and CSV row already published under that name refers to this exact agent, and
+         * renaming it to match its new status would break that.
+         */
+        val PRODUCTION_CANDIDATE_TUNED = PRODUCTION_CANDIDATE.copy(
+            id = "production-candidate-tuned",
+            evalWeightsId = "concave-hand-2",
+            resolveThroughCombatDamage = true,
         )
 
         /**
@@ -180,7 +319,11 @@ data class AiProfile(
 
 /** The only automatic promotion seam: a set-scoped profile cannot leak into another format. */
 object AiProfileSelector {
-    fun select(setCode: String?, requested: AiProfile?, fallback: AiProfile = AiProfile.PRODUCTION): AiProfile {
+    fun select(
+        setCode: String?,
+        requested: AiProfile?,
+        fallback: AiProfile = AiProfile.PRODUCTION_CANDIDATE_TUNED,
+    ): AiProfile {
         if (requested == null) return fallback
         val restriction = requested.restrictedToSet ?: return requested
         return if (setCode?.uppercase() == restriction.uppercase()) requested else fallback

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.ai.engine
 import com.wingedsheep.ai.engine.advisor.CardAdvisorRegistry
 import com.wingedsheep.ai.engine.budget.DecisionBudget
 import com.wingedsheep.ai.engine.evaluation.BoardEvaluator
+import com.wingedsheep.ai.engine.evaluation.LifeDifferential
 import com.wingedsheep.ai.insight.CombatPlanTrace
 import com.wingedsheep.engine.core.DeclareAttackers
 import com.wingedsheep.engine.core.DeclareBlockers
@@ -30,7 +31,25 @@ class CombatAdvisor(
     private val simulator: GameSimulator,
     private val evaluator: BoardEvaluator,
     private val cardRegistry: CardRegistry? = null,
-    private val advisorRegistry: CardAdvisorRegistry = CardAdvisorRegistry()
+    private val advisorRegistry: CardAdvisorRegistry = CardAdvisorRegistry(),
+    /**
+     * Price the estimated crack-back as life actually lost, instead of a flat penalty that only
+     * fires when it is exactly lethal.
+     *
+     * The old rule is a cliff: at 5 life, four incoming damage costs **nothing** and five costs
+     * 3.0. Everything between "free" and "dead" reads as free, so an attack plan that empties the
+     * board of blockers is scored purely on the damage it deals — which is `race-03`, where the
+     * AI sends the ground creature that was the only answer to the crack-back.
+     *
+     * When on, the penalty is `lifeValue(now) - lifeValue(now - incoming)` scaled by the
+     * evaluator's own life weight. That is not a new guess: it is the same curve
+     * [com.wingedsheep.ai.engine.evaluation.LifeDifferential] already uses, so anticipated damage
+     * is charged at exactly the rate real damage is. It is continuous by construction, and still
+     * dominant at lethal because `lifeValue` prices death at −100.
+     */
+    private val priceCrackBackAsLife: Boolean = false,
+    /** The composite evaluator's `life` coefficient, so the two are in the same units. */
+    private val lifeWeight: Double = 1.0,
 ) {
     companion object {
         /**
@@ -930,10 +949,12 @@ class CombatAdvisor(
         val nextTurnDamage = incomingNextTurnDamage(postCombat, postProjected, playerId, myBlockers)
         val myLife = postCombat.lifeTotal(playerId)
 
-        // Light penalty for plans that leave us dead to the crack-back.
-        // Keep this small — the base evaluator already scores life totals and threats.
-        // This just nudges the AI to prefer attack plans that don't leave us wide open.
-        val crackBackPenalty = if (nextTurnDamage >= myLife) {
+        // Penalty for plans that hand the opponent a crack-back. See [priceCrackBackAsLife] for
+        // why the flat version is a cliff and what replaces it.
+        val crackBackPenalty = if (priceCrackBackAsLife) {
+            val after = myLife - nextTurnDamage
+            -(LifeDifferential.lifeValue(myLife) - LifeDifferential.lifeValue(after)) * lifeWeight
+        } else if (nextTurnDamage >= myLife) {
             -3.0
         } else {
             0.0

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
@@ -21,7 +21,9 @@ private val logger = LoggerFactory.getLogger(EngineAiPlayerController::class.jav
  * AI controller powered by the built-in rules-engine [AIPlayer].
  *
  * Runs entirely locally with no API calls. Uses the engine's ActionProcessor, board evaluator,
- * greedy 1-ply [Strategist] and [CombatAdvisor] directly, configured by [AiProfile.PRODUCTION].
+ * [Strategist] and [CombatAdvisor] directly, configured by [AiProfile.PRODUCTION_CANDIDATE_TUNED]
+ * — rollout candidate evaluation over a determinized state, on a four-tier decision budget. The
+ * pre-2026-08-07 greedy 1-ply configuration is [AiProfile.PRODUCTION], kept as the arena baseline.
  *
  * Requires a [gameStateProvider] to access the real (unmasked) [GameState] from
  * the [com.wingedsheep.gameserver.session.GameSession]. This allows the engine AI
@@ -38,7 +40,8 @@ class EngineAiPlayerController(
     insightSink: AiInsightSink? = null,
 ) : AiPlayerController {
 
-    private val aiPlayer = AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION, insightSink = insightSink)
+    private val aiPlayer =
+        AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_TUNED, insightSink = insightSink)
 
     override fun chooseAction(
         state: ClientGameState,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/GameSimulator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/GameSimulator.kt
@@ -6,6 +6,8 @@ import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
 
 /**
@@ -17,7 +19,27 @@ import com.wingedsheep.sdk.model.EntityId
 class GameSimulator(
     private val cardRegistry: CardRegistry,
     private val processor: ActionProcessor = ActionProcessor(EngineServices(cardRegistry), computeUndo = false),
-    private val enumerator: LegalActionEnumerator = LegalActionEnumerator.create(cardRegistry)
+    private val enumerator: LegalActionEnumerator = LegalActionEnumerator.create(cardRegistry),
+    /**
+     * Carry a simulation past the empty stack to the end of the combat damage step, when blockers
+     * are already declared.
+     *
+     * A quiet state is "the stack is empty", which inside combat is *before damage*. Three puzzles
+     * fail on exactly that gap — `instants-05` (Fog), `activate-05` (firebreathing) and their
+     * relatives all pay mana now for something that only materialises when damage is dealt, so the
+     * post-simulation board is strictly worse than passing and the AI passes. Phase 7 answers this
+     * with full playouts; this answers only the case where the answer is already determined, which
+     * is why it costs one step rather than two turns.
+     *
+     * **Scoped to blockers-already-declared on purpose.** From `DECLARE_ATTACKERS` the outcome
+     * still depends on how the defender blocks, and nothing here would declare those blocks — the
+     * simulation would either stall or silently score an unblocked alpha strike. Once blocks are
+     * in, the only thing between the current state and the damage is the damage.
+     *
+     * Off for [AiProfile.LEGACY_V0], which has to stay frozen, and off by default so a
+     * `GameSimulator` built anywhere else keeps its historical horizon.
+     */
+    private val resolveThroughCombatDamage: Boolean = false,
 ) {
     /**
      * Optional resolver for non-trivial decisions encountered during simulation.
@@ -142,7 +164,17 @@ class GameSimulator(
                 continue
             }
 
-            // Stack empty, no pending decision — we've reached a quiet state
+            // Stack empty, no pending decision — normally a quiet state. Inside combat with
+            // blockers already declared it is a *pre-damage* state, and the whole point of the
+            // candidate may be the damage; pass priority to advance the step and look again.
+            if (resolveThroughCombatDamage && isPreDamageCombatState(state)) {
+                if (priorityPlayerId == null || state.gameOver) break
+                current = processor.process(state, PassPriority(priorityPlayerId)).result
+                allEvents = allEvents + current.events
+                iterations++
+                continue
+            }
+
             break
         }
 
@@ -166,6 +198,25 @@ class GameSimulator(
      */
     private fun trivialResponseFor(decision: PendingDecision): DecisionResponse? =
         TrivialDecisions.responseFor(decision)
+
+    /**
+     * True while combat damage is still ahead of us and nothing but priority stands in its way.
+     *
+     * `DECLARE_BLOCKERS` means blocks are in and the damage is next; `FIRST_STRIKE_COMBAT_DAMAGE`
+     * means the first-strike half has been dealt and the regular half has not. Reaching
+     * `COMBAT_DAMAGE` with an empty stack means the damage is already on the board — the turn-based
+     * action happens on entering the step, before anyone gets priority — so that is where we stop.
+     *
+     * The attacker check keeps an empty combat from costing anything: with nothing attacking there
+     * is no damage to wait for, and advancing would only move the evaluation further from the
+     * decision being scored.
+     */
+    private fun isPreDamageCombatState(state: GameState): Boolean {
+        if (state.step != Step.DECLARE_BLOCKERS && state.step != Step.FIRST_STRIKE_COMBAT_DAMAGE) {
+            return false
+        }
+        return state.getBattlefield().any { state.getEntity(it)?.has<AttackingComponent>() == true }
+    }
 }
 
 /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
@@ -47,7 +47,12 @@ object LifeDifferential : BoardFeature {
     private fun sideLifeValue(state: GameState, side: List<EntityId>): Double =
         state.lifePoolsOf(side).sumOf { lifeValue(it) }
 
-    private fun lifeValue(life: Int): Double = when {
+    /**
+     * Public so a consumer that wants to price *anticipated* life loss can charge it at exactly
+     * the rate the evaluator charges life already, instead of inventing a second constant.
+     * [com.wingedsheep.ai.engine.CombatAdvisor]'s crack-back estimate is the caller.
+     */
+    fun lifeValue(life: Int): Double = when {
         life <= 0 -> -100.0
         life <= 3 -> life * 3.0
         life <= 7 -> 9.0 + (life - 3) * 2.0
@@ -341,19 +346,30 @@ object BoardPresence : BoardFeature {
  * — two teammates in topdeck mode really is twice the disaster.
  */
 object CardAdvantage : BoardFeature {
-    override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
+    /** The historical empty-hand value. See [EvaluationWeights.topdeckPenalty] for why it moves. */
+    const val LEGACY_TOPDECK_PENALTY = -3.0
+
+    override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double =
+        score(state, projected, playerId, LEGACY_TOPDECK_PENALTY)
+
+    fun score(
+        state: GameState,
+        @Suppress("UNUSED_PARAMETER") projected: ProjectedState,
+        playerId: EntityId,
+        topdeckPenalty: Double,
+    ): Double {
         val sides = state.sidesFor(playerId) ?: return 0.0
-        val mine = sideHandValue(state, sides.mine)
+        val mine = sideHandValue(state, sides.mine, topdeckPenalty)
         return sides.against(OpponentAggregate.FIELD) { opponent ->
-            mine - sideHandValue(state, opponent)
+            mine - sideHandValue(state, opponent, topdeckPenalty)
         }
     }
 
-    private fun sideHandValue(state: GameState, side: List<EntityId>): Double =
-        side.sumOf { cardValue(state.getZone(it, Zone.HAND).size) }
+    private fun sideHandValue(state: GameState, side: List<EntityId>, topdeckPenalty: Double): Double =
+        side.sumOf { cardValue(state.getZone(it, Zone.HAND).size, topdeckPenalty) }
 
-    private fun cardValue(count: Int): Double = when {
-        count <= 0 -> -3.0
+    private fun cardValue(count: Int, topdeckPenalty: Double): Double = when {
+        count <= 0 -> topdeckPenalty
         count == 1 -> 1.0
         count <= 3 -> 1.0 + (count - 1) * 1.5
         count <= 7 -> 4.0 + (count - 3) * 0.8

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeights.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeights.kt
@@ -21,6 +21,24 @@ data class EvaluationWeights(
     val cardAdvantage: Double = 1.0,
     val threatAssessment: Double = 1.2,
     val tempo: Double = 0.6,
+    /**
+     * What an empty hand is worth, in the same units as [CardAdvantage]'s curve.
+     *
+     * A constant rather than a coefficient, and the one place the hand curve is not concave.
+     * Marginal value runs 1st card **4.0**, 2nd 1.5, 3rd 1.5, 4th 0.8 — every card after the first
+     * is worth less than the one before it, and then the first breaks the pattern by a factor of
+     * nearly three. That spike is measurable as wrong play: it makes holding the last card beat
+     * casting a spell that would put a 2/2 on the board, which is `sequencing-02` (never plays the
+     * last land) and `noncreature-02` (declines a Disenchant that gains 3.6 against a 4.0 charge,
+     * missing by 0.40).
+     *
+     * `-3.0` is the historical value and the default, because [AiProfile.LEGACY_V0] is the frozen
+     * reference every published number is quoted against. A vector that sets this to `-1.0` makes
+     * the curve concave everywhere — the first card still leads at 2.0 — without touching a single
+     * board-side constant, which is the distinction between fixing the guess that is wrong and
+     * inflating a second guess until the two cancel.
+     */
+    val topdeckPenalty: Double = -3.0,
 ) {
     fun toEvaluator(intents: IntentCatalog = IntentCatalog.NONE): BoardEvaluator = CompositeBoardEvaluator(
         listOf(
@@ -28,7 +46,9 @@ data class EvaluationWeights(
             boardPresence to BoardFeature { state, projected, playerId ->
                 BoardPresence.score(state, projected, playerId, intents)
             },
-            cardAdvantage to CardAdvantage,
+            cardAdvantage to BoardFeature { state, projected, playerId ->
+                CardAdvantage.score(state, projected, playerId, topdeckPenalty)
+            },
             threatAssessment to ThreatAssessment,
             tempo to Tempo,
         )

--- a/ai/src/main/resources/ai/eval-weights.json
+++ b/ai/src/main/resources/ai/eval-weights.json
@@ -12,5 +12,21 @@
     "cardAdvantage": 0.0,
     "threatAssessment": 0.0,
     "tempo": 0.0
+  },
+  "concave-hand": {
+    "life": 1.0,
+    "boardPresence": 1.5,
+    "cardAdvantage": 1.0,
+    "threatAssessment": 1.2,
+    "tempo": 0.6,
+    "topdeckPenalty": -1.0
+  },
+  "concave-hand-2": {
+    "life": 1.0,
+    "boardPresence": 1.5,
+    "cardAdvantage": 1.0,
+    "threatAssessment": 1.2,
+    "tempo": 0.6,
+    "topdeckPenalty": -2.0
   }
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -49,6 +49,23 @@ object ArenaAgents {
         ArenaAgent("current", AiProfile.CURRENT),
         // What a player actually faces in a real game: BLB + ONS card advisors.
         ArenaAgent("production", AiProfile.PRODUCTION),
+        // The same, plus everything Phases 4, 7 and 8 built and left switched off. The promotion
+        // gate is `just arena production production-candidate` — not against `v0`, which has
+        // neither the advisors nor `CardIntent` that already shipped.
+        ArenaAgent("production-candidate", AiProfile.PRODUCTION_CANDIDATE),
+        // The cheap targeted fixes — combat-damage horizon + concave hand curve — without and
+        // with rollouts. `just arena production production-tuned` prices them on their own.
+        ArenaAgent("production-tuned", AiProfile.PRODUCTION_TUNED),
+        ArenaAgent("production-candidate-tuned", AiProfile.PRODUCTION_CANDIDATE_TUNED),
+        // One variable each, so an arena delta can be attributed the same way a puzzle delta is.
+        ArenaAgent("production-horizon", AiProfile.PRODUCTION_HORIZON),
+        ArenaAgent("production-concave", AiProfile.PRODUCTION_CONCAVE),
+        ArenaAgent("production-concave-2", AiProfile.PRODUCTION_CONCAVE_2),
+        ArenaAgent("production-horizon-concave", AiProfile.PRODUCTION_HORIZON_CONCAVE),
+        // The suite's best zero-regression combination: 63/66 against production's 60/66.
+        ArenaAgent("production-horizon-concave-2", AiProfile.PRODUCTION_HORIZON_CONCAVE_2),
+        ArenaAgent("production-crackback", AiProfile.PRODUCTION_CRACKBACK),
+        ArenaAgent("production-targeted", AiProfile.PRODUCTION_TARGETED),
         // Explicit ECL candidates. Their resource-backed weights fail closed to production's
         // evaluator until a validated artifact is installed; automatic selection is set-gated.
         ArenaAgent("ecl-apprentice", AiProfile.ECL_APPRENTICE),

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeightsTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeightsTest.kt
@@ -13,7 +13,10 @@ class EvalWeightsTest : StringSpec({
 
     "bundled profiles are selectable without recompiling" {
         EvalWeights.resolve("blind") shouldBe EvaluationWeights.BLIND
-        EvalWeights.ids shouldBe setOf("default", "blind")
+        // `concave-hand*` differ from `default` only in `topdeckPenalty`: -1.0 and -2.0 against
+        // the historical -3.0. Both are arena-measured; -2.0 is the one production takes, because
+        // -1.0 also starts spending the last card on `respond-02`'s negative control.
+        EvalWeights.ids shouldBe setOf("default", "blind", "concave-hand", "concave-hand-2")
     }
 
     "unknown profile safely uses the compiled fallback" {

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -26,6 +26,23 @@ class PuzzleComparisonBenchmark : ScenarioTestBase() {
             val profiles = listOf(
                 AiProfile.LEGACY_V0,
                 AiProfile.PRODUCTION,
+                // The promotion pair. `production` is what ships today and `production-candidate`
+                // is what flipping Phases 4/7/8 on would ship, so this is the only column pair on
+                // the suite that prices the decision actually in front of us.
+                AiProfile.PRODUCTION_CANDIDATE,
+                // The two cheap targeted fixes, with and without the rollouts on top. If
+                // `production-tuned` matches `production-candidate-tuned` on the suite, the
+                // rollouts are not what is closing these puzzles.
+                AiProfile.PRODUCTION_TUNED,
+                AiProfile.PRODUCTION_CANDIDATE_TUNED,
+                // One variable each, so a puzzle that moves can be attributed.
+                AiProfile.PRODUCTION_HORIZON,
+                AiProfile.PRODUCTION_CONCAVE,
+                AiProfile.PRODUCTION_CONCAVE_2,
+                AiProfile.PRODUCTION_HORIZON_CONCAVE,
+                AiProfile.PRODUCTION_HORIZON_CONCAVE_2,
+                AiProfile.PRODUCTION_CRACKBACK,
+                AiProfile.PRODUCTION_TARGETED,
                 // Phase 7's rollout evaluator, isolated from Phases 4 and 6 so the column is
                 // attributable to the rollouts alone.
                 AiProfile.PHASE7,

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -16,8 +16,13 @@ import io.kotest.matchers.shouldBe
  * AI solve `noncreature-04`, this test fails until the id is deleted from the set, which is
  * exactly the moment you want to notice.
  *
- * The reference profile is [AiProfile.PRODUCTION] — what a player actually faces, card advisors
- * included. `PuzzleComparisonBenchmark` runs the same suite across profiles.
+ * The reference profile stays [AiProfile.PRODUCTION] even though
+ * [AiProfile.PRODUCTION_CANDIDATE_TUNED] is what players face since 2026-08-07. `KNOWN_FAILURES`
+ * is only meaningful if it describes a *fixed* agent — repointing it at whatever is live would
+ * make every promotion rewrite the set it is supposed to be checked against, and the rollout
+ * evaluator would also put ~66 playout-driven positions into an always-on suite that runs in
+ * seconds today. `PuzzleComparisonBenchmark` is where the live profile is scored, alongside every
+ * other one.
  */
 class PuzzleSuiteTest : ScenarioTestBase() {
 

--- a/ai/src/test/kotlin/com/wingedsheep/ai/training/EclTrainingInfrastructureTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/training/EclTrainingInfrastructureTest.kt
@@ -49,7 +49,7 @@ class EclTrainingInfrastructureTest : FunSpec({
 
     test("ECL profile selection cannot leak to another set") {
         AiProfileSelector.select("ECL", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.ECL_APPRENTICE
-        AiProfileSelector.select("BLB", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.PRODUCTION
+        AiProfileSelector.select("BLB", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.PRODUCTION_CANDIDATE_TUNED
         AiProfileSelector.select("BLB", AiProfile.CURRENT) shouldBe AiProfile.CURRENT
     }
 

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -1154,3 +1154,87 @@ publication-quality measurement.
 The run reported three `CastSpell: Not enough mana to cast this spell` rejections, all on one paired
 seed and present in both seat orientations. That is the same pre-existing enumerator/processor
 disagreement Phase 7 records above, not a new error class introduced by determinization.
+
+---
+
+# Promotion — `production-candidate-tuned` goes live
+
+Measured 2026-08-07, 8-core M1 Pro, BLB, seed 20260727. Every arena run is 300 paired games,
+100% completed, 0 illegal actions. Reproduce with `just arena production <agent> 300` and
+`just arena-puzzles-compare`.
+
+Phases 4, 7 and 8 shipped as code and were never switched on: `AiProfile.PRODUCTION` set only the
+card advisors and `useCardIntent`, and `EngineAiPlayerController` hardcoded it. This is the run
+that promoted them, plus two targeted fixes built here.
+
+## The gate nobody had run
+
+Every number above is quoted against `v0`, which carries neither the card advisors nor `CardIntent`
+— so "the rollouts are worth +6%" was a statement about an agent nobody plays against. The
+promotion gate is against **`production`**, and it needed a profile that did not exist.
+
+| Matchup | Win share for B | Pair CI | Puzzles (B) |
+|---|---:|---:|---:|
+| `production` vs `production-candidate` | **57.3%** | [53.3%, 61.7%] | 56/66 |
+| `production` vs `production-horizon-concave-2` | 50.3% | [49.3%, 51.3%] | **63/66** |
+| **`production` vs `production-candidate-tuned`** | **56.7%** | **[53.0%, 60.7%]** | 60/66 |
+
+`production` itself scores 60/66.
+
+**The two scoreboards measure nearly orthogonal things here, and the result is a combination rather
+than a choice.** The rollouts win +7.3% and *cost* four puzzles; the two cheap fixes win three
+puzzles and are arena-neutral. Layering both keeps the win rate intact (+6.7%, statistically the
+same as +7.3%) and returns the suite to parity with what shipped.
+
+Latency, which was listed as an unrecorded Phase 4b deliverable: 25.0 s per game over ~504 actions
+with rollouts on one seat, so ~100 ms per candidate decision — an order of magnitude inside the
+2 s NORMAL tier and far under the server's 500 ms `thinkingDelayMs`.
+
+## Two targeted fixes, each isolated
+
+| Agent | Puzzles | Closes | Breaks |
+|---|---:|---|---|
+| `production` | 60/66 | — | — |
+| `production-horizon` | **62/66** | `instants-05`, `activate-05` | none |
+| `production-concave` (−1.0) | 61/66 | `sequencing-02`, `noncreature-02` | `respond-02` |
+| `production-concave-2` (−2.0) | 61/66 | `noncreature-02` | none |
+| `production-horizon-concave-2` | **63/66** | all three above | none |
+
+**1. `resolveThroughCombatDamage`.** A quiet state is "the stack is empty", which inside combat is
+*before damage*. Fog, a regeneration shield and a firebreathing pump therefore read as pure cost.
+Carrying the simulation one step further — only once blockers are declared, since before that the
+outcome still depends on blocks nothing here would declare — closes `instants-05`, the Fog puzzle
+Phase 2 explicitly assigned to Phase 7's rollouts, for one extra step instead of 16 playouts.
+
+**2. `EvaluationWeights.topdeckPenalty`.** `CardAdvantage`'s marginal card value ran 4.0 / 1.5 /
+1.5 / 0.8 — the first card broke concavity by nearly 3×, which is why holding the last card beat
+casting a spell that puts a 2/2 on the board. −2.0 makes the curve concave everywhere. −1.0 also
+closes `sequencing-02` but starts spending the last Counterspell on a 2/2 with seven lands open;
+`respond-02` is the negative control that exists to catch exactly that, so −2.0 is what ships.
+
+## Three findings worth carrying forward
+
+1. **The card advisors are not tactically neutral.** Three prior measurements (arena, pod, puzzles)
+   agreed they were worth nothing, and on win rate they are. But `production` scores 60/66 against
+   `v0-phase4-intent`'s 58/66 — on tactics they are worth +2.
+2. **Phase 4 costs two puzzles.** `production-tuned` (which adds `useMeaningfulFilter` +
+   `TieredBudgetPolicy` on top of the two fixes) scores 61/66 rather than 63/66, losing
+   `instants-02` and `instants-03` — combat tricks, i.e. the budget cutting combat simulations.
+   Neutral in the arena, so it ships, but the nominal tier sizes deserve their own look.
+3. **`priceCrackBackAsLife` is a no-op and `race-03`'s diagnosis was wrong.** Replacing
+   `evaluateAttackPlan`'s flat −3.0-at-lethal with the life actually lost changes nothing on the
+   suite: `incomingNextTurnDamage` is computed on the **post-combat** state, and in `race-03` the
+   blocker has already traded away by then, so there is no crack-back left to price. The cliff it
+   removes is real (at 5 life, 4 damage was free and 5 cost −3.0) but unmeasured. Shipped **off**.
+
+## What the suite still cannot solve
+
+`production-horizon-concave-2` leaves three, and none is a constant away:
+
+- **`sequencing-02`** — only reachable by moving the curve to −1.0, at the cost of a negative
+  control. The real fix is that a land drop should not be charged as card loss at all; it converts
+  a card to mana rather than spending it.
+- **`race-03`** — needs the crack-back estimated on the *pre*-combat state, or a genuine
+  attack-vs-hold model. The rollouts do not close it either.
+- **`respond-05`** — unexplained. `resolveToQuietState` should already resolve the Wrath and see
+  the Troll survive, so the recorded explanation does not match the code path.


### PR DESCRIPTION
## What

Switches the AI players actually face from greedy 1-ply to the rollout evaluator, and adds two targeted evaluation fixes built while measuring it.

Phases 4, 7 and 8 of `backlog/engine-ai-improvement.md` shipped as code and were **never switched on**. `AiProfile.PRODUCTION` set only the card advisors and `useCardIntent`; `EngineAiPlayerController` hardcoded it. The meaningful-action filter, the tiered budget, the rollout evaluator and determinized fair play have all been dark code in production.

## The gate that had never been run

Every number the plan publishes is quoted against `LEGACY_V0`, which carries neither the card advisors nor `CardIntent`. So "the rollouts are worth +6%" was a statement about an agent nobody plays against. The promotion gate is against **`production`**, and it needed a profile that did not exist.

| Matchup | Win share for B | Pair CI | Puzzles (B) |
|---|---:|---:|---:|
| `production` vs `production-candidate` | 57.3% | [53.3%, 61.7%] | 56/66 |
| `production` vs `production-horizon-concave-2` | 50.3% | [49.3%, 51.3%] | **63/66** |
| **`production` vs `production-candidate-tuned`** | **56.7%** | **[53.0%, 60.7%]** | 60/66 |

300 paired games each, 100% completed, 0 illegal actions. `production` itself scores 60/66.

**The two scoreboards measure nearly orthogonal things here, so this is a combination rather than a choice.** The rollouts win +7.3% and *cost* four puzzles; the two cheap fixes win three puzzles and are arena-neutral. Together the win rate holds (+6.7%, statistically the same) and the suite returns to parity.

**Latency** — listed as an unrecorded Phase 4b deliverable, now measured: 25.0 s per game over ~504 actions with rollouts on one seat, so **~100 ms per candidate decision**. An order of magnitude inside the 2 s NORMAL tier, and well under the server's 500 ms `thinkingDelayMs`.

## The two fixes, each isolated

| Agent | Puzzles | Closes | Breaks |
|---|---:|---|---|
| `production` | 60/66 | — | — |
| `production-horizon` | **62/66** | `instants-05`, `activate-05` | none |
| `production-concave` (−1.0) | 61/66 | `sequencing-02`, `noncreature-02` | `respond-02` |
| `production-concave-2` (−2.0) | 61/66 | `noncreature-02` | none |
| `production-horizon-concave-2` | **63/66** | all three | none |

**`resolveThroughCombatDamage`** — a quiet state is "the stack is empty", which inside combat is *before damage*, so Fog, a regeneration shield and a firebreathing pump all read as pure cost. Carrying the simulation one step further closes `instants-05` — the puzzle Phase 2 explicitly assigned to the rollouts — for one extra step instead of 16 playouts. Scoped to blockers-already-declared: before that the outcome still depends on blocks nothing here would declare.

**`EvaluationWeights.topdeckPenalty`** — `CardAdvantage`'s marginal card value ran 4.0 / 1.5 / 1.5 / 0.8. The first card broke concavity by nearly 3×, which is why holding the last card beat casting a spell that puts a 2/2 on the board. −2.0 makes it concave everywhere. It rides the existing resource-backed weights seam rather than a new flag.

## Reviewer notes

- **`priceCrackBackAsLife` is included but shipped OFF.** It replaces `evaluateAttackPlan`'s flat −3.0-at-lethal with the life actually lost — a real cliff (at 5 life, 4 damage was free and 5 cost −3.0) — but it changes **nothing** on the suite, because `incomingNextTurnDamage` reads the *post-combat* state where the blocker has already traded away. `race-03`'s recorded diagnosis was wrong. Happy to drop it from this PR if you'd rather not carry an unmeasured flag.
- **`AiProfile.PRODUCTION` is unchanged**, kept as the baseline every future promotion is measured against — the job `LEGACY_V0` does for the plan's phases, one level up. `PuzzleSuiteTest` deliberately still runs it, so `KNOWN_FAILURES` keeps describing a fixed agent instead of drifting with whatever is live.
- **The id stays `production-candidate-tuned` after promotion** so the arena reports already written under that name still refer to this exact agent.
- **`ECL_APPRENTICE` / `ECL_OVERLAY` still derive from `PRODUCTION`**, so they do not inherit the rollouts. They are unreachable in real games regardless — `AiProfileSelector.select` has no caller outside tests — so this PR does not change their behaviour, but it is worth a decision separately.

## Two findings worth carrying forward

1. **The card advisors are not tactically neutral.** Three prior measurements agreed they were worth nothing, and on win rate they are — but `production` scores 60/66 against `v0-phase4-intent`'s 58/66.
2. **Phase 4 costs two puzzles.** Adding `useMeaningfulFilter` + `TieredBudgetPolicy` on top of the fixes gives 61/66 rather than 63/66, losing `instants-02` and `instants-03` — combat tricks, i.e. the budget cutting combat simulations. Arena-neutral so it ships, but the nominal tier sizes deserve their own look.

## Still open

`sequencing-02`, `race-03` and `respond-05` remain. None is a constant away, and details are in `docs/ai/baseline-metrics.md`. I stopped short of forcing them — driving a 66-position hand-authored suite to exactly 66/66 is the overfit the plan warns about in three places.

## Verification

`just test-ai` and `just test-server` both green. Arena and puzzle runs as tabled above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
