### PR TITLE
Stop charging a land drop as card loss, and promote the fix to live

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -207,7 +207,11 @@ class AIPlayer(
             } else {
                 intents
             }
-            val evaluator = EvalWeights.resolveEvaluator(profile.evalWeightsId, evaluationIntents)
+            val evaluator = EvalWeights.resolveEvaluator(
+                profile.evalWeightsId,
+                evaluationIntents,
+                landDropIsNotCardLoss = profile.landDropIsNotCardLoss,
+            )
             val combatAdvisor = CombatAdvisor(
                 simulator, evaluator, cardRegistry, advisorRegistry,
                 priceCrackBackAsLife = profile.priceCrackBackAsLife,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -102,6 +102,23 @@ data class AiProfile(
      * `CombatSeed`, and which the rollouts do not close either.
      */
     val priceCrackBackAsLife: Boolean = false,
+    /**
+     * Stop charging a land drop as card loss. A land moving from hand to battlefield is not a card
+     * spent, it is a card converted to mana — and mana is what [EvaluationWeights.tempo] and
+     * `BoardPresence` already price.
+     *
+     * See [com.wingedsheep.ai.engine.evaluation.CardAdvantage]'s `heldCardCount`. The target is
+     * `sequencing-02` — "on the last card in hand, still make the land drop" — the one puzzle every
+     * profile measured so far fails, `production` and `production-candidate-tuned` included. It is
+     * also the one whose real-game frequency is highest: any turn whose only card in hand is a land
+     * is a turn the AI skips its land drop, and every game reaches several.
+     *
+     * Not the same lever as [EvaluationWeights.topdeckPenalty], which the promotion run reached for
+     * and rejected. Moving the constant to −1.0 also closes this puzzle, but by making an empty hand
+     * cheaper *everywhere* — which is why it cost `respond-02`. This changes what a hand *contains*
+     * and leaves the cliff exactly where it is.
+     */
+    val landDropIsNotCardLoss: Boolean = false,
     /** Non-null profiles may only be selected automatically for this set. Arena selection stays explicit. */
     val restrictedToSet: String? = null,
 ) {
@@ -204,6 +221,12 @@ data class AiProfile(
             priceCrackBackAsLife = true,
         )
 
+        /** The land-drop accounting on its own, so `sequencing-02` moving can be attributed to it. */
+        val PRODUCTION_LANDDROP = PRODUCTION.copy(
+            id = "production-landdrop",
+            landDropIsNotCardLoss = true,
+        )
+
         /** All three targeted fixes. The best the suite can be pushed to without curve-fitting. */
         val PRODUCTION_TARGETED = PRODUCTION.copy(
             id = "production-targeted",
@@ -225,7 +248,10 @@ data class AiProfile(
         )
 
         /**
-         * **What a player faces in a real game as of 2026-08-07** — see [EngineAiPlayerController].
+         * What a player faced in a real game **from 2026-08-07 until 2026-08-08**, when
+         * [PRODUCTION_CANDIDATE_LANDDROP] replaced it in [EngineAiPlayerController]. Kept unchanged
+         * as the baseline that promotion was measured against — the same job [PRODUCTION] does for
+         * this one.
          *
          * [PRODUCTION_CANDIDATE] with the two cheap fixes on top. The two scoreboards turned out
          * to measure nearly orthogonal things, which is why this is a combination rather than a
@@ -247,6 +273,27 @@ data class AiProfile(
             id = "production-candidate-tuned",
             evalWeightsId = "concave-hand-2",
             resolveThroughCombatDamage = true,
+        )
+
+        /**
+         * **What a player faces in a real game as of 2026-08-08** — see [EngineAiPlayerController].
+         *
+         * [PRODUCTION_CANDIDATE_TUNED] plus [landDropIsNotCardLoss] — the agent that finally makes
+         * its land drop. Promoted on the same bar the two fixes above it were: **arena-neutral and
+         * a puzzle ahead**. 300 paired games against `production-candidate-tuned` measured 49.0%,
+         * CI [46.3%, 51.3%], 300/300 completed, 0 illegal actions; the accounting on its own
+         * (`production` vs `production-landdrop`, 400 games) 49.5%, CI [46.8%, 52.3%]. On the
+         * 66-puzzle suite it closes `sequencing-02` — the only puzzle every profile before it
+         * failed — and moves no other verdict, for the live pair and for `production` alike.
+         *
+         * A new id rather than a flag flipped on the live profile, for the reason
+         * [PRODUCTION_CANDIDATE_TUNED]'s own KDoc gives: every arena report already published under
+         * that name refers to that exact agent, and the baseline a promotion is measured against
+         * cannot be the thing being promoted.
+         */
+        val PRODUCTION_CANDIDATE_LANDDROP = PRODUCTION_CANDIDATE_TUNED.copy(
+            id = "production-candidate-landdrop",
+            landDropIsNotCardLoss = true,
         )
 
         /**
@@ -322,7 +369,7 @@ object AiProfileSelector {
     fun select(
         setCode: String?,
         requested: AiProfile?,
-        fallback: AiProfile = AiProfile.PRODUCTION_CANDIDATE_TUNED,
+        fallback: AiProfile = AiProfile.PRODUCTION_CANDIDATE_LANDDROP,
     ): AiProfile {
         if (requested == null) return fallback
         val restriction = requested.restrictedToSet ?: return requested

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
@@ -21,9 +21,11 @@ private val logger = LoggerFactory.getLogger(EngineAiPlayerController::class.jav
  * AI controller powered by the built-in rules-engine [AIPlayer].
  *
  * Runs entirely locally with no API calls. Uses the engine's ActionProcessor, board evaluator,
- * [Strategist] and [CombatAdvisor] directly, configured by [AiProfile.PRODUCTION_CANDIDATE_TUNED]
- * — rollout candidate evaluation over a determinized state, on a four-tier decision budget. The
- * pre-2026-08-07 greedy 1-ply configuration is [AiProfile.PRODUCTION], kept as the arena baseline.
+ * [Strategist] and [CombatAdvisor] directly, configured by [AiProfile.PRODUCTION_CANDIDATE_LANDDROP]
+ * — rollout candidate evaluation over a determinized state, on a four-tier decision budget, with a
+ * land drop priced as the card conversion it is. Each superseded configuration is kept as the
+ * baseline its successor was measured against: [AiProfile.PRODUCTION_CANDIDATE_TUNED] ran from
+ * 2026-08-07, and the greedy 1-ply [AiProfile.PRODUCTION] before it.
  *
  * Requires a [gameStateProvider] to access the real (unmasked) [GameState] from
  * the [com.wingedsheep.gameserver.session.GameSession]. This allows the engine AI
@@ -41,7 +43,7 @@ class EngineAiPlayerController(
 ) : AiPlayerController {
 
     private val aiPlayer =
-        AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_TUNED, insightSink = insightSink)
+        AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_LANDDROP, insightSink = insightSink)
 
     override fun chooseAction(
         state: ClientGameState,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComp
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
@@ -357,16 +358,53 @@ object CardAdvantage : BoardFeature {
         @Suppress("UNUSED_PARAMETER") projected: ProjectedState,
         playerId: EntityId,
         topdeckPenalty: Double,
+        landDropIsNotCardLoss: Boolean = false,
     ): Double {
         val sides = state.sidesFor(playerId) ?: return 0.0
-        val mine = sideHandValue(state, sides.mine, topdeckPenalty)
+        val mine = sideHandValue(state, sides.mine, topdeckPenalty, landDropIsNotCardLoss)
         return sides.against(OpponentAggregate.FIELD) { opponent ->
-            mine - sideHandValue(state, opponent, topdeckPenalty)
+            mine - sideHandValue(state, opponent, topdeckPenalty, landDropIsNotCardLoss)
         }
     }
 
-    private fun sideHandValue(state: GameState, side: List<EntityId>, topdeckPenalty: Double): Double =
-        side.sumOf { cardValue(state.getZone(it, Zone.HAND).size, topdeckPenalty) }
+    private fun sideHandValue(
+        state: GameState,
+        side: List<EntityId>,
+        topdeckPenalty: Double,
+        landDropIsNotCardLoss: Boolean,
+    ): Double =
+        side.sumOf { cardValue(heldCardCount(state, it, landDropIsNotCardLoss), topdeckPenalty) }
+
+    /**
+     * How many cards in [playerId]'s hand are *cards* rather than mana waiting to be tapped.
+     *
+     * With [landDropIsNotCardLoss] off this is the hand size, which is what every published number
+     * before 2026-08-07 was measured on.
+     *
+     * On, it holds back one land per unused land drop. Playing a land does not spend a card — it
+     * relocates one, from a zone this feature prices to the battlefield that [Tempo] and
+     * [BoardPresence] price. Charging the move as card loss made it a strict debit: the land drop
+     * paid 1.5–3.0 here to buy 2.1 there, and at the empty-hand cliff it did not cover the
+     * difference, which is why the AI would sit on its last land for the rest of the game
+     * (`sequencing-02`). Holding the drop back on *both* sides of the count makes the move exactly
+     * card-neutral, so [Tempo] and [BoardPresence] decide it alone.
+     *
+     * `LandDropsComponent.remaining` rather than the enumerator's `canPlayLand`, which also demands
+     * main phase / empty stack / your turn. Land drops reset for every player at cleanup, so
+     * `remaining` reads 1 for whoever is not the active player too — the earmark is symmetric and
+     * survives a turn boundary instead of flickering on and off within one. It also misses the
+     * `GrantAdditionalLandDrop` statics that `LandDropUtils` adds on top, which needs a
+     * `CardRegistry` this feature does not have: under an Exploration the second drop is still
+     * charged as card loss, which is the old behaviour rather than a new error.
+     */
+    private fun heldCardCount(state: GameState, playerId: EntityId, landDropIsNotCardLoss: Boolean): Int {
+        val hand = state.getZone(playerId, Zone.HAND)
+        if (!landDropIsNotCardLoss) return hand.size
+        val drops = state.getEntity(playerId)?.get<LandDropsComponent>()?.remaining ?: 0
+        if (drops <= 0) return hand.size
+        val lands = hand.count { state.getEntity(it)?.get<CardComponent>()?.isLand == true }
+        return hand.size - minOf(lands, drops)
+    }
 
     private fun cardValue(count: Int, topdeckPenalty: Double): Double = when {
         count <= 0 -> topdeckPenalty

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeights.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeights.kt
@@ -40,14 +40,17 @@ data class EvaluationWeights(
      */
     val topdeckPenalty: Double = -3.0,
 ) {
-    fun toEvaluator(intents: IntentCatalog = IntentCatalog.NONE): BoardEvaluator = CompositeBoardEvaluator(
+    fun toEvaluator(
+        intents: IntentCatalog = IntentCatalog.NONE,
+        landDropIsNotCardLoss: Boolean = false,
+    ): BoardEvaluator = CompositeBoardEvaluator(
         listOf(
             life to LifeDifferential,
             boardPresence to BoardFeature { state, projected, playerId ->
                 BoardPresence.score(state, projected, playerId, intents)
             },
             cardAdvantage to BoardFeature { state, projected, playerId ->
-                CardAdvantage.score(state, projected, playerId, topdeckPenalty)
+                CardAdvantage.score(state, projected, playerId, topdeckPenalty, landDropIsNotCardLoss)
             },
             threatAssessment to ThreatAssessment,
             tempo to Tempo,
@@ -116,10 +119,19 @@ object EvalWeights {
     fun resolve(id: String): EvaluationWeights =
         resourceWeights[id]?.takeIf(::isFinite) ?: EvaluationWeights.DEFAULT
 
-    fun resolveEvaluator(id: String, intents: IntentCatalog): BoardEvaluator =
+    /**
+     * [landDropIsNotCardLoss] reaches only the composite fallback: the raw Phase 9 vectors price
+     * `myHandSize` linearly, so a land drop already costs them one fitted coefficient with no cliff
+     * to step off, and changing what they count would silently invalidate the fit.
+     */
+    fun resolveEvaluator(
+        id: String,
+        intents: IntentCatalog,
+        landDropIsNotCardLoss: Boolean = false,
+    ): BoardEvaluator =
         apprenticeWeights[id]?.takeIf(RawEvaluationWeights::isValid)?.toEvaluator(intents)
             ?: rawResourceWeights[id]?.takeIf(RawEvaluationWeights::isValid)?.toEvaluator(intents)
-            ?: resolve(id).toEvaluator(intents)
+            ?: resolve(id).toEvaluator(intents, landDropIsNotCardLoss)
 
     /** Whether [id] selects a complete, finite raw vector rather than the composite fallback. */
     fun isRawProfile(id: String): Boolean = apprenticeWeights[id]?.isValid() == true || rawResourceWeights[id]?.isValid() == true

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -65,6 +65,12 @@ object ArenaAgents {
         // The suite's best zero-regression combination: 63/66 against production's 60/66.
         ArenaAgent("production-horizon-concave-2", AiProfile.PRODUCTION_HORIZON_CONCAVE_2),
         ArenaAgent("production-crackback", AiProfile.PRODUCTION_CRACKBACK),
+        // The land-drop accounting alone, and — since 2026-08-08 — what players actually face.
+        // `just arena production production-landdrop 1000` prices the accounting without paying for
+        // rollouts on either seat; `just arena production-candidate-tuned production-candidate-landdrop`
+        // was the promotion gate.
+        ArenaAgent("production-landdrop", AiProfile.PRODUCTION_LANDDROP),
+        ArenaAgent("production-candidate-landdrop", AiProfile.PRODUCTION_CANDIDATE_LANDDROP),
         ArenaAgent("production-targeted", AiProfile.PRODUCTION_TARGETED),
         // Explicit ECL candidates. Their resource-backed weights fail closed to production's
         // evaluator until a validated artifact is installed; automatic selection is set-gated.

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/CardAdvantageLandDropTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/CardAdvantageLandDropTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.ai.engine.evaluation
+
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+
+/**
+ * `AiProfile.landDropIsNotCardLoss`: a land drop relocates a card, it does not spend one.
+ *
+ * Asserted on [CardAdvantage] alone rather than through a whole evaluator, because the claim is
+ * about this one feature and the composite would let [Tempo] and `BoardPresence` cover a wrong
+ * number here with a right one there — which is exactly the confusion the flag exists to undo.
+ * That the fix moves the *decision* is `PuzzleSuiteTest`'s `sequencing-02`.
+ */
+class CardAdvantageLandDropTest : FunSpec({
+
+    val registry = CardRegistry().apply { register(TestCards.all) }
+    val penalty = -2.0 // what `concave-hand-2`, and therefore the live profile, charges
+
+    fun boot(): GameState = GameInitializer(registry).initializeGame(
+        GameConfig(
+            players = (1..2).map { PlayerConfig("P$it", Deck.of("Forest" to 30, "Grizzly Bears" to 10)) },
+            skipMulligans = true,
+            startingPlayerIndex = 0,
+            seed = 424242L,
+        )
+    ).state
+
+    /** Empty both hands, so a test's own [draw]s are the whole hand. */
+    fun GameState.withEmptyHands(): GameState = turnOrder.fold(this) { state, playerId ->
+        state.getZone(playerId, Zone.HAND).fold(state) { s, cardId ->
+            s.removeFromZone(ZoneKey(playerId, Zone.HAND), cardId)
+                .addToZone(ZoneKey(playerId, Zone.LIBRARY), cardId)
+        }
+    }
+
+    /** Move one [cardName] from [playerId]'s library into their hand. */
+    fun GameState.draw(playerId: EntityId, cardName: String): GameState {
+        val cardId = getZone(playerId, Zone.LIBRARY)
+            .first { getEntity(it)?.get<CardComponent>()?.name == cardName }
+        return removeFromZone(ZoneKey(playerId, Zone.LIBRARY), cardId)
+            .addToZone(ZoneKey(playerId, Zone.HAND), cardId)
+    }
+
+    /** Play [playerId]'s first land from hand, spending the land drop — what `PlayLandHandler` does. */
+    fun GameState.playLand(playerId: EntityId): GameState {
+        val cardId = getZone(playerId, Zone.HAND)
+            .first { getEntity(it)?.get<CardComponent>()?.isLand == true }
+        return removeFromZone(ZoneKey(playerId, Zone.HAND), cardId)
+            .addToZone(ZoneKey(playerId, Zone.BATTLEFIELD), cardId)
+            .updateEntity(cardId) { it.with(ControllerComponent(playerId)) }
+            .updateEntity(playerId) { it.with(it.get<LandDropsComponent>()!!.use()) }
+    }
+
+    fun GameState.cards(playerId: EntityId, landDropIsNotCardLoss: Boolean): Double =
+        CardAdvantage.score(this, projectedState, playerId, penalty, landDropIsNotCardLoss)
+
+    test("off, a land drop is charged as card loss — the historical behaviour") {
+        val before = boot().withEmptyHands().let { it.draw(it.turnOrder[0], "Forest") }
+        val me = before.turnOrder[0]
+        val after = before.playLand(me)
+
+        withClue("hand 1 -> 0 costs the whole first-card marginal, which is the cliff") {
+            before.cards(me, landDropIsNotCardLoss = false) shouldBe 3.0
+            after.cards(me, landDropIsNotCardLoss = false) shouldBe 0.0
+        }
+    }
+
+    test("on, a land drop is exactly card-neutral") {
+        val before = boot().withEmptyHands().let { it.draw(it.turnOrder[0], "Forest") }
+        val me = before.turnOrder[0]
+        val after = before.playLand(me)
+
+        after.cards(me, landDropIsNotCardLoss = true) shouldBe before.cards(me, landDropIsNotCardLoss = true)
+    }
+
+    test("on, only one land is held back — the second is a card again") {
+        // Two lands in hand and one drop: the drop earmarks one of them, so the *other* is worth a
+        // card. Without the cap this would read a hand of nothing but lands as topdeck mode.
+        val base = boot().withEmptyHands()
+        val me = base.turnOrder[0]
+        val oneLand = base.draw(me, "Forest")
+        val twoLands = oneLand.draw(me, "Forest")
+
+        twoLands.cards(me, landDropIsNotCardLoss = true) shouldBeGreaterThan
+            oneLand.cards(me, landDropIsNotCardLoss = true)
+
+        withClue("after the drop is spent, the land left in hand counts like any other card") {
+            val played = twoLands.playLand(me)
+            played.cards(me, landDropIsNotCardLoss = true) shouldBe
+                oneLand.cards(me, landDropIsNotCardLoss = false)
+        }
+    }
+
+    test("on, a spell is still a card — casting one still costs card advantage") {
+        val base = boot().withEmptyHands()
+        val me = base.turnOrder[0]
+        val withSpell = base.draw(me, "Grizzly Bears")
+
+        withClue("the earmark is for lands only; a 2/2 in hand is not mana") {
+            withSpell.cards(me, landDropIsNotCardLoss = true) shouldBe
+                withSpell.cards(me, landDropIsNotCardLoss = false)
+        }
+        withClue("and spending it still steps off the cliff") {
+            base.cards(me, landDropIsNotCardLoss = true) shouldBeLessThan
+                withSpell.cards(me, landDropIsNotCardLoss = true)
+        }
+    }
+})

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -43,6 +43,10 @@ class PuzzleComparisonBenchmark : ScenarioTestBase() {
                 AiProfile.PRODUCTION_HORIZON_CONCAVE_2,
                 AiProfile.PRODUCTION_CRACKBACK,
                 AiProfile.PRODUCTION_TARGETED,
+                // The land-drop accounting alone, and on top of what is live. `sequencing-02` is the
+                // one verdict that moves in either column, which is what makes it attributable.
+                AiProfile.PRODUCTION_LANDDROP,
+                AiProfile.PRODUCTION_CANDIDATE_LANDDROP,
                 // Phase 7's rollout evaluator, isolated from Phases 4 and 6 so the column is
                 // attributable to the rollouts alone.
                 AiProfile.PHASE7,

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -17,7 +17,7 @@ import io.kotest.matchers.shouldBe
  * exactly the moment you want to notice.
  *
  * The reference profile stays [AiProfile.PRODUCTION] even though
- * [AiProfile.PRODUCTION_CANDIDATE_TUNED] is what players face since 2026-08-07. `KNOWN_FAILURES`
+ * [AiProfile.PRODUCTION_CANDIDATE_LANDDROP] is what players face since 2026-08-08. `KNOWN_FAILURES`
  * is only meaningful if it describes a *fixed* agent — repointing it at whatever is live would
  * make every promotion rewrite the set it is supposed to be checked against, and the rollout
  * evaluator would also put ~66 playout-driven positions into an always-on suite that runs in
@@ -80,8 +80,14 @@ class PuzzleSuiteTest : ScenarioTestBase() {
             // Needs the rollout evaluator (Phase 7) to play out the damage step.
             "instants-05",
             // `CardAdvantage.cardValue(0) = -3.0` makes emptying your hand read as a disaster, so
-            // the AI holds its last land rather than playing it. Phase 9 refits these constants;
-            // sequencing-04 is the same decision with one card of slack and passes.
+            // the AI holds its last land rather than playing it. sequencing-04 is the same decision
+            // with one card of slack and passes.
+            //
+            // **Closed by `AiProfile.landDropIsNotCardLoss`**, which stops charging the land drop as
+            // card loss at all, and still fails here only because [AiProfile.PRODUCTION] is the
+            // frozen baseline this set describes. Measured on the 66-puzzle suite: it is the *only*
+            // verdict that moves, for `production`, `production-horizon-concave-2` and the live
+            // `production-candidate-tuned` alike (+1 each, nothing broken).
             "sequencing-02",
             // No model of "keep a blocker home": every attacker is scored on the damage it deals.
             "race-03",

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/SequencingPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/SequencingPuzzles.kt
@@ -43,7 +43,8 @@ object SequencingPuzzles {
             // Deliberately paired with sequencing-04, which is the same decision with one more
             // card in hand. If 04 passes and this fails, the defect is precisely
             // `CardAdvantage.cardValue(0) = -3.0`: emptying your hand reads as a disaster, so the
-            // AI would rather hold a land forever than play it. Land drops are free.
+            // AI would rather hold a land forever than play it. Land drops are free — which is what
+            // `AiProfile.landDropIsNotCardLoss` finally tells the evaluator.
             check = { shouldPlayLand("Forest") },
         ),
 

--- a/ai/src/test/kotlin/com/wingedsheep/ai/training/EclTrainingInfrastructureTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/training/EclTrainingInfrastructureTest.kt
@@ -49,7 +49,7 @@ class EclTrainingInfrastructureTest : FunSpec({
 
     test("ECL profile selection cannot leak to another set") {
         AiProfileSelector.select("ECL", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.ECL_APPRENTICE
-        AiProfileSelector.select("BLB", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.PRODUCTION_CANDIDATE_TUNED
+        AiProfileSelector.select("BLB", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.PRODUCTION_CANDIDATE_LANDDROP
         AiProfileSelector.select("BLB", AiProfile.CURRENT) shouldBe AiProfile.CURRENT
     }
 

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -1233,8 +1233,90 @@ closes `sequencing-02` but starts spending the last Counterspell on a 2/2 with s
 
 - **`sequencing-02`** — only reachable by moving the curve to −1.0, at the cost of a negative
   control. The real fix is that a land drop should not be charged as card loss at all; it converts
-  a card to mana rather than spending it.
+  a card to mana rather than spending it. **Closed the next day — see below.**
 - **`race-03`** — needs the crack-back estimated on the *pre*-combat state, or a genuine
   attack-vs-hold model. The rollouts do not close it either.
 - **`respond-05`** — unexplained. `resolveToQuietState` should already resolve the Wrath and see
   the Troll survive, so the recorded explanation does not match the code path.
+
+---
+
+# Promotion — `production-candidate-landdrop` goes live
+
+Measured 2026-08-07, 8-core M1 Pro, BLB, seed 20260727, 0 illegal actions and 100% completed on
+both runs. Reproduce with `just arena production production-landdrop 400`,
+`just arena production-candidate-tuned production-candidate-landdrop 300` and
+`just arena-puzzles-compare`.
+
+This is the item the section above left open: **a land drop is not card loss.**
+
+## The defect, measured on the position rather than argued
+
+`sequencing-02` is one Forest on the battlefield and one Forest in hand. Playing it moves
+`CardAdvantage` from `cardValue(1) = 1.0` to `cardValue(0) = −2.0`:
+
+| feature | Δ playing the land | weight | contribution |
+|---|---:|---:|---:|
+| `CardAdvantage` | −3.0 | 1.0 | **−3.00** |
+| `Tempo` (1 → 2 lands) | +2.0 | 0.6 | +1.20 |
+| `BoardPresence` (untapped land) | +0.6 | 1.5 | +0.90 |
+| | | | **−0.90 → pass** |
+
+The land drop was a strict debit: it paid 1.5–3.0 of card advantage to buy 2.1 of board and tempo,
+and at the empty-hand cliff it did not cover the difference. So the AI sat on its last land — and
+unlike the rest of the suite's failures, that position is not a contrivance. Every game reaches
+several turns whose only card in hand is a land.
+
+## Why not the constant, again
+
+Moving `topdeckPenalty` to −1.0 also closes `sequencing-02`. The promotion run above measured that
+and rejected it, because it makes an empty hand cheaper *everywhere* and cost `respond-02` — the
+negative control that exists for it. `AiProfile.landDropIsNotCardLoss` changes what a hand
+*contains* instead: `CardAdvantage.heldCardCount` holds back one land per unused land drop, so the
+drop is **exactly** card-neutral and the cliff stays where it is. `respond-02`'s verdict does not
+move.
+
+The earmark reads `LandDropsComponent.remaining` rather than the enumerator's `canPlayLand`, which
+also demands main phase / empty stack / your turn. Land drops reset for *every* player at cleanup,
+so `remaining` is 1 for the non-active player too — the earmark is symmetric across the table and
+survives a turn boundary rather than flickering on and off inside one. It misses the
+`GrantAdditionalLandDrop` statics `LandDropUtils` adds, which want a `CardRegistry` the feature does
+not have; under an Exploration the second drop is still charged, which is the old behaviour rather
+than a new error.
+
+## Both scoreboards
+
+| Matchup | Win share for B | Pair CI | Games | Puzzles (B) |
+|---|---:|---:|---:|---:|
+| `production` vs `production-landdrop` | 50.5% | [46.8%, 52.3%] for A | 400 | 61/66 |
+| `production-candidate-tuned` vs `production-candidate-landdrop` | **51.0%** | **[46.3%, 51.3%] for A** | 300 | **61/66** |
+
+Both verdicts are *not distinguishable* — the CI spans parity, which is the same bar
+`production-horizon-concave-2` shipped on. What the puzzles say is unambiguous, and it is one line:
+
+| Agent | Puzzles | Closes | Breaks |
+|---|---:|---|---|
+| `production` | 60/66 | — | — |
+| `production-landdrop` | **61/66** | `sequencing-02` | none |
+| `production-horizon-concave-2` | 63/66 | — | — |
+| `production-horizon-concave-2` + land drop | **64/66** | `sequencing-02` | none |
+| `production-candidate-tuned` (was live) | 60/66 | — | — |
+| `production-candidate-landdrop` (**live**) | **61/66** | `sequencing-02` | none |
+
+`sequencing-02` is the only verdict that moves in any column, which is what makes the delta
+attributable to this change and nothing else.
+
+## Two findings worth carrying forward
+
+1. **The live agent's failing set is not the baseline's.** `production` and
+   `production-candidate-tuned` both score 60/66 and they are *not the same 60*: the rollouts trade
+   `instants-05`, `noncreature-02` and `activate-05` for `instants-02`, `instants-03` and
+   `respond-02`. Two consequences. `respond-02` — the negative control that chose
+   `concave-hand-2` over `concave-hand` — is **already failing on the live agent**, so the argument
+   that pinned that constant no longer describes what ships and the choice deserves re-measuring.
+   And a suite total is not a suite result; only the failing *set* localizes.
+2. **A rollout promotion gate costs 40 minutes, not minutes.** 300 paired games with rollouts on
+   *both* seats ran 2,435 s wall clock at 44 s/game on 8 threads — ~26× the 1.7 s/game of the
+   rollout-free pair. Price the mechanism against a cheap baseline first (`production` vs
+   `production-landdrop` took 103 s and gave the same answer), and spend the expensive run only on
+   the gate that actually decides.


### PR DESCRIPTION
## The puzzle

`sequencing-02` — *"on the last card in hand, still make the land drop"* — is the one puzzle **every** measured profile fails: `production`, `production-horizon-concave-2`, and the live `production-candidate-tuned` alike. It is also the one with the highest real-game frequency of the live agent's six failures. Any turn whose only card in hand is a land is a turn the AI skips its land drop, and every game reaches several.

## The defect, measured on the position

One Forest on the battlefield, one Forest in hand:

| feature | Δ playing the land | weight | contribution |
|---|---:|---:|---:|
| `CardAdvantage` (`cardValue(1)=1.0` → `cardValue(0)=−2.0`) | −3.0 | 1.0 | **−3.00** |
| `Tempo` (1 → 2 lands) | +2.0 | 0.6 | +1.20 |
| `BoardPresence` (untapped land) | +0.6 | 1.5 | +0.90 |
| | | | **−0.90 → pass** |

The land drop was a strict debit: it paid 1.5–3.0 of card advantage to buy 2.1 of board and tempo, and at the empty-hand cliff that did not cover the difference. But playing a land does not *spend* a card — it relocates one, into the zone `Tempo` and `BoardPresence` already price.

## The fix

`CardAdvantage.heldCardCount` holds back one land per unused land drop, which makes the drop **exactly** card-neutral and lets `Tempo` and `BoardPresence` decide it alone.

Deliberately **not** the lever the 2026-08-07 promotion run reached for and rejected. Moving `topdeckPenalty` to −1.0 closes this puzzle too, but by making an empty hand cheaper *everywhere*, which is why it cost `respond-02`. This changes what a hand *contains* and leaves the cliff where it is — `respond-02`'s verdict does not move.

The earmark reads `LandDropsComponent.remaining` rather than the enumerator's `canPlayLand`, which also demands main phase / empty stack / your turn. Land drops reset for *every* player at cleanup, so `remaining` is 1 for the non-active player too: the earmark is symmetric across the table and survives a turn boundary rather than flickering inside one. It misses `GrantAdditionalLandDrop` statics, which want a `CardRegistry` the feature does not have — under an Exploration the second drop is still charged, which is the old behaviour rather than a new error.

Behind `AiProfile.landDropIsNotCardLoss`, off by default, because `LEGACY_V0` is the frozen reference every published number is quoted against.

## Both scoreboards

8-core M1 Pro, BLB, seed 20260727. Every run 100% completed, **0 illegal actions**.

| Matchup | Win share for B | Pair CI | Games |
|---|---:|---:|---:|
| `production` vs `production-landdrop` | 50.5% | [46.8%, 52.3%] for A | 400 |
| `production-candidate-tuned` vs `production-candidate-landdrop` | 51.0% | [46.3%, 51.3%] for A | 300 |

Both *not distinguishable* — the CI spans parity, the same bar `production-horizon-concave-2` shipped on.

| Agent | Puzzles (66) | Closes | Breaks |
|---|---:|---|---|
| `production` | 60 → **61** | `sequencing-02` | none |
| `production-horizon-concave-2` | 63 → **64** | `sequencing-02` | none |
| `production-candidate-tuned` (was live) → `production-candidate-landdrop` (**live**) | 60 → **61** | `sequencing-02` | none |

`sequencing-02` is the **only** verdict that moves in any column, which is what makes the delta attributable to this change and nothing else.

## Promotion

Arena-neutral and a puzzle ahead, so `EngineAiPlayerController` and `AiProfileSelector` now build `PRODUCTION_CANDIDATE_LANDDROP`. `PRODUCTION_CANDIDATE_TUNED` keeps its id and its published numbers, in the role `PRODUCTION` holds for it: the baseline this was measured against. `PuzzleSuiteTest`'s `KNOWN_FAILURES` still describes `PRODUCTION` and is unchanged.

## Two findings recorded in `docs/ai/baseline-metrics.md`

1. **The live agent's failing set is not the baseline's.** `production` and `production-candidate-tuned` both score 60/66 and they are *not the same 60* — the rollouts trade `instants-05`, `noncreature-02` and `activate-05` for `instants-02`, `instants-03` and `respond-02`. So `respond-02`, the negative control that chose `concave-hand-2` over `concave-hand`, is **already failing on what ships**, and that constant deserves re-measuring. A suite total is not a suite result; only the failing set localizes.
2. **A rollout promotion gate costs 40 minutes, not minutes.** 300 paired games with rollouts on *both* seats ran 2,435 s at 44 s/game — ~26× the 1.7 s/game of the rollout-free pair, which gave the same answer in 103 s. Price the mechanism against a cheap baseline first.

## Verification

- `just arena production production-landdrop 400` — 400/400 completed, 0 illegal
- `just arena production-candidate-tuned production-candidate-landdrop 300` — 300/300 completed, 0 illegal
- 66-puzzle suite run across `production`, `production-horizon-concave-2`, `production-candidate-tuned` and each with the flag on — the table above
- New `CardAdvantageLandDropTest` pins the accounting itself: off charges the drop, on is exactly neutral, only one land is held back, and a spell is still a card

⚠️ **Not yet run by me:** the JVM test gate on the final tree. Both new profiles are additive and default-off, but `CardAdvantageLandDropTest`, `FrozenBaselineTest` and `EclTrainingInfrastructureTest` (whose `AiProfileSelector` fallback assertion this PR updates) want a green run before merge. Note also that `PuzzleSuiteTest` on `main` is mid-change from a concurrent branch that took the suite to 78 puzzles; every number here was measured on the 66-puzzle catalog at `4db665f7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)