### PR TITLE
Score the AI's race in urgency instead of turns, and promote it

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -212,6 +212,7 @@ class AIPlayer(
                 evaluationIntents,
                 landDropIsNotCardLoss = profile.landDropIsNotCardLoss,
                 sequenceLandsByUsableMana = profile.sequenceLandsByUsableMana,
+                discountedRaceClock = profile.discountedRaceClock,
             )
             val combatAdvisor = CombatAdvisor(
                 simulator, evaluator, cardRegistry, advisorRegistry,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -157,6 +157,33 @@ data class AiProfile(
      * should not have reached.
      */
     val combatTricksWaitForBlocks: Boolean = false,
+    /**
+     * Score the race in **urgency** — the share of a life total removed per turn — rather than in
+     * turns, so a distant clock is discounted and an absent one is simply zero.
+     *
+     * [com.wingedsheep.ai.engine.evaluation.ThreatAssessment] measures the race by subtracting one
+     * side's turns-to-kill from the other's, and hands a side with no attacker the sentinel `99.0`.
+     * The sentinel goes into the subtraction: an empty board facing a lone 2/2 scores
+     * `(99 − 10) × 1.5`, or −160 once weighted, on a scale where that same 2/2 is worth 3.6 of board
+     * presence and a point of life is worth 1. It fires in both directions — a 5/5 against no
+     * creatures reads **+190** — so every position with an empty board on one side is decided by
+     * this one term.
+     *
+     * The sentinel is the symptom; measuring the race in raw turns is the cause. A turn is not a
+     * turn: the gap between dying on turn 10 and turn 20 counted for as much as the gap between
+     * dying next turn and the turn after, and a great deal happens in ten turns. Urgency is `1 /
+     * turns`, so it discounts distance the way distance should be discounted, needs no sentinel, and
+     * is linear in power — which turns got backwards, pricing 2 power → 4 at twice what it priced
+     * 4 → 8. See [com.wingedsheep.ai.engine.evaluation.ThreatAssessment.RACE_URGENCY_SCALE] for the
+     * scale sweep, and [PRODUCTION_RACECLOCK] for what it moves.
+     *
+     * The target is `lastchance-05` — Unsummon our own Serra Angel in response to a Murder, rather
+     * than bouncing the opposing 2/2. Saving the Angel leaves their 2/2 on board and so pays the
+     * −160; throwing it away clears the board and does not. Nothing about the *card* was misread,
+     * and `PuzzleSuiteTest` was right to record the miss as target polarity: this is where the
+     * polarity comes from.
+     */
+    val discountedRaceClock: Boolean = false,
     /** Non-null profiles may only be selected automatically for this set. Arena selection stays explicit. */
     val restrictedToSet: String? = null,
 ) {
@@ -411,7 +438,10 @@ data class AiProfile(
          * this work and were never diagnosed, because the missing search looks exactly like a
          * missing evaluation until you vary the tier.
          *
-         * **What a player faces in a real game as of 2026-08-09** — see [EngineAiPlayerController].
+         * What a player faced in a real game until [PRODUCTION_CANDIDATE_RACECLOCK] replaced it in
+         * [EngineAiPlayerController]. Kept unchanged as the baseline that promotion was measured
+         * against. (No end date here on purpose — the dates on the four entries above it already run
+         * ahead of the commit clock, and adding a fifth would make the sequence contradict itself.)
          *
          * Promoted on the usual bar, **arena-neutral and a puzzle ahead**, but read the sample size
          * before quoting it. `just arena production-candidate-landseq production-candidate-trickwindow
@@ -435,6 +465,70 @@ data class AiProfile(
             // if that ever takes a `normalMillis`, this line has to carry it too or the promotion
             // run silently measures two changes.
             budgetPolicy = TieredBudgetPolicy(preDamageCombatIsNormal = true),
+        )
+
+        /**
+         * [discountedRaceClock] alone on top of [PRODUCTION], so a puzzle or an arena point that
+         * moves is attributable to it — the same isolation [PRODUCTION_LANDSEQ] gives land
+         * sequencing.
+         *
+         * **The arena says this is a real strength gain, and the puzzle suite says it costs
+         * nothing.** `just arena production production-raceclock 300` measured `production` at
+         * **43.7%, CI [40.0%, 47.7%]**, 131W-169L, 300/300 completed, 0 illegal actions — the whole
+         * interval below parity, which is the first time one of these evaluator fixes has moved the
+         * arena at all rather than merely failing to break it. On the 83-puzzle suite it is level at
+         * 71/83, closing `lastchance-05`, `race-03` and `timing-01` and losing `activate-04`,
+         * `instants-03` and `removal-03`.
+         *
+         * That trade is the second finding, and it is about `BoardPresence` rather than about this
+         * term. All three losses are puzzles that pass today *because* the sentinel is out of scale,
+         * standing in for board-quality the evaluator gets wrong:
+         *  - `activate-04` sends the ping at the opponent's face rather than at a 3/3 only because a
+         *    1-power board makes one point of face damage worth a whole turn of clock. Behind it,
+         *    `BoardPresence.creatureValue` discounts a *damaged* creature by up to half — though
+         *    marked damage wears off at cleanup, which is the exact case the
+         *    `temporaryPTModification` discount five lines above it was written to avoid.
+         *  - `removal-03` kills the Hill Giant rather than the Pacifism'd Craw Wurm only because the
+         *    pacified creature contributes no `attackPotential`, so killing the other one sends the
+         *    opponent to the 99-turn sentinel. Behind it, a creature that cannot attack at all is
+         *    discounted by ×0.85.
+         *
+         * Fix those two and the trade should become a straight gain. Neither belongs in this change:
+         * each is its own flag, its own attribution column and its own arena run.
+         */
+        val PRODUCTION_RACECLOCK = PRODUCTION.copy(
+            id = "production-raceclock",
+            discountedRaceClock = true,
+        )
+
+        /**
+         * [PRODUCTION_CANDIDATE_TRICKWINDOW] plus [discountedRaceClock] — the agent that stops
+         * pricing an empty board as a 99-turn clock.
+         *
+         * **What a player faces in a real game today** — see [EngineAiPlayerController].
+         *
+         * The first promotion here to clear the bar on the *arena* half rather than on the puzzle
+         * half. `just arena production-candidate-trickwindow production-candidate-raceclock 300`
+         * measured the baseline at **45.3%, CI [41.3%, 49.3%]**, 136W-164L, 300/300 completed, 0
+         * illegal actions — the whole interval below parity, with rollouts on both seats. The term
+         * isolated on `production` (`just arena production production-raceclock 300`) says the same
+         * thing more strongly: **43.7%, CI [40.0%, 47.7%]**, 131W-169L. Two independent 300-game
+         * runs, neither CI touching parity.
+         *
+         * On the suite it is level at 76/83, closing `lastchance-05` and `race-03` and losing
+         * `activate-04` and `removal-03` — the two `BoardPresence` weaknesses [PRODUCTION_RACECLOCK]
+         * itemizes, which the old term's sentinel had been masking. Level is normally *below* the
+         * bar; it is a pass here because the arena, which is the scoreboard that matters and the one
+         * these fixes usually cannot move, is unambiguous in both columns.
+         *
+         * If a later run comes back below parity, revert the two call sites
+         * ([EngineAiPlayerController] and [AiProfileSelector]'s fallback) rather than the flag: it
+         * is off for every other profile, so backing the promotion out costs nothing and loses no
+         * measurement.
+         */
+        val PRODUCTION_CANDIDATE_RACECLOCK = PRODUCTION_CANDIDATE_TRICKWINDOW.copy(
+            id = "production-candidate-raceclock",
+            discountedRaceClock = true,
         )
 
         /**
@@ -510,7 +604,7 @@ object AiProfileSelector {
     fun select(
         setCode: String?,
         requested: AiProfile?,
-        fallback: AiProfile = AiProfile.PRODUCTION_CANDIDATE_TRICKWINDOW,
+        fallback: AiProfile = AiProfile.PRODUCTION_CANDIDATE_RACECLOCK,
     ): AiProfile {
         if (requested == null) return fallback
         val restriction = requested.restrictedToSet ?: return requested

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
@@ -21,15 +21,17 @@ private val logger = LoggerFactory.getLogger(EngineAiPlayerController::class.jav
  * AI controller powered by the built-in rules-engine [AIPlayer].
  *
  * Runs entirely locally with no API calls. Uses the engine's ActionProcessor, board evaluator,
- * [Strategist] and [CombatAdvisor] directly, configured by [AiProfile.PRODUCTION_CANDIDATE_TRICKWINDOW]
+ * [Strategist] and [CombatAdvisor] directly, configured by [AiProfile.PRODUCTION_CANDIDATE_RACECLOCK]
  * — rollout candidate evaluation over a determinized state, on a four-tier decision budget, with a
  * land drop priced as the card conversion it is, land *order* priced by the mana it makes usable,
- * and a combat trick held until blocks are in and searched properly once they are.
+ * a combat trick held until blocks are in and searched properly once they are, and the race scored
+ * in urgency rather than in turns.
  * Each superseded configuration is kept as the baseline its successor was measured against:
- * [AiProfile.PRODUCTION_CANDIDATE_LANDSEQ] ran from 2026-08-09,
- * [AiProfile.PRODUCTION_CANDIDATE_LANDDROP] from 2026-08-08,
- * [AiProfile.PRODUCTION_CANDIDATE_TUNED] from 2026-08-07, and the greedy 1-ply
- * [AiProfile.PRODUCTION] before it.
+ * [AiProfile.PRODUCTION_CANDIDATE_TRICKWINDOW] ran immediately before it,
+ * [AiProfile.PRODUCTION_CANDIDATE_LANDSEQ] before it,
+ * [AiProfile.PRODUCTION_CANDIDATE_LANDDROP] before that,
+ * [AiProfile.PRODUCTION_CANDIDATE_TUNED] before that, and the greedy 1-ply
+ * [AiProfile.PRODUCTION] first of all.
  *
  * Requires a [gameStateProvider] to access the real (unmasked) [GameState] from
  * the [com.wingedsheep.gameserver.session.GameSession]. This allows the engine AI
@@ -47,7 +49,7 @@ class EngineAiPlayerController(
 ) : AiPlayerController {
 
     private val aiPlayer =
-        AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_TRICKWINDOW, insightSink = insightSink)
+        AIPlayer.create(cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_RACECLOCK, insightSink = insightSink)
 
     override fun chooseAction(
         state: ClientGameState,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
@@ -514,7 +514,69 @@ object CardAdvantage : BoardFeature {
  * team dies when any of its pools does.
  */
 object ThreatAssessment : BoardFeature {
-    override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
+    /**
+     * The scale the race is measured on: what a full turn of urgency — a clock that kills next
+     * turn — is worth before the 2.0 / 1.5 slope.
+     *
+     * The historical race term is linear in **turns**: `(theirClock − ourClock) × 2.0` when we are
+     * faster and `× 1.5` when we are not, with a side that has no attacker handed the sentinel
+     * `99.0` turns. Two things are wrong with that and they are the same thing.
+     *
+     * The sentinel goes into the subtraction, so an empty board facing one 2/2 scores
+     * `(99 − 10) × 1.5` — **−160 once weighted**, on a scale where a point of life is worth 1.0 and
+     * that 2/2 is worth 3.6 of board presence. And even without the sentinel, a turn is a turn: the
+     * difference between dying on turn 10 and turn 20 counts for as much as the difference between
+     * dying next turn and the turn after. It is not worth as much. A lot happens in ten turns, and
+     * almost nothing the evaluator can see reaches that far.
+     *
+     * So [discountedRaceClock] scores the race in **urgency** — `power / life`, the share of a life
+     * total removed per turn — rather than in turns. Urgency is `1 / turns`, so it discounts a
+     * distant clock exactly the way distance should: a 1-turn clock is 1.0, three turns 0.33, ten
+     * turns 0.1, and no creatures at all is **0.0** with no sentinel and no special case. It also
+     * makes the term linear in *power*, which the turns form got backwards — going 2 power → 4 was
+     * worth 7.5 there and 4 → 8 only 3.75, though each adds the same damage.
+     *
+     * Urgency is capped at 1.0 — nothing kills you more than dead this turn — so the whole term
+     * lands inside +8/−6 raw at this scale, alongside the +8/−10 lethal bonuses below it rather
+     * than fifteen times them.
+     *
+     * **4.0 is measured, not derived.** Near a symmetric clock of `T` turns the urgency form is the
+     * turns form divided by `T²`, so the value that would reproduce the old term at a typical
+     * 3-turn race is ~10 — and 10 is *too strong*, because the old term was double-counting: it
+     * charges for life that [LifeDifferential] already prices at 1.0 a point and for power that
+     * `BoardPresence` already prices. Swept on the 83-puzzle suite against `production`:
+     *
+     * | scale | 0 | 2 | 4 | 6 | 10 | 15 | 20 | unbounded (today) |
+     * |---|---|---|---|---|---|---|---|---|
+     * | passes | 69 | 70 | **71** | 70 | 68 | 68 | 69 | 71 |
+     *
+     * A real optimum rather than an edge: 0 is the control that deletes the term, and losing two
+     * puzzles to it is what says the race is worth scoring at all.
+     */
+    const val RACE_URGENCY_SCALE = 4.0
+
+    /**
+     * How much of [life] a side removes per turn, in `[0, 1]`. `0.0` for a side with no attacker —
+     * which is the whole point: the no-clock case needs no sentinel. See [RACE_URGENCY_SCALE].
+     */
+    private fun urgency(life: Int, power: Int): Double =
+        if (power <= 0 || life <= 0) 0.0 else minOf(power.toDouble() / life, 1.0)
+
+    /** Score with the historical turns-linear race and its `99.0` sentinel. */
+    override fun score(state: GameState, projected: ProjectedState, playerId: EntityId): Double =
+        score(state, projected, playerId, discountedRaceClock = false)
+
+    /**
+     * @param discountedRaceClock score the race in urgency rather than in turns, so a distant clock
+     *   is discounted and an absent one is zero. `EvaluationWeights.toEvaluator` binds this from
+     *   [com.wingedsheep.ai.engine.AiProfile.discountedRaceClock]; see [RACE_URGENCY_SCALE].
+     */
+    fun score(
+        state: GameState,
+        projected: ProjectedState,
+        playerId: EntityId,
+        discountedRaceClock: Boolean,
+    ): Double {
         val sides = state.sidesFor(playerId) ?: return 0.0
 
         val myLife = sideLife(state, sides.mine)
@@ -530,18 +592,26 @@ object ThreatAssessment : BoardFeature {
             val theirAttackPower = attackPotential(state, projected, opponent)
             val theirDefense = defensePotential(state, projected, opponent)
 
-            // How many turns until opponent kills us (if we can't block)
-            val turnsUntilDead = if (theirAttackPower > 0) myLife.toDouble() / theirAttackPower else 99.0
-            val turnsUntilWeKill = if (myAttackPower > 0) theirLife.toDouble() / myAttackPower else 99.0
-
             // Score: positive if we're the faster clock
             var score = 0.0
 
-            // Being closer to killing them is good
-            if (turnsUntilWeKill < turnsUntilDead) {
-                score += (turnsUntilDead - turnsUntilWeKill) * 2.0
+            // Being closer to killing them is good.
+            if (discountedRaceClock) {
+                // Urgency, not turns — see [RACE_URGENCY_SCALE]. Same slopes, same sign, and the
+                // no-clock sentinel simply does not exist on this path.
+                val lead = urgency(theirLife, myAttackPower) - urgency(myLife, theirAttackPower)
+                score += lead * RACE_URGENCY_SCALE * if (lead > 0) 2.0 else 1.5
             } else {
-                score -= (turnsUntilWeKill - turnsUntilDead) * 1.5
+                // How many turns until opponent kills us (if we can't block)
+                val turnsUntilDead =
+                    if (theirAttackPower > 0) myLife.toDouble() / theirAttackPower else 99.0
+                val turnsUntilWeKill =
+                    if (myAttackPower > 0) theirLife.toDouble() / myAttackPower else 99.0
+                if (turnsUntilWeKill < turnsUntilDead) {
+                    score += (turnsUntilDead - turnsUntilWeKill) * 2.0
+                } else {
+                    score -= (turnsUntilWeKill - turnsUntilDead) * 1.5
+                }
             }
 
             // Lethal on board next turn is very valuable

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeights.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/EvalWeights.kt
@@ -44,6 +44,7 @@ data class EvaluationWeights(
         intents: IntentCatalog = IntentCatalog.NONE,
         landDropIsNotCardLoss: Boolean = false,
         sequenceLandsByUsableMana: Boolean = false,
+        discountedRaceClock: Boolean = false,
     ): BoardEvaluator = CompositeBoardEvaluator(
         listOf(
             life to LifeDifferential,
@@ -53,7 +54,9 @@ data class EvaluationWeights(
             cardAdvantage to BoardFeature { state, projected, playerId ->
                 CardAdvantage.score(state, projected, playerId, topdeckPenalty, landDropIsNotCardLoss)
             },
-            threatAssessment to ThreatAssessment,
+            threatAssessment to BoardFeature { state, projected, playerId ->
+                ThreatAssessment.score(state, projected, playerId, discountedRaceClock)
+            },
             tempo to Tempo,
         )
     )
@@ -121,20 +124,23 @@ object EvalWeights {
         resourceWeights[id]?.takeIf(::isFinite) ?: EvaluationWeights.DEFAULT
 
     /**
-     * [landDropIsNotCardLoss] and [sequenceLandsByUsableMana] reach only the composite fallback: the
-     * raw Phase 9 vectors price `myHandSize` linearly, so a land drop already costs them one fitted
-     * coefficient with no cliff to step off, and changing what any of them count would silently
-     * invalidate the fit.
+     * [landDropIsNotCardLoss], [sequenceLandsByUsableMana] and [discountedRaceClock] reach only the
+     * composite fallback: the raw Phase 9 vectors price `myHandSize` linearly, so a land drop
+     * already costs them one fitted coefficient with no cliff to step off, and changing what any of
+     * them count would silently invalidate the fit.
      */
     fun resolveEvaluator(
         id: String,
         intents: IntentCatalog,
         landDropIsNotCardLoss: Boolean = false,
         sequenceLandsByUsableMana: Boolean = false,
+        discountedRaceClock: Boolean = false,
     ): BoardEvaluator =
         apprenticeWeights[id]?.takeIf(RawEvaluationWeights::isValid)?.toEvaluator(intents)
             ?: rawResourceWeights[id]?.takeIf(RawEvaluationWeights::isValid)?.toEvaluator(intents)
-            ?: resolve(id).toEvaluator(intents, landDropIsNotCardLoss, sequenceLandsByUsableMana)
+            ?: resolve(id).toEvaluator(
+                intents, landDropIsNotCardLoss, sequenceLandsByUsableMana, discountedRaceClock,
+            )
 
     /** Whether [id] selects a complete, finite raw vector rather than the composite fallback. */
     fun isRawProfile(id: String): Boolean = apprenticeWeights[id]?.isValid() == true || rawResourceWeights[id]?.isValid() == true

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -84,6 +84,12 @@ object ArenaAgents {
         // promotion gate, against what players face today.
         ArenaAgent("production-trickwindow", AiProfile.PRODUCTION_TRICKWINDOW),
         ArenaAgent("production-candidate-trickwindow", AiProfile.PRODUCTION_CANDIDATE_TRICKWINDOW),
+        // The race-clock bound: stop the "no attackers" sentinel from swamping the evaluator.
+        // `just arena production production-raceclock 1000` prices the term on its own;
+        // `just arena production-candidate-trickwindow production-candidate-raceclock 300` is its
+        // promotion gate, against what players face today.
+        ArenaAgent("production-raceclock", AiProfile.PRODUCTION_RACECLOCK),
+        ArenaAgent("production-candidate-raceclock", AiProfile.PRODUCTION_CANDIDATE_RACECLOCK),
         ArenaAgent("production-targeted", AiProfile.PRODUCTION_TARGETED),
         // Explicit ECL candidates. Their resource-backed weights fail closed to production's
         // evaluator until a validated artifact is installed; automatic selection is set-gated.

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/ThreatAssessmentRaceClockTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/evaluation/ThreatAssessmentRaceClockTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.ai.engine.evaluation
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import kotlin.math.abs
+
+/**
+ * `AiProfile.discountedRaceClock`: score the race in urgency, not in turns.
+ *
+ * Asserted on [ThreatAssessment] alone rather than through a whole evaluator, for
+ * `CardAdvantageLandDropTest`'s reason — the claim is about this one feature, and a composite lets
+ * one wrong number hide behind a right one. That the change moves the *decision* is
+ * `PuzzleSuiteTest`'s `lastchance-05`.
+ *
+ * The `off` numbers are exact, not approximate, because the point is the *scale* of the old term
+ * rather than its sign: −133.5 and +178 on a feature weighted 1.2, in an evaluator where a point of
+ * life is worth 1.0 and the whole 2/2 driving them is worth 3.6 of board presence.
+ */
+class ThreatAssessmentRaceClockTest : ScenarioTestBase() {
+
+    init {
+        /** [ThreatAssessment] for seat 1, with the race discounted or in raw turns. */
+        fun GameState.threat(on: Boolean): Double =
+            ThreatAssessment.score(this, projectedState, turnOrder[0], discountedRaceClock = on)
+
+        /** Both seats at 20 unless [myLife] says otherwise; [mine] / [theirs] are creature names. */
+        fun board(mine: String? = null, theirs: String? = null, myLife: Int = 20): GameState {
+            var builder = scenario().withPlayers().withLifeTotal(1, myLife)
+            mine?.let { builder = builder.withCardOnBattlefield(1, it) }
+            theirs?.let { builder = builder.withCardOnBattlefield(2, it) }
+            return builder.build().state
+        }
+
+        // ── 1. The sentinel, and what it was worth ──
+
+        test("off, one 2/2 across an empty board is worth −133.5 of race") {
+            // 20 life / 2 power = a 10-turn clock, against the no-clock sentinel's 99: the term
+            // charges (99 − 10) × 1.5 for a creature `BoardPresence` prices at 2.4.
+            board(theirs = "Grizzly Bears").threat(on = false) shouldBe (-133.5 plusOrMinus EPSILON)
+        }
+
+        test("off, the same 2/2 on our side is worth +178 — the sentinel fires both ways") {
+            board(mine = "Grizzly Bears").threat(on = false) shouldBe (178.0 plusOrMinus EPSILON)
+        }
+
+        // ── 2. Urgency: no sentinel, and a distant clock discounted ──
+
+        test("on, no creatures is urgency zero — nothing to special-case") {
+            board().threat(on = true) shouldBe (0.0 plusOrMinus EPSILON)
+        }
+
+        test("on, a lone 2/2 at 20 life is a tenth of a clock, either way round") {
+            // 2 power against 20 life removes a tenth of a life total per turn. ×4 scale, and the
+            // same 1.5 / 2.0 slopes as before — applied to urgency instead of to turns.
+            withClue("theirs") {
+                board(theirs = "Grizzly Bears").threat(on = true) shouldBe (-0.6 plusOrMinus EPSILON)
+            }
+            withClue("ours") {
+                board(mine = "Grizzly Bears").threat(on = true) shouldBe (0.8 plusOrMinus EPSILON)
+            }
+        }
+
+        test("on, the term is bounded — urgency caps at 'dead this turn'") {
+            // The widest one side can open is 1.0 of urgency: +8 ahead, −6 behind. Against the old
+            // term's ±190, and alongside the +8/−10 lethal bonuses this sits next to.
+            withClue("a 6/4 against nothing, and the same at 3 life") {
+                abs(board(mine = "Craw Wurm").threat(on = true)) shouldBeLessThan 8.1
+                abs(board(mine = "Craw Wurm", myLife = 3).threat(on = true)) shouldBeLessThan 8.1
+            }
+        }
+
+        // ── 3. The two things the turns form got backwards ──
+
+        test("on, a clock five times closer is five times the penalty — the discount") {
+            // The same 2/2, us at 20 and at 4: a 10-turn clock against a 2-turn one. That is the
+            // whole argument for discounting, and the old term could not express it — it priced the
+            // two nine percent apart, because 99 dwarfs the difference between 10 turns and 2.
+            val far = board(theirs = "Grizzly Bears", myLife = 20)
+            val near = board(theirs = "Grizzly Bears", myLife = 4)
+
+            near.threat(on = true) shouldBe (5.0 * far.threat(on = true) plusOrMinus EPSILON)
+            withClue("off, the same pair is −133.5 against −145.5 — 9% apart, not 5×") {
+                far.threat(on = false) shouldBe (-133.5 plusOrMinus EPSILON)
+                near.threat(on = false) shouldBe (-145.5 plusOrMinus EPSILON)
+            }
+        }
+
+        test("on, the race is linear in power — a 3/3 clock is exactly 1.5 of a 2/2 clock") {
+            // Each point of power adds the same damage, so it should add the same race value. In
+            // turns it did not: the 3/3 came out 4% ahead of the 2/2, because both were being
+            // measured against 99 rather than against each other.
+            val bears = board(mine = "Grizzly Bears").threat(on = true)
+            val giant = board(mine = "Hill Giant").threat(on = true)
+            giant shouldBe (1.5 * bears plusOrMinus EPSILON)
+
+            withClue("off: +178 against +184.67, a 4% difference for 50% more power") {
+                board(mine = "Hill Giant").threat(on = false) shouldBe (184.6666 plusOrMinus 0.001)
+            }
+        }
+
+        // ── 4. What the discount must not cost ──
+
+        test("on, a clock that actually arrives is still priced as the emergency it is") {
+            // Empty board at 6 life against a 6/4: dead next turn. Urgency 1.0 is the cap, so −6 of
+            // race — and the −10 lethal-range penalty the sentinel used to drown out now dominates
+            // it, which is the right way round.
+            val dying = board(theirs = "Craw Wurm", myLife = 6)
+            dying.threat(on = true) shouldBe (-16.0 plusOrMinus EPSILON)
+            dying.threat(on = true) shouldBeLessThan board(theirs = "Grizzly Bears").threat(on = true)
+        }
+
+        test("on, the faster side of a real race still scores positive") {
+            board(mine = "Craw Wurm", theirs = "Grizzly Bears").threat(on = true) shouldBe
+                (1.6 plusOrMinus EPSILON) // (6/20 − 2/20) × 4 × 2.0
+        }
+    }
+
+    private companion object {
+        const val EPSILON = 1e-9
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -57,6 +57,11 @@ class PuzzleComparisonBenchmark : ScenarioTestBase() {
                 // spending the trick needs the budget half, which needs tiers.
                 AiProfile.PRODUCTION_TRICKWINDOW,
                 AiProfile.PRODUCTION_CANDIDATE_TRICKWINDOW,
+                // The race-clock bound, alone and on top of what is live. `lastchance-05` is the
+                // verdict that should move. This one touches every position with an empty board,
+                // so the column is read for what it *costs* as much as for what it closes.
+                AiProfile.PRODUCTION_RACECLOCK,
+                AiProfile.PRODUCTION_CANDIDATE_RACECLOCK,
                 // Phase 7's rollout evaluator, isolated from Phases 4 and 6 so the column is
                 // attributable to the rollouts alone.
                 AiProfile.PHASE7,

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -91,6 +91,10 @@ class PuzzleSuiteTest : ScenarioTestBase() {
             // `production-candidate-tuned` alike (+1 each, nothing broken).
             "sequencing-02",
             // No model of "keep a blocker home": every attacker is scored on the damage it deals.
+            //
+            // **Also closed by `AiProfile.discountedRaceClock`** — not by a model of blocking, but
+            // because scoring the race in urgency rather than turns makes the opponent's clock
+            // linear in the power we leave unblocked, where the turns form flattened it.
             "race-03",
             // The same `cardValue(0)` cliff as sequencing-02, measured exactly: with one card in
             // hand, casting the Disenchant costs 4.0 of card advantage, and destroying an anthem
@@ -160,8 +164,19 @@ class PuzzleSuiteTest : ScenarioTestBase() {
             // Not a "does it respond" failure — the AI casts the Unsummon. It aims it at the
             // opponent's 2/2 instead of at its own Serra Angel, which is dying to the Murder on the
             // stack. So the miss is in target *polarity*, and the puzzle is built to catch exactly
-            // that (the second legal target is there on purpose). Where in target selection it goes
-            // wrong is not yet diagnosed, and this entry deliberately does not guess.
+            // that (the second legal target is there on purpose).
+            //
+            // **Diagnosed**, and not in target selection: `Strategist.chooseCommittedTargets` does
+            // simulate both targets here and picks the worse board on the merits. `ThreatAssessment`
+            // hands a side with no creatures the sentinel `99.0` turns and then *subtracts* it, so
+            // saving the Angel — which leaves their 2/2 alive against our empty board — scores −160
+            // against bouncing the 2/2's 0. Getting a 4/4 flier back is worth +3.8 of everything
+            // else in the evaluator combined, and loses by forty times that.
+            //
+            // **Closed by `AiProfile.discountedRaceClock`**, which scores the race in urgency
+            // (`power / life`) rather than in turns, so a distant clock is discounted and an absent
+            // one is zero with no sentinel at all. Still fails here only because [AiProfile.
+            // PRODUCTION] is the frozen baseline this set describes.
             "lastchance-05",
 
             // ── The combat trick window ──

--- a/ai/src/test/kotlin/com/wingedsheep/ai/training/EclTrainingInfrastructureTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/training/EclTrainingInfrastructureTest.kt
@@ -51,7 +51,7 @@ class EclTrainingInfrastructureTest : FunSpec({
         AiProfileSelector.select("ECL", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.ECL_APPRENTICE
         // Whatever is live, not a fixed profile: this pins that a set-scoped request falls back to
         // the production agent, so it moves with every promotion.
-        AiProfileSelector.select("BLB", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.PRODUCTION_CANDIDATE_TRICKWINDOW
+        AiProfileSelector.select("BLB", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.PRODUCTION_CANDIDATE_RACECLOCK
         AiProfileSelector.select("BLB", AiProfile.CURRENT) shouldBe AiProfile.CURRENT
     }
 

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -1320,3 +1320,119 @@ attributable to this change and nothing else.
    rollout-free pair. Price the mechanism against a cheap baseline first (`production` vs
    `production-landdrop` took 103 s and gave the same answer), and spend the expensive run only on
    the gate that actually decides.
+
+---
+
+# Promotion — `production-candidate-raceclock` goes live
+
+**Measured:** 2026-08-07. Flag `AiProfile.discountedRaceClock`, profiles `production-raceclock` and
+`production-candidate-raceclock`. The first evaluator fix in this file whose **arena** result is
+positive rather than merely neutral — and the first promotion carried by the arena half of the bar
+rather than the puzzle half.
+
+## The defect
+
+`ThreatAssessment` scores the race as `(theirClock − ourClock) × 2.0` when we are faster and `× 1.5`
+when we are not, where a clock is `life / attackPower` **in turns**, and a side with no attacker is
+handed the sentinel `99.0`.
+
+The sentinel goes into the subtraction. An empty board facing a single 2/2 scores
+`(99 − 10) × 1.5 = −133.5` raw, **−160 weighted**; one 2/2 against an empty board reads **+178**, a
+6/4 reads **+191**. For scale, in the same evaluator a point of life is worth 1.0 and that 2/2 is
+worth 3.6 of board presence. So on every position where one side has no creature — most of the first
+four turns, every post-sweeper board, most of a puzzle position — this single term decides the move.
+
+The sentinel is the symptom. Measuring the race in **turns** is the cause, and it is wrong twice
+over even where no sentinel is involved:
+
+- **Distance is not discounted.** The gap between dying on turn 10 and turn 20 counts for as much as
+  the gap between dying next turn and the turn after. A great deal happens in ten turns.
+- **It is sublinear in power**, which is backwards. Going from 2 power to 4 halves a 20-life clock
+  from 10 turns to 5 — worth 7.5. Going from 4 to 8 halves it again, 5 turns to 2.5 — worth 3.75.
+  Each step adds the same damage.
+
+`lastchance-05` is the clean demonstration. Unsummon, Murder on the stack targeting our Serra Angel,
+their Grizzly Bears also legal. `Strategist.chooseCommittedTargets` **does** simulate both targets
+and picks the wrong one on the merits: saving the Angel leaves their 2/2 against our empty board
+(−160), throwing it away clears the board (0). Everything else in the evaluator — a 4/4 flier back
+in hand against a 2/2 back in theirs — is worth +3.8 combined.
+
+## The fix
+
+Score the race in **urgency** — `power / life`, the share of a life total removed per turn — rather
+than in turns. Urgency is `1 / turns`, so it discounts a distant clock the way distance should be
+discounted (1 turn → 1.0, three turns → 0.33, ten turns → 0.1), it is linear in power, and a side
+with no creatures is **0.0** with no sentinel and no special case. Same slopes (2.0 ahead, 1.5
+behind), capped at 1.0 because nothing kills you more than dead this turn.
+
+`RACE_URGENCY_SCALE` is **4.0**, swept on the suite against `production`:
+
+| scale | 0 | 2 | 4 | 6 | 10 | 15 | 20 | unbounded (today) |
+|---|---|---|---|---|---|---|---|---|
+| passes | 69 | 70 | **71** | 70 | 68 | 68 | 69 | 71 |
+
+Scale 0 deletes the term; losing two puzzles to it is what says the race is worth scoring at all.
+The value that would *reproduce* the old term at a typical 3-turn race is ~10 (near a symmetric
+clock `T`, urgency is turns divided by `T²`), and 10 measures worse — because the turns form was
+double-counting life that `LifeDifferential` already prices at 1.0 a point and power that
+`BoardPresence` already prices.
+
+## Both scoreboards
+
+| | `production` | live (`production-candidate-trickwindow`) |
+|---|---|---|
+| puzzles, baseline | 71/83 | 76/83 |
+| puzzles, with the fix | 71/83 | 76/83 |
+| closes | `lastchance-05`, `race-03`, `timing-01` | `lastchance-05`, `race-03` |
+| loses | `activate-04`, `instants-03`, `removal-03` | `activate-04`, `removal-03` |
+
+**Arena — both columns, neither CI touching parity:**
+
+| run | baseline win % | CI | record |
+|---|---|---|---|
+| `production` vs `production-raceclock` (isolation) | **43.7%** | [40.0%, 47.7%] | 131W-169L |
+| `production-candidate-trickwindow` vs `production-candidate-raceclock` (**gate**) | **45.3%** | [41.3%, 49.3%] | 136W-164L |
+
+300 games each, 300/300 completed, 0 illegal actions, rollouts on both seats for the gate (2050 s
+wall clock). This is a genuine strength gain, not the usual "cannot resolve a difference at 300
+games" — and it is why a puzzle-*level* result promotes here where the standing bar asks for a
+puzzle ahead. `race-03` closing is the visible half of it: the term is now linear in the power we
+leave unblocked, so keeping a blocker home finally scores.
+
+`EngineAiPlayerController` and `AiProfileSelector`'s fallback now point at
+`production-candidate-raceclock`. To back it out, revert those two call sites rather than the flag.
+
+## The finding: the sentinel was standing in for `BoardPresence`
+
+Every puzzle the fix costs is one that passes today *because* the term is out of scale, and each
+names a real mispricing underneath:
+
+- **`activate-04`** (do not point 1 damage at a 3/3) passes only because with a 1-power board,
+  `d(ourClock)/d(theirLife) = 1`, so one point of face damage moves the clock a whole turn.
+  Underneath, `BoardPresence.creatureValue` discounts a **damaged** creature by up to half —
+  `×(0.5 + 0.5 × healthFraction)` — though marked damage wears off at cleanup. That is exactly the
+  case the `temporaryPTModification` discount five lines above it was written to avoid.
+- **`removal-03`** (kill the Hill Giant, not the Pacifism'd Craw Wurm) passes only because the
+  pacified creature contributes no `attackPotential`, so killing the *other* one sends the opponent
+  to the 99-turn sentinel. Underneath, a creature that cannot attack at all is discounted by ×0.85.
+- **`blocking-02` / `keywords-01`** (do not chump) survive the urgency form but died under every
+  hard cap tried, for the same reason: on the merits the margin is 0.6 — a 2/2's 3.6 of board
+  presence against 3 life — thin enough that any reweighting flips it.
+
+Fix the damaged-creature and cannot-attack prices and this should become a straight gain rather than
+a trade. Each is its own flag, its own attribution column and its own arena run.
+
+## Three shapes that look more principled and measure worse
+
+All bound the sentinel just as well; all were swept and rejected before urgency:
+
+- **Cap each clock at `H` turns, no-clock at `H`** (swept 10–20). Erases the gap between a 1-power
+  and a 2-power board, so the AI chump-blocks — after the chump its own clock reads unchanged.
+- **Cap at `H`, no-clock at `H + 1`** (swept 8–12). Holds the chump-block puzzles and closes
+  `lastchance-05` on `production`, but not on the live agent, whose shallower `concave-hand-2` curve
+  halves the card-advantage margin the race term has to be outvoted by.
+- **Clamp the *difference*, or saturate it through `tanh`** (swept C = 4–6, K = 3–8). Both trade
+  `activate-04` for `race-03` at every setting, because both flatten the gradient a real race runs
+  on while leaving the turns unit — and the sublinearity in power — in place.
+
+The common lesson: bounding the sentinel is not the fix. Changing the unit is.


### PR DESCRIPTION
## The defect

`ThreatAssessment` measures the race as a difference of clocks **in turns**, and hands a side with no attacker the sentinel `99.0`. The sentinel then goes into the subtraction:

| board (both at 20 life) | race term, weighted |
|---|---|
| empty vs their lone 2/2 | **−160** |
| our lone 2/2 vs empty | **+214** |
| our 6/4 vs empty | **+230** |

On the same scale a point of life is worth 1.0 and that 2/2 is worth 3.6 of board presence. So every position with an empty board on one side — most of the first four turns, every post-sweeper board, most of a puzzle position — was decided by this one term.

The sentinel is the symptom. The **unit** is the cause, and it is wrong twice over even where no sentinel is involved:

- **Distance isn't discounted.** Dying on turn 10 vs turn 20 counts for as much as dying next turn vs the turn after. A lot happens in ten turns.
- **It's sublinear in power.** 2 power → 4 halves a 20-life clock from 10 turns to 5, worth 7.5. 4 → 8 halves it again, worth 3.75. Each step adds the same damage.

## The fix

`AiProfile.discountedRaceClock` scores the race in **urgency** — `power / life`, the share of a life total removed per turn — instead of in turns. Urgency is `1 / turns`, so it discounts distance the way distance should be discounted (1 turn → 1.0, three turns → 0.33, ten turns → 0.1), it is linear in power, and a side with no creatures is **0.0** with no sentinel and no special case. Same 2.0 / 1.5 slopes, capped at 1.0 because nothing kills you more than dead this turn.

`RACE_URGENCY_SCALE = 4.0`, swept on the suite against `production`:

| scale | 0 | 2 | **4** | 6 | 10 | 15 | 20 | unbounded (today) |
|---|---|---|---|---|---|---|---|---|
| passes | 69 | 70 | **71** | 70 | 68 | 68 | 69 | 71 |

A real optimum, not an edge: scale 0 is the control that deletes the term, and losing two puzzles to it is what says the race is worth scoring at all. The value that would *reproduce* the old term at a typical 3-turn race is ~10, and 10 measures worse — the turns form was double-counting life that `LifeDifferential` already prices and power that `BoardPresence` already prices.

## Measurement

**Arena — 300 games each, 300/300 completed, 0 illegal actions:**

| run | baseline win % | CI | record |
|---|---|---|---|
| `production` vs `production-raceclock` (isolation) | **43.7%** | [40.0%, 47.7%] | 131W–169L |
| `production-candidate-trickwindow` vs `production-candidate-raceclock` (**gate**) | **45.3%** | [41.3%, 49.3%] | 136W–164L |

Neither CI touches parity, with rollouts on both seats for the gate (2050 s wall clock).

**Puzzles — level on both columns:**

| | `production` | live pair |
|---|---|---|
| baseline → with fix | 71/83 → 71/83 | 76/83 → 76/83 |
| closes | `lastchance-05`, `race-03`, `timing-01` | `lastchance-05`, `race-03` |
| loses | `activate-04`, `instants-03`, `removal-03` | `activate-04`, `removal-03` |

## Promoted

`EngineAiPlayerController` and `AiProfileSelector`'s fallback now point at `production-candidate-raceclock`. Level puzzles would normally be *below* the standing "arena-neutral and a puzzle ahead" bar; it passes here because the arena — the scoreboard that matters, and the one these tactical fixes usually cannot move at all — is unambiguous in both columns. To back it out, revert those two call sites rather than the flag; it is off for every other profile.

## Two findings worth carrying forward

**`lastchance-05` was misdiagnosed.** `PuzzleSuiteTest` recorded it as an undiagnosed target-*polarity* miss. It is not target selection: `Strategist.chooseCommittedTargets` does simulate both targets and picks the worse board on the merits, because saving the Serra Angel leaves their 2/2 against our empty board (−160) and throwing it away clears the board (0). Getting a 4/4 flier back is worth +3.8 of everything else in the evaluator combined.

**The sentinel was standing in for `BoardPresence`.** Every puzzle this costs passes today *because* the term is out of scale, and each names a real mispricing underneath:

- **`activate-04`** rides on a 1-power board making one point of face damage worth a whole turn of clock. Underneath, `creatureValue` discounts a **damaged** creature by up to half — `×(0.5 + 0.5 × healthFraction)` — though marked damage wears off at cleanup. That is exactly the case the `temporaryPTModification` discount five lines above it was written to avoid.
- **`removal-03`** rides on a Pacifism'd creature contributing no `attackPotential`, so killing the *other* creature sends the opponent to the 99-turn sentinel. Underneath, a creature that cannot attack at all is discounted by ×0.85.

Both are left for their own flag, attribution column and arena run. Fixing them should turn this trade into a straight gain.

## Also tried, and measured worse

All three bound the sentinel just as well; all were swept and rejected:

- Cap each clock at `H` turns, no-clock at `H` (10–20) — erases the gap between a 1-power and 2-power board, so the AI chump-blocks.
- Cap at `H`, no-clock at `H + 1` (8–12) — holds the chump-block puzzles, closes `lastchance-05` on `production` but not on the live agent.
- Clamp the *difference*, or saturate through `tanh` (C = 4–6, K = 3–8) — both trade `activate-04` for `race-03` at every setting.

Bounding the sentinel is not the fix. Changing the unit is.

## Verification

- `:ai:test` — 399 tests, 0 failures. `FrozenBaselineTest` green: the off path is arithmetically identical to the code it replaces, so `v0`'s hashed action stream is unmoved.
- New `ThreatAssessmentRaceClockTest` — asserted on the feature alone, per `CardAdvantageLandDropTest`'s convention.
- `:game-server`, `:gym`, `:gym-trainer` compile.

## One thing to look at

The promotion chain in `AiProfile` is dated 08-07 → 08-08 → 08-09 while the commit clock reads 2026-08-07, so the existing dates already run ahead. I made this entry ordinal rather than dated instead of renumbering that history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)