### PR TITLE
Show rarity and type line on deck rows, and a per-type deck breakdown

### DIFF
--- a/web-client/src/components/sealed/DeckBuilderOverlay.tsx
+++ b/web-client/src/components/sealed/DeckBuilderOverlay.tsx
@@ -11,6 +11,16 @@ import { SetSynergiesButton, type Archetype } from '../draft/SetSynergiesOverlay
 import { DeckbuilderChatPanel } from './DeckbuilderChatPanel'
 import { fetchAdvisors, type AdvisorInfo } from '@/api/aiAssist'
 import { buildArenaDeckList } from './arenaExport'
+import {
+  CARD_TYPE_COLORS,
+  cardTypeLabel,
+  formatTypeLine,
+  rarityColor,
+  rarityInitial,
+  rarityLabel,
+  summarizeDeckTypes,
+  type DeckCardType,
+} from './cardTypes'
 import type { AutoBuildResult } from '@/store/slices/types'
 import {
   detectProducedColors,
@@ -287,17 +297,6 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
       if (info) cardInfos.push(info)
     }
 
-    let creatureCount = 0
-    let nonCreatureCount = 0
-    for (const card of cardInfos) {
-      if (card.typeLine.toLowerCase().includes('land')) continue
-      if (card.typeLine.toLowerCase().includes('creature')) {
-        creatureCount++
-      } else {
-        nonCreatureCount++
-      }
-    }
-
     // Mana curve
     const curve: Record<number, number> = {}
     for (const card of cardInfos) {
@@ -342,7 +341,20 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
 
     const creatureTypes = getCreatureSubtypes(cardInfos)
 
-    return { creatureCount, nonCreatureCount, curve, colorSymbols, landColors, creatureTypes }
+    // Per-card-type distribution. Basic lands live outside `state.deck`, so fold their total into
+    // the Land bucket — the breakdown is meant to sum to the deck the player will actually shuffle.
+    const basicLands = Object.values(state.landCounts).reduce((a, b) => a + b, 0)
+    const typeCounts = summarizeDeckTypes(cardInfos.map((c) => c.typeLine), basicLands)
+    const typeTotal = typeCounts.reduce((sum, t) => sum + t.count, 0)
+
+    return {
+      curve,
+      colorSymbols,
+      landColors,
+      creatureTypes,
+      typeCounts,
+      typeTotal,
+    }
   }, [state.deck, state.cardPool, state.landCounts])
 
   // Pool-level creature type stats (across entire card pool, not just deck)
@@ -1158,18 +1170,15 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
               borderBottom: '1px solid #333',
             }}
           >
-            {/* Live counters */}
-            <div style={{ display: 'flex', gap: 12, marginBottom: 8, flexWrap: 'wrap' }}>
-              <DeckStat label="Creatures" value={deckAnalytics.creatureCount} color="#8bc34a" />
-              <DeckStat label="Spells" value={deckAnalytics.nonCreatureCount} color="#4fc3f7" />
-              <DeckStat label="Lands" value={landCount} color="#a1887f" />
-            </div>
+            {/* Card-type distribution — one bucket per card, so the counts sum to the deck size */}
+            <DeckTypeDistribution counts={deckAnalytics.typeCounts} total={deckAnalytics.typeTotal} />
 
-            {/* Mana curve histogram */}
-            <div style={{ display: 'flex', alignItems: 'flex-end', gap: 3, height: 48 }}>
+            {/* Mana curve histogram. The 62px box is the tallest bar (36) plus both 9px labels and
+                their margins — at 48 the count label overflowed upward into whatever sat above. */}
+            <div style={{ display: 'flex', alignItems: 'flex-end', gap: 3, height: 62 }}>
               {[0, 1, 2, 3, 4, 5, 6, 7].map((cmc) => {
                 const count = deckAnalytics.curve[cmc] || 0
-                const height = maxCurveCount > 0 ? (count / maxCurveCount) * 40 : 0
+                const height = maxCurveCount > 0 ? (count / maxCurveCount) * 36 : 0
                 return (
                   <div key={cmc} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 1, minWidth: 0 }}>
                     {count > 0 && (
@@ -1826,11 +1835,59 @@ function AnimatedDots() {
 /**
  * Small stat display for deck analytics.
  */
-function DeckStat({ label, value, color }: { label: string; value: number; color: string }) {
+function DeckTypeDistribution({
+  counts,
+  total,
+}: {
+  counts: ReadonlyArray<{ type: DeckCardType; count: number }>
+  total: number
+}) {
+  if (total === 0) {
+    return (
+      <div style={{ color: '#666', fontSize: 10, marginBottom: 8 }}>
+        Click cards in the pool to build your deck
+      </div>
+    )
+  }
+
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-      <span style={{ color, fontSize: 14, fontWeight: 700 }}>{value}</span>
-      <span style={{ color: '#888', fontSize: 10 }}>{label}</span>
+    <div style={{ marginBottom: 8 }}>
+      {/* Stacked proportion bar — same visual language as the colour bars below the curve */}
+      <div style={{ display: 'flex', gap: 1, height: 6, borderRadius: 3, overflow: 'hidden' }}>
+        {counts.map(({ type, count }) => (
+          <div
+            key={type}
+            style={{
+              flex: count,
+              backgroundColor: CARD_TYPE_COLORS[type],
+              transition: 'flex 0.2s',
+            }}
+            title={`${count} ${cardTypeLabel(type, count)} (${Math.round((count / total) * 100)}%)`}
+          />
+        ))}
+      </div>
+      {/* Per-type counts */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2px 10px', marginTop: 5 }}>
+        {counts.map(({ type, count }) => (
+          <div
+            key={type}
+            style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+            title={`${count} ${cardTypeLabel(type, count).toLowerCase()} — ${Math.round((count / total) * 100)}% of the deck`}
+          >
+            <span
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: 2,
+                backgroundColor: CARD_TYPE_COLORS[type],
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ color: CARD_TYPE_COLORS[type], fontSize: 13, fontWeight: 700 }}>{count}</span>
+            <span style={{ color: '#888', fontSize: 10 }}>{cardTypeLabel(type, count)}</span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }
@@ -2008,7 +2065,7 @@ function DeckListRow({
       style={{
         display: 'flex',
         alignItems: 'center',
-        height: 28,
+        height: 36,
         padding: '0 8px 0 0',
         cursor: disabled ? 'default' : 'pointer',
         opacity: disabled ? 0.8 : 1,
@@ -2041,16 +2098,51 @@ function DeckListRow({
       >
         {count}
       </span>
-      {/* Card name */}
-      <span style={{
-        color: offIdentity ? '#ef9a9a' : '#ddd',
-        fontSize: 12,
-        flex: 1,
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-      }}>
-        {card.name}
+      {/* Rarity badge */}
+      <span
+        title={rarityLabel(card.rarity)}
+        style={{
+          width: 14,
+          height: 14,
+          marginRight: 6,
+          flexShrink: 0,
+          borderRadius: 3,
+          border: `1px solid ${rarityColor(card.rarity)}`,
+          color: rarityColor(card.rarity),
+          backgroundColor: 'rgba(0, 0, 0, 0.35)',
+          fontSize: 9,
+          fontWeight: 700,
+          lineHeight: '12px',
+          textAlign: 'center',
+        }}
+      >
+        {rarityInitial(card.rarity)}
+      </span>
+      {/* Card name over its printed type line */}
+      <span style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <span style={{
+          color: offIdentity ? '#ef9a9a' : '#ddd',
+          fontSize: 12,
+          lineHeight: '14px',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}>
+          {card.name}
+        </span>
+        <span
+          title={formatTypeLine(card.typeLine)}
+          style={{
+            color: '#7d7d7d',
+            fontSize: 9.5,
+            lineHeight: '11px',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {formatTypeLine(card.typeLine)}
+        </span>
       </span>
       {/* Commander crown — only in commander-shape lobbies */}
       {showCommanderControls && (
@@ -2186,20 +2278,6 @@ function LandRow({
  * Section header for rarity grouping.
  */
 function RaritySectionHeader({ rarity, count }: { rarity: string; count: number }) {
-  const colors: Record<string, string> = {
-    MYTHIC: '#ff8b00',
-    RARE: '#ffd700',
-    UNCOMMON: '#c0c0c0',
-    COMMON: '#888888',
-  }
-
-  const labels: Record<string, string> = {
-    MYTHIC: 'Mythic Rare',
-    RARE: 'Rare',
-    UNCOMMON: 'Uncommon',
-    COMMON: 'Common',
-  }
-
   return (
     <div
       style={{
@@ -2208,11 +2286,11 @@ function RaritySectionHeader({ rarity, count }: { rarity: string; count: number 
         gap: 8,
         marginBottom: 6,
         paddingBottom: 4,
-        borderBottom: `2px solid ${colors[rarity] || '#888'}`,
+        borderBottom: `2px solid ${rarityColor(rarity)}`,
       }}
     >
-      <span style={{ color: colors[rarity] || '#888', fontWeight: 600, fontSize: 13 }}>
-        {labels[rarity] || rarity}
+      <span style={{ color: rarityColor(rarity), fontWeight: 600, fontSize: 13 }}>
+        {rarityLabel(rarity)}
       </span>
       <span style={{ color: '#666', fontSize: 11 }}>({count})</span>
     </div>

--- a/web-client/src/components/sealed/cardTypes.test.ts
+++ b/web-client/src/components/sealed/cardTypes.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyCardType,
+  formatTypeLine,
+  rarityInitial,
+  rarityLabel,
+  summarizeDeckTypes,
+} from './cardTypes'
+
+describe('classifyCardType', () => {
+  it('buckets the plain card types', () => {
+    expect(classifyCardType('Instant')).toBe('Instant')
+    expect(classifyCardType('Sorcery')).toBe('Sorcery')
+    expect(classifyCardType('Artifact — Equipment')).toBe('Artifact')
+    expect(classifyCardType('Enchantment — Aura')).toBe('Enchantment')
+    expect(classifyCardType('Legendary Planeswalker — Jace')).toBe('Planeswalker')
+    expect(classifyCardType('Battle — Siege')).toBe('Battle')
+  })
+
+  it('treats multi-type cards as creatures', () => {
+    expect(classifyCardType('Artifact Creature — Golem')).toBe('Creature')
+    expect(classifyCardType('Enchantment Creature — Nymph')).toBe('Creature')
+    expect(classifyCardType('Legendary Creature — Human Wizard')).toBe('Creature')
+  })
+
+  it('treats land creatures as lands — they eat the land drop, not a spell slot', () => {
+    expect(classifyCardType('Land Creature — Forest Dryad')).toBe('Land')
+    expect(classifyCardType('Artifact Land')).toBe('Land')
+    expect(classifyCardType('Basic Land — Island')).toBe('Land')
+  })
+
+  it('ignores subtypes when matching card types', () => {
+    // "Artificer" and "Islandwalk"-ish subtypes must not leak into the card-type check.
+    expect(classifyCardType('Creature — Human Artificer')).toBe('Creature')
+    expect(classifyCardType('Enchantment — Saga')).toBe('Enchantment')
+  })
+
+  it('handles the ASCII dash some definitions carry', () => {
+    expect(classifyCardType('Creature - Goblin Warrior')).toBe('Creature')
+  })
+
+  it('falls back to Other for unrecognised type lines', () => {
+    expect(classifyCardType('Conspiracy')).toBe('Other')
+  })
+})
+
+describe('summarizeDeckTypes', () => {
+  it('counts each card once, in display order, dropping empty buckets', () => {
+    expect(
+      summarizeDeckTypes([
+        'Creature — Goblin',
+        'Artifact Creature — Golem',
+        'Instant',
+        'Instant',
+        'Enchantment — Aura',
+      ]),
+    ).toEqual([
+      { type: 'Creature', count: 2 },
+      { type: 'Instant', count: 2 },
+      { type: 'Enchantment', count: 1 },
+    ])
+  })
+
+  it('folds basic lands into the Land bucket', () => {
+    expect(summarizeDeckTypes(['Land — Desert', 'Sorcery'], 16)).toEqual([
+      { type: 'Sorcery', count: 1 },
+      { type: 'Land', count: 17 },
+    ])
+  })
+
+  it('returns nothing for an empty deck', () => {
+    expect(summarizeDeckTypes([])).toEqual([])
+    expect(summarizeDeckTypes([], 0)).toEqual([])
+  })
+})
+
+describe('rarity helpers', () => {
+  it('uses M for mythic and the initial otherwise', () => {
+    expect(rarityInitial('MYTHIC')).toBe('M')
+    expect(rarityInitial('rare')).toBe('R')
+    expect(rarityInitial('UNCOMMON')).toBe('U')
+    expect(rarityInitial('COMMON')).toBe('C')
+  })
+
+  it('labels known rarities and passes unknown ones through uppercased', () => {
+    expect(rarityLabel('mythic')).toBe('Mythic Rare')
+    expect(rarityLabel('WEIRD')).toBe('WEIRD')
+  })
+})
+
+describe('formatTypeLine', () => {
+  it('normalizes the ASCII dash to an em-dash', () => {
+    expect(formatTypeLine('Creature - Goblin Warrior')).toBe('Creature — Goblin Warrior')
+    expect(formatTypeLine('Creature — Goblin Warrior')).toBe('Creature — Goblin Warrior')
+    expect(formatTypeLine('Instant')).toBe('Instant')
+  })
+})

--- a/web-client/src/components/sealed/cardTypes.ts
+++ b/web-client/src/components/sealed/cardTypes.ts
@@ -1,0 +1,147 @@
+/**
+ * Card-type classification helpers shared by the sealed/draft deck builder's deck panel.
+ *
+ * The deck breakdown assigns every card exactly one bucket so the counts sum to the deck size —
+ * a "distribution", not a set of overlapping tallies.
+ */
+
+/** Buckets tracked by the deck breakdown, in display order. */
+export const DECK_CARD_TYPES = [
+  'Creature',
+  'Instant',
+  'Sorcery',
+  'Artifact',
+  'Enchantment',
+  'Planeswalker',
+  'Battle',
+  'Land',
+  'Other',
+] as const
+
+export type DeckCardType = (typeof DECK_CARD_TYPES)[number]
+
+/** Bar/chip colour per bucket. Creature/Land reuse the shades the old Creatures/Lands stats used. */
+export const CARD_TYPE_COLORS: Record<DeckCardType, string> = {
+  Creature: '#8bc34a',
+  Instant: '#4fc3f7',
+  Sorcery: '#ba68c8',
+  Artifact: '#b0bec5',
+  Enchantment: '#ffd54f',
+  Planeswalker: '#ff8a65',
+  Battle: '#ef5350',
+  Land: '#a1887f',
+  Other: '#888888',
+}
+
+/** Plural chip label per bucket ("Other" is already a mass noun). */
+const CARD_TYPE_PLURALS: Record<DeckCardType, string> = {
+  Creature: 'Creatures',
+  Instant: 'Instants',
+  Sorcery: 'Sorceries',
+  Artifact: 'Artifacts',
+  Enchantment: 'Enchantments',
+  Planeswalker: 'Planeswalkers',
+  Battle: 'Battles',
+  Land: 'Lands',
+  Other: 'Other',
+}
+
+/** Chip label for a bucket, singular at a count of one ("1 Artifact", not "1 Artifacts"). */
+export function cardTypeLabel(type: DeckCardType, count: number): string {
+  return count === 1 ? (type === 'Other' ? 'Other' : type) : CARD_TYPE_PLURALS[type]
+}
+
+/** Rarity swatch colours, shared by the pool's section headers and the deck rows' rarity badge. */
+export const RARITY_COLORS: Record<string, string> = {
+  MYTHIC: '#ff8b00',
+  RARE: '#ffd700',
+  UNCOMMON: '#c0c0c0',
+  COMMON: '#888888',
+  SPECIAL: '#b565d8',
+  BONUS: '#b565d8',
+}
+
+export const RARITY_LABELS: Record<string, string> = {
+  MYTHIC: 'Mythic Rare',
+  RARE: 'Rare',
+  UNCOMMON: 'Uncommon',
+  COMMON: 'Common',
+  SPECIAL: 'Special',
+  BONUS: 'Bonus',
+}
+
+/** Single-letter badge per rarity — 'M', 'R', 'U', 'C'. Falls back to the first letter. */
+export function rarityInitial(rarity: string): string {
+  const key = rarity.toUpperCase()
+  return key === 'MYTHIC' ? 'M' : (key.charAt(0) || '?')
+}
+
+export function rarityColor(rarity: string): string {
+  return RARITY_COLORS[rarity.toUpperCase()] ?? '#888888'
+}
+
+export function rarityLabel(rarity: string): string {
+  const key = rarity.toUpperCase()
+  return RARITY_LABELS[key] ?? key
+}
+
+/**
+ * Everything before the type line's dash — the card types and supertypes. Handles both the
+ * em-dash Scryfall prints and the ASCII " - " some of our own definitions carry.
+ *
+ * Splitting first matters: subtypes would otherwise poison substring checks (an
+ * "Enchantment — Saga" is not an artifact, but "Artificer" would match a naive `includes`).
+ */
+function cardTypesPortion(typeLine: string): string {
+  const dashIndex = typeLine.indexOf('—')
+  const hyphenIndex = typeLine.indexOf(' - ')
+  const splitIndex = dashIndex !== -1 ? dashIndex : hyphenIndex
+  return (splitIndex === -1 ? typeLine : typeLine.slice(0, splitIndex)).toLowerCase()
+}
+
+/**
+ * Put a card in exactly one bucket. Precedence resolves multi-type cards the way a deckbuilder
+ * thinks about them: an Artifact Creature is a creature, and Dryad Arbor is a land (it costs no
+ * mana and eats the land drop).
+ */
+export function classifyCardType(typeLine: string): DeckCardType {
+  const types = cardTypesPortion(typeLine)
+  if (types.includes('land')) return 'Land'
+  if (types.includes('creature')) return 'Creature'
+  if (types.includes('planeswalker')) return 'Planeswalker'
+  if (types.includes('battle')) return 'Battle'
+  if (types.includes('instant')) return 'Instant'
+  if (types.includes('sorcery')) return 'Sorcery'
+  if (types.includes('artifact')) return 'Artifact'
+  if (types.includes('enchantment')) return 'Enchantment'
+  return 'Other'
+}
+
+/**
+ * Count deck cards per bucket. `extraLands` folds in the basic lands, which live outside the
+ * card list in `landCounts`.
+ */
+export function summarizeDeckTypes(
+  typeLines: readonly string[],
+  extraLands = 0,
+): Array<{ type: DeckCardType; count: number }> {
+  const counts = new Map<DeckCardType, number>()
+  for (const typeLine of typeLines) {
+    const type = classifyCardType(typeLine)
+    counts.set(type, (counts.get(type) ?? 0) + 1)
+  }
+  if (extraLands > 0) counts.set('Land', (counts.get('Land') ?? 0) + extraLands)
+  return DECK_CARD_TYPES.filter((type) => (counts.get(type) ?? 0) > 0).map((type) => ({
+    type,
+    count: counts.get(type) ?? 0,
+  }))
+}
+
+/**
+ * The subtitle shown under a deck row's card name: the printed type line with its dash
+ * normalized to an em-dash, so "Creature - Goblin Warrior" and "Creature — Goblin Warrior"
+ * render identically.
+ */
+export function formatTypeLine(typeLine: string): string {
+  return typeLine.replace(' - ', ' — ').trim()
+}


### PR DESCRIPTION
The sealed/draft deck panel told you a card's name and mana cost and nothing else, so deciding what to cut meant hovering each row one at a time, and the only shape information was three numbers (Creatures / Spells / Lands). Two additions.

## Rarity and type line on every deck row

Each row now carries a rarity badge — `C` / `U` / `R` / `M` outlined in the rarity's colour — and the card's printed type line under its name: `Creature — Goblin Warrior`, `Enchantment — Aura`, `Instant`. Rows grow 28px → 36px to fit the second line.

## A per-type distribution above the curve

The three counters become a stacked proportion bar plus a count per card type — Creatures, Instants, Sorceries, Artifacts, Enchantments, Planeswalkers, Battles, Lands — with empty buckets dropped and the label singular at a count of one. Each card lands in **exactly one** bucket so the counts sum to the deck; basic lands (which live outside `state.deck`, in `landCounts`) fold into Lands.

`web-client/src/components/sealed/cardTypes.ts` holds the classification. Two things it gets right, both covered by `cardTypes.test.ts`:

- **Precedence resolves multi-type cards the way a deckbuilder thinks about them.** An Artifact Creature is a creature; Dryad Arbor is a land, because it costs no mana and eats the land drop.
- **Card types are matched against the portion of the type line before the dash.** A naive `typeLine.includes('artifact')` calls `Creature — Human Artificer` an artifact.

## Drive-by fix

The mana curve's count labels need 62px (36px bar + two 9px labels + margins) but sat in a 48px box, so the tallest bar's label overflowed upward into whatever was above it. Visible in the "before" shot below, where the curve's `9` collides with `16 Lands`.

## Screenshots

Before / after, deck panel:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deckbuilder-card-detail-screenshots/before-panel.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deckbuilder-card-detail-screenshots/after-panel.png) |

Full screen (different pool — sealed pools are generated per game, so the two captures can't share one):

![after full](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deckbuilder-card-detail-screenshots/after-full.png)

`deckbuilder-card-detail-screenshots` is a throwaway branch holding only these PNGs; delete it once this merges.

## Verification

- `npm run build` (typecheck + production build) — clean
- `npx vitest run` — 35 files, 427 tests passing, including 12 new ones for the classifier
- Screenshots captured against a live solo sealed game (Lorwyn Eclipsed) on the running game server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
