### PR TITLE
Keep meld results out of draft, sealed and deck pools

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/FormatCardPool.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/FormatCardPool.kt
@@ -44,6 +44,10 @@ class FormatCardPool(
             // (custom/unreleased content). Excluding it keeps the deck honestly format-legal
             // rather than silently smuggling unknowns in.
             .filter { format in it.legalFormats }
+            // A meld result is format-legal on Scryfall (the meld *parts* are the legal card) but
+            // is never a card you own — building it into a deck just deals a permanent that can't
+            // be cast.
+            .filterNot { it.meldResult }
     }
 
     /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/RandomDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/RandomDeckGenerator.kt
@@ -63,9 +63,10 @@ class RandomDeckGenerator(
         // Step 1: Pick 1-2 colors randomly
         val colors = pickColors()
 
-        // Step 2: Filter card pool to matching colors (non-lands)
+        // Step 2: Filter card pool to matching colors (non-lands). Meld results are in the pool as
+        // corpus entries but are never cards a player owns, so they can't go in a deck.
         val availableSpells = cardPool.filter { card ->
-            !card.isLand && cardMatchesColors(card, colors)
+            !card.isLand && !card.meldResult && cardMatchesColors(card, colors)
         }
 
         // Step 3: Select spells with good mana curve

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -115,6 +115,14 @@ section; do not let SDK additions land without a corresponding doc update.
 - `cantBeCopied: Boolean` — spell can't be copied (CR 707.10); copy effects that name it create no copy (Display of Power).
 - `conditionalFlash: Condition?` — gains flash while condition holds.
 - `layout: CardLayout` — physical layout shape (see §2).
+- `meldResult: Boolean` — this card is the permanent a **meld pair** combines into (CR 701.42) — Chittering Host,
+  Brisela, Voice of Nightmares, Hanweir, the Writhing Township, Ragnarok, Divine Deliverance. Set it on the *result*,
+  never on the meld parts (those are ordinary cards). A meld result is physically the two parts' back halves, so it is
+  never opened, drafted, or put in a deck: the flag drops it from the booster/sealed pool (`BoosterGenerator`), the
+  constructed pool (`FormatCardPool`), and random AI decks. Scryfall can't be the source — it reports meld results as
+  `booster: true` and format-legal, because the card they're printed on is. The result is still authored as a normal
+  card so the corpus carries its characteristics (meld itself is not modelled; the parts' meld triggers are unwired),
+  and scenario tests can still put it directly onto the battlefield.
 
 **Ability blocks inside `card { ... }`**
 
@@ -209,6 +217,8 @@ section; do not let SDK additions land without a corresponding doc update.
 - `releaseDate: String?` — `YYYY-MM-DD`.
 - `inBooster: Boolean` — part of the draft/sealed product (default `true`; `false` for Special Guests / starter
   exclusives). Gates both the booster pool and the basic-land variants offered during limited deck building.
+  It mirrors Scryfall's product-level `booster` flag, so it is *not* the lever for meld results (Scryfall marks
+  those `true`) — use the card-level `meldResult` flag in §1 for those.
 - `oracleTextOverride: String?` — bypass auto-generated oracle text.
 
 **Reprints** — add a `Printing` row in the new set's `Reprints.kt` and wire it into `MtgSet.printings`. Never duplicate

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -345,6 +345,14 @@ class CardBuilder(private val name: String) {
      */
     var mayStartOnBattlefield: Boolean = false
 
+    /**
+     * Meld-result marker (CR 701.42). Set on the permanent two meld cards combine into —
+     * Chittering Host, Brisela, Voice of Nightmares, Hanweir, the Writhing Township — never on the
+     * meld parts, which are ordinary cards. A flagged card is defined for the corpus but kept out
+     * of every pool a player can draw a deck from; see [CardDefinition.meldResult].
+     */
+    var meldResult: Boolean = false
+
     // The `mayBeginGameOnBattlefield()` helper lives in `dsl/mechanics/BeginGameOnBattlefieldDsl.kt`; it sets this flag.
 
     // =========================================================================
@@ -912,7 +920,8 @@ class CardBuilder(private val name: String) {
             // Lands are never *cast* at all (CR 305 — they're played), so a blank mana cost
             // there carries none of CR 202.1b/118.6's "can't be cast normally" implication;
             // scoping the flag to non-lands keeps every land's golden snapshot untouched.
-            hasNoManaCost = manaCost.isBlank() && !parsedTypeLine.isLand
+            hasNoManaCost = manaCost.isBlank() && !parsedTypeLine.isLand,
+            meldResult = meldResult
         )
     }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
@@ -223,7 +223,25 @@ data class CardDefinition(
      * [ManaCost.ZERO] for other reasons (a printed "{0}" cost parses to a non-empty one-symbol
      * list and leaves this false).
      */
-    val hasNoManaCost: Boolean = false
+    val hasNoManaCost: Boolean = false,
+    /**
+     * True for a **meld result** (CR 701.42) — the single permanent two meld cards combine into,
+     * such as Chittering Host (Graf Rats + Midnight Scavengers) or Brisela, Voice of Nightmares
+     * (Bruna, the Fading Light + Gisela, the Broken Blade).
+     *
+     * A meld result is physically the *back halves* of its two meld parts, not a card of its own:
+     * it is never opened in a booster, never drafted, never picked in limited, and never put in a
+     * deck — the only way it exists is by melding the pair on the battlefield. We nonetheless
+     * define it as a standalone [CardDefinition] so the corpus carries its characteristics for when
+     * meld is supported (today the parts' meld triggers are deliberately unwired).
+     *
+     * That "in the corpus but not a real deck card" split is exactly what this flag exists for:
+     * every pool that answers *"which cards can a player end up owning?"* — booster / draft /
+     * sealed pools, constructed pools, the deckbuilder catalog — filters it out. Scryfall can't be
+     * the source here: it marks meld results `booster: true` and format-legal, because the physical
+     * card they're printed on is in the booster and legal (as the meld *parts*).
+     */
+    val meldResult: Boolean = false,
 ) {
     init {
         if (typeLine.isCreature) {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BriselaVoiceOfNightmares.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BriselaVoiceOfNightmares.kt
@@ -16,13 +16,15 @@ import com.wingedsheep.sdk.scripting.references.Player
  *
  * This is a meld result (Bruna, the Fading Light + Gisela, the Broken Blade). Meld itself is a
  * blocked mechanic, so per the task scope Brisela is authored as a normal colorless legendary
- * creature with its printed abilities; the meld linkage is ignored.
+ * creature with its printed abilities; the meld linkage is ignored. `meldResult = true` keeps it
+ * out of booster, draft and deckbuilding pools — it's only ever created by melding the pair.
  *
  * The cast restriction is the reused [PlayersCantCastSpells] primitive scoped to each opponent
  * (Void Winnower / Grand Abolisher family), filtered to spells with mana value 3 or less.
  */
 val BriselaVoiceOfNightmares = card("Brisela, Voice of Nightmares") {
     manaCost = ""
+    meldResult = true
     colorIdentity = ""
     typeLine = "Legendary Creature — Eldrazi Angel"
     power = 9

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ChitteringHost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/ChitteringHost.kt
@@ -21,9 +21,15 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * Haste
  * Menace (This creature can't be blocked except by two or more creatures.)
  * When this creature enters, other creatures you control get +1/+0 and gain menace until end of turn.
+ *
+ * This is a meld result (Graf Rats + Midnight Scavengers). Meld is out of scope, so Chittering Host
+ * is authored as a normal creature with its printed abilities and the meld linkage is ignored.
+ * `meldResult = true` keeps it out of booster, draft and deckbuilding pools — it's only ever
+ * created by melding the pair, never opened or drafted as a card of its own.
  */
 val ChitteringHost = card("Chittering Host") {
     manaCost = ""
+    meldResult = true
     colorIdentity = "B"
     typeLine = "Creature — Eldrazi Horror"
     oracleText = "Haste\nMenace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, other creatures you control get +1/+0 and gain menace until end of turn."

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/HanweirTheWrithingTownship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/HanweirTheWrithingTownship.kt
@@ -18,9 +18,12 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * This is a meld result (Hanweir Garrison + Hanweir Battlements). Meld is out of scope, so Hanweir
  * is authored as a normal colorless legendary creature with its printed abilities. The
  * tapped-and-attacking tokens use [CreateTokenEffect] with `tapped`/`attacking`.
+ * `meldResult = true` keeps it out of booster, draft and deckbuilding pools — it's only ever
+ * created by melding the pair.
  */
 val HanweirTheWrithingTownship = card("Hanweir, the Writhing Township") {
     manaCost = ""
+    meldResult = true
     colorIdentity = ""
     typeLine = "Legendary Creature — Eldrazi Ooze"
     power = 7

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RagnarokDivineDeliverance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RagnarokDivineDeliverance.kt
@@ -23,7 +23,8 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * blocked mechanic, so — following the Brisela, Voice of Nightmares precedent — Ragnarok is
  * authored as a normal legendary creature with its printed abilities and the meld linkage is
  * ignored (it has no mana cost, matching the printed card). Ragnarok can still be exercised by
- * putting it on the battlefield directly.
+ * putting it on the battlefield directly. `meldResult = true` keeps it out of booster, draft and
+ * deckbuilding pools — it's only ever created by melding the pair.
  *
  * The dies trigger has two independent targets chosen when it's put on the stack (CR 603.3d):
  * a permanent to destroy and a nonlegendary permanent card in your graveyard to reanimate. Each
@@ -33,6 +34,7 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  */
 val RagnarokDivineDeliverance = card("Ragnarok, Divine Deliverance") {
     manaCost = ""
+    meldResult = true
     colorIdentity = "BG"
     typeLine = "Legendary Creature — Beast Avatar"
     power = 7

--- a/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/MeldResultFlagTest.kt
+++ b/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/MeldResultFlagTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * Guards [com.wingedsheep.sdk.model.CardDefinition.meldResult] against the way it rots: someone
+ * authors a meld result (a new set's meld pair, or a reprint whose canonical lands here) and it
+ * silently joins the booster / draft / constructed pools as an uncastable card — the Chittering
+ * Host bug.
+ *
+ * The expectation is derived, not listed: a meld *part* names its result in its oracle text
+ * ("… exile them, then meld them into Chittering Host."), so every result the corpus already knows
+ * about is discoverable from the parts. A meld result that isn't authored yet simply isn't checked;
+ * one that is must carry the flag.
+ */
+class MeldResultFlagTest : FunSpec({
+
+    val meldsInto = Regex("""meld them into ([^.]+)\.""")
+
+    val allCards = MtgSetCatalog.all.flatMap { it.cards }
+    val byName = allCards.associateBy { it.name }
+
+    val namedResults = allCards
+        .flatMap { meldsInto.findAll(it.oracleText).map { m -> m.groupValues[1] } }
+        .distinct()
+        .sorted()
+
+    test("meld parts name their results (the derivation this test rests on)") {
+        namedResults.shouldNotBeEmpty()
+    }
+
+    test("every authored meld result is flagged meldResult") {
+        assertSoftly {
+            for (name in namedResults) {
+                val result = byName[name] ?: continue  // result not implemented yet — nothing to flag
+                withClue("$name is the result of a meld pair, so it must set meldResult = true") {
+                    result.meldResult shouldBe true
+                }
+            }
+        }
+    }
+
+    // The inverse: nothing that *is* a real card gets flagged. A flagged card drops out of every
+    // pool a player can draw a deck from, so a stray flag would silently delete a draftable card.
+    test("only meld results are flagged") {
+        assertSoftly {
+            for (card in allCards.filter { it.meldResult }) {
+                withClue("${card.name} is flagged meldResult but no meld part melds into it") {
+                    (card.name in namedResults) shouldBe true
+                }
+            }
+        }
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -492,7 +492,8 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a7a212e-e0b6-4f12-a95c-173cae023f93.jpg?1782711940"
     },
     "colorIdentityOverride": [],
-    "hasNoManaCost": true
+    "hasNoManaCost": true,
+    "meldResult": true
 }
 
 // Bruna, the Fading Light
@@ -681,7 +682,8 @@
     "colorIdentityOverride": [
         "BLACK"
     ],
-    "hasNoManaCost": true
+    "hasNoManaCost": true,
+    "meldResult": true
 }
 
 // Clear Shot
@@ -2729,7 +2731,8 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/7/671fe14d-0070-4bc7-8983-707b570f4492.jpg?1782711861"
     },
     "colorIdentityOverride": [],
-    "hasNoManaCost": true
+    "hasNoManaCost": true,
+    "meldResult": true
 }
 
 // Harmless Offering

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -14510,7 +14510,8 @@
         "BLACK",
         "GREEN"
     ],
-    "hasNoManaCost": true
+    "hasNoManaCost": true,
+    "meldResult": true
 }
 
 // Random Encounter

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -438,21 +438,27 @@ class BoosterGenerator(
         setConfigs.singleOrNull()?.boosterStrategy ?: StandardBooster()
 
     /**
-     * Strip basic lands and non-booster cards (Special Guests / The List / promos), plus any
-     * cards on the tournament host's [bannedCardNames] ban list; strategies operate on the
+     * Strip basic lands, meld results, and non-booster cards (Special Guests / The List / promos),
+     * plus any cards on the tournament host's [bannedCardNames] ban list; strategies operate on the
      * booster pool only. Banned names are matched case-insensitively so a host typo in casing
      * still excludes the card.
+     *
+     * Meld results ([CardDefinition.meldResult]) are dropped here rather than left to
+     * `metadata.inBooster`: Scryfall reports them as `booster: true` — the physical card *is* in
+     * the pack, as the meld parts' back halves — so the product-level flag can't tell a drafter
+     * they're unobtainable. Opening one hands a player a permanent they can never cast.
      */
     private fun boosterPool(
         allCards: List<CardDefinition>,
         bannedCardNames: Set<String> = emptySet(),
     ): List<CardDefinition> {
         if (bannedCardNames.isEmpty()) {
-            return allCards.filter { !it.typeLine.isBasicLand && it.metadata.inBooster }
+            return allCards.filter { it.isBoosterEligible }
         }
         val banned = bannedCardNames.mapTo(HashSet(bannedCardNames.size)) { it.trim().lowercase() }
-        return allCards.filter {
-            !it.typeLine.isBasicLand && it.metadata.inBooster && it.name.trim().lowercase() !in banned
-        }
+        return allCards.filter { it.isBoosterEligible && it.name.trim().lowercase() !in banned }
     }
+
+    private val CardDefinition.isBoosterEligible: Boolean
+        get() = !typeLine.isBasicLand && !meldResult && metadata.inBooster
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorMeldResultTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/limited/BoosterGeneratorMeldResultTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.limited
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.ScryfallMetadata
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+
+/**
+ * Pins that a meld result never reaches a player's card pool.
+ *
+ * A meld result (Chittering Host, Brisela, …) is the *back halves* of two meld cards combined, not
+ * a card of its own: it can only be created by melding the pair on the battlefield. Scryfall still
+ * reports it `booster: true` — the physical card is in the pack, as the meld parts — so the
+ * product-level `metadata.inBooster` flag can't exclude it and [CardDefinition.meldResult] must.
+ *
+ * The bug this locks down: a drafted Chittering Host went into a deck and was drawn as a permanent
+ * its controller could never cast.
+ */
+class BoosterGeneratorMeldResultTest : DescribeSpec({
+
+    fun common(name: String) = CardDefinition.creature(
+        name = name,
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2,
+        metadata = ScryfallMetadata(collectorNumber = name.hashCode().toString()),
+    )
+
+    // 13 ordinary commons plus the meld result. A pack draws 12 distinct commons out of 14, so an
+    // unfiltered pool would surface the meld result in nearly every pack — a sharp control.
+    val meldResultName = "Chittering Host"
+    fun poolOf(setCode: String) =
+        (1..13).map { common("$setCode Common $it") } + common(meldResultName).copy(meldResult = true)
+
+    fun generator(vararg setCodes: String) = BoosterGenerator(
+        setCodes.associateWith { code ->
+            BoosterGenerator.SetConfig(
+                setCode = code,
+                setName = "Set $code",
+                cards = poolOf(code),
+                basicLands = emptyList(),
+            )
+        }
+    )
+
+    describe("single-set booster") {
+        it("never opens a meld result") {
+            val gen = generator("AAA")
+            repeat(60) {
+                gen.generateBooster("AAA").map { it.name } shouldNotContain meldResultName
+            }
+        }
+
+        it("opens the same card when it isn't a meld result (control)") {
+            val gen = BoosterGenerator(
+                mapOf(
+                    "AAA" to BoosterGenerator.SetConfig(
+                        setCode = "AAA",
+                        setName = "Set AAA",
+                        cards = (1..13).map { common("AAA Common $it") } + common(meldResultName),
+                        basicLands = emptyList(),
+                    )
+                )
+            )
+            val names = (1..60).flatMap { gen.generateBooster("AAA").map { c -> c.name } }
+            names shouldContain meldResultName
+        }
+    }
+
+    describe("sealed pool") {
+        it("excludes a meld result from a single-set pool") {
+            generator("AAA").generateSealedPool("AAA", boosterCount = 6)
+                .map { it.name } shouldNotContain meldResultName
+        }
+
+        it("excludes a meld result from a seeded multi-set pool") {
+            generator("AAA", "BBB")
+                .generateSealedPool(listOf("AAA", "BBB"), boosterCount = 6, distributionSeed = 42L)
+                .map { it.name } shouldNotContain meldResultName
+        }
+
+        it("excludes a meld result from an explicit-distribution pool") {
+            generator("AAA", "BBB").generateSealedPool(mapOf("AAA" to 3, "BBB" to 3))
+                .map { it.name } shouldNotContain meldResultName
+        }
+
+        it("excludes a meld result from a chaos pool") {
+            generator("AAA", "BBB")
+                .generateSealedPool(listOf("AAA", "BBB"), boosterCount = 6, chaos = true)
+                .map { it.name } shouldNotContain meldResultName
+        }
+    }
+})


### PR DESCRIPTION
## The bug

An opponent drafted **Chittering Host** from an INR pack and drew it in game — a 5/6 with no mana cost that can never be cast.

Chittering Host is a **meld result** (CR 701.42): the permanent Graf Rats + Midnight Scavengers combine into. It's physically those two cards' *back halves*, not a card of its own — you can never open, draft, or deck it. The same is true of Brisela, Voice of Nightmares; Hanweir, the Writhing Township; and Ragnarok, Divine Deliverance.

## Why nothing caught it

Both pool builders trust Scryfall, and Scryfall reports meld results as `booster: true` and format-legal — correctly, because the physical card they're printed on *is* in the pack and *is* legal, as the meld parts. So:

- `metadata.inBooster` mirrors that flag → true.
- `legalFormats` mirrors the legalities → legal.
- `SetCoverageService.limitedCardNames` is baked from the same data, and `boosterCardPool` *forces* `inBooster = true` for every name on a set's limited list — so even hand-setting `inBooster = false` on the canonical card would have been overridden for INR.

There was no card-level way to say "this exists in the corpus but is not a card anyone owns".

## The fix

A card-level `CardDefinition.meldResult` flag, set via `card { meldResult = true }` on the four authored meld results, and filtered out of the three pools that answer *"which cards can a player end up owning?"*:

| Pool | Path |
|---|---|
| Booster / draft / sealed | `BoosterGenerator.boosterPool` |
| AI constructed + commander | `FormatCardPool.legalPool` |
| Random AI decks | `RandomDeckGenerator` |

The results stay authored as normal cards so the corpus keeps their characteristics for when meld is supported (the parts' meld triggers remain deliberately unwired).

**Deliberately not changed:** the `/api/cards` catalog. The scenario builder reads it, and putting a meld result directly onto the battlefield is currently the only way to exercise these cards — that's how `RagnarokDivineDeliveranceScenarioTest` works.

## Tests

- **`BoosterGeneratorMeldResultTest`** (new) — a meld result is never opened, across the single-set, multi-set, explicit-distribution, chaos and sealed paths, with a control proving the same card *is* opened when the flag is off.
- **`MeldResultFlagTest`** (new) — derives its expectation instead of listing names: reads `"meld them into X"` out of every meld part's oracle text and asserts each authored `X` carries the flag, plus the inverse (nothing else is flagged). A future set's meld pair can't regress this silently.
- Card snapshots re-blessed — the diff is exactly the four cards gaining `"meldResult": true` (EMN ×3, FIN ×1).

## Verification

| Gate | Result |
|---|---|
| `:rules-engine:test --tests BoosterGeneratorMeldResultTest` | 6/6 pass |
| `:mtg-sets:test` (full module — snapshots, lint, facade boundary, new guard) | pass |
| `:ai:test` (full module) | pass |
| `:game-server:compileKotlin` | pass |

Docs: `docs/card-sdk-language-reference.md` §1 documents `meldResult`, and the `inBooster` entry in §2 now says why it is *not* the lever for meld results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)