### PR TITLE
Add command-zone triggered abilities (eminence) and Edgar Markov

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3464,7 +3464,34 @@ work for abilities-on-stack (which carry no `CardComponent`).
 
 ## 8. Triggered abilities (`Triggers.*`)
 
-`triggeredAbility { trigger; effect; target?; triggerCondition?; optional?; elseEffect?; checkOnNextState?; dealsDamageBeforeResolve?; controlledByTriggeringEntityController?; oncePerTurn?; triggersOnce? }`.
+`triggeredAbility { trigger; effect; target?; triggerZone?/triggerZones?; triggerCondition?; optional?; elseEffect?; checkOnNextState?; dealsDamageBeforeResolve?; controlledByTriggeringEntityController?; oncePerTurn?; triggersOnce? }`.
+
+**`triggerZones` — which zones the trigger condition functions in (CR 113.6b).** Defaults to
+`setOf(Zone.BATTLEFIELD)`, which CR 113.6 makes the rule for a permanent card's abilities. It is a
+*set* because CR 113.6k lets one ability function from several zones at once. `triggerZone` is the
+single-zone shorthand (`triggerZone = Zone.GRAVEYARD`) and is what almost every card wants.
+
+`TriggerDetector` scans each declared non-battlefield zone; the card there is *owned*, not
+controlled, so its owner controls any ability it produces. Coverage differs by zone, deliberately:
+
+| Zone | Per-event triggers | Step/phase triggers | Example |
+|---|---|---|---|
+| `BATTLEFIELD` | ✅ | ✅ | the default |
+| `GRAVEYARD` | ✅ | ✅ | Pyre Zombie, Gigapede, Killian's Confidence |
+| `COMMAND` | ✅ | ✅ | *eminence* — Edgar Markov |
+| `EXILE` | — (dedicated paths) | ✅ | suspend, madness, paradigm |
+
+Exile has no general per-event pass on purpose: suspend, madness and paradigm each already have a
+dedicated detector, and a general pass would fire them twice.
+
+**Eminence** (CR 207.2c — an ability word, no rules meaning of its own) is just
+`triggerZones = setOf(Zone.BATTLEFIELD, Zone.COMMAND)`; there is no eminence keyword or engine type.
+The printed "if [this] is in the command zone or on the battlefield" clause is *also* an
+intervening-"if" (CR 603.4), so it is checked again at resolution — and the engine does **not**
+re-check `triggerCondition` at resolution time. Supply that half by gating the effect on the same
+test, `ConditionalEffect(Conditions.SourceInZone(Zone.BATTLEFIELD, Zone.COMMAND), effect)`, which is
+what makes killing Edgar in response to the Vampire spell produce no token. See
+`c17/cards/EdgarMarkov.kt`.
 
 **`oncePerTurn` vs `triggersOnce` — two firing caps.** `oncePerTurn = true` caps the ability to one
 fire per turn ("This ability triggers only once each turn", e.g. Scavenger's Talent), tracked by a
@@ -6848,6 +6875,12 @@ answer it and would silently return `false`.
   entering creature — Leonardo, Sewer Samurai ("creatures you cast from your graveyard enter with a
   finality counter") and Mikey & Don ("creatures you cast from the top of your library enter with an
   extra +1/+1 counter", `WasCastFromZone(Zone.LIBRARY)`).
+- `SourceInZone(vararg zones)` — where the source object is **right now**. A live zone-membership
+  lookup, so unlike `WasCastFromZone` (frozen at cast time) it answers differently once the source
+  moves; it reads identically at resolution and under projection. Its job is CR 603.4's
+  resolution-time re-check for an ability whose printed intervening-"if" is a zone test — *eminence*
+  is `SourceInZone(Zone.BATTLEFIELD, Zone.COMMAND)` gating the effect, so an Edgar Markov killed
+  after the trigger fires makes no token. See §8's `triggerZones`.
 - `WasKicked` — cast with kicker / multikicker / offspring (i.e. an `OptionalAdditionalCost` with `branchesEffect = true` whose extra cost was paid). FlashKicker payments are intentionally invisible to this condition.
 - `WasBargained` — the spell's **bargain** additional cost was declared as it was cast (CR 702.166b, Wilds of Eldraine). A facade over `CastChoiceMade(ChoiceSlot.BARGAINED)`, so bargain needs no condition type of its own. Reads the durable flag on a resolved permanent (an "if it was bargained" enters trigger) *and* the declaration carried on a still-on-the-stack spell (an "if this spell was bargained" rider), and is also the condition a `CostGating.OnlyIf` cost reduction gates on. Never true for a merely kicked spell.
 - `SneakCostWasPaid` — the source was cast for its `Sneak` cost (CR 702.190 — mana + returning an unblocked attacker). Reads the durable `ChoiceSlot.SNEAK` flag on a resolved permanent, falling back to the resolution context for a non-permanent spell's own effect. Backs riders like Leonardo, Leader in Blue and The Last Ronin's Technique.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1372,8 +1372,26 @@ class TriggeredAbilityBuilder {
     var target: TargetRequirement? = null
     var optional: Boolean = false
     var elseEffect: Effect? = null
-    var triggerZone: Zone = Zone.BATTLEFIELD
-    /** Intervening-if condition (Rule 603.4): checked when trigger would fire AND at resolution. */
+    /**
+     * The zones this ability's trigger condition functions in (CR 113.6b). Defaults to the
+     * battlefield. Use the set form when an ability functions in more than one zone at once — an
+     * *eminence* ability is `setOf(Zone.BATTLEFIELD, Zone.COMMAND)`.
+     */
+    var triggerZones: Set<Zone> = setOf(Zone.BATTLEFIELD)
+
+    /**
+     * Single-zone shorthand for [triggerZones] — `triggerZone = Zone.GRAVEYARD`. Reading it back
+     * yields the first zone, so prefer [triggerZones] for an ability that functions in several.
+     */
+    var triggerZone: Zone
+        get() = triggerZones.first()
+        set(value) { triggerZones = setOf(value) }
+
+    /**
+     * Intervening-if condition (Rule 603.4): checked when the trigger would fire. Note the engine
+     * does not yet re-check it at resolution — an ability that needs the second half of CR 603.4
+     * has to gate its own effect on the same condition (`ConditionalEffect`).
+     */
     var triggerCondition: Condition? = null
     /** When true, the triggered ability is controlled by the triggering entity's controller. */
     var controlledByTriggeringEntityController: Boolean = false
@@ -1417,7 +1435,7 @@ class TriggeredAbilityBuilder {
             targetRequirement = primaryTarget,
             additionalTargetRequirements = additionalTargets,
             elseEffect = elseEffect,
-            activeZone = triggerZone,
+            activeZones = triggerZones,
             triggerCondition = triggerCondition,
             controlledByTriggeringEntityController = controlledByTriggeringEntityController,
             oncePerTurn = oncePerTurn,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.sdk.scripting.conditions.NoManaSpentToCast as NoManaSpent
 import com.wingedsheep.sdk.scripting.conditions.NoManaSpentToCastEntered as NoManaSpentToCastEnteredCondition
 import com.wingedsheep.sdk.scripting.conditions.WasCastFromHand as WasCastFromHandCondition
 import com.wingedsheep.sdk.scripting.conditions.WasCastFromZone as WasCastFromZoneCondition
+import com.wingedsheep.sdk.scripting.conditions.SourceInZone as SourceInZoneCondition
 import com.wingedsheep.sdk.scripting.conditions.WasKicked as WasKickedCondition
 import com.wingedsheep.sdk.scripting.conditions.BlightWasPaid as BlightWasPaidCondition
 import com.wingedsheep.sdk.scripting.conditions.WaterbendWasPaid as WaterbendWasPaidCondition
@@ -808,6 +809,17 @@ object Conditions {
      */
     fun WasCastFromZone(zone: Zone): ConditionInterface =
         WasCastFromZoneCondition(zone)
+
+    /**
+     * If the ability's source is *currently* in one of [zones] — a live lookup, unlike
+     * [WasCastFromZone]'s frozen cast-time answer.
+     *
+     * The eminence shape is `SourceInZone(Zone.BATTLEFIELD, Zone.COMMAND)`, gating the ability's
+     * effect so CR 603.4's resolution-time re-check holds: an Edgar Markov that leaves both zones
+     * after the trigger fires produces nothing.
+     */
+    fun SourceInZone(vararg zones: Zone): ConditionInterface =
+        SourceInZoneCondition(zones.toSet())
 
     /**
      * If this spell was cast from a graveyard.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Madness.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Madness.kt
@@ -63,7 +63,7 @@ object Madness {
             to = Zone.EXILE
         ),
         binding = TriggerBinding.SELF,
-        activeZone = Zone.EXILE,
+        activeZones = setOf(Zone.EXILE),
         effect = CompositeEffect(
             listOf(
                 MayEffect(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Paradigm.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Paradigm.kt
@@ -26,7 +26,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *  - **Recurring free recast** — [recastAbility] below, the single triggered ability the engine
  *    synthesizes for every exiled card carrying the paradigm marker. It fires at the beginning of
  *    the owner's precombat (first) main phase — the trigger detector already scans exile for
- *    `activeZone == EXILE` triggers and treats exiled cards as owner-controlled — and lets the owner
+ *    `EXILE in activeZones` triggers and treats exiled cards as owner-controlled — and lets the owner
  *    cast a **copy** of the exiled card for free through the ordinary
  *    [CopyCardIntoCollectionEffect] → [CastFromCollectionWithoutPayingCostEffect] pipeline (which
  *    handles target / X selection). The original never leaves exile, so the trigger recurs every
@@ -43,7 +43,7 @@ object Paradigm {
 
     /**
      * The synthesized triggered ability granted (by the engine) to any exiled card that carries
-     * the paradigm marker. Functions only in exile (`activeZone == EXILE`), so it is inert anywhere
+     * the paradigm marker. Functions only in exile (`activeZones == {EXILE}`), so it is inert anywhere
      * else and harmless to return universally.
      */
     val recastAbility: TriggeredAbility = TriggeredAbility(
@@ -51,7 +51,7 @@ object Paradigm {
         // "your first main phase" = the precombat main phase (CR 505 — the first main phase).
         trigger = EventPattern.StepEvent(Step.PRECOMBAT_MAIN, Player.You),
         binding = TriggerBinding.SELF,
-        activeZone = Zone.EXILE,
+        activeZones = setOf(Zone.EXILE),
         effect = MayEffect(
             CompositeEffect(
                 listOf(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Suspend.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/Suspend.kt
@@ -31,7 +31,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *    keys on.
  *  - **Counting down and casting** — [countdownAbility] below, a single triggered ability
  *    the engine synthesizes for every exiled card carrying the suspend marker. It fires on
- *    the owner's upkeep (the trigger detector already scans exile for `activeZone == EXILE`
+ *    the owner's upkeep (the trigger detector already scans exile for `EXILE in activeZones`
  *    triggers and treats exiled cards as owner-controlled), removes one time counter, and —
  *    when that empties the pile — grants haste and plays the card for free through the
  *    ordinary [CastFromCollectionWithoutPayingCostEffect] pipeline (which handles target / X
@@ -59,7 +59,7 @@ object Suspend {
         id = AbilityId("suspend_countdown"),
         trigger = EventPattern.StepEvent(Step.UPKEEP, Player.You),
         binding = TriggerBinding.SELF,
-        activeZone = Zone.EXILE,
+        activeZones = setOf(Zone.EXILE),
         // Only count down while counters remain; this also makes a leftover marker inert.
         triggerCondition = hasTimeCounter,
         effect = CompositeEffect(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TriggeredAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TriggeredAbility.kt
@@ -28,8 +28,24 @@ data class TriggeredAbility(
     /** Additional target requirements for multi-target triggered abilities (e.g., exchange control). */
     val additionalTargetRequirements: List<TargetRequirement> = emptyList(),
     val elseEffect: Effect? = null,
-    val activeZone: Zone = Zone.BATTLEFIELD,
-    /** Intervening-if condition (Rule 603.4): checked when trigger would fire AND at resolution. */
+    /**
+     * The zones this ability's trigger condition functions in (CR 113.6b — "an ability that states
+     * which zones it functions in functions only from those zones"). Defaults to the battlefield,
+     * which CR 113.6 makes the rule for a permanent card's abilities.
+     *
+     * A *set* rather than a single zone because CR 113.6k allows one triggered ability to function
+     * from several zones at once. Two shapes need it today: a graveyard/exile-resident ability
+     * (`{GRAVEYARD}`, `{EXILE}` — Pyre Zombie, suspend, madness) and an *eminence* ability, which
+     * functions from the command zone **and** the battlefield (`{BATTLEFIELD, COMMAND}` — Edgar
+     * Markov). The detector scans each declared zone independently, so a card sitting in exactly
+     * one of them fires exactly once.
+     */
+    val activeZones: Set<Zone> = setOf(Zone.BATTLEFIELD),
+    /**
+     * Intervening-if condition (Rule 603.4): checked when the trigger would fire. The engine does
+     * not re-check it at resolution — an ability that needs CR 603.4's second half gates its own
+     * effect on the same condition instead (see Edgar Markov's eminence ability).
+     */
     val triggerCondition: Condition? = null,
     /** When true, the triggered ability is controlled by the triggering entity's controller
      * instead of the source permanent's controller. Used for cards like Death Match. */
@@ -105,7 +121,7 @@ data class TriggeredAbility(
             targetRequirement: TargetRequirement? = null,
             additionalTargetRequirements: List<TargetRequirement> = emptyList(),
             elseEffect: Effect? = null,
-            activeZone: Zone = Zone.BATTLEFIELD,
+            activeZones: Set<Zone> = setOf(Zone.BATTLEFIELD),
             triggerCondition: Condition? = null,
             controlledByTriggeringEntityController: Boolean = false,
             oncePerTurn: Boolean = false,
@@ -121,7 +137,7 @@ data class TriggeredAbility(
                 targetRequirement = targetRequirement,
                 additionalTargetRequirements = additionalTargetRequirements,
                 elseEffect = elseEffect,
-                activeZone = activeZone,
+                activeZones = activeZones,
                 triggerCondition = triggerCondition,
                 controlledByTriggeringEntityController = controlledByTriggeringEntityController,
                 oncePerTurn = oncePerTurn,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
@@ -244,6 +244,35 @@ data object AnyEnteredOrWasCastFromExile : Condition {
 }
 
 /**
+ * Condition: "if this is in [zones]" — where the ability's source object sits *right now*.
+ *
+ * Distinct from [WasCastFromZone], which asks where a spell came *from* at cast time and is frozen
+ * for the rest of the spell's life. This one is a live lookup, so it answers differently before and
+ * after the source moves.
+ *
+ * Its reason for existing is CR 603.4's second half. An eminence ability reads "Whenever you cast
+ * another Vampire spell, **if Edgar is in the command zone or on the battlefield**, …": the zone
+ * test is an intervening-"if", so it is checked both when the trigger fires and again as the ability
+ * resolves, and the official Edgar Markov ruling spells out the consequence — if Edgar leaves that
+ * zone in between, the ability does nothing. Trigger-time is already covered by
+ * [com.wingedsheep.sdk.scripting.TriggeredAbility.activeZones]; gating the effect on this condition
+ * is what supplies the resolution-time half.
+ *
+ * Evaluates identically at resolution and during projection — it reads only zone membership.
+ */
+@SerialName("SourceInZone")
+@Serializable
+data class SourceInZone(val zones: Set<Zone>) : Condition {
+    init {
+        require(zones.isNotEmpty()) { "SourceInZone needs at least one zone" }
+    }
+
+    override val description: String =
+        "this is " + zones.sortedBy { it.ordinal }
+            .joinToString(" or ") { if (it == Zone.BATTLEFIELD) "on the battlefield" else "in ${it.displayName}" }
+}
+
+/**
  * Condition: "If this spell was cast from [zone]"
  * Used for flashback spells and other zone-dependent effects.
  * Checks whether the spell was cast from the specified zone.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/EdgarMarkov.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/EdgarMarkov.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Edgar Markov — Commander 2017 #36 (earliest printing; later reprinted in Innistrad Remastered).
+ *
+ * {3}{R}{W}{B} Legendary Creature — Vampire Knight, 4/4
+ *   Eminence — Whenever you cast another Vampire spell, if Edgar is in the command zone or on the
+ *   battlefield, create a 1/1 black Vampire creature token.
+ *   First strike, haste
+ *   Whenever Edgar attacks, put a +1/+1 counter on each Vampire you control.
+ *
+ * **Eminence** is an ability word (CR 207.2c) — no rules meaning of its own. What makes the ability
+ * work is CR 113.6b: "an ability that states which zones it functions in functions only from those
+ * zones". The printed "if Edgar is in the command zone or on the battlefield" is that statement, so
+ * the trigger condition functions from both zones, which is exactly
+ * `triggerZones = setOf(Zone.BATTLEFIELD, Zone.COMMAND)`. `TriggerDetector` scans the command zone
+ * for those (see `NON_BATTLEFIELD_EVENT_TRIGGER_ZONES`); no eminence-specific engine type exists.
+ *
+ * The same clause is also an intervening-"if" (CR 603.4), so it is checked *twice* — when the
+ * trigger fires and again as the ability resolves. The official ruling is explicit: "If it's on the
+ * battlefield or in the command zone when you cast another Vampire spell but leaves that zone before
+ * the ability resolves, the ability won't do anything as it resolves." `triggerZones` covers the
+ * fire-time half; the [ConditionalEffect] on [Conditions.SourceInZone] covers the resolution-time
+ * half, so killing Edgar in response to the Vampire spell produces no token.
+ *
+ * **"another"** needs no filter of its own. For the triggering spell to *be* Edgar, Edgar's card has
+ * to be on the stack — and a card on the stack is in neither of the two zones this ability functions
+ * from, so the zone gate already declines it. Casting Edgar out of the command zone therefore makes
+ * no token, which `EdgarMarkovScenarioTest` pins down.
+ *
+ * The attack trigger reuses the Cathars' Crusade idiom: [Effects.ForEachInGroup] over the Vampires
+ * you control, with the inner counter aimed at [EffectTarget.Self] (the iterated member).
+ */
+val EdgarMarkov = card("Edgar Markov") {
+    manaCost = "{3}{R}{W}{B}"
+    colorIdentity = "RWB"
+    typeLine = "Legendary Creature — Vampire Knight"
+    power = 4
+    toughness = 4
+    oracleText = "Eminence — Whenever you cast another Vampire spell, if Edgar is in the command " +
+        "zone or on the battlefield, create a 1/1 black Vampire creature token.\n" +
+        "First strike, haste\n" +
+        "Whenever Edgar attacks, put a +1/+1 counter on each Vampire you control."
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSubtype(Subtype.VAMPIRE)
+        triggerZones = setOf(Zone.BATTLEFIELD, Zone.COMMAND)
+        effect = ConditionalEffect(
+            condition = Conditions.SourceInZone(Zone.BATTLEFIELD, Zone.COMMAND),
+            effect = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Vampire"),
+            ),
+        )
+        description = "Eminence — Whenever you cast another Vampire spell, if Edgar is in the " +
+            "command zone or on the battlefield, create a 1/1 black Vampire creature token."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl().withSubtype(Subtype.VAMPIRE)),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+        )
+        description = "Whenever Edgar attacks, put a +1/+1 counter on each Vampire you control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "36"
+        artist = "Volkan Baǵa"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d94b8ec-ecda-43c8-a60e-1ba33e6a54a4.jpg?1783935938"
+
+        ruling("2017-08-25", "Edgar Markov's eminence ability is a triggered ability. Edgar must be on the battlefield or in the command zone when you cast another Vampire spell and also as the triggered ability resolves. If it's on the battlefield or in the command zone when you cast another Vampire spell but leaves that zone before the ability resolves, the ability won't do anything as it resolves.")
+        ruling("2017-08-25", "Notably, if Edgar Markov is on the battlefield and its eminence ability triggers, but it's put into the command zone before that ability resolves, that ability won't do anything as it resolves. This is because an object that changes zones is considered a new object.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/EdgarMarkovReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/EdgarMarkovReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Innistrad Remastered printing; the canonical definition lives in C17. */
+val EdgarMarkovReprint = Printing(
+    oracleId = "41e2790d-49f5-4e98-b8d9-04179f47f13a",
+    name = "Edgar Markov",
+    setCode = "INR",
+    collectorNumber = "234",
+    scryfallId = "a577ba08-0aa8-45be-aa83-d5078770127c",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a577ba08-0aa8-45be-aa83-d5078770127c.jpg?1783908078",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/Ringwraiths.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/Ringwraiths.kt
@@ -22,7 +22,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * that creature is legendary, its controller loses 3 life.
  * When the Ring tempts you, return this card from your graveyard to your hand.
  *
- * Gap 21 (graveyard-functional triggered ability) is engine-landed (`TriggeredAbility.activeZone`,
+ * Gap 21 (graveyard-functional triggered ability) is engine-landed (`TriggeredAbility.activeZones`,
  * DSL `triggerZone = Zone.GRAVEYARD`; templates Pyre Zombie, Persistent Marshstalker). The legendary
  * rider is checked mid-resolution (the targeted creature is still on the battlefield until SBAs run
  * after the ability finishes), so printed order works.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/EdgarMarkovReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/EdgarMarkovReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Edgar Markov reprint in PZ2. Canonical CardDefinition lives in C17 (its earliest printing).
+ */
+val EdgarMarkovReprint = Printing(
+    oracleId = "41e2790d-49f5-4e98-b8d9-04179f47f13a",
+    name = "Edgar Markov",
+    setCode = "PZ2",
+    collectorNumber = "65693",
+    scryfallId = "a365937a-a2c8-4522-aa2e-4b471af5ab93",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a365937a-a2c8-4522-aa2e-4b471af5ab93.jpg?1783935587",
+    releaseDate = "2017-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/KilliansConfidence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/sos/cards/KilliansConfidence.kt
@@ -23,7 +23,7 @@ import com.wingedsheep.sdk.scripting.targets.TargetCreature
  * If you do, return this card from your graveyard to your hand.
  *
  * The recursion ability functions only while this card is in the graveyard
- * ([activeZone] = [Zone.GRAVEYARD], CR 113.6). The optional hybrid payment is modeled with
+ * ([activeZones] = {[Zone.GRAVEYARD]}, CR 113.6b). The optional hybrid payment is modeled with
  * [MayPayManaEffect]; on payment the card returns itself ([EffectTarget.Self]) to its owner's hand.
  */
 val KilliansConfidence = card("Killian's Confidence") {

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -13546,7 +13546,9 @@
                         "placement": "TappedAndAttacking"
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "triggerCondition": {
                     "type": "Compare",
                     "left": {

--- a/mtg-sets/src/test/resources/snapshots/cards/C17.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/C17.json
@@ -1,3 +1,108 @@
+// Edgar Markov
+{
+    "name": "Edgar Markov",
+    "manaCost": "{3}{R}{W}{B}",
+    "typeLine": "Legendary Creature — Vampire Knight",
+    "oracleText": "Eminence — Whenever you cast another Vampire spell, if Edgar is in the command zone or on the battlefield, create a 1/1 black Vampire creature token.\nFirst strike, haste\nWhenever Edgar attacks, put a +1/+1 counter on each Vampire you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Vampire"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "SourceInZone",
+                            "zones": [
+                                "Battlefield",
+                                "Command"
+                            ]
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "BLACK"
+                        ],
+                        "creatureTypes": [
+                            "Vampire"
+                        ]
+                    }
+                },
+                "activeZones": [
+                    "Battlefield",
+                    "Command"
+                ],
+                "descriptionOverride": "Eminence — Whenever you cast another Vampire spell, if Edgar is in the command zone or on the battlefield, create a 1/1 black Vampire creature token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Vampire ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever Edgar attacks, put a +1/+1 counter on each Vampire you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "MYTHIC",
+        "artist": "Volkan Baǵa",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d94b8ec-ecda-43c8-a60e-1ba33e6a54a4.jpg?1783935938",
+        "rulings": [
+            {
+                "date": "2017-08-25",
+                "text": "Edgar Markov's eminence ability is a triggered ability. Edgar must be on the battlefield or in the command zone when you cast another Vampire spell and also as the triggered ability resolves. If it's on the battlefield or in the command zone when you cast another Vampire spell but leaves that zone before the ability resolves, the ability won't do anything as it resolves."
+            },
+            {
+                "date": "2017-08-25",
+                "text": "Notably, if Edgar Markov is on the battlefield and its eminence ability triggers, but it's put into the command zone before that ability resolves, that ability won't do anything as it resolves. This is because an object that changes zones is considered a new object."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Ramos, Dragon Engine
 {
     "name": "Ramos, Dragon Engine",

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -361,7 +361,9 @@
                     "target": "Self",
                     "destination": "Battlefield"
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "Whenever you activate an exhaust ability, return this card from your graveyard to the battlefield."
             }
         ],

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -2505,7 +2505,9 @@
                         }
                     ]
                 },
-                "activeZone": "Exile",
+                "activeZones": [
+                    "Exile"
+                ],
                 "triggerCondition": {
                     "type": "Compare",
                     "left": {
@@ -4304,7 +4306,9 @@
                         }
                     ]
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ]
     },
@@ -7473,7 +7477,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ]
     },
@@ -14168,7 +14174,9 @@
                         "placement": "TappedAndAttacking"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -5840,7 +5840,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "Eerie — Whenever an enchantment you control enters, you may return this card from your graveyard to your hand."
             },
             {
@@ -5856,7 +5858,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "Eerie — Whenever you fully unlock a Room, you may return this card from your graveyard to your hand."
             }
         ],

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -805,7 +805,9 @@
                         }
                     ]
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "staticAbilities": [
@@ -17384,7 +17386,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "replacementEffects": [

--- a/mtg-sets/src/test/resources/snapshots/cards/FRF.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FRF.json
@@ -36,7 +36,9 @@
                         "destination": "Battlefield"
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "triggerCondition": {
                     "type": "Exists",
                     "player": "You",

--- a/mtg-sets/src/test/resources/snapshots/cards/INV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/INV.json
@@ -10023,7 +10023,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "activatedAbilities": [
@@ -11237,7 +11239,9 @@
                     },
                     "descriptionOverride": "You may exile this creature. If you do, shuffle all creature cards from your graveyard into your library."
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/LGN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LGN.json
@@ -3016,7 +3016,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "replacementEffects": [

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -2573,7 +2573,9 @@
                         }
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "triggerCondition": {
                     "type": "Exists",
                     "player": "You",
@@ -14041,7 +14043,9 @@
                     "target": "Self",
                     "destination": "Hand"
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -7064,7 +7064,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -6296,7 +6296,9 @@
                         "destination": "Battlefield"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "staticAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/RNA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RNA.json
@@ -168,7 +168,9 @@
                         "fromZone": "Graveyard"
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "Whenever a Gate you control enters, you may put this card from your graveyard on top of your library."
             }
         ],

--- a/mtg-sets/src/test/resources/snapshots/cards/SCG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SCG.json
@@ -675,7 +675,9 @@
                         "destination": "Battlefield"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "staticAbilities": [
@@ -2507,7 +2509,9 @@
                     "then": "ReturnSelfToBattlefieldAttached",
                     "descriptionOverride": "Attach Dragon Breath to this creature?"
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "activatedAbilities": [
@@ -2583,7 +2587,9 @@
                     "then": "ReturnSelfToBattlefieldAttached",
                     "descriptionOverride": "Attach Dragon Fangs to this creature?"
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "staticAbilities": [
@@ -2713,7 +2719,9 @@
                     "then": "ReturnSelfToBattlefieldAttached",
                     "descriptionOverride": "Attach Dragon Scales to this creature?"
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "staticAbilities": [
@@ -2770,7 +2778,9 @@
                     "then": "ReturnSelfToBattlefieldAttached",
                     "descriptionOverride": "Attach Dragon Shadow to this creature?"
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "staticAbilities": [
@@ -2906,7 +2916,9 @@
                     "then": "ReturnSelfToBattlefieldAttached",
                     "descriptionOverride": "Attach Dragon Wings to this creature?"
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ],
         "staticAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -8292,7 +8292,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "Whenever one or more creatures you control deal combat damage to a player, you may pay {W/B}. If you do, return this card from your graveyard to your hand."
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -6195,7 +6195,9 @@
                         "destination": "Hand"
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "Whenever a creature you control dies while this card is in your graveyard, you may pay {1}{W}. If you do, return this card from your graveyard to your hand."
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -22747,7 +22747,9 @@
                         ]
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "Whenever you draw your second card each turn, you may pay {B}. If you do, return this card from your graveyard to the battlefield with a finality counter on it."
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -8199,7 +8199,9 @@
                         }
                     ]
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "When this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library."
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -12952,7 +12952,9 @@
                     ],
                     "descriptionOverride": "You may exile this creature. When you do, return target creature card from your graveyard to your hand."
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -13190,7 +13190,9 @@
                         "fromZone": "Graveyard"
                     }
                 },
-                "activeZone": "Graveyard"
+                "activeZones": [
+                    "Graveyard"
+                ]
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -276,7 +276,9 @@
                         "fromZone": "Graveyard"
                     }
                 },
-                "activeZone": "Graveyard",
+                "activeZones": [
+                    "Graveyard"
+                ],
                 "descriptionOverride": "Landfall — Whenever a land you control enters, you may return this card from your graveyard to the battlefield."
             }
         ],

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Envelopes.kt
@@ -50,6 +50,12 @@ internal fun BridgeBuilder.structuralEnvelopes() {
     // wrapper only sets the ability's `activateFromZone` (Zone.HAND / Zone.GRAVEYARD).
     envelope("FromHand", "envelope: activated ability used from hand (activateFromZone = Zone.HAND)")
     envelope("FromGraveyard", "envelope: activated ability used from graveyard (activateFromZone = Zone.GRAVEYARD)")
+    // FromCommandZoneOrBattlefield — the *eminence* ability word (C17's commander cycle). Wraps a
+    // TriggerI whose condition is ThisCardIsInTheCommandZoneOrOnTheBattlefield; the wrapper only
+    // decides where the ability functions (`triggerZones = setOf(Zone.BATTLEFIELD, Zone.COMMAND)`,
+    // CR 113.6b) plus the CR 603.4 resolution-time re-check (a `SourceInZone` gate over the body).
+    // The real capability is the nested trigger + actions.
+    envelope("FromCommandZoneOrBattlefield", "envelope: eminence — triggered ability functioning from the command zone")
     envelope("And", "envelope: cost/action conjunction")
     // A `_Trigger: "Or"` combinator — "whenever [trigger A] or [trigger B]" (Bogwater Lumaret:
     // "whenever this creature or another creature you control enters"). Structural: the capability is

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1922,6 +1922,14 @@ internal fun EmitCtx.triggerBlock(
     oncePerTurn: Boolean = false,
     triggerCondition: String? = null,
     triggersOnce: Boolean = false,
+    /** Rendered `triggerZones` rider — the zones the trigger functions in (CR 113.6b). */
+    triggerZones: String? = null,
+    /**
+     * Rendered condition to gate the whole effect on, supplying CR 603.4's resolution-time re-check
+     * for an ability whose intervening-"if" must hold *again* as it resolves. Wraps the effect in a
+     * `ConditionalEffect`, which is what the hand-authored eminence idiom does.
+     */
+    gateEffectOn: String? = null,
 ): List<Stmt>? {
     // A "choose one —" modal triggered ability hosts its modal as a plain effect:
     // `triggeredAbility { trigger = …; effect = ModalEffect.chooseOne(Mode.…, Mode.…) }`. Render the
@@ -2014,13 +2022,21 @@ internal fun EmitCtx.triggerBlock(
     } ?: return null
 
     val stmts = mutableListOf<Stmt>(Assign("trigger", Lit(spec)))
+    if (triggerZones != null) stmts.add(Assign("triggerZones", Lit(triggerZones)))
     val triggerCond = effTriggerCondition ?: condFromIf
     if (triggerCond != null) stmts.add(Assign("triggerCondition", Lit(triggerCond)))
     if (oncePerTurn) stmts.add(Assign("oncePerTurn", Lit("true")))
     if (triggersOnce) stmts.add(Assign("triggersOnce", Lit("true")))
     if (mayWrapped && !selfOptional) stmts.add(Assign("optional", Lit("true")))
     if (tvar != null) stmts.add(targetLocal(tnode!!))
-    stmts.add(Assign("effect", edsl))
+    stmts.add(
+        Assign(
+            "effect",
+            if (gateEffectOn != null) {
+                call("ConditionalEffect", arg("condition", Lit(gateEffectOn)), arg("effect", edsl))
+            } else edsl
+        )
+    )
     return listOf(Sub(Block("triggeredAbility", stmts)))
 }
 
@@ -3756,6 +3772,59 @@ internal fun EmitCtx.fromGraveyardBlock(rule: JsonObject): List<Stmt>? {
         "Activated", "ActivatedWithModifiers" -> activatedBlock(inner, activateFromZone = "Zone.GRAVEYARD")
         else -> { reasons.add("FromGraveyard"); return null }
     }
+}
+
+/**
+ * `FromCommandZoneOrBattlefield(TriggerI(trigger, ThisCardIsInTheCommandZoneOrOnTheBattlefield, actions))`
+ * -> the **eminence** ability word (C17's commander cycle: Edgar Markov, Arahbo, Inalla, Mirri, …).
+ *
+ * "Eminence — Whenever you cast another Vampire spell, if Edgar is in the command zone or on the
+ * battlefield, create a 1/1 black Vampire creature token."
+ * →
+ * ```
+ * triggeredAbility {
+ *     trigger = Triggers.YouCastSubtype(Subtype.VAMPIRE)
+ *     triggerZones = setOf(Zone.BATTLEFIELD, Zone.COMMAND)
+ *     effect = ConditionalEffect(
+ *         condition = Conditions.SourceInZone(Zone.BATTLEFIELD, Zone.COMMAND),
+ *         effect = Effects.CreateToken(…))
+ * }
+ * ```
+ *
+ * Two halves, because the printed zone clause does two jobs. As a CR 113.6b zone statement it makes
+ * the trigger *function* from the command zone — `triggerZones`. As an intervening-"if" (CR 603.4) it
+ * is checked again on resolution, which the engine does not do for `triggerCondition`, so it is also
+ * rendered as a `ConditionalEffect` gate over the body. Dropping either half would be lossy: without
+ * the first the ability never fires from the command zone, and without the second a source that left
+ * both zones still produces its effect.
+ *
+ * Renders only the exact shape above — a lone `TriggerI` whose condition node is
+ * `ThisCardIsInTheCommandZoneOrOnTheBattlefield`. The inner trigger and actions go through the shared
+ * [triggerBlock] path, so anything it can't render whole still declines to SCAFFOLD.
+ */
+internal fun EmitCtx.fromCommandZoneOrBattlefieldBlock(rule: JsonObject): List<Stmt>? {
+    val inner = rule["args"] as? JsonObject
+    if (inner?.strField("_Rule") != "TriggerI") { reasons.add("FromCommandZoneOrBattlefield"); return null }
+
+    val args = inner["args"].asArr ?: run { reasons.add("FromCommandZoneOrBattlefield"); return null }
+    val cond = args.getOrNull(1) as? JsonObject
+    if (cond?.strField("_Condition") != "ThisCardIsInTheCommandZoneOrOnTheBattlefield") {
+        reasons.add("FromCommandZoneOrBattlefield")
+        return null
+    }
+
+    // Re-key [trigger, condition, actions] into the TriggerA-shaped [trigger, actions] the shared
+    // renderer expects; the condition is re-expressed by the two riders below rather than as a
+    // `triggerCondition` (which would only cover the fire-time half).
+    val triggerA = buildJsonObject {
+        put("_Rule", JsonPrimitive("TriggerA"))
+        put("args", JsonArray(listOfNotNull(args.getOrNull(0)) + listOfNotNull(args.getOrNull(2))))
+    }
+    return triggerBlock(
+        triggerA,
+        triggerZones = "setOf(Zone.BATTLEFIELD, Zone.COMMAND)",
+        gateEffectOn = "Conditions.SourceInZone(Zone.BATTLEFIELD, Zone.COMMAND)",
+    )
 }
 
 /**

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/Emitter.kt
@@ -229,6 +229,12 @@ object Emitter {
                 rname == "AbilitiesTriggerAnAdditionalTime" -> block = ctx.additionalSourceTriggersBlock(rule)
                 rname == "FromAnyZone" -> block = ctx.fromAnyZoneBlock(rule)
                 rname == "FromGraveyard" -> block = ctx.fromGraveyardBlock(rule)
+                // Eminence (C17's commander cycle) — a triggered ability that functions from the
+                // command zone as well as the battlefield.
+                rname == "FromCommandZoneOrBattlefield" -> {
+                    block = ctx.fromCommandZoneOrBattlefieldBlock(rule)
+                    if (block == null) { gap(rname)?.let { return it }; continue }
+                }
                 // "You may cast this from your graveyard if [condition]. If you do, it enters with a +1/+1
                 // counter." (Undead Sprinter) — a conditional self-cast permission + cast-this-way counter
                 // rider. Only the exact MayCastGraveyardCardWithEnterActions(self, [+1/+1]) shape gated by a

--- a/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
@@ -2992,7 +2992,7 @@ val EdgarMarkov = card("Edgar Markov") {
     power = 4
     toughness = 4
     keywords(Keyword.FIRST_STRIKE, Keyword.HASTE)
-    // STRUCTURE needs human wiring: FromCommandZoneOrBattlefield
+    // STRUCTURE needs human wiring: trigger-shape
     metadata {
         rarity = Rarity.MYTHIC
         collectorNumber = "234"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
@@ -258,7 +258,7 @@ class DeathAndLeaveTriggerDetector(
             for (ability in entry.abilities) {
                 val trigger = ability.trigger
                 if (trigger !is EventPattern.CreatureDealtDamageBySourceDiesEvent) continue
-                if (ability.activeZone != Zone.BATTLEFIELD) continue
+                if (Zone.BATTLEFIELD !in ability.activeZones) continue
 
                 val sourceFilter = trigger.sourceFilter
                 val fires = if (sourceFilter == null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
@@ -109,7 +109,7 @@ class StateTriggerPoller(
             trigger = EventPattern.StateConditionMetEvent,
             binding = TriggerBinding.SELF,
             effect = effect,
-            activeZone = activeZone,
+            activeZones = setOf(activeZone),
             descriptionOverride = descriptionOverride ?: description
         )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerAbilityResolver.kt
@@ -114,7 +114,7 @@ class TriggerAbilityResolver(
 
     /**
      * Grant [com.wingedsheep.sdk.scripting.Suspend.countdownAbility] to any card carrying the
-     * [SuspendedComponent] marker. The ability functions only in exile (`activeZone == EXILE`),
+     * [SuspendedComponent] marker. The ability functions only in exile (`activeZones == {EXILE}`),
      * so it is inert anywhere else and harmless to return universally.
      */
     private fun getSuspendTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> =
@@ -126,7 +126,7 @@ class TriggerAbilityResolver(
 
     /**
      * Grant [com.wingedsheep.sdk.scripting.Paradigm.recastAbility] to any card carrying the
-     * [ParadigmComponent] marker. The ability functions only in exile (`activeZone == EXILE`), so
+     * [ParadigmComponent] marker. The ability functions only in exile (`activeZones == {EXILE}`), so
      * it is inert anywhere else and harmless to return universally.
      */
     private fun getParadigmTriggeredAbilities(entityId: EntityId, state: GameState): List<TriggeredAbility> =

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -129,7 +129,7 @@ class TriggerDetector(
             // Categorize by event types this entity's triggers respond to
             val entityCategories = mutableSetOf<TriggerCategory>()
             for (ability in abilities) {
-                if (ability.activeZone == Zone.BATTLEFIELD) {
+                if (Zone.BATTLEFIELD in ability.activeZones) {
                     entityCategories.addAll(TriggerIndex.triggerToCategories(ability.trigger, ability.binding))
 
                     // Index damage observer triggers
@@ -169,29 +169,28 @@ class TriggerDetector(
             }
         }
 
-        // Phase 3: Index graveyard/exile cards whose abilities function from that zone, but only
-        // for the batch / observer categories that are consumed exclusively by the dedicated
+        // Phase 3: Index cards in the non-battlefield zones whose abilities function from that zone,
+        // but only for the batch / observer categories that are consumed exclusively by the dedicated
         // detectors (see TriggerIndex.NON_BATTLEFIELD_BATCH_CATEGORIES). These shapes are skipped
-        // by the per-event graveyard/exile passes (TriggerMatcher returns false for them), so they
+        // by the per-event zone passes (TriggerMatcher returns false for them), so they
         // would otherwise never fire from outside the battlefield. Enables graveyard-active
-        // recursion triggers like Killian's Confidence.
-        for (zone in listOf(Zone.GRAVEYARD, Zone.EXILE)) {
+        // recursion triggers like Killian's Confidence, and the batch-shaped eminence abilities.
+        for (zone in NON_BATTLEFIELD_ACTIVE_ZONES) {
             for (playerId in state.turnOrder) {
-                val zoneEntities = if (zone == Zone.GRAVEYARD) state.getGraveyard(playerId) else state.getExile(playerId)
-                for (entityId in zoneEntities) {
+                for (entityId in state.getZone(playerId, zone)) {
                     val container = state.getEntity(entityId) ?: continue
                     val cardComponent = container.get<CardComponent>() ?: continue
                     val abilities =
                         abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state, statics)
                     if (abilities.isEmpty()) continue
-                    // The controller of a card in the graveyard/exile is its owner.
+                    // The controller of a card outside the battlefield is its owner.
                     val ownerId = cardComponent.ownerId
                         ?: container.get<OwnerComponent>()?.playerId
                         ?: playerId
                     val entry = TriggerIndex.IndexedEntity(entityId, cardComponent, ownerId, abilities)
                     val entityCategories = mutableSetOf<TriggerCategory>()
                     for (ability in abilities) {
-                        if (ability.activeZone != zone) continue
+                        if (zone !in ability.activeZones) continue
                         for (cat in TriggerIndex.triggerToCategories(ability.trigger, ability.binding)) {
                             if (cat in TriggerIndex.NON_BATTLEFIELD_BATCH_CATEGORIES) entityCategories.add(cat)
                         }
@@ -507,7 +506,7 @@ class TriggerDetector(
         // Check battlefield entities with StepEvent triggers
         for (entry in index.getEntitiesForCategory(TriggerCategory.STEP)) {
             for (ability in entry.abilities) {
-                if (ability.activeZone != Zone.BATTLEFIELD) continue
+                if (Zone.BATTLEFIELD !in ability.activeZones) continue
                 if (matcher.matchesStepTrigger(ability.trigger, step, entry.controllerId, state, entry.entityId)) {
                     triggers.add(
                         PendingTrigger(
@@ -529,7 +528,7 @@ class TriggerDetector(
             for (entry in attachments) {
                 for (ability in entry.abilities) {
                     if (ability.binding != TriggerBinding.ATTACHED) continue
-                    if (ability.activeZone != Zone.BATTLEFIELD) continue
+                    if (Zone.BATTLEFIELD !in ability.activeZones) continue
                     val trigger = ability.trigger as? EventPattern.StepEvent ?: continue
                     if (step != trigger.step) continue
                     if (matcher.matchesPlayerForStep(trigger.player, enchantedController, state)) {
@@ -547,58 +546,37 @@ class TriggerDetector(
             }
         }
 
-        // Check graveyard cards for step-based triggers with activeZone == GRAVEYARD
-        for (playerId in state.turnOrder) {
-            for (entityId in state.getGraveyard(playerId)) {
-                val container = state.getEntity(entityId) ?: continue
-                val cardComponent = container.get<CardComponent>() ?: continue
+        // Check the non-battlefield zones a card's abilities can function from for step-based
+        // triggers (CR 113.6b). Graveyard: Gigapede's upkeep return. Exile: suspend's countdown,
+        // paradigm's main-phase offer. Command zone: an *eminence* ability worded as a step trigger
+        // (Arahbo, Roar of the World's beginning-of-combat pump).
+        //
+        // Cards in all three are owned rather than controlled, so the owner is the controller of
+        // any ability they produce.
+        for (zone in NON_BATTLEFIELD_ACTIVE_ZONES) {
+            for (playerId in state.turnOrder) {
+                for (entityId in state.getZone(playerId, zone)) {
+                    val container = state.getEntity(entityId) ?: continue
+                    val cardComponent = container.get<CardComponent>() ?: continue
 
-                val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state, index.statics)
+                    val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state, index.statics)
 
-                for (ability in abilities) {
-                    if (ability.activeZone != Zone.GRAVEYARD) continue
-                    // Use the card's owner as controller (graveyard cards are owned, not controlled)
-                    val ownerId = cardComponent.ownerId
-                        ?: container.get<OwnerComponent>()?.playerId
-                        ?: continue
-                    if (matcher.matchesStepTrigger(ability.trigger, step, ownerId, state, entityId)) {
-                        triggers.add(
-                            PendingTrigger(
-                                ability = ability,
-                                sourceId = entityId,
-                                sourceName = cardComponent.name,
-                                controllerId = ownerId,
-                                triggerContext = TriggerContext(step = step, triggeringEntityId = activePlayerId)
+                    for (ability in abilities) {
+                        if (zone !in ability.activeZones) continue
+                        val ownerId = cardComponent.ownerId
+                            ?: container.get<OwnerComponent>()?.playerId
+                            ?: continue
+                        if (matcher.matchesStepTrigger(ability.trigger, step, ownerId, state, entityId)) {
+                            triggers.add(
+                                PendingTrigger(
+                                    ability = ability,
+                                    sourceId = entityId,
+                                    sourceName = cardComponent.name,
+                                    controllerId = ownerId,
+                                    triggerContext = TriggerContext(step = step, triggeringEntityId = activePlayerId)
+                                )
                             )
-                        )
-                    }
-                }
-            }
-        }
-
-        // Check exiled cards for step-based triggers with activeZone == EXILE
-        for (playerId in state.turnOrder) {
-            for (entityId in state.getExile(playerId)) {
-                val container = state.getEntity(entityId) ?: continue
-                val cardComponent = container.get<CardComponent>() ?: continue
-
-                val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state, index.statics)
-
-                for (ability in abilities) {
-                    if (ability.activeZone != Zone.EXILE) continue
-                    val ownerId = cardComponent.ownerId
-                        ?: container.get<OwnerComponent>()?.playerId
-                        ?: continue
-                    if (matcher.matchesStepTrigger(ability.trigger, step, ownerId, state, entityId)) {
-                        triggers.add(
-                            PendingTrigger(
-                                ability = ability,
-                                sourceId = entityId,
-                                sourceName = cardComponent.name,
-                                controllerId = ownerId,
-                                triggerContext = TriggerContext(step = step, triggeringEntityId = activePlayerId)
-                            )
-                        )
+                        }
                     }
                 }
             }
@@ -1024,7 +1002,7 @@ class TriggerDetector(
             val controllerId = entry.controllerId
 
             for (ability in entry.abilities) {
-                if (ability.activeZone != Zone.BATTLEFIELD) continue
+                if (Zone.BATTLEFIELD !in ability.activeZones) continue
                 if (matcher.matchesTrigger(ability.trigger, ability.binding, event, entityId, controllerId, state)) {
                     // For "whenever a creature attacks" (AttackEvent with ANY binding),
                     // create one trigger per attacking creature (Rule 603.2c)
@@ -1359,41 +1337,52 @@ class TriggerDetector(
             }
         }
 
-        // Check graveyard cards for non-step triggers with activeZone == GRAVEYARD
-        // (e.g., Dragon Shadow: "When a creature with MV 6+ enters, return this from graveyard")
-        for (playerId in state.turnOrder) {
-            for (entityId in state.getGraveyard(playerId)) {
-                val container = state.getEntity(entityId) ?: continue
-                val cardComponent = container.get<CardComponent>() ?: continue
+        // Check the non-battlefield zones a card's abilities can function from for non-step triggers
+        // (CR 113.6b). Graveyard: Dragon Shadow's "when a creature with MV 6+ enters, return this
+        // from graveyard". Command zone: an *eminence* cast trigger — Edgar Markov's "whenever you
+        // cast another Vampire spell" has to fire while Edgar sits in the command zone, which no
+        // battlefield scan reaches.
+        //
+        // Exile is deliberately absent: every exile-active shape today (suspend, madness, paradigm)
+        // already has its own dedicated detection path, and a general exile pass here would fire
+        // those a second time.
+        for (zone in NON_BATTLEFIELD_EVENT_TRIGGER_ZONES) {
+            for (playerId in state.turnOrder) {
+                for (entityId in state.getZone(playerId, zone)) {
+                    val container = state.getEntity(entityId) ?: continue
+                    val cardComponent = container.get<CardComponent>() ?: continue
 
-                // The card's OWN battlefield-exit (its death / leaving) is owned by the dedicated
-                // death and leaves-battlefield detectors below, which resolve the dying entity's
-                // abilities regardless of activeZone. Skipping it here prevents a graveyard-active
-                // dies trigger (triggerZone = GRAVEYARD, e.g. Paramecia Coloniex) from being
-                // detected twice — once here, because the dead card already sits in the graveyard
-                // and its trigger pattern matches its own death event, and once in
-                // detectDeathTriggers. Other graveyard-resident reactions (another creature dying,
-                // entering, etc.) still fall through to the matcher below.
-                if (event is ZoneChangeEvent && event.fromZone == Zone.BATTLEFIELD &&
-                    event.entityId == entityId) continue
+                    // The card's OWN battlefield-exit (its death / leaving) is owned by the dedicated
+                    // death and leaves-battlefield detectors below, which resolve the dying entity's
+                    // abilities regardless of activeZones. Skipping it here prevents a
+                    // graveyard-active dies trigger (triggerZone = GRAVEYARD, e.g. Paramecia
+                    // Coloniex) from being detected twice — once here, because the dead card already
+                    // sits in the graveyard and its trigger pattern matches its own death event, and
+                    // once in detectDeathTriggers. The same guard covers a commander that died and
+                    // went to the command zone instead. Other zone-resident reactions (another
+                    // creature dying, entering, a spell being cast) still fall through to the
+                    // matcher below.
+                    if (event is ZoneChangeEvent && event.fromZone == Zone.BATTLEFIELD &&
+                        event.entityId == entityId) continue
 
-                val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state, index.statics)
+                    val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state, index.statics)
 
-                for (ability in abilities) {
-                    if (ability.activeZone != Zone.GRAVEYARD) continue
-                    val ownerId = cardComponent.ownerId
-                        ?: container.get<OwnerComponent>()?.playerId
-                        ?: continue
-                    if (matcher.matchesTrigger(ability.trigger, ability.binding, event, entityId, ownerId, state)) {
-                        triggers.add(
-                            PendingTrigger(
-                                ability = ability,
-                                sourceId = entityId,
-                                sourceName = cardComponent.name,
-                                controllerId = ownerId,
-                                triggerContext = TriggerContext.fromEvent(event)
+                    for (ability in abilities) {
+                        if (zone !in ability.activeZones) continue
+                        val ownerId = cardComponent.ownerId
+                            ?: container.get<OwnerComponent>()?.playerId
+                            ?: continue
+                        if (matcher.matchesTrigger(ability.trigger, ability.binding, event, entityId, ownerId, state)) {
+                            triggers.add(
+                                PendingTrigger(
+                                    ability = ability,
+                                    sourceId = entityId,
+                                    sourceName = cardComponent.name,
+                                    controllerId = ownerId,
+                                    triggerContext = TriggerContext.fromEvent(event)
+                                )
                             )
-                        )
+                        }
                     }
                 }
             }
@@ -1550,7 +1539,7 @@ class TriggerDetector(
             if (ability.trigger !is EventPattern.BecomesUnattachedEvent) continue
             // The ability functioned from the battlefield right up to the moment it left; a
             // graveyard/exile-active ability is a different thing entirely.
-            if (ability.activeZone != Zone.BATTLEFIELD) continue
+            if (Zone.BATTLEFIELD !in ability.activeZones) continue
             if (!matcher.matchesTrigger(
                     ability.trigger, ability.binding, event, attachmentId, event.controllerId, state
                 )
@@ -2299,7 +2288,7 @@ class TriggerDetector(
                     for (ability in abilities) {
                         val trigger = ability.trigger
                         if (trigger !is EventPattern.PermanentsSacrificedEvent) continue
-                        if (ability.activeZone != Zone.BATTLEFIELD) continue
+                        if (Zone.BATTLEFIELD !in ability.activeZones) continue
 
                         if (trigger.perPermanent) {
                             // Per-permanent template ("a/another permanent") where the source is
@@ -3763,5 +3752,21 @@ class TriggerDetector(
                 )
             }
         }
+    }
+
+    private companion object {
+        /**
+         * Every non-battlefield zone an ability can declare in `activeZones` (CR 113.6b). All three
+         * are per-player zones keyed the same way, so one loop covers them. Used by the trigger-index
+         * batch pass and the step-trigger pass, both of which are safe for all three.
+         */
+        val NON_BATTLEFIELD_ACTIVE_ZONES = listOf(Zone.GRAVEYARD, Zone.EXILE, Zone.COMMAND)
+
+        /**
+         * The non-battlefield zones scanned for per-*event* triggers. Exile is excluded on purpose:
+         * suspend, madness and paradigm are the only exile-active shapes, and each already has a
+         * dedicated detection path that a general pass here would duplicate.
+         */
+        val NON_BATTLEFIELD_EVENT_TRIGGER_ZONES = listOf(Zone.GRAVEYARD, Zone.COMMAND)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -90,6 +90,7 @@ import com.wingedsheep.engine.state.components.battlefield.CastForImpendingCompo
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.conditions.WasCast
 import com.wingedsheep.sdk.scripting.conditions.WasCastFromHand
+import com.wingedsheep.sdk.scripting.conditions.SourceInZone
 import com.wingedsheep.sdk.scripting.conditions.WasCastFromZone
 import com.wingedsheep.engine.state.components.battlefield.CastFromGraveyardComponent
 import com.wingedsheep.engine.state.components.battlefield.CastFromLibraryComponent
@@ -204,6 +205,9 @@ class ConditionEvaluator(
             is Compare -> evaluateCompareCtx(state, condition, ctx)
             is NumberMatches -> evaluateNumberMatchesCtx(state, condition, ctx)
             is Exists -> evaluateExistsCtx(state, condition, ctx)
+
+            // Pure zone-membership lookup, so it reads the same in both modes.
+            is SourceInZone -> evaluateSourceInZone(state, condition, ctx)
 
             // CR 805 — "your turn" is the active team's turn for every member of that team.
             is IsYourTurn -> ctx.controllerId?.let { state.isActiveTurnFor(it) } ?: false
@@ -1134,6 +1138,23 @@ class ConditionEvaluator(
         // For permanents (triggered abilities), fall back to battlefield component
         val sourceId = context.sourceId ?: return false
         return state.getEntity(sourceId)?.has<CastFromHandComponent>() == true
+    }
+
+    /**
+     * Where the source object sits *now* (CR 113.6b's zone test, and the resolution-time half of an
+     * eminence ability's intervening-"if" per CR 603.4).
+     *
+     * Scans the zone map by zone *type* rather than reaching for per-zone accessors, because the
+     * shared zones (battlefield, stack, exile) and the per-player ones (command zone, graveyard,
+     * hand) are keyed differently and the condition is parameterized over both.
+     */
+    private fun evaluateSourceInZone(
+        state: GameState,
+        condition: SourceInZone,
+        ctx: ConditionEvaluationContext
+    ): Boolean {
+        val sourceId = ctx.sourceId ?: return false
+        return state.zones.any { (key, ids) -> key.zoneType in condition.zones && sourceId in ids }
     }
 
     private fun evaluateWasCastFromZone(state: GameState, condition: WasCastFromZone, context: EffectContext): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -3338,7 +3338,7 @@ class CastSpellHandler(
                             trigger = SdkGameEvent.SpellCastEvent(player = Player.You),
                             binding = TriggerBinding.SELF,
                             effect = stormEffect,
-                            activeZone = Zone.STACK,
+                            activeZones = setOf(Zone.STACK),
                             descriptionOverride = "Storm — copy ${cardComponent.name} $stormCount time(s)"
                         )
                         PendingTrigger(
@@ -3374,7 +3374,7 @@ class CastSpellHandler(
                         trigger = SdkGameEvent.SpellCastEvent(player = Player.You),
                         binding = TriggerBinding.SELF,
                         effect = copyEffect,
-                        activeZone = Zone.STACK,
+                        activeZones = setOf(Zone.STACK),
                         descriptionOverride = "Conspire — copy ${cardComponent.name}"
                     )
                     listOf(
@@ -3411,7 +3411,7 @@ class CastSpellHandler(
                         trigger = SdkGameEvent.SpellCastEvent(player = Player.You),
                         binding = TriggerBinding.SELF,
                         effect = copyEffect,
-                        activeZone = Zone.STACK,
+                        activeZones = setOf(Zone.STACK),
                         descriptionOverride = "Casualty — copy ${cardComponent.name}"
                     )
                     listOf(
@@ -4275,7 +4275,7 @@ class CastSpellHandler(
             effect = com.wingedsheep.sdk.scripting.effects.CopyTargetSpellEffect(
                 target = com.wingedsheep.sdk.scripting.targets.EffectTarget.TriggeringEntity
             ),
-            activeZone = Zone.STACK,
+            activeZones = setOf(Zone.STACK),
             descriptionOverride = "Copy ${cardComponent.name}. You may choose new targets for the copy."
         )
         val pending = PendingTrigger(
@@ -4328,7 +4328,7 @@ class CastSpellHandler(
             trigger = SdkGameEvent.SpellCastEvent(player = Player.You),
             binding = TriggerBinding.SELF,
             effect = com.wingedsheep.sdk.dsl.Patterns.Library.scry(amount),
-            activeZone = Zone.STACK,
+            activeZones = setOf(Zone.STACK),
             descriptionOverride = "Scry $amount"
         )
         val pending = PendingTrigger(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/CommandZoneTriggerDetectionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/CommandZoneTriggerDetectionTest.kt
@@ -1,0 +1,225 @@
+package com.wingedsheep.engine.event
+
+import com.wingedsheep.engine.core.SpellCastEvent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for the command-zone arm of trigger detection — abilities that declare
+ * [Zone.COMMAND] in `activeZones` (CR 113.6b), which is what makes an *eminence* ability work
+ * while its card sits in the command zone.
+ *
+ * Drives [TriggerDetector] directly with hand-crafted events (the sibling style of
+ * [TriggerDetectorBatchTriggerTest]) so the assertions are about detection — zone gating, owner
+ * as controller, no double-fire — rather than about effect resolution.
+ * `EdgarMarkovScenarioTest` covers the shipped card end to end.
+ */
+class CommandZoneTriggerDetectionTest : FunSpec({
+
+    // The eminence *event*-trigger shape: functions from the battlefield and the command zone.
+    val eminenceCastWatcher = card("Eminence Cast Watcher") {
+        manaCost = "{3}{B}"
+        typeLine = "Legendary Creature — Vampire"
+        power = 2
+        toughness = 2
+        triggeredAbility {
+            trigger = Triggers.YouCastSubtype(Subtype.VAMPIRE)
+            triggerZones = setOf(Zone.BATTLEFIELD, Zone.COMMAND)
+            effect = LoseLifeEffect(1, EffectTarget.PlayerRef(Player.You))
+        }
+    }
+
+    // The same, but command-zone-only, to prove the two zones are independent gates.
+    val commandOnlyCastWatcher = card("Command Only Cast Watcher") {
+        manaCost = "{3}{B}"
+        typeLine = "Legendary Creature — Vampire"
+        power = 2
+        toughness = 2
+        triggeredAbility {
+            trigger = Triggers.YouCastSubtype(Subtype.VAMPIRE)
+            triggerZones = setOf(Zone.COMMAND)
+            effect = LoseLifeEffect(1, EffectTarget.PlayerRef(Player.You))
+        }
+    }
+
+    // The default shape — battlefield only — which must stay inert in the command zone.
+    val battlefieldOnlyCastWatcher = card("Battlefield Only Cast Watcher") {
+        manaCost = "{3}{B}"
+        typeLine = "Legendary Creature — Vampire"
+        power = 2
+        toughness = 2
+        triggeredAbility {
+            trigger = Triggers.YouCastSubtype(Subtype.VAMPIRE)
+            effect = LoseLifeEffect(1, EffectTarget.PlayerRef(Player.You))
+        }
+    }
+
+    // The eminence *step*-trigger shape (Arahbo, Roar of the World's beginning-of-combat pump),
+    // which travels the detectPhaseStepTriggers path instead.
+    val eminenceStepWatcher = card("Eminence Step Watcher") {
+        manaCost = "{3}{G}"
+        typeLine = "Legendary Creature — Cat"
+        power = 2
+        toughness = 2
+        triggeredAbility {
+            trigger = Triggers.YourUpkeep
+            triggerZones = setOf(Zone.BATTLEFIELD, Zone.COMMAND)
+            effect = LoseLifeEffect(1, EffectTarget.PlayerRef(Player.You))
+        }
+    }
+
+    val vampireSpell = CardDefinition.creature(
+        name = "Test Vampire",
+        manaCost = ManaCost.parse("{B}"),
+        subtypes = setOf(Subtype.VAMPIRE),
+        power = 1,
+        toughness = 1
+    )
+
+    fun createDriver(vararg extras: CardDefinition): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + extras.toList())
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20))
+        return driver
+    }
+
+    fun detectorFor(driver: GameTestDriver): TriggerDetector = TriggerDetector(driver.cardRegistry)
+
+    /** A cast event for a Vampire spell put on the stack by [caster]. */
+    fun castVampire(driver: GameTestDriver, caster: EntityId): SpellCastEvent {
+        val spellId = driver.putCardInHand(caster, "Test Vampire")
+        return SpellCastEvent(spellEntityId = spellId, cardName = "Test Vampire", casterId = caster)
+    }
+
+    test("a cast trigger fires while its card is in the command zone") {
+        val driver = createDriver(eminenceCastWatcher, vampireSpell)
+        val watcher = driver.putCardInCommandZone(driver.player1, "Eminence Cast Watcher")
+
+        val cast = castVampire(driver, driver.player1)
+        val triggers = detectorFor(driver).detectTriggers(driver.state, listOf(cast))
+
+        triggers shouldHaveSize 1
+        triggers[0].sourceId shouldBe watcher
+        // A card in the command zone is owned, not controlled — the owner controls the ability.
+        triggers[0].controllerId shouldBe driver.player1
+    }
+
+    test("the same ability still fires from the battlefield") {
+        val driver = createDriver(eminenceCastWatcher, vampireSpell)
+        val watcher = driver.putCreatureOnBattlefield(driver.player1, "Eminence Cast Watcher")
+
+        val cast = castVampire(driver, driver.player1)
+        val triggers = detectorFor(driver).detectTriggers(driver.state, listOf(cast))
+
+        triggers shouldHaveSize 1
+        triggers[0].sourceId shouldBe watcher
+    }
+
+    test("it fires exactly once — the battlefield and command-zone passes don't both claim it") {
+        val driver = createDriver(eminenceCastWatcher, vampireSpell)
+        driver.putCardInCommandZone(driver.player1, "Eminence Cast Watcher")
+
+        val cast = castVampire(driver, driver.player1)
+        val triggers = detectorFor(driver).detectTriggers(driver.state, listOf(cast))
+
+        triggers shouldHaveSize 1
+    }
+
+    test("a command-zone-only ability does not fire from the battlefield") {
+        val driver = createDriver(commandOnlyCastWatcher, vampireSpell)
+        driver.putCreatureOnBattlefield(driver.player1, "Command Only Cast Watcher")
+
+        val cast = castVampire(driver, driver.player1)
+        detectorFor(driver).detectTriggers(driver.state, listOf(cast)).shouldBeEmpty()
+    }
+
+    test("a battlefield-only ability does not fire from the command zone") {
+        val driver = createDriver(battlefieldOnlyCastWatcher, vampireSpell)
+        driver.putCardInCommandZone(driver.player1, "Battlefield Only Cast Watcher")
+
+        val cast = castVampire(driver, driver.player1)
+        detectorFor(driver).detectTriggers(driver.state, listOf(cast)).shouldBeEmpty()
+
+        // Not vacuous: the very same board fires once when the ability declares COMMAND.
+        val control = createDriver(eminenceCastWatcher, vampireSpell)
+        control.putCardInCommandZone(control.player1, "Eminence Cast Watcher")
+        val controlCast = castVampire(control, control.player1)
+        detectorFor(control).detectTriggers(control.state, listOf(controlCast)) shouldHaveSize 1
+    }
+
+    test("casting the source itself does not trigger it — that is what \"another\" costs us nothing") {
+        // Edgar's ability reads "another Vampire spell" and needs no filter for it: to be the
+        // triggering spell, the card has to be on the stack, and the stack is neither of the two
+        // zones the ability functions from. Model exactly that — the card has left the command zone
+        // for the stack, which is the state when its own SpellCastEvent fires.
+        val driver = createDriver(eminenceCastWatcher)
+        val watcher = driver.putCardInCommandZone(driver.player1, "Eminence Cast Watcher")
+        driver.replaceState(
+            driver.state
+                .removeFromZone(
+                    com.wingedsheep.engine.state.ZoneKey(driver.player1, Zone.COMMAND),
+                    watcher
+                )
+                .addToZone(
+                    com.wingedsheep.engine.state.ZoneKey(driver.player1, Zone.STACK),
+                    watcher
+                )
+        )
+
+        val ownCast = SpellCastEvent(
+            spellEntityId = watcher,
+            cardName = "Eminence Cast Watcher",
+            casterId = driver.player1
+        )
+
+        detectorFor(driver).detectTriggers(driver.state, listOf(ownCast)).shouldBeEmpty()
+    }
+
+    test("a command-zone ability ignores an opponent's cast when the trigger is scoped to you") {
+        val driver = createDriver(eminenceCastWatcher, vampireSpell)
+        driver.putCardInCommandZone(driver.player1, "Eminence Cast Watcher")
+
+        val cast = castVampire(driver, driver.player2)
+        detectorFor(driver).detectTriggers(driver.state, listOf(cast)).shouldBeEmpty()
+    }
+
+    test("a step trigger fires while its card is in the command zone") {
+        val driver = createDriver(eminenceStepWatcher)
+        val watcher = driver.putCardInCommandZone(driver.player1, "Eminence Step Watcher")
+
+        val triggers = detectorFor(driver)
+            .detectPhaseStepTriggers(driver.state, Step.UPKEEP, driver.player1)
+
+        triggers.filter { it.sourceId == watcher } shouldHaveSize 1
+    }
+
+    test("a command-zone step trigger is scoped to its owner's turn") {
+        // "At the beginning of your upkeep" resolves "your" against the *state's* active player, so
+        // the owner is what decides it: player 1 is active, and player 2's command-zone copy stays
+        // quiet. (Only the owner's copy fired in the test above, on the same active player.)
+        val driver = createDriver(eminenceStepWatcher)
+        val theirs = driver.putCardInCommandZone(driver.player2, "Eminence Step Watcher")
+        driver.state.activePlayerId shouldBe driver.player1
+
+        val triggers = detectorFor(driver)
+            .detectPhaseStepTriggers(driver.state, Step.UPKEEP, driver.player1)
+
+        triggers.filter { it.sourceId == theirs }.shouldBeEmpty()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerDetectorBatchTriggerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerDetectorBatchTriggerTest.kt
@@ -94,7 +94,7 @@ class TriggerDetectorBatchTriggerTest : FunSpec({
 
     // A dies trigger that functions from the graveyard (triggerZone = GRAVEYARD), the shape
     // Paramecia Coloniex uses so its effect can reference Self after the creature has died and
-    // is sitting in the graveyard. Its activeZone is GRAVEYARD, which made the graveyard-resident
+    // is sitting in the graveyard. Its activeZones is {GRAVEYARD}, which made the graveyard-resident
     // trigger scan match its own death event in addition to the dedicated death detector — the
     // double-fire this test guards against.
     val graveyardActiveDiesWatcher = card("Graveyard Active Dies Watcher") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EdgarMarkovScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EdgarMarkovScenarioTest.kt
@@ -1,0 +1,209 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Edgar Markov (Commander 2017 #36, reprinted in Innistrad Remastered #234).
+ *
+ *   Eminence — Whenever you cast another Vampire spell, if Edgar is in the command zone or on the
+ *   battlefield, create a 1/1 black Vampire creature token.
+ *   First strike, haste
+ *   Whenever Edgar attacks, put a +1/+1 counter on each Vampire you control.
+ *
+ * The eminence ability is the point: its trigger condition functions from the command zone as well
+ * as the battlefield (CR 113.6b), and the printed zone clause is also an intervening-"if"
+ * (CR 603.4), so it is re-checked as the ability resolves. Both of the card's official rulings get
+ * a test.
+ */
+class EdgarMarkovScenarioTest : ScenarioTestBase() {
+
+    /** +1/+1 counters on [id], or 0 when the permanent has none. */
+    private fun TestGame.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        test("eminence triggers from the command zone") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInCommandZone(1, "Edgar Markov")
+                .withCardInHand(1, "Vampire Interloper")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            withClue("no token before the Vampire spell is cast") {
+                game.findPermanents("Vampire Token").size shouldBe 0
+            }
+
+            game.castSpell(1, "Vampire Interloper").error shouldBe null
+            game.resolveStack()
+
+            val tokens = game.findPermanents("Vampire Token")
+            tokens.size shouldBe 1
+            val projected = game.state.projectedState
+            projected.getPower(tokens[0]) shouldBe 1
+            projected.getToughness(tokens[0]) shouldBe 1
+        }
+
+        test("eminence also triggers from the battlefield") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Edgar Markov")
+                .withCardInHand(1, "Vampire Interloper")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Vampire Interloper").error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Vampire Token").size shouldBe 1
+        }
+
+        test("eminence stays inert while Edgar is in a zone the ability doesn't function from") {
+            // The graveyard is neither the battlefield nor the command zone, so CR 113.6b keeps the
+            // trigger from functioning at all.
+            val game = scenario()
+                .withPlayers()
+                .withCardInGraveyard(1, "Edgar Markov")
+                .withCardInHand(1, "Vampire Interloper")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Vampire Interloper").error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Vampire Token").size shouldBe 0
+        }
+
+        test("eminence ignores a non-Vampire spell") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInCommandZone(1, "Edgar Markov")
+                .withCardInHand(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Grizzly Bears").error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Vampire Token").size shouldBe 0
+        }
+
+        test("eminence ignores an opponent's Vampire spell") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInCommandZone(1, "Edgar Markov")
+                .withCardInHand(2, "Vampire Interloper")
+                .withLandsOnBattlefield(2, "Swamp", 2)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(2, "Vampire Interloper").error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Vampire Token").size shouldBe 0
+        }
+
+        test("ruling: Edgar leaving the battlefield before the trigger resolves produces no token") {
+            // "If it's on the battlefield or in the command zone when you cast another Vampire spell
+            // but leaves that zone before the ability resolves, the ability won't do anything as it
+            // resolves." (CR 603.4's second check.)
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Edgar Markov")
+                .withCardInHand(1, "Vampire Interloper")
+                .withCardInHand(1, "Murder")
+                .withLandsOnBattlefield(1, "Swamp", 5)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val edgar = game.findPermanent("Edgar Markov")!!
+
+            // Casting the Vampire puts the eminence trigger on the stack above it...
+            game.castSpell(1, "Vampire Interloper").error shouldBe null
+            // ...and Murder (an instant) goes on top of that, so Edgar dies first.
+            game.castSpell(1, "Murder", edgar).error shouldBe null
+            game.resolveStack()
+
+            withClue("Edgar is gone") { game.findPermanent("Edgar Markov") shouldBe null }
+            withClue("the eminence trigger resolved but did nothing") {
+                game.findPermanents("Vampire Token").size shouldBe 0
+            }
+        }
+
+        test("first strike and haste") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Edgar Markov")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val edgar = game.findPermanent("Edgar Markov")!!
+            val projected = game.state.projectedState
+            projected.hasKeyword(edgar, Keyword.FIRST_STRIKE) shouldBe true
+            projected.hasKeyword(edgar, Keyword.HASTE) shouldBe true
+        }
+
+        test("attacking puts a +1/+1 counter on each Vampire you control") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Edgar Markov")
+                .withCardOnBattlefield(1, "Vampire Interloper")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Vampire Interloper")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val edgar = game.findPermanent("Edgar Markov")!!
+            val myVampire = game.findPermanents("Vampire Interloper")
+                .first { game.state.projectedState.getController(it) == game.player1Id }
+            val theirVampire = game.findPermanents("Vampire Interloper")
+                .first { game.state.projectedState.getController(it) == game.player2Id }
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Edgar Markov" to 2)).error shouldBe null
+            game.resolveStack()
+
+            withClue("Edgar counts himself — he is a Vampire you control") {
+                game.plusOneCounters(edgar) shouldBe 1
+            }
+            game.plusOneCounters(myVampire) shouldBe 1
+            withClue("only Vampires") { game.plusOneCounters(bears) shouldBe 0 }
+            withClue("only yours") { game.plusOneCounters(theirVampire) shouldBe 0 }
+        }
+
+        test("attacking also pumps the tokens eminence made") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Edgar Markov")
+                .withCardInHand(1, "Vampire Interloper")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Vampire Interloper").error shouldBe null
+            game.resolveStack()
+            val token = game.findPermanents("Vampire Token").single()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Edgar Markov" to 2)).error shouldBe null
+            game.resolveStack()
+
+            game.plusOneCounters(token) shouldBe 1
+            game.state.projectedState.getPower(token) shouldBe 2
+        }
+    }
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -697,14 +697,24 @@ class GameTestDriver {
     }
 
     /**
-     * Put a specific card directly into a player's graveyard (test helper).
-     * Creates a new card entity from the registry and adds it to graveyard.
+     * Mint a fresh card entity for [cardName] owned and controlled by [playerId], register it in
+     * the state, and return its id — *without* placing it in any zone.
+     *
+     * One place builds the hand-rolled [CardComponent] that the zone-placement helpers below all
+     * need, so a newly precomputed printed characteristic added to `CardEntityFactory` has a single
+     * spot to be mirrored into rather than four that silently keep defaulting.
+     *
+     * [decorate] applies `CardEntityFactory.applyDefinitionDecorations`. It is off for the exile
+     * helper only, preserving that helper's long-standing behavior.
      */
-    fun putCardInGraveyard(playerId: EntityId, cardName: String): EntityId {
+    private fun mintCardEntity(
+        playerId: EntityId,
+        cardName: String,
+        decorate: Boolean = true
+    ): EntityId {
         val cardDef = cardRegistry.requireCard(cardName)
         val cardId = EntityId.generate()
 
-        // Create card entity
         val cardComponent = CardComponent(
             cardDefinitionId = cardDef.name,
             name = cardDef.name,
@@ -731,14 +741,21 @@ class GameTestDriver {
             OwnerComponent(playerId),
             ControllerComponent(playerId)
         )
-        container = com.wingedsheep.engine.core.CardEntityFactory.applyDefinitionDecorations(container, cardDef)
+        if (decorate) {
+            container = com.wingedsheep.engine.core.CardEntityFactory.applyDefinitionDecorations(container, cardDef)
+        }
 
         _state = _state.withEntity(cardId, container)
+        return cardId
+    }
 
-        // Add to graveyard
-        val graveyardZone = ZoneKey(playerId, Zone.GRAVEYARD)
-        _state = _state.addToZone(graveyardZone, cardId)
-
+    /**
+     * Put a specific card directly into a player's graveyard (test helper).
+     * Creates a new card entity from the registry and adds it to graveyard.
+     */
+    fun putCardInGraveyard(playerId: EntityId, cardName: String): EntityId {
+        val cardId = mintCardEntity(playerId, cardName)
+        _state = _state.addToZone(ZoneKey(playerId, Zone.GRAVEYARD), cardId)
         return cardId
     }
 
@@ -749,39 +766,23 @@ class GameTestDriver {
      * (so it reads as face-up). Used to set up "a face-up exiled card they own" scenarios.
      */
     fun putCardInExile(playerId: EntityId, cardName: String): EntityId {
-        val cardDef = cardRegistry.requireCard(cardName)
-        val cardId = EntityId.generate()
-
-        val cardComponent = CardComponent(
-            cardDefinitionId = cardDef.name,
-            name = cardDef.name,
-            manaCost = cardDef.manaCost,
-            typeLine = cardDef.typeLine,
-            oracleText = cardDef.oracleText,
-            baseStats = cardDef.creatureStats,
-            baseKeywords = cardDef.keywords,
-            baseFlags = cardDef.flags,
-            colors = cardDef.colors,
-            ownerId = playerId,
-            spellEffect = cardDef.spellEffect,
-            hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
-            hasActivatedAbility = cardDef.hasActivatedAbility,
-            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
-            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
-            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
-            hasAdventure = cardDef.isAdventure,
-            originalSetCode = cardDef.setCode,
-        )
-
-        val container = com.wingedsheep.engine.state.ComponentContainer.of(
-            cardComponent,
-            OwnerComponent(playerId),
-            ControllerComponent(playerId)
-        )
-
-        _state = _state.withEntity(cardId, container)
+        val cardId = mintCardEntity(playerId, cardName, decorate = false)
         _state = _state.addToZone(ZoneKey(playerId, Zone.EXILE), cardId)
+        return cardId
+    }
 
+    /**
+     * Put a specific card into a player's command zone (test helper).
+     *
+     * Stands in for the commander a real Commander game starts with, for the abilities that
+     * function from there (CR 113.6b) — an *eminence* trigger such as Edgar Markov's. It only
+     * places the card; tag it with
+     * [com.wingedsheep.engine.state.components.identity.CommanderComponent] and set
+     * `Format.Commander()` as well when the test also needs the commander state-based actions.
+     */
+    fun putCardInCommandZone(playerId: EntityId, cardName: String): EntityId {
+        val cardId = mintCardEntity(playerId, cardName)
+        _state = _state.addToZone(ZoneKey(playerId, Zone.COMMAND), cardId)
         return cardId
     }
 
@@ -790,38 +791,7 @@ class GameTestDriver {
      * Creates a new card entity from the registry and prepends it to the library.
      */
     fun putCardOnTopOfLibrary(playerId: EntityId, cardName: String): EntityId {
-        val cardDef = cardRegistry.requireCard(cardName)
-        val cardId = EntityId.generate()
-
-        val cardComponent = CardComponent(
-            cardDefinitionId = cardDef.name,
-            name = cardDef.name,
-            manaCost = cardDef.manaCost,
-            typeLine = cardDef.typeLine,
-            oracleText = cardDef.oracleText,
-            baseStats = cardDef.creatureStats,
-            baseKeywords = cardDef.keywords,
-            baseFlags = cardDef.flags,
-            colors = cardDef.colors,
-            ownerId = playerId,
-            spellEffect = cardDef.spellEffect,
-            hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
-            hasActivatedAbility = cardDef.hasActivatedAbility,
-            // Keep driver-minted cards in step with CardEntityFactory: precomputed printed
-            // characteristics other code reads back (SpellCastPredicate.CastAsAdventure,
-            // CardPredicate.HasAdventure / OriginallyPrintedInSet).
-            hasAdventure = cardDef.isAdventure,
-            originalSetCode = cardDef.setCode,
-        )
-
-        var container = com.wingedsheep.engine.state.ComponentContainer.of(
-            cardComponent,
-            OwnerComponent(playerId),
-            ControllerComponent(playerId)
-        )
-        container = com.wingedsheep.engine.core.CardEntityFactory.applyDefinitionDecorations(container, cardDef)
-
-        _state = _state.withEntity(cardId, container)
+        val cardId = mintCardEntity(playerId, cardName)
 
         // Prepend to library (top = index 0)
         val libraryZone = ZoneKey(playerId, Zone.LIBRARY)


### PR DESCRIPTION
Innistrad Remastered's last plain-looking card wasn't plain. Edgar Markov's eminence ability has to trigger while the card sits in the **command zone**, and `TriggerDetector` had no pass over that zone.

## The shape of it

Eminence is an ability word (CR 207.2c) with no rules meaning of its own, so **nothing here is eminence-specific**. What makes it work is CR 113.6b — *"an ability that states which zones it functions in functions only from those zones"* — which the engine already modeled as `TriggeredAbility.activeZone`, just one zone at a time.

### `activeZone: Zone` → `activeZones: Set<Zone>`

CR 113.6k allows a single triggered ability to function from several zones, which is exactly what eminence needs (`{BATTLEFIELD, COMMAND}`). `triggerZone` remains the single-zone DSL shorthand, so the ~25 graveyard-active cards are untouched.

| Zone | Per-event triggers | Step triggers | Example |
|---|---|---|---|
| `BATTLEFIELD` | ✅ | ✅ | the default |
| `GRAVEYARD` | ✅ | ✅ | Pyre Zombie, Gigapede |
| `COMMAND` | ✅ **new** | ✅ **new** | eminence |
| `EXILE` | — (dedicated paths) | ✅ | suspend, madness, paradigm |

Exile stays out of the per-event loop deliberately: suspend, madness and paradigm each already have a dedicated detector that a general pass would double-fire. The two duplicated graveyard/exile step passes collapsed into one loop over the non-battlefield zones.

### New `SourceInZone(zones)` condition

A *live* zone-membership lookup — unlike `WasCastFromZone`, which freezes the answer at cast time. Valid in both evaluation contexts (it reads only zone membership).

## The CR 603.4 wrinkle

The printed zone clause does **two** jobs. As a CR 113.6b zone statement it decides where the ability functions. As an intervening-"if" (CR 603.4) it is checked *again* as the ability resolves — and both of Edgar's official rulings turn on that second check:

> If it's on the battlefield or in the command zone when you cast another Vampire spell but leaves that zone before the ability resolves, the ability won't do anything as it resolves.

The engine checks `triggerCondition` only at fire time, never at resolution. Rather than change that engine-wide (a broad behavioral change across every card with an intervening-if), the card supplies the second half itself by gating its effect on `SourceInZone`. Killing Edgar in response to the Vampire spell now correctly produces no token.

**Known gap, unchanged by this PR:** the engine-wide resolution-time half of CR 603.4 is still missing. `TriggeredAbility.triggerCondition` and the DSL now document that instead of claiming otherwise (the old KDoc said "checked when trigger would fire AND at resolution", which was not true).

Second ruling — battlefield → command zone is a new object, so it also fizzles — is **not** covered: that needs object identity across zones, and `BattlefieldEntryTimestampComponent` only stamps the battlefield. Noted rather than faked.

## "Another Vampire spell"

Needs no filter. For the triggering spell to *be* Edgar, the card has to be on the stack — which is neither zone the ability functions from, so the zone gate already declines it. There's a test pinning that rather than leaving it to be rediscovered.

## Card placement

Canonical `card("Edgar Markov")` goes in **C17** (its earliest printing, 2017-08-25) with `Printing` rows for INR #234 and PZ2. `just check-card-printing "Edgar Markov"` is clean.

**INR: 286 → 287 of 290.**

## mtgish generator (Step 8b)

The IR does have a tag for this — `FromCommandZoneOrBattlefield`. The emitter now recognises the envelope and renders both halves (`triggerZones` + the `SourceInZone` gate). It declines one level deeper, on the unsupported `Other(ThisSpell)` spell filter, rather than silently dropping "another" — a separate capability that would need a real exclude-self spell filter in the SDK.

## Verification

- `just build` — green (full suite).
- `CommandZoneTriggerDetectionTest` — 9 tests: fires from the command zone, still fires from the battlefield, fires *exactly once* (the two passes don't both claim it), command-only stays inert on the battlefield, battlefield-only stays inert in the command zone (with a non-vacuous control), own-cast declines, opponent's cast declines, step triggers both directions.
- `EdgarMarkovScenarioTest` — 9 tests end to end, including both rulings, first strike + haste, and the attack trigger pumping Edgar, your other Vampires, and the tokens (but not Grizzly Bears, and not the opponent's Vampire).
- 20 card snapshots re-blessed for the `activeZone` → `activeZones` rename. I diffed every one: nothing but that key moved, and C17's only other change is the new card.

## Note for the reviewer

`backlog/token-art-gaps.md` is stale on `main` — regenerating it reports a new EMN gap (a 1/1 green Insect from It of the Horrid Swarm, from the earlier emerge PR). That's not mine, so I reverted the regeneration rather than fold it in. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)