### PR TITLE
Add Emrakul, the Promised End (INR 288/290)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5034,7 +5034,12 @@ staticAbility {
   `YourSpeed` (the casting player's speed, 0–4, CR 702.179 — Samut, the Driving Force's "Noncreature
   spells you cast cost {X} less to cast, where X is your speed"; "no speed" reads as 0 per CR
   702.179f, so a player who never started their engines simply gets no reduction),
-  `CardsInGraveyardMatchingFilter`, `FixedIfAnyTargetMatches`,
+  `CardsInGraveyardMatchingFilter`,
+  `CardTypesInYourGraveyard(amountPerType = 1)` (the number of *card types* among cards in your
+  graveyard — Emrakul, the Promised End. Distinct types (CR 205.2a), never supertypes or subtypes,
+  so nine creature cards shave only {1}; the counting sibling of `CardsInGraveyardMatchingFilter`,
+  which totals cards. Same aggregation as `Conditions.Delirium` over the same zone, capped by the
+  number of card types — {9} for Emrakul), `FixedIfAnyTargetMatches`,
   `FixedIfCreatureDiedThisTurn(amount)` (the morbid discount — "costs {N} less to cast if a creature
   died this turn", Dreaded Bat-Cloud. Reads the same per-player `CreaturesDiedThisTurnComponent`
   tallies as `Conditions.CreatureDiedThisTurn`, summed across the table, so an opponent's creature
@@ -6033,6 +6038,14 @@ composite abilities).
 - `Protection(color)` — protection from a single color.
 - `ProtectionFrom(set)` — protection from a set of colors/types.
 - `Protection(ProtectionScope.Supertype("Legendary"))` / `KeywordAbility.protectionFromSupertype("Legendary")` — protection from a supertype, e.g. "protection from legendary creatures" (Tsabo Tavoc). Enforced across targeting, blocking, and combat damage via projected `PROTECTION_FROM_SUPERTYPE_<X>` keywords.
+- `Protection(ProtectionScope.CardType("Instant"))` — protection from a card type, e.g. "protection from
+  instants" (Emrakul, the Promised End). Projected as `PROTECTION_FROM_CARDTYPE_<TYPE>` — the same keyword
+  the *granted* card-type protections emit ([`GrantProtectionFromCardType`](#14-static-abilities) on Sword of
+  Wealth and Power, `GrantProtectionFromChosenCardType` on Pippin), so targeting (`TargetValidator`,
+  `StackResolver`), damage prevention (`DamageUtils`, `CombatDamagePipeline`, `CombatDamageManager`), and
+  block evasion (`BlockEvasionRules`) all honour it with no per-card wiring. Protection only functions on
+  the battlefield (CR 702.16), so a spell that targets the permanent while it is still on the stack is
+  unaffected. Rides on the card entity as `ProtectionComponent.cardTypes`.
 - `Hexproof(ProtectionScope.Color(Color.WHITE))` — "hexproof from white" (Knight of Malice). Projected as
   `HEXPROOF_FROM_<COLOR>`.
 - `Hexproof(ProtectionScope.CardType("Instant"))` — "hexproof from instants" (Elenda, Saint of Dusk).
@@ -6041,8 +6054,9 @@ composite abilities).
   validation (`TargetValidator`), and the resolution-time fizzle check (`StackResolver`). Like every
   hexproof it only stops **opponents** — the permanent's controller can still target it — and it honours
   hexproof-suppressing effects. The printed keyword rides on the card entity as `HexproofFromComponent`
-  (attached by `CardEntityFactory.applyDefinitionDecorations`); other `ProtectionScope`s format the oracle
-  text but have no targeting wiring yet and are deliberately not projected.
+  (attached by `CardEntityFactory.applyDefinitionDecorations`); the remaining `ProtectionScope`s in the
+  *hexproof* namespace format the oracle text but have no targeting wiring yet and are deliberately not
+  projected.
 - `Affinity(filter)` — cost reduction per matching permanent.
 - `Amplify(n)` — ETB reveal-creatures-for-counters.
 - `Devour(multiplier, sacrificeFilter, variant)` — "As this enters, you may sacrifice any number of [sacrificeFilter]. It enters with [multiplier] × that many +1/+1 counters." Plain Devour uses `sacrificeFilter = Creature` and `variant = ""`; the Edge of Eternities variant "Devour land N" uses `KeywordAbility.devourLand(n)` (`sacrificeFilter = Land`, `variant = "land"`). The keyword surfaces the rules text; pair with [`EntersWithDevour`](#15-replacement-effects) for the mechanical behavior.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -710,6 +710,30 @@ sealed interface CostReductionSource {
     ) : CostReductionSource {
         override val description: String = "the number of creatures that attacked this turn"
     }
+
+    /**
+     * Reduces cost by [amountPerType] for each *card type* among the cards in the caster's
+     * graveyard — Emrakul, the Promised End ("This spell costs {1} less to cast for each card type
+     * among cards in your graveyard").
+     *
+     * Counts distinct card types (CR 205.2a: artifact, battle, creature, enchantment, instant,
+     * kindred, land, planeswalker, sorcery), never supertypes or subtypes. A single card with
+     * several types (an artifact creature) contributes each of its types once, and the same type
+     * across many cards still counts once — so the cap is the number of card types in the game,
+     * not the graveyard's size.
+     *
+     * The counting sibling of [CardsInGraveyardMatchingFilter], which totals *cards*: nine
+     * creature cards reduce by nine there and by one here. Uses the same aggregation as
+     * `Conditions.Delirium` (`Aggregation.DISTINCT_TYPES` over the graveyard), so a card that
+     * satisfies delirium sees a matching reduction.
+     */
+    @SerialName("CardTypesInYourGraveyard")
+    @Serializable
+    data class CardTypesInYourGraveyard(
+        val amountPerType: Int = 1
+    ) : CostReductionSource {
+        override val description: String = "the number of card types among cards in your graveyard"
+    }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/EmrakulThePromisedEnd.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/EmrakulThePromisedEnd.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Emrakul, the Promised End
+ * {13}
+ * Legendary Creature — Eldrazi
+ * 13/13
+ *
+ * This spell costs {1} less to cast for each card type among cards in your graveyard.
+ * When you cast this spell, you gain control of target opponent during that player's next turn.
+ * After that turn, that player takes an extra turn.
+ * Flying, trample, protection from instants
+ *
+ * Implementation notes:
+ * - The cost reduction is a self-cast [ModifySpellCost] over
+ *   [CostReductionSource.CardTypesInYourGraveyard] — distinct *types*, not cards, so nine creature
+ *   cards in the graveyard still only shave {1}. Emrakul's cost is all generic, and the generic
+ *   reduction rail floors at {0}, so the maximum discount is {9} (2025-01-24 ruling: the nine card
+ *   types that can sit in a graveyard).
+ * - "Protection from instants" is the printed keyword [ProtectionScope.CardType], projected as
+ *   `PROTECTION_FROM_CARDTYPE_INSTANT`. Per the rulings this only bites while Emrakul is on the
+ *   battlefield — a spell that targets it on the stack (Syncopate) is unaffected, which falls out of
+ *   the enforcement sites all gating on battlefield membership.
+ * - The cast trigger is [Triggers.WhenYouCastThisSpell] (CR 603.2 — it resolves *before* Emrakul and
+ *   still resolves if Emrakul is countered), targeting an opponent once and feeding both halves:
+ *   [Effects.HijackNextTurn] takes over that player's next turn, and [Effects.TakeExtraTurn] hands
+ *   them the turn after it. The extra turn is modelled the engine's usual way — every other player
+ *   skips their next turn — so in a two-player game the hijacked turn is followed directly by the
+ *   opponent's extra turn, which is exactly the printed sequence.
+ */
+val EmrakulThePromisedEnd = card("Emrakul, the Promised End") {
+    manaCost = "{13}"
+    colorIdentity = ""
+    typeLine = "Legendary Creature — Eldrazi"
+    power = 13
+    toughness = 13
+    oracleText = "This spell costs {1} less to cast for each card type among cards in your graveyard.\n" +
+        "When you cast this spell, you gain control of target opponent during that player's next " +
+        "turn. After that turn, that player takes an extra turn.\n" +
+        "Flying, trample, protection from instants"
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardTypesInYourGraveyard()
+            )
+        )
+    }
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.CardType("Instant")))
+
+    triggeredAbility {
+        trigger = Triggers.WhenYouCastThisSpell()
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.Composite(
+            Effects.HijackNextTurn(opponent),
+            Effects.TakeExtraTurn(target = opponent)
+        )
+        description = "When you cast this spell, you gain control of target opponent during that " +
+            "player's next turn. After that turn, that player takes an extra turn."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "6"
+        artist = "Jaime Jones"
+        flavorText = "An enigma as vexing as life itself."
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d74a469-c71d-4773-99d3-5456b31df424.jpg?1783937526"
+
+        ruling(
+            "2025-01-24",
+            "The card types that could appear in your graveyard are artifact, battle, creature, " +
+                "enchantment, instant, kindred, land, planeswalker, and sorcery. Supertypes (such " +
+                "as legendary and basic) and subtypes (such as Human and Equipment) are not " +
+                "counted. The maximum discount that Emrakul's own ability can provide is {9}."
+        )
+        ruling(
+            "2025-01-24",
+            "Protection from instants means that Emrakul can't be the target of instant spells or " +
+                "activated or triggered abilities from instant cards, and damage that would be " +
+                "dealt to it by instant spells or cards is prevented. Instant spells may still " +
+                "affect it in other ways; for example, it would still receive the bonus from Rally " +
+                "the Peasants."
+        )
+        ruling(
+            "2025-01-24",
+            "Protection abilities only apply while the object with the ability is on the " +
+                "battlefield. Notably, Emrakul may be the target of a spell that targets it while " +
+                "on the stack, such as Syncopate."
+        )
+        ruling(
+            "2025-01-24",
+            "An ability that triggers when a player casts a spell resolves before the spell that " +
+                "caused it to trigger. It resolves even if that spell is countered or otherwise " +
+                "leaves the stack without resolving."
+        )
+        ruling("2025-01-24", "The player you're controlling is still the active player during that turn.")
+        ruling(
+            "2025-01-24",
+            "You only control the player. You don't control any of that player's permanents, " +
+                "spells, or abilities."
+        )
+        ruling(
+            "2025-01-24",
+            "While controlling another player, you make all choices and decisions that player is " +
+                "allowed to make or is told to make during that turn. This includes choices about " +
+                "what spells to cast or what abilities to activate, as well as any decisions " +
+                "called for by triggered abilities or for any other reason."
+        )
+        ruling(
+            "2025-01-24",
+            "You can use only the affected player's resources (cards, mana, and so on) to pay " +
+                "costs for that player; you can't use your own. Similarly, you can use the " +
+                "affected player's resources only to pay that player's costs; you can't spend " +
+                "them on your costs."
+        )
+        ruling(
+            "2025-01-24",
+            "While controlling another player, you can see all cards in the game that player can " +
+                "see. This includes cards in that player's hand, face-down cards that player " +
+                "controls, and any cards in that player's library the player may look at."
+        )
+        ruling(
+            "2025-01-24",
+            "If the targeted player skips their next turn, you'll control the next turn the " +
+                "affected player actually takes, and the extra turn the player takes will be " +
+                "after that turn."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/EmrakulThePromisedEndReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/EmrakulThePromisedEndReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Emrakul, the Promised End reprint in INR. Canonical CardDefinition lives in EMN (Eldritch Moon),
+ * the card's earliest real-expansion printing.
+ */
+val EmrakulThePromisedEndReprint = Printing(
+    oracleId = "4e7a8817-1a66-45c3-ade9-eac79b40b89f",
+    name = "Emrakul, the Promised End",
+    setCode = "INR",
+    collectorNumber = "5",
+    scryfallId = "71911392-42b0-4b6d-baf7-918a4bd3b924",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/71911392-42b0-4b6d-baf7-918a4bd3b924.jpg?1783908188",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -1858,6 +1858,123 @@
     ]
 }
 
+// Emrakul, the Promised End
+{
+    "name": "Emrakul, the Promised End",
+    "manaCost": "{13}",
+    "typeLine": "Legendary Creature — Eldrazi",
+    "oracleText": "This spell costs {1} less to cast for each card type among cards in your graveyard.\nWhen you cast this spell, you gain control of target opponent during that player's next turn. After that turn, that player takes an extra turn.\nFlying, trample, protection from instants",
+    "creatureStats": {
+        "power": 13,
+        "toughness": 13
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.CardType",
+                "cardType": "Instant"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CastThisSpellEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "HijackNextTurn",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "TakeExtraTurn",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When you cast this spell, you gain control of target opponent during that player's next turn. After that turn, that player takes an extra turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": "CardTypesInYourGraveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "MYTHIC",
+        "artist": "Jaime Jones",
+        "flavorText": "An enigma as vexing as life itself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d74a469-c71d-4773-99d3-5456b31df424.jpg?1783937526",
+        "rulings": [
+            {
+                "date": "2025-01-24",
+                "text": "The card types that could appear in your graveyard are artifact, battle, creature, enchantment, instant, kindred, land, planeswalker, and sorcery. Supertypes (such as legendary and basic) and subtypes (such as Human and Equipment) are not counted. The maximum discount that Emrakul's own ability can provide is {9}."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "Protection from instants means that Emrakul can't be the target of instant spells or activated or triggered abilities from instant cards, and damage that would be dealt to it by instant spells or cards is prevented. Instant spells may still affect it in other ways; for example, it would still receive the bonus from Rally the Peasants."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "Protection abilities only apply while the object with the ability is on the battlefield. Notably, Emrakul may be the target of a spell that targets it while on the stack, such as Syncopate."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "An ability that triggers when a player casts a spell resolves before the spell that caused it to trigger. It resolves even if that spell is countered or otherwise leaves the stack without resolving."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "The player you're controlling is still the active player during that turn."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "You only control the player. You don't control any of that player's permanents, spells, or abilities."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "While controlling another player, you make all choices and decisions that player is allowed to make or is told to make during that turn. This includes choices about what spells to cast or what abilities to activate, as well as any decisions called for by triggered abilities or for any other reason."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "You can use only the affected player's resources (cards, mana, and so on) to pay costs for that player; you can't use your own. Similarly, you can use the affected player's resources only to pay that player's costs; you can't spend them on your costs."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "While controlling another player, you can see all cards in the game that player can see. This includes cards in that player's hand, face-down cards that player controls, and any cards in that player's library the player may look at."
+            },
+            {
+                "date": "2025-01-24",
+                "text": "If the targeted player skips their next turn, you'll control the next turn the affected player actually takes, and the extra turn the player takes will be after that turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Faith Unbroken
 {
     "name": "Faith Unbroken",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
@@ -136,8 +136,24 @@ object CardEntityFactory {
         val protectionSupertypes = protections.mapNotNull {
             (it.scope as? ProtectionScope.Supertype)?.supertype
         }.toSet()
-        if (protectionColors.isNotEmpty() || protectionSubtypes.isNotEmpty() || protectionSupertypes.isNotEmpty()) {
-            result = result.with(ProtectionComponent(protectionColors, protectionSubtypes, protectionSupertypes))
+        // "Protection from instants" (Emrakul, the Promised End). Normalized to the uppercase card
+        // type name here so the projector can emit `PROTECTION_FROM_CARDTYPE_<TYPE>` — the same
+        // keyword the *granted* card-type protections (Sword of Wealth and Power, Pippin) project,
+        // so every consumer downstream already honors it.
+        val protectionCardTypes = protections.mapNotNull {
+            (it.scope as? ProtectionScope.CardType)?.cardType?.uppercase()
+        }.toSet()
+        if (protectionColors.isNotEmpty() || protectionSubtypes.isNotEmpty() ||
+            protectionSupertypes.isNotEmpty() || protectionCardTypes.isNotEmpty()
+        ) {
+            result = result.with(
+                ProtectionComponent(
+                    protectionColors,
+                    protectionSubtypes,
+                    protectionSupertypes,
+                    protectionCardTypes
+                )
+            )
         }
 
         // Card-intrinsic "would be put into [zone] from anywhere → redirect instead" self-replacements

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -108,6 +108,7 @@ class StateProjector(
                         (container.get<ProtectionComponent>()?.colors?.map { "PROTECTION_FROM_${it.name}" } ?: emptyList()) +
                         (container.get<ProtectionComponent>()?.subtypes?.map { "PROTECTION_FROM_SUBTYPE_${it.uppercase()}" } ?: emptyList()) +
             (container.get<ProtectionComponent>()?.supertypes?.map { "PROTECTION_FROM_SUPERTYPE_${it.uppercase()}" } ?: emptyList()) +
+                        (container.get<ProtectionComponent>()?.cardTypes?.map { "PROTECTION_FROM_CARDTYPE_$it" } ?: emptyList()) +
                         (container.get<HexproofFromComponent>()?.colors?.map { "HEXPROOF_FROM_${it.name}" } ?: emptyList()) +
                         (container.get<HexproofFromComponent>()?.cardTypes?.map { "HEXPROOF_FROM_CARDTYPE_$it" } ?: emptyList()) +
                         (container.get<ToxicComponent>()?.let { listOf("TOXIC_${it.amount}") } ?: emptyList()) +

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -463,8 +463,27 @@ class CostCalculator(
                 state.permanentsSacrificedThisTurn * source.amountPerPermanent
             is CostReductionSource.CreaturesThatAttackedThisTurn ->
                 countCreaturesThatAttackedThisTurn(state) * source.amountPerCreature
+            is CostReductionSource.CardTypesInYourGraveyard ->
+                countGraveyardCardTypes(state, playerId) * source.amountPerType
         }
     }
+
+    /**
+     * The number of distinct card types (CR 205.2a) among the cards in [playerId]'s graveyard —
+     * Emrakul, the Promised End. Supertypes and subtypes never count, and a type shared by several
+     * cards counts once, so this is bounded by the number of card types rather than the graveyard's
+     * size.
+     *
+     * The graveyard is not the battlefield, so the printed type line is authoritative and no
+     * projection is needed (continuous effects don't change the types of cards in a graveyard).
+     * Mirrors `Aggregation.DISTINCT_TYPES` in `DynamicAmountEvaluator`, which backs
+     * `Conditions.Delirium` over the same zone.
+     */
+    private fun countGraveyardCardTypes(state: GameState, playerId: EntityId): Int =
+        state.getGraveyard(playerId)
+            .mapNotNull { state.getEntity(it)?.get<CardComponent>()?.typeLine?.cardTypes }
+            .flatMapTo(mutableSetOf()) { it }
+            .size
 
     /**
      * The number of creatures declared as attackers this turn by any player, across every combat

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/ProtectionComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/ProtectionComponents.kt
@@ -5,13 +5,22 @@ import com.wingedsheep.sdk.core.Color
 import kotlinx.serialization.Serializable
 
 /**
- * Static protection from one or more colors (Rule 702.16).
+ * Static protection from one or more qualities (Rule 702.16) printed on the card itself.
  * Attached to permanents/cards that have innate protection (e.g., Disciple of Grace).
  * Dynamic protection granted by spells (e.g., Akroma's Blessing) uses floating effects instead.
+ *
+ * Each quality is projected as its own keyword — `PROTECTION_FROM_<COLOR>`,
+ * `PROTECTION_FROM_SUBTYPE_<X>`, `PROTECTION_FROM_SUPERTYPE_<X>`,
+ * `PROTECTION_FROM_CARDTYPE_<TYPE>` — which is what the targeting, damage-prevention, and
+ * block-evasion checks consult. A quality that lands in no field here is silently unenforced,
+ * so every [com.wingedsheep.sdk.scripting.ProtectionScope] the engine honors needs a home.
+ *
+ * @property cardTypes Uppercase card type names, e.g. `INSTANT` for "protection from instants".
  */
 @Serializable
 data class ProtectionComponent(
     val colors: Set<Color>,
     val subtypes: Set<String> = emptySet(),
-    val supertypes: Set<String> = emptySet()
+    val supertypes: Set<String> = emptySet(),
+    val cardTypes: Set<String> = emptySet()
 ) : Component

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmrakulThePromisedEndScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmrakulThePromisedEndScenarioTest.kt
@@ -1,0 +1,222 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent
+import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Emrakul, the Promised End (EMN #6) — {13} Legendary Creature — Eldrazi, 13/13.
+ *
+ * "This spell costs {1} less to cast for each card type among cards in your graveyard.
+ *  When you cast this spell, you gain control of target opponent during that player's next turn.
+ *  After that turn, that player takes an extra turn.
+ *  Flying, trample, protection from instants"
+ *
+ * Three pieces of new engine behaviour to pin down:
+ *  - `CostReductionSource.CardTypesInYourGraveyard` counts distinct card *types*, so the
+ *    many-cards-one-type case is the one that separates it from
+ *    `CardsInGraveyardMatchingFilter` — a card-counting implementation passes the mixed graveyard
+ *    test and fails that one.
+ *  - A *printed* `ProtectionScope.CardType` now reaches the projection as
+ *    `PROTECTION_FROM_CARDTYPE_INSTANT`. Before this change `CardEntityFactory` dropped the scope
+ *    on the floor, so the keyword never existed and instants could target Emrakul freely.
+ *  - The cast trigger has to feed the *same* targeted opponent to both halves (hijack + extra
+ *    turn); `TakeExtraTurn` defaults to the controller, so a dropped target silently hands the
+ *    caster the extra turn instead.
+ */
+class EmrakulThePromisedEndScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Emrakul, the Promised End — cost reduction per card type in your graveyard") {
+
+            test("empty graveyard → full {13}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Emrakul, the Promised End")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Emrakul, the Promised End"),
+                    game.player1Id,
+                )
+
+                withClue("nothing in the graveyard, so the generic component stays at 13") {
+                    cost.genericAmount shouldBe 13
+                }
+            }
+
+            test("six card types in the graveyard → {7}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Emrakul, the Promised End")
+                    .withCardInGraveyard(1, "Grizzly Bears")   // creature
+                    .withCardInGraveyard(1, "Mountain")        // land
+                    .withCardInGraveyard(1, "Lightning Bolt")  // instant
+                    .withCardInGraveyard(1, "Wrath of God")    // sorcery
+                    .withCardInGraveyard(1, "Pacifism")        // enchantment
+                    .withCardInGraveyard(1, "Sol Ring")        // artifact
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Emrakul, the Promised End"),
+                    game.player1Id,
+                )
+
+                withClue("six distinct card types shave {6} off the {13}") {
+                    cost.genericAmount shouldBe 7
+                }
+            }
+
+            test("many cards of one type still only reduce by {1}") {
+                // The case that distinguishes counting *types* from counting *cards*: three creature
+                // cards are one card type, so the discount is {1} and not {3}.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Emrakul, the Promised End")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Emrakul, the Promised End"),
+                    game.player1Id,
+                )
+
+                withClue("three creature cards are a single card type → {12}") {
+                    cost.genericAmount shouldBe 12
+                }
+            }
+
+            test("only your own graveyard counts") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Emrakul, the Promised End")
+                    .withCardInGraveyard(1, "Grizzly Bears")   // creature — ours
+                    .withCardInGraveyard(2, "Mountain")        // land — the opponent's
+                    .withCardInGraveyard(2, "Lightning Bolt")  // instant — the opponent's
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Emrakul, the Promised End"),
+                    game.player1Id,
+                )
+
+                withClue("\"your graveyard\" excludes the opponent's two extra types → {12}") {
+                    cost.genericAmount shouldBe 12
+                }
+            }
+        }
+
+        context("Emrakul, the Promised End — protection from instants") {
+
+            test("an instant spell can't target Emrakul on the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Emrakul, the Promised End")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val emrakul = game.findPermanent("Emrakul, the Promised End")!!
+
+                withClue("the printed protection scope reaches the projection") {
+                    game.state.projectedState
+                        .hasKeyword(emrakul, "PROTECTION_FROM_CARDTYPE_INSTANT") shouldBe true
+                }
+
+                val bolt = game.castSpell(2, "Lightning Bolt", emrakul)
+
+                withClue("Lightning Bolt is an instant, so targeting Emrakul is illegal") {
+                    bolt.error shouldNotBe null
+                }
+            }
+
+            test("a noninstant spell may still target Emrakul") {
+                // Protection is from instants only — a sorcery-source removal spell is unaffected.
+                // Pinning this down guards against the keyword being read as "protection from
+                // everything" at the enforcement sites.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Emrakul, the Promised End")
+                    .withCardInHand(2, "Pacifism")
+                    .withLandsOnBattlefield(2, "Plains", 2) // Pacifism is {1}{W}
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val emrakul = game.findPermanent("Emrakul, the Promised End")!!
+                val aura = game.castSpell(2, "Pacifism", emrakul)
+
+                withClue("Pacifism is an enchantment, not an instant: ${aura.error}") {
+                    aura.error shouldBe null
+                }
+            }
+        }
+
+        context("Emrakul, the Promised End — cast trigger") {
+
+            test("hijacks the targeted opponent's next turn and hands them an extra turn after it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Emrakul, the Promised End")
+                    .withLandsOnBattlefield(1, "Mountain", 13)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellTargetingPlayer(1, "Emrakul, the Promised End", 2)
+                withClue("Emrakul is castable off 13 lands: ${cast.error}") { cast.error shouldBe null }
+
+                // The cast trigger goes on the stack above Emrakul and resolves first (CR 603.2).
+                game.resolveStack()
+
+                val hijack = game.state.getEntity(game.player2Id)?.get<PlayerTurnHijackedComponent>()
+                withClue("Player2's next turn is scheduled to be controlled by Player1") {
+                    hijack shouldNotBe null
+                    hijack!!.controllerId shouldBe game.player1Id
+                    hijack.state shouldBe PlayerTurnHijackedComponent.HijackState.SCHEDULED
+                }
+
+                withClue("the extra turn goes to the targeted opponent, so the *caster* skips a turn") {
+                    game.state.getEntity(game.player1Id)?.get<SkipNextTurnComponent>()?.turns shouldBe 1
+                    game.state.getEntity(game.player2Id)?.get<SkipNextTurnComponent>() shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Implements **Emrakul, the Promised End** — canonical `CardDefinition` in EMN (Eldritch Moon, the card's earliest real printing), `Printing` row in INR. Innistrad Remastered goes **287 → 288 / 290**.

> {13} Legendary Creature — Eldrazi, 13/13
> This spell costs {1} less to cast for each card type among cards in your graveyard.
> When you cast this spell, you gain control of target opponent during that player's next turn. After that turn, that player takes an extra turn.
> Flying, trample, protection from instants

## Scope note

INR was already at 287/290, and **none of the three leftovers is a plain `cardDef`** — each is blocked on a subsystem:

| Card | Blocker |
|---|---|
| Emrakul, the Promised End | cost reduction by graveyard card types — **this PR** |
| Through the Breach | Splice onto Arcane (CR 702.47) — cast-time reveal + pay + append effects to a spell already on the stack |
| Invasion of Innistrad | the Battle card type — `CardType` has no `BATTLE` entry at all; needs defense counters, protectors, attacking battles, defeat-and-cast-transformed, plus client work |

So this is one card rather than a batch, on purpose. The other two are each their own feature-sized unit.

## Engine changes

Two bounded additions. Both reuse machinery that already existed rather than introducing new types.

### 1. `CostReductionSource.CardTypesInYourGraveyard`

Counts **distinct card types** (CR 205.2a) — never supertypes or subtypes. It's the counting sibling of the existing `CardsInGraveyardMatchingFilter`, which totals *cards*: nine creature cards shave `{1}` here and `{9}` there. Uses the same aggregation as `Conditions.Delirium` over the same zone, so a card that satisfies delirium sees a matching reduction. Capped at `{9}` for Emrakul, matching the 2025-01-24 ruling.

One SDK variant + one `CostCalculator` branch + a graveyard type-count helper. Graveyard is a non-battlefield zone, so the printed type line is authoritative and no projection is needed.

### 2. Printed protection from a card type now reaches the projection

`PROTECTION_FROM_CARDTYPE_<TYPE>` was **already** honored at every enforcement site — `TargetValidator`, `StackResolver`, `DamageUtils`, `CombatDamagePipeline`, `CombatDamageManager`, `BlockEvasionRules` — for *granted* card-type protection (Sword of Wealth and Power, Pippin). But `CardEntityFactory` only collected the color / subtype / supertype scopes, so a **printed** `ProtectionScope.CardType` was dropped on the floor and silently unenforced. That was the whole printed family, not just Emrakul.

Fix is three small edits: `ProtectionComponent` gains a `cardTypes` field, `CardEntityFactory` collects the scope, `StateProjector` emits the keyword the consumers already read. No new enforcement code.

### 3. Turn control — nothing new needed

`Effects.HijackNextTurn` and `Effects.TakeExtraTurn` both existed. Feeding both halves the *same* targeted opponent produces the printed sequence: an extra turn is modelled as every other player skipping their next turn, so in a two-player game the hijacked turn is followed directly by the opponent's extra turn. (`TakeExtraTurn` defaults to the controller, so dropping the target would silently hand the caster the extra turn — the scenario test pins this.)

## Tests

`EmrakulThePromisedEndScenarioTest` — 7 tests, all passing:

- cost reduction: empty graveyard `{13}`; six types `{7}`; **many cards of one type still only `{1}`** (the case a card-counting implementation would fail); only your own graveyard counts
- protection: an instant can't target Emrakul on the battlefield; a noninstant still can (guards against the keyword being read as protection-from-everything)
- cast trigger: hijack scheduled on the targeted opponent, and the *caster* is the one who skips a turn

## Verification

| Gate | Result |
|---|---|
| `:rules-engine:test` (forced, `--rerun --no-build-cache`) | 9738 passed, 0 failed |
| `:mtg-sets:test` (snapshot + lint) | 807 passed |
| `:ai:test` + `:game-server:test` (forced) | 470 passed |
| `just rebless-cards` golden diff | `EMN.json` only, insertions only |
| `just check-card-printing "Emrakul, the Promised End"` | ok — canonical in earliest printing, INR rows present |

Note: `:rules-engine:test` reported `UP-TO-DATE` / `FROM-CACHE` after an earlier `--tests`-filtered run, so the full suite was forced explicitly rather than trusted.

## Known gap, deliberately not fixed here

Legal-target **enumeration** doesn't filter *any* protection scope — not colors, subtypes, supertypes, or card types. `TargetFinder` / `TargetEnumerationUtils` only handle hexproof and player-level protection. So the client can offer Emrakul as a Lightning Bolt target and the server rejects it on submit.

This is pre-existing and family-wide (and inconsistent: hexproof-from-card-type *is* enumerated at `TargetFinder.kt:644`). Fixing it changes behavior for every protection card in the repo, so it belongs in its own change rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
