### PR TITLE
Add five cards to The Hobbit, and render Compare conditions as English

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7358,7 +7358,11 @@ default to "you" so card authors don't need to pass it explicitly.
 - `All(c1, c2, ...)` — AND.
 - `Any(c1, c2, ...)` — OR.
 - `Not(c)` — negate.
-- `Compare(v1, op, v2)` — numeric comparison between `DynamicAmount`s.
+- `Compare(v1, op, v2)` — numeric comparison between `DynamicAmount`s. Its `description` is
+  player-facing (a `CantAttackUnless` restriction renders it into the "can't attack" message), so it
+  reads as a sentence: `ComparisonOperator.phrase` supplies the English comparative and the whole
+  condition comes out as "the number of other Wolf creatures you control **is at least** 2". Use
+  `ComparisonOperator.symbol` (`>=`) only for diagnostics — never in text a player sees.
 - `NumberMatches(amount, NumberProperty.{Prime,Even,Odd,MultipleOf(n)})` — unary numeric predicate
   over one `DynamicAmount` (primality/parity/divisibility); facades `AmountIsPrime/Even/Odd/MultipleOf`.
 - `Exists(player, zone, filter)` — at least one matching object exists.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
@@ -127,6 +127,10 @@ data class TargetIsSpellOnStack(
 enum class ComparisonOperator {
     LT, LTE, EQ, NEQ, GT, GTE;
 
+    /**
+     * The mathematical symbol. Debug/diagnostic rendering only — anything a player reads should use
+     * [phrase] instead, so "…can't attack unless X >= 2" comes out as "…unless X is at least 2".
+     */
     val symbol: String
         get() = when (this) {
             LT -> "<"
@@ -135,6 +139,24 @@ enum class ComparisonOperator {
             NEQ -> "!="
             GT -> ">"
             GTE -> ">="
+        }
+
+    /**
+     * English rendering of the comparison, phrased to follow an "is": "is **at least** 2",
+     * "is **greater than** the number of creatures defending player controls".
+     *
+     * Mirrors Magic's own comparative wording ("two or more" → at least, "fewer than" → less than)
+     * rather than inventing a house style, so a [Compare] description drops into rules text without
+     * reading like a debug dump.
+     */
+    val phrase: String
+        get() = when (this) {
+            LT -> "less than"
+            LTE -> "at most"
+            EQ -> "exactly"
+            NEQ -> "not"
+            GT -> "greater than"
+            GTE -> "at least"
         }
 }
 
@@ -158,7 +180,7 @@ data class Compare(
     val operator: ComparisonOperator,
     val right: DynamicAmount
 ) : Condition {
-    override val description: String = "${left.description} ${operator.symbol} ${right.description}"
+    override val description: String = "${left.description} is ${operator.phrase} ${right.description}"
     override fun applyTextReplacement(replacer: TextReplacer): Condition {
         val newLeft = left.applyTextReplacement(replacer)
         val newRight = right.applyTextReplacement(replacer)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -61,18 +61,33 @@ data class GameObjectFilter(
 
     /**
      * The English indefinite article ("a" or "an") for this filter's type name.
-     * Derived from the card predicates' type word (e.g. "artifact", "equipment"),
+     * Derived from the card predicates' leading type word (e.g. "artifact", "equipment"),
      * not from the full [description] — which may include "you control" prefixes
      * that would give the wrong first letter.
+     *
+     * Reads the predicates in [orderedCardPredicates] order, the same order [description] renders
+     * them in, so the article always agrees with the word it precedes: "**an** Elf creature", not
+     * "a Elf creature". The only consumer pairs the two directly (`CostAtom`'s
+     * "from <article> <description> you control").
      */
     val indefiniteArticle: String
         get() {
-            val typeWord = cardPredicates.firstOrNull()?.description?.trim()
-                ?: if (anyOf.isNotEmpty()) anyOf.first().indefiniteArticle
+            val typeWord = orderedCardPredicates().firstOrNull()?.description?.trim()
+                ?: if (anyOf.isNotEmpty()) return anyOf.first().indefiniteArticle
                 else description.trim()
             val first = typeWord.firstOrNull()?.lowercaseChar() ?: return "a"
             return if (first in "aeiou") "an" else "a"
         }
+
+    /**
+     * Card predicates in rendering order: subtypes ahead of the card type, because Magic templates
+     * them that way — "Wolf creature", "Equipment artifact", never "creature Wolf". A stable
+     * partition, so every other pairing keeps its original insertion order.
+     */
+    private fun orderedCardPredicates(): List<CardPredicate> {
+        val (subtypes, rest) = cardPredicates.partition { it is CardPredicate.HasSubtype }
+        return subtypes + rest
+    }
 
     private fun buildDescription(): String = buildString {
         controllerPredicate?.let {
@@ -85,7 +100,7 @@ data class GameObjectFilter(
             append(predicate.description)
             append(" ")
         }
-        cardPredicates.forEach { predicate ->
+        orderedCardPredicates().forEach { predicate ->
             append(predicate.description)
             append(" ")
         }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -330,15 +330,28 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
     companion object {
         /**
          * Pluralize the last word of a filter description for use in counting phrases.
-         * Examples: "creature" → "creatures", "land" → "lands", "sorcery" → "sorceries"
+         * Examples: "creature" → "creatures", "land" → "lands", "sorcery" → "sorceries",
+         * "Wolf" → "Wolves", "Leech" → "Leeches"
+         *
+         * Creature types drive most of these, and Magic has plenty that a bare "+s" gets wrong:
+         * Wolf/Elf/Dwarf take -ves, and the sibilant endings (Leech, Fish, Sphinx) take -es.
+         * Irregular plurals (Ox → Oxen) aren't worth a lookup table — they read acceptably as
+         * "Oxes" and cost more in maintenance than they return.
          */
         internal fun pluralize(filterDesc: String): String {
             if (filterDesc.isEmpty()) return "cards"
             val words = filterDesc.split(" ")
             val lastWord = words.last()
+            val lower = lastWord.lowercase()
             val plural = when {
-                lastWord.endsWith("s") -> lastWord
-                lastWord.endsWith("y") && !lastWord.endsWith("ey") -> lastWord.dropLast(1) + "ies"
+                lower.endsWith("s") -> lastWord
+                // Wolf → Wolves, Knife → Knives. "Dwarf" is the one Magic spells "Dwarves".
+                lower.endsWith("f") -> lastWord.dropLast(1) + "ves"
+                lower.endsWith("fe") -> lastWord.dropLast(2) + "ves"
+                // Sibilants need the extra syllable: Leech → Leeches, Sphinx → Sphinxes.
+                lower.endsWith("ch") || lower.endsWith("sh") ||
+                    lower.endsWith("x") || lower.endsWith("z") -> lastWord + "es"
+                lower.endsWith("y") && !lower.endsWith("ey") -> lastWord.dropLast(1) + "ies"
                 else -> lastWord + "s"
             }
             return (words.dropLast(1) + plural).joinToString(" ")

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/CompareDescriptionTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/CompareDescriptionTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.sdk.scripting
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+
+/**
+ * [Compare] descriptions surface directly to players — a `CantAttackUnless` restriction renders its
+ * condition into the "you can't attack with that" message, and trigger/activation conditions render
+ * into ability text. They must read as English, not as a debug dump of the underlying comparison.
+ */
+class CompareDescriptionTest : DescribeSpec({
+
+    describe("ComparisonOperator.phrase") {
+
+        it("renders every operator as an English comparative that follows an 'is'") {
+            ComparisonOperator.LT.phrase shouldBe "less than"
+            ComparisonOperator.LTE.phrase shouldBe "at most"
+            ComparisonOperator.EQ.phrase shouldBe "exactly"
+            ComparisonOperator.NEQ.phrase shouldBe "not"
+            ComparisonOperator.GT.phrase shouldBe "greater than"
+            ComparisonOperator.GTE.phrase shouldBe "at least"
+        }
+
+        it("keeps the mathematical symbols available for diagnostics") {
+            ComparisonOperator.GTE.symbol shouldBe ">="
+            ComparisonOperator.LT.symbol shouldBe "<"
+        }
+    }
+
+    describe("Compare.description") {
+
+        it("reads as a sentence rather than an operator dump") {
+            Conditions.YouControlAtLeast(3, GameObjectFilter.Creature).description shouldBe
+                "the number of creatures you control is at least 3"
+        }
+
+        it("compares two dynamic amounts without leaking a symbol (Goblin Goon)") {
+            val moreCreaturesThanDefender = Compare(
+                DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature),
+                ComparisonOperator.GT,
+                DynamicAmount.AggregateBattlefield(Player.DefendingPlayer, GameObjectFilter.Creature)
+            )
+            moreCreaturesThanDefender.description shouldBe
+                "the number of creatures you control is greater than " +
+                "the number of creatures defending player controls"
+        }
+
+        it("renders the whole CantAttackUnless message for Chief Warg's Company") {
+            val twoOtherWolves = Compare(
+                DynamicAmount.AggregateBattlefield(
+                    player = Player.You,
+                    filter = GameObjectFilter.Creature.withSubtype(Subtype.WOLF),
+                    excludeSelf = true
+                ),
+                ComparisonOperator.GTE,
+                DynamicAmount.Fixed(2)
+            )
+            val message = CantAttackUnless(twoOtherWolves).description
+            message shouldBe "can't attack unless the number of other Wolf creatures you control is at least 2"
+            message shouldNotContain ">="
+        }
+    }
+
+    describe("filter descriptions feeding those comparisons") {
+
+        it("templates the subtype ahead of the card type, as Magic does") {
+            GameObjectFilter.Creature.withSubtype(Subtype.WOLF).description shouldBe "Wolf creature"
+            GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).description shouldBe
+                "Equipment artifact"
+        }
+
+        it("keeps the controller qualifier in front of the type words") {
+            GameObjectFilter.Creature.withSubtype(Subtype.WOLF).youControl().description shouldBe
+                "you control Wolf creature"
+        }
+
+        it("agrees the indefinite article with the word the description now leads on") {
+            // The article is rendered immediately before the description (CostAtom's
+            // "sacrifice ... from <article> <description>"), so hoisting the subtype has to move
+            // the article with it — "an Elf creature", never "a Elf creature".
+            val elf = GameObjectFilter.Creature.withSubtype(Subtype.ELF)
+            elf.indefiniteArticle shouldBe "an"
+
+            val wolf = GameObjectFilter.Creature.withSubtype(Subtype.WOLF)
+            wolf.indefiniteArticle shouldBe "a"
+
+            // No subtype to hoist: still keyed off the card type.
+            GameObjectFilter.Artifact.indefiniteArticle shouldBe "an"
+            GameObjectFilter.Creature.indefiniteArticle shouldBe "a"
+        }
+    }
+
+    describe("pluralization of counted filters") {
+
+        it("uses -ves for the f-ending creature types Magic actually prints") {
+            DynamicAmount.AggregateBattlefield(
+                Player.You, GameObjectFilter.Creature.withSubtype(Subtype.WOLF)
+            ).description shouldBe "the number of Wolf creatures you control"
+
+            DynamicAmount.AggregateBattlefield(
+                Player.You, GameObjectFilter.Any.withSubtype(Subtype.DWARF)
+            ).description shouldBe "the number of Dwarves you control"
+
+            DynamicAmount.AggregateBattlefield(
+                Player.You, GameObjectFilter.Any.withSubtype(Subtype.ELF)
+            ).description shouldBe "the number of Elves you control"
+        }
+
+        it("uses -es after a sibilant") {
+            DynamicAmount.AggregateBattlefield(
+                Player.You, GameObjectFilter.Any.withSubtype(Subtype("Leech"))
+            ).description shouldBe "the number of Leeches you control"
+        }
+
+        it("still handles the plain and -y cases") {
+            DynamicAmount.AggregateBattlefield(
+                Player.You, GameObjectFilter.Creature
+            ).description shouldBe "the number of creatures you control"
+
+            DynamicAmount.AggregateBattlefield(
+                Player.You, GameObjectFilter.Sorcery
+            ).description shouldBe "the number of sorceries you control"
+        }
+    }
+})

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HowlsquadHeavy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/HowlsquadHeavy.kt
@@ -73,9 +73,12 @@ val HowlsquadHeavy = card("Howlsquad Heavy") {
             cost = Costs.Tap
             effect = Effects.AddMana(
                 Color.RED,
+                // No `.youControl()` on the filter: `battlefield(Player.You, …)` already restricts
+                // to permanents you control, and the redundant predicate only doubled the
+                // qualifier in the generated description ("you control Goblins you control").
                 DynamicAmounts.battlefield(
                     Player.You,
-                    filter = GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN).youControl()
+                    filter = GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN)
                 ).count(),
             )
             manaAbility = true

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ChiefWargsCompany.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ChiefWargsCompany.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Chief Warg's Company — The Hobbit #151
+ * {1}{B}{G} · Creature — Wolf · Rare
+ * 5/3
+ *
+ * Trample
+ * This creature can't attack unless you control two or more other Wolves.
+ * At the beginning of your upkeep, create a 2/2 green Wolf creature token.
+ *
+ * The attack restriction counts *other* Wolves, so it is `AggregateBattlefield(excludeSelf = true)`
+ * rather than a plain "three or more Wolves" tally: `CantAttackUnlessDefenderRule` evaluates the
+ * condition with `sourceId` set to the attacker, which is what `excludeSelf` keys off. Counting three
+ * Wolves total would silently diverge the moment this creature stops being a Wolf (a type-changing
+ * effect), or when it isn't itself the one attacking.
+ *
+ * The tokens it makes are Wolves too, so the restriction unlocks itself after two upkeeps.
+ */
+val ChiefWargsCompany = card("Chief Warg's Company") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Wolf"
+    power = 5
+    toughness = 3
+    oracleText = "Trample\n" +
+        "This creature can't attack unless you control two or more other Wolves.\n" +
+        "At the beginning of your upkeep, create a 2/2 green Wolf creature token."
+
+    keywords(Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = CantAttackUnless(
+            Compare(
+                DynamicAmount.AggregateBattlefield(
+                    player = Player.You,
+                    filter = GameObjectFilter.Creature.withSubtype(Subtype.WOLF),
+                    excludeSelf = true
+                ),
+                ComparisonOperator.GTE,
+                DynamicAmount.Fixed(2)
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Wolf"),
+            controller = EffectTarget.Controller,
+            imageUri = "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1783924694",
+        )
+        description = "At the beginning of your upkeep, create a 2/2 green Wolf creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "151"
+        artist = "Jason Kang"
+        flavorText = "Seldom did Wargs venture near the dwellings of Humans, preferring instead to " +
+            "hunt and den over the Edge of the Wild."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbc634af-63d2-444a-8123-85f16fe3e364.jpg?1784733927"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/IronHills.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/IronHills.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Iron Hills — The Hobbit #185
+ * Land · Common
+ *
+ * This land enters tapped.
+ * {T}: Add {R} or {W}.
+ * {2}{R}{W}, {T}, Sacrifice this land: Put two +1/+1 counters on target Dwarf you control.
+ * Activate only as a sorcery.
+ *
+ * The tribal half of the HOB tapland cycle. "Add {R} or {W}" is two separate mana abilities (one per
+ * color), matching how every other dual tapland in the engine is modelled — the player picks which
+ * ability to activate rather than making a choice on resolution.
+ *
+ * The sacrifice ability is a normal activated ability with [TimingRule.SorcerySpeed] for "Activate
+ * only as a sorcery". It targets, so it is simply removed from the stack if no Dwarf you control is a
+ * legal target when it would be put there (CR 603.3d) — but the cost, land and all, is already paid.
+ */
+val IronHills = card("Iron Hills") {
+    manaCost = ""
+    colorIdentity = "RW"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {R} or {W}.\n" +
+        "{2}{R}{W}, {T}, Sacrifice this land: Put two +1/+1 counters on target Dwarf you control. " +
+        "Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}{W}"), Costs.Tap, Costs.SacrificeSelf)
+        val dwarf = target(
+            "target Dwarf you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.DWARF))
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, dwarf)
+        timing = TimingRule.SorcerySpeed
+        description = "Put two +1/+1 counters on target Dwarf you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Marina Ortega Lorente"
+        flavorText = "The hills provided quality iron, allowing Dáin's folk to clad themselves in " +
+            "hauberks of steel mail and hoses of fine metal mesh."
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78045c43-5cbe-48ff-837d-e7c6baac2937.jpg?1785323594"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/IronHillsBlacksmith.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/IronHillsBlacksmith.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
+
+/**
+ * Iron Hills Blacksmith — The Hobbit #16
+ * {1}{W} · Creature — Dwarf Artificer · Uncommon
+ * 1/1
+ *
+ * Double strike
+ * When this creature enters, create a colorless Equipment artifact token named Axe with
+ * "Equipped creature gets +1/+0" and equip {2}.
+ *
+ * The Axe is a named Equipment with printed abilities, so it goes through
+ * [CreatePredefinedTokenEffect] against the `PredefinedTokens.Axe` definition (the Sword /
+ * Sturdy Shield shell) rather than an ad-hoc `CreateToken` — that is what gives the token a real
+ * card definition, so its static bonus and equip ability actually resolve.
+ */
+val IronHillsBlacksmith = card("Iron Hills Blacksmith") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Artificer"
+    power = 1
+    toughness = 1
+    oracleText = "Double strike\n" +
+        "When this creature enters, create a colorless Equipment artifact token named Axe with " +
+        "\"Equipped creature gets +1/+0\" and equip {2}."
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreatePredefinedTokenEffect("Axe")
+        description = "When this creature enters, create a colorless Equipment artifact token named " +
+            "Axe with \"Equipped creature gets +1/+0\" and equip {2}."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "16"
+        artist = "Jarel Threat"
+        flavorText = "Dáin heard Thorin's urgent plea and ordered his smiths to fetch their " +
+            "strongest axes and mattocks."
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/370e09c2-36c5-4662-8350-1db798afad3e.jpg?1784631771"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LakeshoreApothecary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LakeshoreApothecary.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lakeshore Apothecary — The Hobbit #43
+ * {1}{U} · Creature — Human Cleric · Common
+ * 1/2
+ *
+ * Vigilance
+ * Whenever you draw your second card each turn, put a +1/+1 counter on this creature.
+ *
+ * The draw trigger is [Triggers.NthCardDrawn] (CR 121.2) — it reads the per-player draw counter and
+ * fires exactly once per turn, on the crossing into the second draw, so a single two-card draw fires
+ * it once rather than twice. No target: the counter always goes on this creature.
+ */
+val LakeshoreApothecary = card("Lakeshore Apothecary") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 2
+    oracleText = "Vigilance\n" +
+        "Whenever you draw your second card each turn, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Wei Guan"
+        flavorText = "After Smaug fell, Bard took the lead with the hard task of governing and " +
+            "protecting the people. Most would have perished in the winter that now hurried if " +
+            "help had not been to hand."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abfbb255-a39b-4df5-bfb6-5298584e89f0.jpg?1785497053"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheSackvilleBagginses.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheSackvilleBagginses.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * The Sackville-Bagginses — The Hobbit #83
+ * {1}{B} · Legendary Creature — Halfling Citizen · Rare
+ * 2/2
+ *
+ * When The Sackville-Bagginses enter, you may sacrifice another creature or artifact.
+ * If you do, draw a card and create a Treasure token.
+ * Whenever you sacrifice a token, target opponent loses 1 life.
+ *
+ * The "you may sacrifice another creature or artifact. If you do, …" clause is the Swarm Culler /
+ * Comet Crawler shell — a declared permanent under a [MayEffect], so the "if you do" rider is bound to
+ * a sacrifice that is guaranteed to happen once the controller accepts. With no other creature or
+ * artifact on the battlefield there is nothing to declare and the trigger simply does nothing.
+ *
+ * The second ability is a per-permanent sacrifice trigger ([Triggers.YouSacrificeA]), so sacrificing
+ * three tokens at once fires it three times (CR 603.2c) rather than once — and it fires for *any*
+ * token, including the Treasure this card just made and the Sackville-Bagginses themselves if they
+ * happen to be a token copy.
+ */
+val TheSackvilleBagginses = card("The Sackville-Bagginses") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Halfling Citizen"
+    power = 2
+    toughness = 2
+    oracleText = "When The Sackville-Bagginses enter, you may sacrifice another creature or " +
+        "artifact. If you do, draw a card and create a Treasure token.\n" +
+        "Whenever you sacrifice a token, target opponent loses 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val sacrificed = target(
+            "another creature or artifact",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.youControl().or(GameObjectFilter.Artifact.youControl())
+                ).other()
+            )
+        )
+        effect = MayEffect(
+            Effects.SacrificeTarget(sacrificed) then
+                Effects.DrawCards(1) then
+                Effects.CreateTreasure()
+        )
+        description = "When The Sackville-Bagginses enter, you may sacrifice another creature or " +
+            "artifact. If you do, draw a card and create a Treasure token."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Any.token())
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.LoseLife(1, opponent)
+        description = "Whenever you sacrifice a token, target opponent loses 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "83"
+        artist = "Denman Rooke"
+        flavorText = "It took more than Bilbo showing up alive to convince some that he was not, in " +
+            "fact, \"presumed dead.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/ed87b471-79f9-45ec-9188-69e970f6121e.jpg?1784894871"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -859,6 +859,28 @@ object PredefinedTokens {
     }
 
     /**
+     * Axe — the colorless Equipment artifact token created by Iron Hills Blacksmith (The Hobbit):
+     * "Equipped creature gets +1/+0" and equip {2}.
+     *
+     * Same shape as [Sword] and [SturdyShield], with a different name, art, and stat bonus.
+     */
+    val Axe = card("Axe") {
+        typeLine = "Artifact — Equipment"
+        oracleText = "Equipped creature gets +1/+0.\nEquip {2}"
+
+        staticAbility {
+            ability = ModifyStats(+1, 0, Filters.EquippedCreature)
+        }
+
+        equipAbility("{2}")
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/6/f/6f7a3999-e341-43bb-9b8f-6c1a05b98906.jpg?1785497989"
+            artist = "Nathaniel Himawan"
+        }
+    }
+
+    /**
      * All predefined token definitions.
      * Register these in the CardRegistry so token abilities are resolved.
      */
@@ -894,6 +916,7 @@ object PredefinedTokens {
         Zabu,
         Moloid,
         Galactus,
-        SturdyShield
+        SturdyShield,
+        Axe
     )
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/DFT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DFT.json
@@ -8407,7 +8407,7 @@
                     "amount": {
                         "type": "AggregateBattlefield",
                         "player": "You",
-                        "filter": "creature Goblin ctrl:you"
+                        "filter": "creature Goblin"
                     }
                 },
                 "timing": "ManaAbility",
@@ -8426,7 +8426,7 @@
                     }
                 ],
                 "isManaAbility": true,
-                "descriptionOverride": "Max speed — {T}: Add {R} for each the number of you control creature Goblins you control"
+                "descriptionOverride": "Max speed — {T}: Add {R} for each the number of Goblin creatures you control"
             }
         ],
         "staticAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -465,6 +465,77 @@
     ]
 }
 
+// Chief Warg's Company
+{
+    "name": "Chief Warg's Company",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Trample\nThis creature can't attack unless you control two or more other Wolves.\nAt the beginning of your upkeep, create a 2/2 green Wolf creature token.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Wolf"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1783924694",
+                    "controller": "Controller"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, create a 2/2 green Wolf creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Wolf",
+                        "excludeSelf": true
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "RARE",
+        "artist": "Jason Kang",
+        "flavorText": "Seldom did Wargs venture near the dwellings of Humans, preferring instead to hunt and den over the Edge of the Wild.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbc634af-63d2-444a-8123-85f16fe3e364.jpg?1784733927"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Confusticate and Bebother
 {
     "name": "Confusticate and Bebother",
@@ -2113,6 +2184,129 @@
     "colorIdentityOverride": []
 }
 
+// Iron Hills
+{
+    "name": "Iron Hills",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {R} or {W}.\n{2}{R}{W}, {T}, Sacrifice this land: Put two +1/+1 counters on target Dwarf you control. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Dwarf you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Dwarf ctrl:you"
+                        },
+                        "id": "target Dwarf you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Put two +1/+1 counters on target Dwarf you control."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Marina Ortega Lorente",
+        "flavorText": "The hills provided quality iron, allowing Dáin's folk to clad themselves in hauberks of steel mail and hoses of fine metal mesh.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78045c43-5cbe-48ff-837d-e7c6baac2937.jpg?1785323594"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
+// Iron Hills Blacksmith
+{
+    "name": "Iron Hills Blacksmith",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Dwarf Artificer",
+    "oracleText": "Double strike\nWhen this creature enters, create a colorless Equipment artifact token named Axe with \"Equipped creature gets +1/+0\" and equip {2}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Axe"
+                },
+                "descriptionOverride": "When this creature enters, create a colorless Equipment artifact token named Axe with \"Equipped creature gets +1/+0\" and equip {2}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "UNCOMMON",
+        "artist": "Jarel Threat",
+        "flavorText": "Dáin heard Thorin's urgent plea and ordered his smiths to fetch their strongest axes and mattocks.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/370e09c2-36c5-4662-8350-1db798afad3e.jpg?1784631771"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Iron Hills Stalwart
 {
     "name": "Iron Hills Stalwart",
@@ -2248,6 +2442,48 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Lakeshore Apothecary
+{
+    "name": "Lakeshore Apothecary",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Vigilance\nWhenever you draw your second card each turn, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Wei Guan",
+        "flavorText": "After Smaug fell, Bard took the lead with the hard task of governing and protecting the people. Most would have perished in the winter that now hurried if help had not been to hand.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abfbb255-a39b-4df5-bfb6-5298584e89f0.jpg?1785497053"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -3959,6 +4195,100 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// The Sackville-Bagginses
+{
+    "name": "The Sackville-Bagginses",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Creature — Halfling Citizen",
+    "oracleText": "When The Sackville-Bagginses enter, you may sacrifice another creature or artifact. If you do, draw a card and create a Treasure token.\nWhenever you sacrifice a token, target opponent loses 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SacrificeTarget",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "another creature or artifact"
+                                }
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure"
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|artifact ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another creature or artifact"
+                },
+                "descriptionOverride": "When The Sackville-Bagginses enter, you may sacrifice another creature or artifact. If you do, draw a card and create a Treasure token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "token",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "Whenever you sacrifice a token, target opponent loses 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "RARE",
+        "artist": "Denman Rooke",
+        "flavorText": "It took more than Bilbo showing up alive to convince some that he was not, in fact, \"presumed dead.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed87b471-79f9-45ec-9188-69e970f6121e.jpg?1784894871"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Five more cards for The Hobbit, plus a fix to how `Compare` conditions render for players.

## Cards

All five are HOB-original printings, so HOB is canonical for each (`just check-card-printing` confirms).

| Card | Cost | What it does |
|---|---|---|
| **Lakeshore Apothecary** #43 | `{1}{U}` | Vigilance; `NthCardDrawn(2)` → +1/+1 counter on itself |
| **Iron Hills Blacksmith** #16 | `{1}{W}` | Double strike; ETB mints the Axe Equipment token |
| **The Sackville-Bagginses** #83 | `{1}{B}` | ETB may-sacrifice → draw + Treasure; per-token sacrifice drain |
| **Chief Warg's Company** #151 | `{1}{B}{G}` | Trample; gated attack restriction; upkeep Wolf tokens |
| **Iron Hills** #185 | — | R/W tapland; sorcery-speed sac for two +1/+1 counters on a Dwarf |

**Axe token.** Iron Hills Blacksmith's Equipment has printed abilities, so it goes through `CreatePredefinedTokenEffect` against a new `PredefinedTokens.Axe` following the existing Sword / Sturdy Shield shell — that is what gives the token a real card definition, so its `+1/+0` static and equip `{2}` actually resolve. Art is the `thob` printing.

**Chief Warg's Company counts *other* Wolves.** `AggregateBattlefield(excludeSelf = true)` rather than a "three or more Wolves" tally. `CantAttackUnlessDefenderRule` evaluates the condition with `sourceId` set to the attacker, which is what `excludeSelf` keys off; the two readings diverge the moment a type-changing effect stops it being a Wolf, or when it isn't itself the attacker. Its own tokens are Wolves, so the restriction unlocks itself after two upkeeps.

**The Sackville-Bagginses' ETB** uses the Swarm Culler / Comet Crawler shell for the identical oracle wording ("you may sacrifice another creature or artifact. If you do, …") — a declared permanent under a `MayEffect`, so the "if you do" rider binds to a sacrifice guaranteed to happen once the controller accepts. Its second ability is `YouSacrificeA` (per-permanent, CR 603.2c), so sacrificing three tokens at once fires it three times, and it fires for any token including the Treasure the first ability just made.

## `Compare` description rendering

`Compare.description` is player-facing — `CantAttackUnless` renders it straight into the "you can't attack with that" message — but it emitted the raw mathematical symbol. Chief Warg's Company read:

> can't attack unless the number of other creature **Wolfs** you control **>= 2**

Three defects in that one sentence, all fixed:

1. **The operator dump.** `ComparisonOperator` gains a `phrase` (`at least`, `at most`, `greater than`, `less than`, `exactly`, `not`) and `Compare` renders `"<left> is <phrase> <right>"`. `symbol` stays for diagnostics. Every `Compare`-gated card benefits — Lupine Prototype, `YouControlAtLeast`, the tracker conditions.
2. **`Wolfs`.** `pluralize()` only knew `+s` and `-y → -ies`, so the f-ending creature types Magic actually prints came out wrong. Added the `-f`/`-fe` → `-ves` rule and the sibilant `-es` rule (Leech → Leeches).
3. **`creature Wolf`.** Filter descriptions emitted card predicates in insertion order; Magic templates the subtype first. Subtypes are now hoisted ahead of the card type via a *stable* partition, so every other pairing keeps its order. `indefiniteArticle` reads the same ordering so the article still agrees with the word it precedes ("an Elf creature", not "a Elf creature") — it's rendered immediately before the description by `CostAtom`.

Now reads:

> can't attack unless the number of other Wolf creatures you control is at least 2

**Correction to my earlier note on this PR:** I previously said the message "drops the 'you control' qualifier". That was wrong — `AggregateBattlefield.description` already appended it. The actual defects were the three above; I found them by printing the rendered strings rather than reading the code.

**Collateral:** Howlsquad Heavy (DFT) passed both `battlefield(Player.You, …)` and a redundant `.youControl()` on the filter, doubling the qualifier in its generated description. Dropped the redundant predicate — description-only, since the evaluator already restricts to the named player.

**Deliberately left alone:** `AddManaEffect` composes "for each" with an amount that already reads "the number of …", giving "Add {R} for each the number of Goblin creatures you control". Fixing that needs a singular phrasing on `DynamicAmount` — a wider refactor than belongs here.

## Verification

- `just build` and `just test` — green across mtg-sdk, mtg-sets, and rules-engine (0 failures in all three).
- The rendering change's blast radius across the whole corpus was **one** golden line (Howlsquad Heavy's generated description); every other card description was unaffected. Re-blessed.
- `just rebless-cards` for the cards — only the five new HOB entries were added; nothing else moved.
- New `CompareDescriptionTest` (mtg-sdk) pins every operator phrase, the full Chief Warg's Company message, the subtype-first ordering, article agreement, and each pluralization rule.
- Every card field (name, mana cost, type line, oracle text, P/T, rarity, collector number, artist, flavor text, image URI) diffed programmatically against live Scryfall HOB data — exact match on all five. All seven image URIs return HTTP 200.
- `just check-card-printing` passes for each card.

No scenario tests for the cards: each composes existing primitives, so the snapshot and lint nets cover them (per the `add-card` skill's Step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
