### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ColdCaseCracker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ColdCaseCracker.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cold Case Cracker
+ * {3}{U}
+ * Creature — Spirit Detective
+ * 3/3
+ * Flying
+ * When this creature dies, investigate.
+ */
+val ColdCaseCracker = card("Cold Case Cracker") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit Detective"
+    oracleText = "Flying\n" +
+        "When this creature dies, investigate. (Create a Clue token. It's an artifact with " +
+        "\"{2}, Sacrifice this token: Draw a card.\")"
+    power = 3
+    toughness = 3
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Investigate()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Wayne Wu"
+        flavorText = "\"It's a rare privilege to investigate one's own death.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f082111b-9b1c-4a25-8c5d-d6ef77533a9b.jpg?1783912913"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CuriousInquiry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CuriousInquiry.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Curious Inquiry
+ * {U}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +1/+1 and has "Whenever this creature deals combat damage to a
+ *   player, investigate."
+ *
+ * The trigger is *granted to the enchanted creature* (GrantTriggeredAbility over the
+ * attached-creature filter, SELF binding) rather than modelled as an Aura-bound trigger, so
+ * the Clue goes to the enchanted creature's controller — which matters when this enchants a
+ * creature you don't control.
+ */
+val CuriousInquiry = card("Curious Inquiry") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+1 and has \"Whenever this creature deals combat damage to a " +
+        "player, investigate.\" (Create a Clue token. It's an artifact with \"{2}, Sacrifice this " +
+        "token: Draw a card.\")"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EnchantedCreature)
+    }
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToPlayer.event,
+                binding = Triggers.DealsCombatDamageToPlayer.binding,
+                effect = Effects.Investigate()
+            ),
+            filter = Filters.EnchantedCreature
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Ekaterina Burmak"
+        flavorText = "Each time he replayed the attack in his mind, new details emerged."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5a3603c6-92df-45c7-b402-1f0a552ea398.jpg?1783912912"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Deduce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Deduce.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deduce
+ * {1}{U}
+ * Instant
+ * Draw a card. Investigate.
+ */
+val Deduce = card("Deduce") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw a card. Investigate. (Create a Clue token. It's an artifact with " +
+        "\"{2}, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Effects.Investigate()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Quintin Gleim"
+        flavorText = "Proft lit up like a man who had just been handed a glorious and unexpected gift. " +
+            "\"I know who's responsible for this,\" he said. \"And I can prove it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7cbb17af-e17e-438a-ad72-0c942e6706b6.jpg?1783912912"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/NoviceInspector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/NoviceInspector.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Novice Inspector
+ * {W}
+ * Creature — Human Detective
+ * 1/2
+ * When this creature enters, investigate.
+ */
+val NoviceInspector = card("Novice Inspector") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Detective"
+    oracleText = "When this creature enters, investigate. (Create a Clue token. It's an artifact with " +
+        "\"{2}, Sacrifice this token: Draw a card.\")"
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Investigate()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Fajareka Setiawan"
+        flavorText = "\"If the perfect evidence appears at your feet, your first task is to rule out " +
+            "misdirection.\"\n—The Ravnican Agency of Magicological Investigations handbook"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ad38866-fc5f-4f62-89c1-afc0f50765aa.jpg?1783912920"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UnscrupulousAgent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UnscrupulousAgent.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Unscrupulous Agent
+ * {1}{B}
+ * Creature — Elf Detective
+ * 1/1
+ * When this creature enters, target opponent exiles a card from their hand.
+ *
+ * The exile is chosen by the target opponent: `Patterns.Hand.exileFromHand` derives the
+ * chooser from the effect target, so the opponent picks which of their own cards is exiled
+ * (same primitive as Skullcap Snail).
+ */
+val UnscrupulousAgent = card("Unscrupulous Agent") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Elf Detective"
+    oracleText = "When this creature enters, target opponent exiles a card from their hand."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Patterns.Hand.exileFromHand(1, opponent)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Michal Ivan"
+        flavorText = "Obtaining evidence through the \"proper\" channels can take weeks of paperwork. " +
+            "Sometimes justice just can't wait."
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37692f9a-3825-43aa-aacb-1bb92cb5bd07.jpg?1783912890"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1,3 +1,43 @@
+// Cold Case Cracker
+{
+    "name": "Cold Case Cracker",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Spirit Detective",
+    "oracleText": "Flying\nWhen this creature dies, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Wayne Wu",
+        "flavorText": "\"It's a rare privilege to investigate one's own death.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f082111b-9b1c-4a25-8c5d-d6ef77533a9b.jpg?1783912913"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Commercial District
 {
     "name": "Commercial District",
@@ -31,6 +71,89 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Curious Inquiry
+{
+    "name": "Curious Inquiry",
+    "manaCost": "{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+1 and has \"Whenever this creature deals combat damage to a player, investigate.\" (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "damageType": "DamageCombat",
+                        "recipient": "AnyPlayer"
+                    },
+                    "effect": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Clue"
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Ekaterina Burmak",
+        "flavorText": "Each time he replayed the attack in his mind, new details emerged.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5a3603c6-92df-45c7-b402-1f0a552ea398.jpg?1783912912"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Deduce
+{
+    "name": "Deduce",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Draw a card. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Quintin Gleim",
+        "flavorText": "Proft lit up like a man who had just been handed a glorious and unexpected gift. \"I know who's responsible for this,\" he said. \"And I can prove it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7cbb17af-e17e-438a-ad72-0c942e6706b6.jpg?1783912912"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -1281,6 +1404,42 @@
     ]
 }
 
+// Novice Inspector
+{
+    "name": "Novice Inspector",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "When this creature enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Fajareka Setiawan",
+        "flavorText": "\"If the perfect evidence appears at your feet, your first task is to rule out misdirection.\"\n—The Ravnican Agency of Magicological Investigations handbook",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0ad38866-fc5f-4f62-89c1-afc0f50765aa.jpg?1783912920"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Pick Your Poison
 {
     "name": "Pick Your Poison",
@@ -1986,6 +2145,85 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Unscrupulous Agent
+{
+    "name": "Unscrupulous Agent",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Elf Detective",
+    "oracleText": "When this creature enters, target opponent exiles a card from their hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "exiled",
+                            "prompt": "Choose a card to exile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Michal Ivan",
+        "flavorText": "Obtaining evidence through the \"proper\" channels can take weeks of paperwork. Sometimes justice just can't wait.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/37692f9a-3825-43aa-aacb-1bb92cb5bd07.jpg?1783912890"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CuriousInquiryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CuriousInquiryScenarioTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Curious Inquiry (MKM #51, {U} Enchantment — Aura).
+ *
+ *   Enchant creature
+ *   Enchanted creature gets +1/+1 and has "Whenever this creature deals combat damage to a
+ *   player, investigate."
+ *
+ * The interesting part is that the trigger is *granted to the enchanted creature* rather than
+ * bound to the Aura, so the Clue belongs to the creature's controller. This is the first Aura
+ * in the card pool to use `GrantTriggeredAbility` (the shape previously only appeared on
+ * Equipment), so both the self-enchant and the enchant-an-opponent's-creature cases are covered.
+ */
+class CuriousInquiryScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Curious Inquiry") {
+
+            test("enchanted creature gets +1/+1 and investigates on combat damage to a player") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Curious Inquiry", "Grizzly Bears")
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                run {
+                    val projected = stateProjector.project(game.state)
+                    withClue("Enchanted Grizzly Bears should be 3/3 (2/2 base +1/+1)") {
+                        projected.getPower(bears) shouldBe 3
+                        projected.getToughness(bears) shouldBe 3
+                    }
+                }
+
+                clueCount(game, 1) shouldBe 0
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.passPriority()
+                game.resolveStack()
+
+                withClue("Opponent took 3 combat damage from the enchanted 3/3") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+                withClue("Dealing combat damage to a player investigated for the Aura's controller") {
+                    clueCount(game, 1) shouldBe 1
+                }
+            }
+
+            test("no combat damage to a player means no Clue") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Curious Inquiry", "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3 blocker eats the 3/3 attacker's damage
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Hill Giant" to listOf("Grizzly Bears")))
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.passPriority()
+                game.resolveStack()
+
+                withClue("Damage went to a blocker, not a player — the granted trigger stays silent") {
+                    clueCount(game, 1) shouldBe 0
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("enchanting an opponent's creature gives the Clue to that creature's controller") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Curious Inquiry", "Grizzly Bears")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 1))
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.passPriority()
+                game.resolveStack()
+
+                withClue("Player 1 took 3 combat damage from the enchanted 3/3") {
+                    game.getLifeTotal(1) shouldBe 17
+                }
+                withClue("The granted ability belongs to the enchanted creature's controller") {
+                    clueCount(game, 2) shouldBe 1
+                    clueCount(game, 1) shouldBe 0
+                }
+            }
+        }
+    }
+
+    /** Clue tokens on the battlefield controlled by [playerNumber]. */
+    private fun clueCount(game: TestGame, playerNumber: Int): Int {
+        val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getBattlefield().count { id ->
+            val entity = game.state.getEntity(id) ?: return@count false
+            entity.get<CardComponent>()?.name == "Clue" &&
+                entity.get<ControllerComponent>()?.playerId == playerId
+        }
+    }
+}


### PR DESCRIPTION
Five more MKM cards, all built from existing SDK primitives — no new engine vocabulary.

| Card | Cost | What it does |
|---|---|---|
| Novice Inspector | `{W}` | 1/2 Human Detective — ETB investigate |
| Deduce | `{1}{U}` | Instant — draw a card, investigate |
| Cold Case Cracker | `{3}{U}` | 3/3 Spirit Detective with flying — dies → investigate |
| Curious Inquiry | `{U}` | Aura — enchanted creature gets +1/+1 and has "deals combat damage to a player → investigate" |
| Unscrupulous Agent | `{1}{B}` | 1/1 Elf Detective — ETB target opponent exiles a card from their hand |

## Notes

**Curious Inquiry** grants its trigger to the enchanted creature (`GrantTriggeredAbility` over
`Filters.EnchantedCreature`, SELF binding) rather than modelling it as an Aura-bound trigger. That
matters for rules fidelity: the ability belongs to the enchanted creature's controller, so enchanting
an opponent's creature hands *them* the Clue. This shape previously only appeared on Equipment
(Thief's Knife), so it gets a scenario test — self-enchant, blocked attacker (no Clue), and
enchanting an opponent's creature (Clue goes to the opponent).

**Unscrupulous Agent** reuses `Patterns.Hand.exileFromHand`, which derives the chooser from the effect
target, so the opponent picks which of their own cards is exiled (same primitive as Skullcap Snail).

Cards *not* picked from MKM this round: anything with **collect evidence** or **disguise**. Neither
mechanic exists in the engine yet — those are `add-feature` work, not card work.

## Verification

- `just build` — green (full gate: compile, card linter, facade boundary, snapshot, rules-engine suite)
- `just test-class CuriousInquiryScenarioTest` — 3/3 passing
- `just check-card-printing` — clean for all five (MKM is the canonical earliest printing for each)
- Card snapshot re-blessed; only the five new cards moved in `MKM.json` (additions only)
- All five `imageUri` values verified HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)