### PR TITLE
Fix hover preview hidden behind the graveyard/exile browser overlay

### DIFF
--- a/e2e-scenarios/helpers/scenarioApi.ts
+++ b/e2e-scenarios/helpers/scenarioApi.ts
@@ -17,6 +17,7 @@ export interface PlayerConfig {
   battlefield?: BattlefieldCardConfig[]
   graveyard?: string[]
   library?: string[]
+  exile?: string[]
 }
 
 export interface ScenarioRequest {

--- a/e2e-scenarios/tests/general/zone-browser-hover-preview.spec.ts
+++ b/e2e-scenarios/tests/general/zone-browser-hover-preview.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '../../fixtures/scenarioFixture'
+import type { Page } from '@playwright/test'
+
+/**
+ * E2E browser test: the card hover preview must paint above the graveyard/exile browsers.
+ *
+ * The zone browsers (graveyard, exile, deck, …) are full-screen overlays portalled to `<body>`
+ * at z-index 2000. The hover preview used to render in place, inside the board tree — fine for a
+ * player, but the spectator and replay shells wrap the whole board in their own
+ * `position: fixed; z-index: 1500` stacking context, which clamped the preview *below* those
+ * body-level overlays: hovering a card in the graveyard showed it dimmed behind the backdrop
+ * instead of on top. The preview is now portalled to `<body>` on the tooltip layer.
+ *
+ * The assertions encode that invariant structurally (portal parent + z-index ordering) rather
+ * than by pixel comparison, since a screenshot can't distinguish "behind a 0.85 black scrim"
+ * from "slightly dark card art".
+ */
+
+interface PreviewStacking {
+  previewZ: number
+  /** z-indexes of any stacking contexts between the preview layer and <body>. */
+  trappingAncestors: number[]
+  /** z-index of the zone browser's full-screen backdrop. */
+  overlayZ: number | null
+}
+
+/** Computed stacking facts for the hover preview of `cardName`, or null if it isn't showing. */
+function previewStacking(page: Page, cardName: string): Promise<PreviewStacking | null> {
+  return page.evaluate((name) => {
+    // The preview renders the card at ~280px wide; grid tiles are 160px or less.
+    const img = Array.from(document.querySelectorAll('img')).find(
+      (i) => i.alt === name && i.getBoundingClientRect().width > 250,
+    )
+    if (!img) return null
+
+    // The preview layer is the positioned wrapper HoverCardPreview renders.
+    let layer: HTMLElement = img
+    while (layer.parentElement && getComputedStyle(layer).position !== 'fixed') {
+      layer = layer.parentElement
+    }
+
+    // Every z-indexed ancestor between that layer and <body> is a stacking context that would
+    // trap the preview underneath a body-level overlay.
+    const trappingAncestors: number[] = []
+    for (let el = layer.parentElement; el && el !== document.body; el = el.parentElement) {
+      const z = parseInt(getComputedStyle(el).zIndex, 10)
+      if (!Number.isNaN(z)) trappingAncestors.push(z)
+    }
+
+    // The zone browser's backdrop: the fixed full-screen ancestor of its heading.
+    const heading = Array.from(document.querySelectorAll('h2')).find((h) =>
+      /Graveyard|Exile/.test(h.textContent ?? ''),
+    )
+    let overlayZ: number | null = null
+    for (let el = heading?.parentElement ?? null; el && el !== document.body; el = el.parentElement) {
+      if (getComputedStyle(el).position === 'fixed') {
+        overlayZ = parseInt(getComputedStyle(el).zIndex, 10)
+        break
+      }
+    }
+
+    return {
+      previewZ: parseInt(getComputedStyle(layer).zIndex, 10),
+      trappingAncestors,
+      overlayZ,
+    }
+  }, cardName)
+}
+
+/**
+ * Open `playerId`'s `zone` pile, hover `cardName` in the browser it opens, and assert the preview
+ * paints above the overlay.
+ */
+async function expectPreviewOnTop(
+  page: Page,
+  playerId: string,
+  zone: 'graveyard' | 'exile',
+  cardName: string,
+) {
+  // Address the pile by owner: seat order differs between the player's view and a spectator's.
+  await page.locator(`[data-${zone}-id="${playerId}"]`).click()
+
+  // Zone browsers are portalled to <body>, so scope the grid to that overlay — the same card
+  // name also sits on the (unopened) pile behind it.
+  const heading = new RegExp(`${zone === 'graveyard' ? 'Graveyard' : 'Exile'} \\(\\d+\\)`, 'i')
+  const overlay = page
+    .locator('body > div')
+    .filter({ has: page.getByRole('heading', { name: heading }) })
+  await overlay.waitFor({ state: 'visible', timeout: 10_000 })
+  await overlay.locator(`img[alt="${cardName}"]`).first().hover()
+
+  await expect
+    .poll(async () => (await previewStacking(page, cardName)) !== null, { timeout: 10_000 })
+    .toBe(true)
+
+  const stacking = (await previewStacking(page, cardName))!
+  expect(stacking.trappingAncestors, 'no stacking context may sit between preview and <body>').toEqual([])
+  expect(stacking.overlayZ, 'zone browser backdrop not found').not.toBeNull()
+  expect(stacking.previewZ).toBeGreaterThan(stacking.overlayZ!)
+
+  await page.keyboard.press('Escape')
+  await overlay.waitFor({ state: 'detached', timeout: 10_000 })
+}
+
+async function checkZoneBrowsers(page: Page, playerId: string) {
+  await expectPreviewOnTop(page, playerId, 'graveyard', 'Hill Giant')
+  await expectPreviewOnTop(page, playerId, 'exile', 'Goblin Bully')
+}
+
+test.describe('Zone browsers — hover preview stacking', () => {
+  test('graveyard and exile previews paint above the overlay, for player and spectator', async ({
+    createGame,
+    browser,
+  }) => {
+    const { player1, response } = await createGame({
+      player1Name: 'Alice',
+      player2Name: 'Bob',
+      player1: {
+        battlefield: [{ name: 'Mountain' }, { name: 'Grizzly Bears' }],
+        graveyard: ['Lightning Bolt', 'Hill Giant'],
+        exile: ['Goblin Bully'],
+        library: ['Mountain', 'Mountain'],
+      },
+      player2: {
+        battlefield: [{ name: 'Swamp' }],
+        library: ['Swamp', 'Swamp'],
+      },
+      phase: 'PRECOMBAT_MAIN',
+      activePlayer: 1,
+    })
+
+    const alice = response.player1.playerId
+
+    // The player's own view — the board is the root stacking context here.
+    await checkZoneBrowsers(player1.page, alice)
+
+    // A spectator's view — the board sits inside the spectator shell's stacking context, which
+    // is what used to bury the preview.
+    const spectatorContext = await browser.newContext()
+    const spectator = await spectatorContext.newPage()
+    await spectator.goto(`/?spectate=${response.sessionId}`)
+    await spectator
+      .locator(`[data-graveyard-id="${alice}"]`)
+      .waitFor({ state: 'visible', timeout: 30_000 })
+    await checkZoneBrowsers(spectator, alice)
+    await spectatorContext.close()
+  })
+})

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1109,11 +1109,14 @@ export const styles: Record<string, React.CSSProperties> = {
     zIndex: 12,
   } as React.CSSProperties,
   // Card preview styles
+  // Mobile fullscreen card preview. On the tooltip layer, and portalled to <body> by its
+  // renderer — the spectator/replay shells wrap the board in a z-index:1500 stacking context,
+  // which would otherwise clamp it below the <body>-portalled zone browsers.
   cardPreviewOverlay: {
     position: 'fixed',
     top: 20,
     left: 20,
-    zIndex: 2500,
+    zIndex: 'var(--z-tooltip)' as unknown as number,
     pointerEvents: 'none',
   } as React.CSSProperties,
   cardPreviewContainer: {

--- a/web-client/src/components/game/card/CardPreview.tsx
+++ b/web-client/src/components/game/card/CardPreview.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import { useGameStore } from '@/store/gameStore.ts'
 import { selectGameState, selectViewingPlayerId, useCardLegalActions } from '@/store/selectors.ts'
 import { ZoneType, zoneIdEquals } from '@/types'
@@ -368,7 +369,10 @@ function MobileCardPreview({ card }: { card: import('@/types').ClientCard }) {
   const previewWidth = 200
   const previewHeight = Math.round(previewWidth * 1.4)
 
-  return (
+  // Portalled to <body> for the same reason HoverCardPreview is: the spectator/replay shells
+  // wrap the board in their own stacking context, and the zone browsers (graveyard/exile/deck)
+  // portal to <body> — an in-tree preview lands underneath them.
+  return createPortal(
     <div style={{
       ...styles.cardPreviewOverlay,
       top: 0, left: 0, right: 0, bottom: 0,
@@ -436,6 +440,7 @@ function MobileCardPreview({ card }: { card: import('@/types').ClientCard }) {
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
 import { useGameStore } from '@/store/gameStore.ts'
 import { useHasLegalActions } from '@/store/selectors.ts'
 import type { ClientCard, EntityId } from '@/types'
@@ -2357,15 +2356,14 @@ function GameCardImpl({
         </div>
       )}
 
-      {/* Original-card preview portalled to <body> so it escapes the card's
-          overflow:hidden / transform containing block (tapped cards rotate). */}
-      {!faceDown && card.copyOf && copyBadgeHoverPos && createPortal(
+      {/* Original-card preview. HoverCardPreview portals itself to <body>, so it escapes the
+          card's overflow:hidden / transform containing block (tapped cards rotate). */}
+      {!faceDown && card.copyOf && copyBadgeHoverPos && (
         <HoverCardPreview
           name={card.copyOf}
           imageUri={null}
           pos={copyBadgeHoverPos}
-        />,
-        document.body,
+        />
       )}
 
       {/* Active effect badges (evasion, type/color change, etc.) — sized off the battlefield

--- a/web-client/src/components/ui/HoverCardPreview.tsx
+++ b/web-client/src/components/ui/HoverCardPreview.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { getCardImageUrl } from '@/utils/cardImages.ts'
 
 const PREVIEW_WIDTH = 280
@@ -30,6 +31,14 @@ export interface HoverCardPreviewProps {
 /**
  * Shared card hover preview — positions a large card image near the cursor.
  * Used by the game board, deck builder, and all draft overlays.
+ *
+ * Always portalled to `<body>` on the tooltip layer (`--z-tooltip`). A cursor-following
+ * preview is a viewport-level layer, so it must not be trapped in whatever stacking context
+ * happens to wrap its caller: the spectator/replay shells wrap the whole board in a
+ * `position: fixed; z-index: 1500` container, which clamped an in-tree preview *below* the
+ * zone browsers (graveyard/exile/deck) that portal to `<body>` at z-index 2000. Cards can
+ * also live inside `overflow: hidden` / transformed ancestors (a tapped permanent rotates),
+ * which would clip a preview rendered in place.
  */
 export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rulings, children, overlay, extraHeight = 0, imageRotateDeg = 0 }: HoverCardPreviewProps) {
   const [showRulings, setShowRulings] = useState(false)
@@ -90,14 +99,14 @@ export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rul
     }
   }
 
-  return (
+  return createPortal(
     <div
       style={{
         position: 'fixed',
         top,
         left,
         pointerEvents: 'none',
-        zIndex: 2500,
+        zIndex: 'var(--z-tooltip)' as unknown as number,
         display: 'flex',
         flexDirection: 'column',
         gap: GAP,
@@ -153,7 +162,8 @@ export function HoverCardPreview({ name, imageUri, imageSize = 'large', pos, rul
           Hold to see rulings...
         </div>
       )}
-    </div>
+    </div>,
+    document.body,
   )
 }
 


### PR DESCRIPTION
## The bug

Hovering a card while browsing a graveyard or exile pile showed the card preview **behind the browser's dark backdrop** instead of on top of it.

It only happens when the board is *not* the root stacking context — i.e. **while spectating a game or watching a replay**, which is where I reproduced it:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/fix-zone-browser-hover-preview-screenshots/graveyard-hover-before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/fix-zone-browser-hover-preview-screenshots/graveyard-hover-after.png) |

Exile, same view, after the fix:

![exile](https://raw.githubusercontent.com/wingedsheep/argentum-engine/fix-zone-browser-hover-preview-screenshots/exile-hover-after.png)

## Root cause

The zone browsers (graveyard, exile, plotted, paradigm, suspended, deck) are full-screen overlays **portalled to `<body>`** at z-index 2000. The hover preview rendered **in place, inside the board tree**, at z-index 2500.

That ordering only holds while the board's ancestors are all `z-index: auto`. `SpectatorGameBoard` and `ReplayPlayer` each wrap the whole board in a `position: fixed; z-index: 1500` container — a stacking context — so the preview's 2500 became local to that context and the entire board (preview included) was painted below the body-level overlay at 2000. In a normal player's view the same code paints correctly, which is why this only showed up in spectate/replay.

## Fix

A cursor-following preview is a viewport-level layer, so it's now built as one:

- `HoverCardPreview` portals itself to `<body>` and sits on the shared tooltip layer (`--z-tooltip`), instead of rendering in-tree at a hard-coded 2500. Every caller benefits — game board, deck browser, deckbuilder, drafts, cube editor, set completion.
- `MobileCardPreview` (the fullscreen tap preview) gets the same treatment, so touch spectators aren't left with the old behaviour.
- `GameCard` no longer needs its own `createPortal` around the copy-of preview — it was hand-rolling this same escape for a related reason (a tapped permanent's `transform`).

No behavioural change for a player at the table: the preview was already the top-most thing there, and it still is.

## Verification

- `web-client`: `npm run typecheck`, `npm test` (415 passed), `npm run build` — all clean.
- New regression test `e2e-scenarios/tests/general/zone-browser-hover-preview.spec.ts`: opens Alice's graveyard and exile from **both her own view and a spectator's**, asserting no stacking context sits between the preview and `<body>` and that the preview outranks the browser backdrop. Passes on this branch; against the unfixed client it fails with `trappingAncestors: [1500]` at the spectator step and passes the player step — i.e. it pins exactly the broken case.
- `PlayerConfig` in `helpers/scenarioApi.ts` gained `exile?: string[]`, which the dev scenario API already supported and the new test needs.
- Screenshots above are the real app (game server + worktree dev server, Playwright/Chrome). The `fix-zone-browser-hover-preview-screenshots` branch hosting them is throwaway — delete it once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
