### PR TITLE
Hold a counterspell for a spell worth the card, and promote it

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -248,6 +248,7 @@ class AIPlayer(
                     intents = intents,
                     combatTricksWaitForBlocks = profile.combatTricksWaitForBlocks,
                     holdRemovalForBetterTargets = profile.holdRemovalForBetterTargets,
+                    holdCountersForBetterSpells = profile.holdCountersForBetterSpells,
                     cashCantripsInTheEndStep = profile.cashCantripsInTheEndStep,
                     // Same seam as `CombatAdvisor`'s `lifeWeight`: a raw Phase 9 profile resolves
                     // to the compiled fallback here, which is the right answer for a policy that

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -222,6 +222,32 @@ data class AiProfile(
      */
     val holdRemovalForBetterTargets: Boolean = false,
     /**
+     * The same question [holdRemovalForBetterTargets] asks about a creature, asked about a spell on
+     * the stack: **is this worth the counterspell?**
+     *
+     * The target is `respond-02` — a Counterspell spent on a Grizzly Bears while the opponent still
+     * holds cards and five untapped lands. The leaf sees an opposing spell gone and has no term for
+     * the option the counter *was*, so it fires at whatever it is offered. On the live agent that
+     * mistake beats passing by **+1.28**, where the four counters the same category says it *should*
+     * make win by 10 to 20 — small enough for a discount to fix, and far enough from the right plays
+     * that nothing correct is at risk.
+     *
+     * [com.wingedsheep.ai.engine.knowledge.CounterPatience] sets its bar at what the caster can still
+     * deploy this turn — `1.4 × their untapped lands`, the same per-mana rate the removal bar uses —
+     * and charges what the countered spell falls short of it. An opponent who tapped out scores a bar
+     * of zero, which is why every other counterspell position in the suite is untouched by
+     * construction; an instant or a sorcery is declined outright, because its worth *is* what it does
+     * to the board and the leaf already simulates that. It shares
+     * [com.wingedsheep.ai.engine.knowledge.Patience]'s three releases with the removal bar, plus one
+     * of its own: an opponent with an empty hand has nothing better coming.
+     *
+     * The countered spell is priced by what it **is** rather than what it cost, which is what makes
+     * an anthem come out right in both directions: "creatures you control get +1/+1" cast into an
+     * empty board is worth letting resolve, and the same card cast by a player with ten creatures
+     * prices out above any bar. Needs [useCardIntent], like everything else the policy reads.
+     */
+    val holdCountersForBetterSpells: Boolean = false,
+    /**
      * Hand an instant-speed draw spell the opponent's-end-step window
      * [com.wingedsheep.ai.engine.knowledge.HoldPolicy] already hands instant-speed removal.
      *
@@ -798,7 +824,9 @@ data class AiProfile(
          * both of which were the wrong first guesses here. `PuzzleRunner.stockLibraries` carries the
          * fix and the general rule.
          *
-         * **What a player faces in a real game today** — see [EngineAiPlayerController].
+         * What a player faced in a real game until [PRODUCTION_CANDIDATE_COUNTERPATIENCE] replaced it
+         * in [EngineAiPlayerController]. Kept unchanged as the baseline that promotion was measured
+         * against.
          *
          * Promoted on the puzzle half, with the arena half returning the same **degenerate null**
          * the patience promotion did: `just arena production-candidate-boardvalue
@@ -851,6 +879,72 @@ data class AiProfile(
         val PRODUCTION_CANDIDATE_MANALANDS = PRODUCTION_CANDIDATE_CANTRIP.copy(
             id = "production-candidate-manalands",
             priceLandsInHandAsMana = true,
+        )
+
+        /**
+         * [holdCountersForBetterSpells] alone on top of [PRODUCTION], so a puzzle or an arena point
+         * that moves is attributable to it — the same isolation [PRODUCTION_LANDSEQ] gives land
+         * sequencing.
+         *
+         * This column **cannot** close its own puzzle, and that is not a failure of the term:
+         * `production` already passes `respond-02`, because a greedy agent declines to counter there
+         * for reasons of its own. So what it measures is what the term *costs* across the other 86
+         * positions — the same reading [PRODUCTION_PATIENCE]'s and [PRODUCTION_PACIFIED]'s columns
+         * get, and for the same structural reason.
+         *
+         * **Measured: 74/87, a failing set identical to [PRODUCTION]'s.** Nothing moves in either
+         * direction, which is the cheapest available evidence that what closes `respond-02` one
+         * column over is this term rather than an interaction, and that no counter the AI *should*
+         * make was traded for it.
+         */
+        val PRODUCTION_COUNTERPATIENCE = PRODUCTION.copy(
+            id = "production-counterpatience",
+            holdCountersForBetterSpells = true,
+        )
+
+        /**
+         * The promotion candidate: [PRODUCTION_CANDIDATE_CANTRIP] plus [holdCountersForBetterSpells]
+         * — the agent that stops spending its only counterspell on the first two-drop it sees.
+         *
+         * Stacked on [PRODUCTION_CANDIDATE_CANTRIP] rather than [PRODUCTION_CANDIDATE_MANALANDS]
+         * because the cantrip window is what [EngineAiPlayerController] actually points at; the
+         * manalands model is a live experiment whose arena half is still out, and a candidate has to
+         * be one flag away from what players face. If manalands promotes first, re-base this on it
+         * and re-measure rather than assuming the two are independent.
+         *
+         * **Measured: 84/87 → 85/87**, closing `respond-02`, with a failing set that is a strict
+         * subset of [PRODUCTION_CANDIDATE_CANTRIP]'s — what is left is `respond-05` and `timing-03`,
+         * both of which need a horizon past the current resolution rather than a term.
+         *
+         * The negative controls are the rest of its own category — `respond-01` (Serra Angel), `-03`
+         * (Wrath), `-04` (Murder aimed at our Angel) and `-06` (Negate over Essence Scatter) — all
+         * four cast by a *tapped out* opponent, so
+         * [com.wingedsheep.ai.engine.knowledge.CounterPatience]'s bar is zero there by construction.
+         * All four hold, as do the other 82 positions.
+         *
+         * **What a player faces in a real game today** — see [EngineAiPlayerController].
+         *
+         * Promoted on the puzzle half, with the arena half returning the same **degenerate null**
+         * the patience and cantrip promotions did: `just arena production-candidate-cantrip
+         * production-candidate-counterpatience 100` measured **50.0%, CI [50.0%, 50.0%]**,
+         * 49W-49L-2D, 0 illegal actions — and every scored pair at 1-1-0. Read that as "this term
+         * changes the outcome of a real sealed game rarely", which is what the mechanism predicts:
+         * it fires only on a turn where the AI holds a counterspell against a spell whose caster
+         * still has mana up. A CI spanning parity is a pass by the standing bar, and the evidence
+         * here is the puzzle side, at +1 with nothing traded.
+         *
+         * The two unfinished games were a pre-existing `NoClassDefFoundError` on a test worker's
+         * classpath (`sdk.scripting.RetainUnspentColoredMana`, a class that exists in source and in
+         * `mtg-sdk/build`), not an agent fault, and they hit both sides of the same pair.
+         *
+         * If a later run comes back below parity, revert the two call sites
+         * ([EngineAiPlayerController] and [AiProfileSelector]'s fallback) rather than the flag: it
+         * is off for every other profile, so backing the promotion out costs nothing and loses no
+         * measurement.
+         */
+        val PRODUCTION_CANDIDATE_COUNTERPATIENCE = PRODUCTION_CANDIDATE_CANTRIP.copy(
+            id = "production-candidate-counterpatience",
+            holdCountersForBetterSpells = true,
         )
 
         /**
@@ -926,7 +1020,7 @@ object AiProfileSelector {
     fun select(
         setCode: String?,
         requested: AiProfile?,
-        fallback: AiProfile = AiProfile.PRODUCTION_CANDIDATE_CANTRIP,
+        fallback: AiProfile = AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE,
     ): AiProfile {
         if (requested == null) return fallback
         val restriction = requested.restrictedToSet ?: return requested

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
@@ -22,15 +22,17 @@ private val logger = LoggerFactory.getLogger(EngineAiPlayerController::class.jav
  *
  * Runs entirely locally with no API calls. Uses the engine's ActionProcessor, board evaluator,
  * [Strategist] and [CombatAdvisor] directly, configured by
- * [AiProfile.PRODUCTION_CANDIDATE_CANTRIP]
+ * [AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE]
  * — rollout candidate evaluation over a determinized state, on a four-tier decision budget, with a
  * land drop priced as the card conversion it is, land *order* priced by the mana it makes usable,
  * a combat trick held until blocks are in and searched properly once they are, the race scored
  * in urgency rather than in turns, removal held for a target worth a card, and a creature priced by
  * what it can still do — marked damage wearing off at cleanup, "can't attack" costing the power —
- * and a cantrip cashed in the window where its mana was going to evaporate anyway.
+ * a cantrip cashed in the window where its mana was going to evaporate anyway, and a counterspell
+ * held while the caster still has the mana for something bigger.
  * Each superseded configuration is kept as the baseline its successor was measured against:
- * [AiProfile.PRODUCTION_CANDIDATE_BOARDVALUE] ran immediately before it,
+ * [AiProfile.PRODUCTION_CANDIDATE_CANTRIP] ran immediately before it,
+ * [AiProfile.PRODUCTION_CANDIDATE_BOARDVALUE] before it,
  * [AiProfile.PRODUCTION_CANDIDATE_PATIENCE] before it,
  * [AiProfile.PRODUCTION_CANDIDATE_RACECLOCK] before it,
  * [AiProfile.PRODUCTION_CANDIDATE_TRICKWINDOW] before it,
@@ -56,7 +58,7 @@ class EngineAiPlayerController(
 
     private val aiPlayer =
         AIPlayer.create(
-            cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_CANTRIP, insightSink = insightSink,
+            cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE, insightSink = insightSink,
         )
 
     override fun chooseAction(

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -93,6 +93,11 @@ class Strategist(
      * hands it to [com.wingedsheep.ai.engine.knowledge.RemovalPatience].
      */
     private val holdRemovalForBetterTargets: Boolean = false,
+    /**
+     * [AiProfile.holdCountersForBetterSpells] — passed straight through to [HoldPolicy], which
+     * hands it to [com.wingedsheep.ai.engine.knowledge.CounterPatience].
+     */
+    private val holdCountersForBetterSpells: Boolean = false,
     /** [AiProfile.cashCantripsInTheEndStep] — passed straight through to [HoldPolicy]. */
     private val cashCantripsInTheEndStep: Boolean = false,
     /**
@@ -118,6 +123,7 @@ class Strategist(
         intents,
         tricksWaitForBlocks = combatTricksWaitForBlocks,
         holdRemovalForBetterTargets = holdRemovalForBetterTargets,
+        holdCountersForBetterSpells = holdCountersForBetterSpells,
         cashCantripsInTheEndStep = cashCantripsInTheEndStep,
         boardPresenceWeight = boardPresenceWeight,
     )

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/evaluation/BoardFeatures.kt
@@ -339,7 +339,68 @@ object BoardPresence : BoardFeature {
         if (intent.anthemBonus <= 0) return intent.staticPriorValue
         val controller = projected.getController(entityId) ?: return intent.staticPriorValue
         val pumped = projected.getBattlefieldControlledBy(controller).count { projected.isCreature(it) }
-        return intent.staticPriorValue + ANTHEM_VALUE_PER_STAT * intent.anthemBonus * pumped
+        return intentValue(intent, pumped)
+    }
+
+    /**
+     * The same prior for a permanent that is not on the battlefield yet, where the creature count
+     * has to be supplied rather than read off the permanent's own controller.
+     *
+     * [spellValue] is the caller: an anthem *spell* is worth what it will pump, and that is the
+     * caster's board, counted before it resolves.
+     */
+    private fun intentValue(intent: CardIntent, pumpedCreatures: Int): Double =
+        intent.staticPriorValue + ANTHEM_VALUE_PER_STAT * intent.anthemBonus * pumpedCreatures
+
+    /**
+     * What a spell on the stack would be worth on the battlefield if it resolved, or **null** when
+     * that question does not apply — the spell is an instant or a sorcery, or it is a permanent this
+     * agent cannot read.
+     *
+     * A null is not "worth nothing", it is "not answerable this way", and the difference is the
+     * whole reason [com.wingedsheep.ai.engine.knowledge.CounterPatience] can exist: an instant's or
+     * a sorcery's worth *is* what it does to the board, which the leaf score already simulates, so
+     * there is nothing for a prior to add. A permanent spell is the opposite case — the leaf sees it
+     * only as one card leaving their hand, and what it will be once it lands is exactly the thing
+     * the counterspell is trading for.
+     *
+     * The valuation is [permanentValue]'s, minus the parts that need a battlefield: no counters, no
+     * summoning sickness, no marked damage, no attachment, and printed P/T and keywords rather than
+     * projected ones. What is deliberately *kept* is the anthem term, because "creatures you control
+     * get +1/+1" cast into an empty board and the same card cast into ten creatures are different
+     * cards, and countering the second one is the whole point.
+     *
+     * @param casterId whose board the spell would join — the anthem term's creature count.
+     */
+    internal fun spellValue(
+        projected: ProjectedState,
+        card: CardComponent,
+        casterId: EntityId,
+        intents: IntentCatalog,
+    ): Double? {
+        // Lands are played, not cast; a land "spell" is a face the AI should not be pricing here.
+        if (!card.isPermanent || card.isLand) return null
+
+        if (card.isCreature) {
+            val power = card.baseStats?.basePower ?: return null
+            val toughness = card.baseStats?.baseToughness ?: return null
+            val keywords = card.baseKeywords.mapTo(mutableSetOf()) { it.name }
+            return creatureBodyValue(power, toughness, keywords).coerceAtLeast(0.1)
+        }
+
+        val intent = intents.forName(card.name) ?: return null
+        val pumped = projected.getBattlefieldControlledBy(casterId).count { projected.isCreature(it) }
+        // One card, one reading — [priorValue]'s "baseline plus what each reading adds over it"
+        // collapses to a max when there is a single intent, and a Room is not castable as one spell.
+        val prior = maxOf(CardIntent.UNKNOWN.staticPriorValue, intentValue(intent, pumped))
+
+        // The same floors [permanentValue] applies, in the same order. A planeswalker's loyalty is
+        // its card's starting loyalty, which the stack object does not carry, so it gets the flat
+        // floor rather than the loyalty-scaled one; an Aura is priced as attached because resolving
+        // is what attaches it.
+        if (card.isPlaneswalker) return maxOf(4.0, prior)
+        if (card.isAura) return maxOf(1.5, prior)
+        return maxOf(0.5, prior)
     }
 
     /** Board value of one point of P/T an anthem hands to one creature. */
@@ -348,24 +409,24 @@ object BoardPresence : BoardFeature {
     /** Board value of one loyalty counter. Only reached with card knowledge on. */
     private const val LOYALTY_VALUE = 0.8
 
-    private fun creatureValue(
-        state: GameState,
-        projected: ProjectedState,
-        entityId: EntityId,
-        container: ComponentContainer,
-        valuation: CreatureValuation = CreatureValuation.LEGACY,
+    /**
+     * What a creature's **body** is worth — the half of [creatureValue] that reads only stats and
+     * keywords, and so is the same question whether the creature is on the battlefield or still a
+     * spell on the stack ([spellValue] is the other caller).
+     *
+     * The keyword bonuses scale with [power] rather than [settledPower] deliberately: a Giant Growth
+     * on a flier really is buying evasive damage right now, even though the stats it buys are gone
+     * at cleanup. Off the battlefield there are no temporary modifications, so the two coincide and
+     * the defaults are the printed numbers.
+     */
+    private fun creatureBodyValue(
+        power: Int,
+        toughness: Int,
+        keywords: Set<String>,
+        /** [power] and [toughness] with "until end of turn" modifications taken back off. */
+        settledPower: Int = power,
+        settledToughness: Int = toughness,
     ): Double {
-        val power = projected.getPower(entityId) ?: 0
-        val toughness = projected.getToughness(entityId) ?: 0
-        val keywords = projected.getKeywords(entityId)
-
-        // Discount temporary P/T modifications. "Until end of turn" effects expire
-        // at cleanup — evaluate using the permanent stats so killing a 2/2 with -2/-2
-        // scores better than merely shrinking a 2/3 (which recovers next turn).
-        val tempMod = temporaryPTModification(state, entityId)
-        val settledPower = (power - tempMod.first).coerceAtLeast(0)
-        val settledToughness = (toughness - tempMod.second).coerceAtLeast(0)
-
         // Base: power matters more than toughness for winning
         var value = settledPower * 1.0 + settledToughness * 0.4
 
@@ -397,12 +458,43 @@ object BoardPresence : BoardFeature {
         if (Keyword.PROTECTION.name in keywords) value += 1.0
 
         // ── Drawbacks ──
-        // "Can't attack", whether printed as DEFENDER or hung on the creature by a Pacifism, takes
-        // away the same thing: the power. [CreatureValuation.cantAttackCostsPower] is what makes the
-        // two spellings agree — see its KDoc for why the flat multiplier they used to disagree over
-        // is the wrong shape.
-        val cantAttack = Keyword.DEFENDER.name in keywords || projected.cantAttack(entityId)
-        if (Keyword.DEFENDER.name in keywords || (valuation.cantAttackCostsPower && cantAttack)) {
+        if (Keyword.DEFENDER.name in keywords) value -= power * 0.8 // can't attack, power mostly wasted
+
+        return value
+    }
+
+    private fun creatureValue(
+        state: GameState,
+        projected: ProjectedState,
+        entityId: EntityId,
+        container: ComponentContainer,
+        valuation: CreatureValuation = CreatureValuation.LEGACY,
+    ): Double {
+        val power = projected.getPower(entityId) ?: 0
+        val toughness = projected.getToughness(entityId) ?: 0
+        val keywords = projected.getKeywords(entityId)
+
+        // Discount temporary P/T modifications. "Until end of turn" effects expire
+        // at cleanup — evaluate using the permanent stats so killing a 2/2 with -2/-2
+        // scores better than merely shrinking a 2/3 (which recovers next turn).
+        val tempMod = temporaryPTModification(state, entityId)
+        val settledPower = (power - tempMod.first).coerceAtLeast(0)
+        val settledToughness = (toughness - tempMod.second).coerceAtLeast(0)
+
+        // Everything that is a property of the card's own body — stats, keywords, DEFENDER — is
+        // [creatureBodyValue]; everything below is a property of this permanent in this position.
+        var value = creatureBodyValue(power, toughness, keywords, settledPower, settledToughness)
+
+        // ── Drawbacks ──
+        // "Can't attack" hung on the creature by a Pacifism takes away the same thing DEFENDER
+        // does: the power. [CreatureValuation.cantAttackCostsPower] is what makes the two spellings
+        // agree — see its KDoc for why the flat multiplier they used to disagree over is the wrong
+        // shape. DEFENDER itself is already paid inside [creatureBodyValue]; this is the other
+        // spelling, and the guard is what keeps it from being charged twice.
+        if (valuation.cantAttackCostsPower &&
+            projected.cantAttack(entityId) &&
+            Keyword.DEFENDER.name !in keywords
+        ) {
             value -= power * 0.8 // can't attack, power mostly wasted
         }
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CounterPatience.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CounterPatience.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.ai.engine.knowledge
+
+import com.wingedsheep.ai.engine.evaluation.BoardPresence
+import com.wingedsheep.ai.engine.isOpponentTo
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * "Is this spell worth the counterspell?" — [RemovalPatience]'s question, asked about the stack.
+ *
+ * The AI counters the first thing it is offered for the same reason it used to Pacifism the first
+ * 1/1: the leaf score sees an opposing spell gone and has no term at all for the option the counter
+ * *was*. `respond-02` is the position that names it — a Counterspell spent on a Grizzly Bears while
+ * the opponent still has five lands untapped and a hand to spend them from. Measured on the live
+ * agent, countering there beat passing by **+1.28**, where every counter the AI *should* make in the
+ * same category wins by 10 to 20. So the mistake is real and it is small, which is exactly the shape
+ * a discount can fix without touching the plays that are right.
+ *
+ * ## The bar is their open mana, not the counter's cost
+ *
+ * [RemovalPatience] bets that a better target will show up in some future turn, which is a bet a
+ * constant can only approximate. A counterspell's bar is sharper, and it is visible on the table:
+ *
+ * > A counterspell should answer the best spell the opponent can still cast **this turn**. What they
+ * > can still cast is bounded by the mana they have left, and holding costs us nothing — our own
+ * > mana stays up either way.
+ *
+ * So the bar is `1.4 × their untapped lands`, at the same [Patience.FAIR_TRADE_VALUE_PER_MANA] rate
+ * the removal bar uses, and the discount is what the spell in front of us falls *short* of it. An
+ * opponent who tapped out has no better spell coming and no discount at all — which is why every
+ * other counterspell position in the suite (`respond-01`, `-03`, `-04`, `-06`, all of them cast by a
+ * tapped-out opponent) is untouched by construction rather than by the size of a number.
+ *
+ * ## What the spell is worth is what it *is*, not what it cost
+ *
+ * Pricing the countered spell at its mana value would close `respond-02` just as well and would be a
+ * worse model: it would tell the AI to let a two-mana 5/5 resolve, which is the commonest real
+ * position where countering a cheap spell is right. So the worth comes from
+ * [BoardPresence.spellValue] — the same scale the evaluator prices the battlefield on, read off the
+ * spell's printed body or its [CardIntent] prior.
+ *
+ * That is also what makes the anthem case come out right, and it is the case that motivated using a
+ * *board* value rather than a static prior: "creatures you control get +1/+1" cast into an empty
+ * board is worth almost nothing and should be allowed to resolve; the same card cast by a player
+ * with ten creatures prices out above any bar and gets countered.
+ *
+ * **Instants and sorceries are declined outright**, by the same reasoning that makes
+ * [RemovalPatience] decline on non-creature permanents: their worth *is* what they do to the board,
+ * which the leaf score already simulates, so there is no option value for a prior to add. That is
+ * the whole of `respond-03` (Wrath) and `respond-04` (Murder), answered before any arithmetic runs.
+ *
+ * Carried on [com.wingedsheep.ai.engine.AiProfile.holdCountersForBetterSpells], so the arena can
+ * price the whole idea at one flag.
+ */
+object CounterPatience {
+
+    /**
+     * How much to subtract from a counterspell's leaf score for pointing at a spell that is not
+     * worth it yet, in raw evaluator units. `0.0` whenever the question does not apply — which is
+     * most of the time, and every early return below says which case it is.
+     *
+     * @param intent the *counterspell's* intent. Only [IntentTag.COUNTERSPELL] reaches the bar.
+     * @param targets the *materialized* targets the AI would submit, not the requirement list.
+     * @param boardPresenceWeight the profile's `EvaluationWeights.boardPresence`, so the discount is
+     *   quoted in the same currency as the board value it is comparing against.
+     */
+    fun discount(
+        state: GameState,
+        playerId: EntityId,
+        intent: CardIntent,
+        targets: List<ChosenTarget>,
+        intents: IntentCatalog,
+        boardPresenceWeight: Double,
+    ): Double {
+        if (IntentTag.COUNTERSPELL !in intent.tags) return 0.0
+
+        // Exactly one, deliberately, for the same reason [RemovalPatience] insists on it: a spell
+        // answering two things at once is answering a stack rather than making a trade.
+        val spellId = targets.filterIsInstance<ChosenTarget.Spell>().singleOrNull()?.spellEntityId
+            ?: return 0.0
+        val spell = state.getEntity(spellId) ?: return 0.0
+        val casterId = spell.get<SpellOnStackComponent>()?.casterId ?: return 0.0
+        if (!state.isOpponentTo(casterId, playerId)) return 0.0
+        val card = spell.get<CardComponent>() ?: return 0.0
+
+        val projected = state.projectedState
+        // Null is "not a question this can answer" — an instant, a sorcery, or a permanent this
+        // agent cannot read. See [BoardPresence.spellValue].
+        val worth = BoardPresence.spellValue(projected, card, casterId, intents) ?: return 0.0
+
+        // Patience is a bet that something better is coming, and an empty hand is the one case where
+        // we can *see* that nothing is. Hand size is public information (CR 400.2), unlike its
+        // contents, so this costs the fair-play line nothing.
+        if (state.getZone(casterId, Zone.HAND).isEmpty()) return 0.0
+
+        val patience = Patience.factorFor(state, projected, playerId)
+        if (patience <= 0.0) return 0.0
+
+        val bar = Patience.FAIR_TRADE_VALUE_PER_MANA * openMana(state, projected, casterId)
+        return boardPresenceWeight * patience * (bar - worth).coerceAtLeast(0.0)
+    }
+
+    /**
+     * How much more the caster can still spend this turn — the size of the best spell still to come,
+     * and the release that costs nothing to state: an opponent who tapped out scores `0.0` here, so
+     * the bar collapses and the counter is spent on what is actually in front of us.
+     *
+     * Untapped **lands**, the same thing `Tempo` counts and the same approximation
+     * `BoardPresence.landSequencing` makes: a Sol Ring or a mana creature is not counted, and
+     * neither are colours, cost reductions or floating mana. This term only has to say "they can
+     * clearly still deploy something bigger" and a `ManaSolver` run per evaluated candidate is not
+     * affordable.
+     */
+    private fun openMana(state: GameState, projected: ProjectedState, casterId: EntityId): Int =
+        projected.getBattlefieldControlledBy(casterId)
+            .filter { projected.hasType(it, "LAND") }
+            .count { state.getEntity(it)?.has<TappedComponent>() != true }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/HoldPolicy.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/HoldPolicy.kt
@@ -47,6 +47,12 @@ class HoldPolicy(
      */
     private val holdRemovalForBetterTargets: Boolean = false,
     /**
+     * [AiProfile.holdCountersForBetterSpells][com.wingedsheep.ai.engine.AiProfile.holdCountersForBetterSpells]
+     * — charge a counterspell for answering a spell smaller than what the caster can still deploy.
+     * See [CounterPatience].
+     */
+    private val holdCountersForBetterSpells: Boolean = false,
+    /**
      * [AiProfile.cashCantripsInTheEndStep][com.wingedsheep.ai.engine.AiProfile.cashCantripsInTheEndStep]
      * — hand an instant-speed draw spell the end-step window this policy already hands removal.
      */
@@ -95,18 +101,33 @@ class HoldPolicy(
         return TimingVerdict.Adjust(windowDelta - patience, reason = "patience")
     }
 
-    /** The patience discount for [cast], or `0.0` when the flag is off or the shape doesn't fit. */
+    /**
+     * The patience discount for [cast], or `0.0` when the flags are off or the shape doesn't fit.
+     *
+     * The two bars are summed rather than chosen between, which costs nothing: each declines on the
+     * other's shape — [RemovalPatience] wants a single opposing *permanent* target and
+     * [CounterPatience] a single opposing *spell* — so at most one of them is ever non-zero.
+     */
     private fun patienceFor(
         state: GameState,
         playerId: EntityId,
         intent: CardIntent,
         cast: CastSpell?,
     ): Double {
-        if (!holdRemovalForBetterTargets || cast == null) return 0.0
+        if (cast == null) return 0.0
         val card = state.getEntity(cast.cardId)?.get<CardComponent>() ?: return 0.0
-        return RemovalPatience.discount(
-            state, playerId, intent, card, cast.targets, boardPresenceWeight,
-        )
+
+        val removal = if (holdRemovalForBetterTargets) {
+            RemovalPatience.discount(state, playerId, intent, card, cast.targets, boardPresenceWeight)
+        } else {
+            0.0
+        }
+        val counter = if (holdCountersForBetterSpells) {
+            CounterPatience.discount(state, playerId, intent, cast.targets, intents, boardPresenceWeight)
+        } else {
+            0.0
+        }
+        return removal + counter
     }
 
     /** The window half — "is this the moment?", which only an instant-speed card can get wrong. */

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/Patience.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/Patience.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.ai.engine.knowledge
+
+import com.wingedsheep.ai.engine.evaluation.ThreatAssessment
+import com.wingedsheep.engine.core.MaximumHandSize
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * When holding a card is still free — the part [RemovalPatience] and [CounterPatience] share.
+ *
+ * Both ask a version of "is what I am pointing this at worth the card?", and they differ only in
+ * the bar: [RemovalPatience] measures a creature against the removal's own mana value,
+ * [CounterPatience] measures a spell against what the caster can still deploy this turn. Everything
+ * about *when the question stops applying* is common, and it is the half that keeps patience from
+ * turning a card into a brick.
+ *
+ * Patience that never ends is just a dead card, so it ends three ways:
+ *
+ *  1. **We are dying.** [ThreatAssessment.lethalOnBoardAgainst] is a hard veto, not a discount: on a
+ *     turn where doing nothing loses the game there is no bar at all. The evaluator would very
+ *     probably have outvoted a discount here anyway — that is an argument about magnitudes, which
+ *     holds only until someone refits the weights, and this is a rule, which holds always. It is
+ *     the same predicate the evaluator's own `−10.0` lethal term uses, so there is one definition of
+ *     "they have lethal" rather than two that can drift.
+ *  2. **The hand is full.** At [MaximumHandSize.DEFAULT] cards the next draw is a discard, so
+ *     holding stops being free and the bar goes to zero outright. `>=` rather than `>`: at exactly
+ *     the maximum, this turn's cleanup discards nothing but the next draw step puts the hand over,
+ *     so the card being weighed is already the one that will be pitched.
+ *  3. **The game moves on.** Patience is a bet that something better is coming, and the bet gets
+ *     worse every turn — see [byTurn]. By [SPENT_BY_TURN] the AI simply spends the card.
+ *
+ * A fourth release is not stated here because it is automatic: short of lethal, a discount is only a
+ * nudge in the evaluator's own units, so a creature that is racing us or a spell that wins the game
+ * is priced by `ThreatAssessment` and `LifeDifferential` on a scale patience cannot reach.
+ *
+ * [MaximumHandSize.DEFAULT] rather than `MaximumHandSize.effective`, which needs a `CardRegistry`
+ * and two evaluators this has no reason to carry. The cost of the simplification is that a
+ * Reliquary Tower makes the AI spend a card it could have kept — the same constant, and the same
+ * trade, that `CardAdvantage.cardValue`'s "past 7 cards, you're discarding anyway" branch already
+ * makes one file over.
+ */
+internal object Patience {
+
+    /**
+     * How much of a patience bar still stands for [playerId] right now — `1.0` early, decaying to
+     * `0.0`, and `0.0` outright whenever one of the releases has fired.
+     */
+    fun factorFor(state: GameState, projected: ProjectedState, playerId: EntityId): Double {
+        if (ThreatAssessment.lethalOnBoardAgainst(state, projected, playerId)) return 0.0
+        if (state.getZone(playerId, Zone.HAND).size >= MaximumHandSize.DEFAULT) return 0.0
+        return byTurn(state.turnNumber)
+    }
+
+    /**
+     * How much of the bar still stands on turn [turnNumber], from `1.0` down to `0.0`.
+     *
+     * Early the bet is a good one — the opponent's best card is still in their deck, and a card held
+     * is a card aimed. Late it is a bad one twice over: there are fewer draws left to improve on
+     * what is already down, and the mana that would have cast it has been idling for turns. So the
+     * bar decays rather than switching off.
+     *
+     * [GameState.turnNumber] counts **turns, not rounds** (`TurnManager` increments it on every turn
+     * change), so these read as roughly "through round three" and "by round seven".
+     */
+    fun byTurn(turnNumber: Int): Double = when {
+        turnNumber <= FULL_THROUGH_TURN -> 1.0
+        turnNumber >= SPENT_BY_TURN -> 0.0
+        else -> (SPENT_BY_TURN - turnNumber).toDouble() / (SPENT_BY_TURN - FULL_THROUGH_TURN)
+    }
+
+    /**
+     * Board value of the permanent one mana should expect to answer or buy.
+     *
+     * Read straight off `BoardPresence.creatureValue`'s own scale rather than chosen: a vanilla
+     * creature at its rate on the curve prices out at about this per mana — Grizzly Bears (2 mana
+     * 2/2) 2.8, Hill Giant (4 mana 3/3) 4.2, Craw Wurm (6 mana 6/4) 7.6, Air Elemental (5 mana 4/4
+     * flier) 8.3. So `mana × 1.4` is "a permanent that size", stated in the units the evaluator
+     * already speaks — which is what lets [RemovalPatience] scale its bar with the removal's own
+     * cost and [CounterPatience] scale its bar with the mana the opponent has left.
+     */
+    const val FAIR_TRADE_VALUE_PER_MANA = 1.4
+
+    /** Through this turn the bet on something better is a good one, and the bar is at full height. */
+    const val FULL_THROUGH_TURN = 6
+
+    /** From this turn on there is no bar at all — see [byTurn]. */
+    const val SPENT_BY_TURN = 14
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/RemovalPatience.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/RemovalPatience.kt
@@ -1,13 +1,10 @@
 package com.wingedsheep.ai.engine.knowledge
 
 import com.wingedsheep.ai.engine.evaluation.BoardPresence
-import com.wingedsheep.ai.engine.evaluation.ThreatAssessment
 import com.wingedsheep.ai.engine.isOpponentTo
-import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
-import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 
 /**
@@ -41,23 +38,17 @@ import com.wingedsheep.sdk.model.EntityId
  * genuinely wants, so the Disenchant that killed the constant is untouched twice over — it is not
  * a creature, and [discount] declines on non-creature targets by construction.
  *
- * ## The three releases
+ * ## The releases
  *
- * Patience that never ends is just a dead card, so it ends four ways:
+ * Patience that never ends is just a dead card. [Patience.factorFor] owns when it ends — we are
+ * dying, the hand is full, the game has moved on — and [CounterPatience] releases on exactly the
+ * same three. What is local to this file is the *bar*.
  *
- *  1. **We are dying.** [facingLethal] is a hard veto, not a discount: on a turn where doing
- *     nothing loses the game there is no bar at all. The evaluator would very probably have
- *     outvoted the discount here anyway — that is an argument about magnitudes, and this is a rule.
- *  2. **The hand is full.** At [com.wingedsheep.engine.core.MaximumHandSize.DEFAULT] cards the next
- *     draw is a discard, so holding stops being free and the discount goes to zero outright.
- *  3. **The game moves on.** Patience is a bet that a better target is coming, and the bet gets
- *     worse every turn — see [patienceFactor]. By [PATIENCE_SPENT_BY_TURN] the AI simply spends its
- *     removal.
- *  4. **The board outvotes it.** Short of lethal, the discount is still only a nudge in the
- *     evaluator's own units, capped by the removal's mana value, so a creature that is racing us or
- *     a blocker we need gone is priced by `ThreatAssessment` and `LifeDifferential` on a scale this
- *     cannot reach. That is what keeps the pressure cases below outright lethal honest without a
- *     second threshold to tune.
+ * Short of those, the discount is only ever a nudge the evaluator is free to outvote, and on the
+ * numbers it does: it is capped at `1.4 × manaValue × boardPresence` — about 6 for a three-mana
+ * removal spell — while `ThreatAssessment` pays 10.0 raw for being dead on board and
+ * `LifeDifferential` prices the life on top of that. That is what keeps the pressure cases below
+ * outright lethal honest without a second threshold to tune.
  *
  * Every number below is a hand-set prior, in the same sense as `CardIntent.staticPriorValue` — and
  * carried on [com.wingedsheep.ai.engine.AiProfile.holdRemovalForBetterTargets], so the arena can
@@ -110,94 +101,14 @@ object RemovalPatience {
         // is precisely the regression that killed the Phase 6 attempt (`noncreature-01`).
         if (!projected.isCreature(victim)) return 0.0
 
-        if (facingLethal(state, projected, playerId)) return 0.0
-        if (mustDiscardSoon(state, playerId)) return 0.0
-        val patience = patienceFactor(state.turnNumber)
+        val patience = Patience.factorFor(state, projected, playerId)
         if (patience <= 0.0) return 0.0
 
         val victimCard = state.getEntity(victim)?.get<CardComponent>() ?: return 0.0
         val worth = BoardPresence.permanentValue(state, projected, victim, victimCard)
-        val fairTrade = FAIR_TRADE_VALUE_PER_MANA * card.manaValue
+        val fairTrade = Patience.FAIR_TRADE_VALUE_PER_MANA * card.manaValue
         return boardPresenceWeight * patience * (fairTrade - worth).coerceAtLeast(0.0)
     }
-
-    /**
-     * Whether the board as it stands kills [playerId] — the release that is a **guarantee** rather
-     * than a nudge.
-     *
-     * Everything else in this file is a discount the evaluator is free to outvote, and on the
-     * numbers it does: the discount is capped at `1.4 × manaValue × boardPresence` (about 6 for a
-     * three-mana removal spell), while `ThreatAssessment` pays 10.0 raw for being dead on board and
-     * `LifeDifferential` prices the life on top of that. So the AI was already going to cast here.
-     *
-     * That is an argument about magnitudes, and the rule it is standing in for is not: **the AI
-     * must never sit on removal on a turn where doing nothing loses the game.** A magnitude
-     * argument holds until someone refits the weights (Phase 9 is explicitly going to), and it
-     * holds only for the profiles measured. A veto holds always, and it costs one boolean.
-     *
-     * [ThreatAssessment.lethalOnBoardAgainst] is the same predicate the evaluator's own `−10.0`
-     * lethal term uses, so there is one definition of "they have lethal" rather than two that can
-     * drift. It re-asks every turn, which is what makes the *narrow* reading sufficient: at 4 life
-     * against a lone 2/2 nothing fires yet, and by the time the same board reads lethal — at 2 life
-     * — the removal is released with a turn still in hand.
-     */
-    private fun facingLethal(state: GameState, projected: ProjectedState, playerId: EntityId): Boolean =
-        ThreatAssessment.lethalOnBoardAgainst(state, projected, playerId)
-
-    /**
-     * Whether holding one more card costs [playerId] a discard.
-     *
-     * `>=` rather than `>`: at exactly the maximum, this turn's cleanup discards nothing but the
-     * next draw step puts the hand over, so the card being weighed is already the one that will be
-     * pitched. Waiting for the strict overflow would mean spending the removal a turn after the
-     * decision stopped being free.
-     *
-     * [com.wingedsheep.engine.core.MaximumHandSize.DEFAULT] rather than `MaximumHandSize.effective`,
-     * which needs a `CardRegistry` and two evaluators this policy has no reason to carry. The cost
-     * of the simplification is that a Reliquary Tower makes the AI spend removal it could have kept
-     * — the same constant, and the same trade, that `CardAdvantage.cardValue`'s "past 7 cards,
-     * you're discarding anyway" branch already makes one file over.
-     */
-    private fun mustDiscardSoon(state: GameState, playerId: EntityId): Boolean =
-        state.getZone(playerId, Zone.HAND).size >= com.wingedsheep.engine.core.MaximumHandSize.DEFAULT
-
-    /**
-     * How much of the bar still stands on turn [turnNumber], from `1.0` down to `0.0`.
-     *
-     * Patience is a bet that a better target is coming. Early it is a good bet — the opponent's
-     * best card is still in their deck, and a removal spell held is a removal spell aimed. Late it
-     * is a bad one twice over: there are fewer draws left to improve on what is already down, and
-     * the mana that would have cast it has been idling for turns. So the bar decays rather than
-     * switching off, and by [PATIENCE_SPENT_BY_TURN] the AI is simply spending its removal at
-     * whatever is there.
-     *
-     * [GameState.turnNumber] counts **turns, not rounds** (`TurnManager` increments it on every
-     * turn change), so these read as roughly "through round three" and "by round seven".
-     */
-    private fun patienceFactor(turnNumber: Int): Double = when {
-        turnNumber <= PATIENCE_FULL_THROUGH_TURN -> 1.0
-        turnNumber >= PATIENCE_SPENT_BY_TURN -> 0.0
-        else -> (PATIENCE_SPENT_BY_TURN - turnNumber).toDouble() /
-            (PATIENCE_SPENT_BY_TURN - PATIENCE_FULL_THROUGH_TURN)
-    }
-
-    /**
-     * Board value of the creature a removal spell of mana value 1 should expect to trade with.
-     *
-     * Read straight off `BoardPresence.creatureValue`'s own scale rather than chosen: a vanilla
-     * creature at its rate on the curve prices out at about this per mana — Grizzly Bears (2 mana
-     * 2/2) 2.8, Hill Giant (4 mana 3/3) 4.2, Craw Wurm (6 mana 6/4) 7.6, Air Elemental (5 mana 4/4
-     * flier) 8.3. So `manaValue × 1.4` is "a creature this spell's size", stated in the units the
-     * evaluator already speaks, and the bar moves with the card: a Shock is content with a 1/1 and
-     * a Murder is not.
-     */
-    const val FAIR_TRADE_VALUE_PER_MANA = 1.4
-
-    /** Through this turn the bet on a better target is a good one, and the bar is at full height. */
-    const val PATIENCE_FULL_THROUGH_TURN = 6
-
-    /** From this turn on there is no bar at all — see [patienceFactor]. */
-    const val PATIENCE_SPENT_BY_TURN = 14
 
     /** The intents that spend one whole card to answer one permanent. */
     private val ANSWERED_BY_ONE_CARD = setOf(

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -116,6 +116,13 @@ object ArenaAgents {
         // promotion gate. Expect this one to *move*, unlike the four before it.
         ArenaAgent("production-manalands", AiProfile.PRODUCTION_MANALANDS),
         ArenaAgent("production-candidate-manalands", AiProfile.PRODUCTION_CANDIDATE_MANALANDS),
+        // The counterspell half of removal patience: a counter is worth holding while the caster
+        // still has the mana for something bigger. `just arena production production-counterpatience
+        // 300` prices the term on its own; `just arena production-candidate-cantrip
+        // production-candidate-counterpatience 300` is the promotion gate, against what players face
+        // today. Expect a rare shape and therefore a wide or degenerate CI, as with patience.
+        ArenaAgent("production-counterpatience", AiProfile.PRODUCTION_COUNTERPATIENCE),
+        ArenaAgent("production-candidate-counterpatience", AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE),
         ArenaAgent("production-targeted", AiProfile.PRODUCTION_TARGETED),
         // Explicit ECL candidates. Their resource-backed weights fail closed to production's
         // evaluator until a validated artifact is installed; automatic selection is set-gated.

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/CounterPatienceTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/CounterPatienceTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.ai.engine.knowledge
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The one feature, measured on its own rather than through an evaluator.
+ *
+ * `PuzzleSuiteTest` measures the outcome (`respond-02`, with the rest of its category as the
+ * control); this pins the *shape* of the discount. Four claims, one test each:
+ *
+ *  1. The bar is **their open mana** — a tapped-out caster is answered, a rich one is not.
+ *  2. The worth is **what the spell is**, not what it cost, which is why the same anthem is worth
+ *     countering behind a board and not behind an empty one.
+ *  3. It is **scoped** — instants and sorceries are out, which is what keeps `respond-03`'s Wrath
+ *     and `respond-04`'s Murder safe by construction rather than by the size of a number.
+ *  4. It **ends** — an empty hand across the table, and a late turn, both take it to zero.
+ */
+class CounterPatienceTest : ScenarioTestBase() {
+
+    /** The default `EvaluationWeights.boardPresence`, which is what every profile here runs on. */
+    private val boardPresence = 1.5
+
+    private val intents by lazy { IntentCatalog.of(cardRegistry) }
+
+    /**
+     * The discount for seat 1 countering whatever seat 2 has on the stack, reading the spell off
+     * real game state rather than synthesizing components.
+     */
+    private fun TestGame.counterDiscount(): Double {
+        val spellId = state.stack.singleOrNull() ?: error("expected exactly one spell on the stack")
+        return CounterPatience.discount(
+            state,
+            player1Id,
+            intents.forName("Counterspell")!!,
+            listOf(ChosenTarget.Spell(spellId)),
+            intents,
+            boardPresence,
+        )
+    }
+
+    /**
+     * `respond-02`'s board: seat 2 has lands, a grip, and has just cast [spell] off them. The land
+     * counts are exact because the bar is `1.4 × the ones still untapped` — casting a two-drop off
+     * eight lands leaves six.
+     */
+    private fun position(
+        spell: String,
+        forests: Int = 0,
+        plains: Int = 0,
+        grip: Int = 3,
+        theirCreatures: Int = 0,
+        turn: Int = 1,
+    ) = scenario()
+        .withPlayers()
+        .withTurnNumber(turn)
+        .withActivePlayer(2)
+        .apply { if (forests > 0) withLandsOnBattlefield(2, "Forest", forests) }
+        .apply { if (plains > 0) withLandsOnBattlefield(2, "Plains", plains) }
+        .withCardInHand(2, spell)
+        .withCardsInHand(2, "Craw Wurm", grip)
+        .apply { repeat(theirCreatures) { withCardOnBattlefield(2, "Grizzly Bears") } }
+        .withLandsOnBattlefield(1, "Island", 2)
+        .withCardInHand(1, "Counterspell")
+        .build()
+        .also { it.castSpell(2, spell) }
+
+    init {
+        test("the bar is the mana they still have open, so a tapped-out caster is answered") {
+            // Grizzly Bears prices at 2.8 of board value. Cast off eight Forests it leaves six
+            // untapped, so the bar is 1.4 x 6 = 8.4 and the Bears is 5.6 short of it.
+            position("Grizzly Bears", forests = 8).counterDiscount() shouldBe
+                (boardPresence * (1.4 * 6 - 2.8)).plusOrMinus(0.01)
+
+            // The same spell with nothing left behind it: no better spell is coming this turn, the
+            // bar collapses to zero, and the counter is spent on what is in front of it. This is
+            // `respond-01`, `-03`, `-04` and `-06` in one line — every counter the AI *should* make
+            // in the suite is cast by an opponent who tapped out.
+            position("Grizzly Bears", forests = 2).counterDiscount() shouldBe 0.0
+        }
+
+        test("a spell worth more than the bar is countered however much mana is behind it") {
+            // Craw Wurm is a 6/4 and prices at 7.6. Off twelve lands it leaves six open — a bar of
+            // 8.4 — and is charged the 0.8 it falls short; off eight it leaves two, and clears the
+            // bar outright. The same card, ranked by what else the turn could still produce.
+            position("Craw Wurm", forests = 12).counterDiscount() shouldBeGreaterThan 0.0
+            position("Craw Wurm", forests = 8).counterDiscount() shouldBe 0.0
+        }
+
+        test("an anthem is priced by the board it would pump, not by its mana value") {
+            // The case that decides the shape of the whole feature. Glorious Anthem is the same
+            // three-mana card in both positions and the caster has the same three mana left open —
+            // a bar of 4.2. Behind an empty board the anthem is worth its 3.0 prior and is charged;
+            // behind five creatures it is worth 3.0 + 5 x 0.25 and clears the bar.
+            val alone = position("Glorious Anthem", plains = 6, theirCreatures = 0).counterDiscount()
+            val backedUp = position("Glorious Anthem", plains = 6, theirCreatures = 5).counterDiscount()
+
+            alone shouldBe (boardPresence * (1.4 * 3 - 3.0)).plusOrMinus(0.01)
+            backedUp shouldBe 0.0
+        }
+
+        test("a sorcery is never charged") {
+            // Half of the negative control: `respond-03` counters a Wrath with the caster's mana
+            // still up. Its worth is what it does to the board, which the leaf score already
+            // simulates, so this declines outright rather than trying to price it.
+            position("Wrath of God", plains = 8).counterDiscount() shouldBe 0.0
+        }
+
+        test("an instant is never charged either, however small its target") {
+            // The other half: `respond-04`'s Murder, aimed at our own creature, off a board with
+            // five lands still open.
+            val game = scenario()
+                .withPlayers()
+                .withActivePlayer(2)
+                .withLandsOnBattlefield(2, "Swamp", 8)
+                .withCardInHand(2, "Murder")
+                .withCardsInHand(2, "Craw Wurm", 3)
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withCardInHand(1, "Counterspell")
+                .withCardOnBattlefield(1, "Serra Angel")
+                .build()
+            game.castSpell(2, "Murder", game.findPermanent("Serra Angel"))
+
+            game.counterDiscount() shouldBe 0.0
+        }
+
+        test("an opponent with an empty hand has nothing better coming") {
+            position("Grizzly Bears", forests = 8, grip = 0).counterDiscount() shouldBe 0.0
+        }
+
+        test("patience decays with the turn and is gone by the time the bet is bad") {
+            fun onTurn(turn: Int) = position("Grizzly Bears", forests = 8, turn = turn).counterDiscount()
+
+            val early = onTurn(Patience.FULL_THROUGH_TURN)
+            val middle = onTurn((Patience.FULL_THROUGH_TURN + Patience.SPENT_BY_TURN) / 2)
+            early shouldBeGreaterThan 0.0
+            middle shouldBeGreaterThan 0.0
+            middle shouldBeLessThan early
+            onTurn(Patience.SPENT_BY_TURN) shouldBe 0.0
+        }
+
+        test("the hold policy stays silent unless the profile asks for counter patience") {
+            val game = position("Grizzly Bears", forests = 8)
+            val cast = CastSpell(
+                playerId = game.player1Id,
+                cardId = game.findCardsInHand(1, "Counterspell").first(),
+                targets = listOf(ChosenTarget.Spell(game.state.stack.single())),
+            )
+
+            // Off is the pre-change behaviour: a counterspell with something on the stack is in its
+            // window, and nothing charges it for what it is pointed at.
+            HoldPolicy(intents)
+                .verdictFor(game.state, game.player1Id, "Counterspell", cast) shouldBe TimingVerdict.Neutral
+
+            HoldPolicy(intents, holdCountersForBetterSpells = true)
+                .verdictFor(game.state, game.player1Id, "Counterspell", cast)
+                .shouldBeInstanceOf<TimingVerdict.Adjust>()
+                .delta shouldBeLessThan 0.0
+        }
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/RemovalPatienceTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/RemovalPatienceTest.kt
@@ -208,15 +208,13 @@ class RemovalPatienceTest : ScenarioTestBase() {
                 .build()
                 .discountOf("Murder", "Mons's Goblin Raiders")
 
-            val early = onTurn(RemovalPatience.PATIENCE_FULL_THROUGH_TURN)
-            val middle = onTurn(
-                (RemovalPatience.PATIENCE_FULL_THROUGH_TURN + RemovalPatience.PATIENCE_SPENT_BY_TURN) / 2
-            )
+            val early = onTurn(Patience.FULL_THROUGH_TURN)
+            val middle = onTurn((Patience.FULL_THROUGH_TURN + Patience.SPENT_BY_TURN) / 2)
             early shouldBeGreaterThan 0.0
             middle shouldBeGreaterThan 0.0
             middle shouldBeLessThan early
-            onTurn(RemovalPatience.PATIENCE_SPENT_BY_TURN) shouldBe 0.0
-            onTurn(RemovalPatience.PATIENCE_SPENT_BY_TURN + 10) shouldBe 0.0
+            onTurn(Patience.SPENT_BY_TURN) shouldBe 0.0
+            onTurn(Patience.SPENT_BY_TURN + 10) shouldBe 0.0
         }
 
         test("the hold policy stays silent unless the profile asks for patience") {

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -88,6 +88,12 @@ class PuzzleComparisonBenchmark : ScenarioTestBase() {
                 // this model supersedes was built for.
                 AiProfile.PRODUCTION_MANALANDS,
                 AiProfile.PRODUCTION_CANDIDATE_MANALANDS,
+                // Counterspell patience, alone and on top of what is live. `respond-02` is the
+                // verdict that should move; the rest of the `respond` category is the negative
+                // control, and all four of those are cast by a tapped-out opponent, where the bar
+                // is zero by construction.
+                AiProfile.PRODUCTION_COUNTERPATIENCE,
+                AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE,
                 // Phase 7's rollout evaluator, isolated from Phases 4 and 6 so the column is
                 // attributable to the rollouts alone.
                 AiProfile.PHASE7,

--- a/ai/src/test/kotlin/com/wingedsheep/ai/training/EclTrainingInfrastructureTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/training/EclTrainingInfrastructureTest.kt
@@ -51,7 +51,8 @@ class EclTrainingInfrastructureTest : FunSpec({
         AiProfileSelector.select("ECL", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.ECL_APPRENTICE
         // Whatever is live, not a fixed profile: this pins that a set-scoped request falls back to
         // the production agent, so it moves with every promotion.
-        AiProfileSelector.select("BLB", AiProfile.ECL_APPRENTICE) shouldBe AiProfile.PRODUCTION_CANDIDATE_CANTRIP
+        AiProfileSelector.select("BLB", AiProfile.ECL_APPRENTICE) shouldBe
+            AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE
         AiProfileSelector.select("BLB", AiProfile.CURRENT) shouldBe AiProfile.CURRENT
     }
 

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -1869,3 +1869,98 @@ pacified creature, a cantrip at an end step, removal aimed at a 1/1 — and the 
 degenerate null CIs did so because those shapes are rare. This one changes what *every hand
 containing a land* is worth, on every evaluation, inside every rollout. A null result here would
 itself be surprising.
+
+---
+
+# Counterspell patience
+
+**Measured:** 2026-08-08. `AiProfile.holdCountersForBetterSpells`, as
+`production-candidate-counterpatience`. The counterspell twin of removal patience: `RemovalPatience`
+asks whether a *creature* is worth the removal, `CounterPatience` asks whether a *spell on the stack*
+is worth the counter.
+
+The target is `respond-02` — a Counterspell spent on a Grizzly Bears while the opponent still holds
+cards and five untapped lands. What made it worth doing before anything was built is the margin. The
+live agent's own scores, off the insight sink:
+
+| position | opponent's lands | AI's move | advantage over passing |
+|---|---|---|---|
+| `respond-01` (Serra Angel) | 5/5 **tapped** | counters ✓ | +10.45 |
+| **`respond-02`** (Grizzly Bears) | 2 tapped, **5 open** | counters ✗ | **+1.28** |
+| `respond-03` (Wrath) | 4/4 tapped | counters ✓ | +19.61 |
+| `respond-04` (Murder) | 3/3 tapped | counters ✓ | +15.97 |
+| `respond-06` (Wrath, Negate) | 4/4 tapped | Negates ✓ | +14.17 |
+
+The mistake is worth an order of magnitude less than every counter the AI *should* make, and the one
+position where it happens is the only one whose caster has mana left. Both facts came out of one
+insight dump, and together they say a discount can fix this without endangering anything correct.
+
+## The bar is their open mana
+
+`RemovalPatience` bets a better target arrives on some future turn, which is a bet a constant can
+only approximate. A counterspell's bar is sharper and it is visible on the table: **a counter should
+answer the best spell they can still cast *this turn*, what they can still cast is bounded by the
+mana they have left, and holding costs us nothing — our own mana stays up either way.**
+
+So the bar is `1.4 × their untapped lands`, at the same per-mana rate the removal bar uses, and the
+discount is what the spell in front of us falls short of it. A tapped-out caster scores a bar of
+zero, which is why the four negative controls above are untouched by construction rather than by the
+size of a number. It shares `Patience`'s three releases (lethal on board, hand at the discard limit,
+decay to nothing by turn 14) with the removal bar and adds one of its own: an opponent with an empty
+hand has nothing better coming.
+
+## Priced by what the spell is, not what it cost
+
+Pricing the countered spell at its mana value would close `respond-02` just as well and would be a
+worse model — it would tell the AI to let a two-mana 5/5 resolve, the commonest real position where
+countering a cheap spell is right. So the worth comes from `BoardPresence.spellValue`, the same scale
+the evaluator prices the battlefield on, read off the spell's printed body or its `CardIntent` prior.
+
+That is also what makes an anthem come out right in both directions, and it is the case that decided
+the shape: "creatures you control get +1/+1" cast into an empty board is worth 3.0 and gets let
+through; the same card cast by a player with five creatures is worth 4.25 and clears the bar.
+`CounterPatienceTest` pins both, on the same card with the same mana open.
+
+Instants and sorceries are **declined outright**, by the reasoning that makes `RemovalPatience`
+decline on non-creature permanents: their worth *is* what they do to the board, which the leaf score
+already simulates. That answers `respond-03` and `respond-04` before any arithmetic runs.
+
+## Puzzles — 87 positions
+
+| | `production` | live (`production-candidate-cantrip`) |
+|---|---|---|
+| baseline | 74/87 | 84/87 |
+| with the term | 74/87 | **85/87** |
+| closes | — | `respond-02` |
+| loses | — | — |
+
+The isolation column is quiet **because it cannot be anything else**: `production` already passes
+`respond-02` — a greedy agent does not counter there for reasons of its own — so what that column
+measures is what the term *costs* across the other 86 positions, and the answer is nothing. Same
+shape as `production-patience`'s and `production-pacified`'s columns. The candidate's failing set is
+a strict subset of its baseline's: `respond-05` and `timing-03`, both of which need a horizon past
+the current resolution rather than a term.
+
+## The arena half
+
+`just arena production-candidate-cantrip production-candidate-counterpatience 100`:
+
+```
+Record:       49W-49L-2D for production-candidate-cantrip
+Pair win %:   50.0%  CI [50.0%, 50.0%]   <- the merge gate
+Completed:    98 / 100     Illegal acts: 0
+Wall clock:   1002s on 8 threads
+```
+
+The third **degenerate null** in this sequence, and the same reading as the patience and cantrip
+promotions: every scored pair came back 1-1-0, which says the term changes the outcome of a real
+sealed game *rarely*, not that it is worthless. That is what the mechanism predicts — it fires only
+on a turn where the AI holds a counterspell against a spell whose caster still has mana up. A CI
+spanning parity is a pass under the standing bar, and the puzzle side is the evidence.
+
+The two unfinished games were a `NoClassDefFoundError` on a test worker's classpath
+(`sdk.scripting.RetainUnspentColoredMana`, which exists in source and in `mtg-sdk/build` — a stale
+jar, most likely a build race with a parallel agent). Both games were the same pair, so it cancels
+out of the comparison. Unrelated to this change, which touches `:ai` only.
+
+**Promoted 2026-08-08** in `EngineAiPlayerController` and `AiProfileSelector`'s fallback.


### PR DESCRIPTION
Closes `respond-02`, the last failure in the `respond` puzzle category: the AI spent its only Counterspell on a Grizzly Bears while the opponent still held cards and five untapped lands.

## Why it happened

A one-ply leaf sees an opposing spell gone and has no term at all for the option the counter *was*, so it fires at whatever it is offered. `RemovalPatience` already asks that question about a creature and could not reach this one twice over — a Counterspell is tagged `COUNTERSPELL` rather than `REMOVAL`, and a spell on the stack arrives as `ChosenTarget.Spell` where that bar wants a `Permanent`.

What made it worth fixing before anything was built is the margin. The live agent's own scores, off the insight sink:

| position | opponent's lands | AI's move | advantage over passing |
|---|---|---|---|
| `respond-01` (Serra Angel) | 5/5 **tapped** | counters ✓ | +10.45 |
| **`respond-02`** (Grizzly Bears) | 2 tapped, **5 open** | counters ✗ | **+1.28** |
| `respond-03` (Wrath) | 4/4 tapped | counters ✓ | +19.61 |
| `respond-04` (Murder) | 3/3 tapped | counters ✓ | +15.97 |
| `respond-06` (Wrath, Negate) | 4/4 tapped | Negates ✓ | +14.17 |

The mistake is worth an order of magnitude less than every counter the AI *should* make, and the one position where it happens is the only one whose caster has mana left.

## The bar is their open mana

`RemovalPatience` bets a better target arrives on some future turn, which a constant can only approximate. A counterspell's bar is sharper and visible on the table: **a counter should answer the best spell they can still cast *this turn*, what they can cast is bounded by the mana they have left, and holding costs us nothing — our own mana stays up either way.**

So the bar is `1.4 × their untapped lands`, at the same per-mana rate the removal bar uses, and the discount is what the spell in front of us falls short of it. A tapped-out caster scores a bar of zero, which is why the four negative controls are untouched by construction rather than by the size of a number. Shares `Patience`'s three releases (lethal on board, hand at the discard limit, decay to nothing by turn 14) and adds one of its own: an opponent with an empty hand has nothing better coming.

## Priced by what the spell is, not what it cost

Pricing the countered spell at its mana value would close the puzzle just as well and would be a worse model — it would tell the AI to let a two-mana 5/5 resolve. So worth comes from a new `BoardPresence.spellValue`, on the same scale the evaluator prices the battlefield on.

That is also what makes an anthem come out right in both directions, and it is the case that decided the shape: *"creatures you control get +1/+1"* is worth 3.0 cast into an empty board and gets let through; the same card cast by a player with five creatures is worth 4.25 and clears the bar. `CounterPatienceTest` pins both, on the same card with the same mana open.

Instants and sorceries are **declined outright**, by the reasoning that makes `RemovalPatience` decline on non-creature permanents: their worth *is* what they do to the board, which the leaf already simulates. That answers `respond-03` and `respond-04` before any arithmetic runs.

## Two extractions, both on their second user

- `Patience` — the three releases both bars share, lifted out of `RemovalPatience`.
- `BoardPresence.creatureBodyValue` — the stats-and-keywords half of `creatureValue`, so a spell on the stack and a permanent on the battlefield are priced on one scale.

Both are behaviour-preserving: `PuzzleSuiteTest` holds at `production`'s exact failing set.

## Measurement

**Puzzles (87 positions):**

| | `production` | live (`production-candidate-cantrip`) |
|---|---|---|
| baseline | 74/87 | 84/87 |
| with the term | 74/87 | **85/87** |
| closes | — | `respond-02` |
| loses | — | — |

The isolation column is quiet because it cannot be anything else — `production` already passes `respond-02`, a greedy agent declining there for reasons of its own — so it measures what the term *costs* across the other 86 positions, and the answer is nothing. Same shape as `production-patience`'s and `production-pacified`'s columns. The candidate's failing set is a strict subset: `respond-05` and `timing-03`, both of which need a horizon past the current resolution rather than a term.

**Arena** — `just arena production-candidate-cantrip production-candidate-counterpatience 100`:

```
Record:       49W-49L-2D for production-candidate-cantrip
Pair win %:   50.0%  CI [50.0%, 50.0%]   <- the merge gate
Completed:    98 / 100     Illegal acts: 0
```

The third degenerate null in this sequence, and what the mechanism predicts: every scored pair came back 1-1-0, which says the term changes the outcome of a real sealed game *rarely*, not that it is worthless. A CI spanning parity is a pass under the standing "arena-neutral and a puzzle ahead" bar, so `EngineAiPlayerController` and `AiProfileSelector`'s fallback now point at `production-candidate-counterpatience`. Reverting is those two lines — the flag is off for every other profile.

## Unrelated failure seen during the run, not touched

2 of 100 arena games died on `NoClassDefFoundError: com/wingedsheep/sdk/scripting/RetainUnspentColoredMana`. That class exists in `mtg-sdk` source *and* in `mtg-sdk/build/classes`, so it is a stale jar on a test worker's classpath — most likely a build race with a parallel agent. Both games were the same pair, so it cancels out of the comparison, and this change touches `:ai` only.

## Verification

- `:ai:test --tests "*Patience*" --tests "*PuzzleSuiteTest" --tests "*HoldPolicyTest" --tests "*BoardPresence*" --tests "*EclTrainingInfrastructureTest"` — green, including the 8 new `CounterPatienceTest` cases.
- The 87-puzzle suite across four profiles, and the 100-game arena above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)