### PR TITLE
Hold flash creatures for the ambush window instead of jamming them

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -250,6 +250,7 @@ class AIPlayer(
                     holdRemovalForBetterTargets = profile.holdRemovalForBetterTargets,
                     holdCountersForBetterSpells = profile.holdCountersForBetterSpells,
                     cashCantripsInTheEndStep = profile.cashCantripsInTheEndStep,
+                    holdFlashPermanentsForAmbush = profile.holdFlashPermanentsForAmbush,
                     // Same seam as `CombatAdvisor`'s `lifeWeight`: a raw Phase 9 profile resolves
                     // to the compiled fallback here, which is the right answer for a policy that
                     // only needs to know what a point of board value trades against.

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -1022,9 +1022,13 @@ data class AiProfile(
          * gives: a category of "don't cast" positions scores 100% for an agent that never casts
          * anything, so the half that says *do* has to be asserted too.
          *
-         * **Not yet promoted.** [com.wingedsheep.server.game.EngineAiPlayerController] still points
-         * at [PRODUCTION_CANDIDATE_COUNTERPATIENCE]; the arena half of the standing bar is what
-         * moves it, and until that is run this is a candidate and nothing else.
+         * The arena half returned the sequence's **fourth degenerate null**: `just arena
+         * production-candidate-counterpatience production-candidate-ambush 100` measured **50.0%,
+         * CI [50.0%, 50.0%]**, 100/100 completed, 0 illegal actions, every scored pair 1-1-0. Read
+         * that as "this term changes the outcome of a real sealed game rarely", which is what the
+         * mechanism predicts — it fires only on a turn where the AI holds a flash permanent with
+         * the ambush window still ahead. A CI spanning parity is a pass by the standing bar, and
+         * the evidence is the puzzle side, at +1 with nothing traded.
          *
          * If a later arena run comes back below parity, revert the two call sites
          * (`EngineAiPlayerController` and [AiProfileSelector]'s fallback) rather than the flag: it is

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -267,6 +267,38 @@ data class AiProfile(
      */
     val cashCantripsInTheEndStep: Boolean = false,
     /**
+     * Stop deploying a **flash creature on our own turn** when the ambush window is still ahead.
+     *
+     * The target is `instants-09`, taken from a real game: turn 7, our own precombat main, a
+     * Restoration Angel in hand and four Plains untapped, and the AI jams it. The leaf sees a 3/4
+     * flier on the battlefield and scores it the same wherever in the turn it landed, so casting
+     * beat passing by **+4.06** — the creature's whole board value — and every reason flash was
+     * printed (hold the mana, see their attack, ambush a creature) is worth exactly zero to a
+     * one-ply evaluator.
+     *
+     * [com.wingedsheep.ai.engine.knowledge.AmbushWindow] answers it with a
+     * [com.wingedsheep.ai.engine.knowledge.TimingVerdict.NoWindow] rather than a discount, and its
+     * KDoc carries the argument for why this is the one window branch that can honestly do that:
+     * a bonus on the *good* window — the shape the removal branch uses — cannot correct a decision
+     * made three steps earlier, and unlike "hold the removal" the claim is provable. Casting a
+     * no-haste flash permanent now is dominated by casting it at the next free window *unless the
+     * permanent does something in between*, and that list is finite and readable off the card:
+     * it attacks, its ETB changes a combat, its ETB hands us a resource to spend, or there is
+     * something on the stack. Any of the four and the floor declines.
+     *
+     * It inherits [com.wingedsheep.ai.engine.knowledge.Patience]'s three releases whole — lethal on
+     * board, a hand at maximum size, a game past turn 14 — which is what keeps a floor this hard
+     * from turning the card into a brick, and adds one of its own: once the opponent declares
+     * attackers, holding longer buys nothing. Needs [useCardIntent], like everything else the
+     * policy reads.
+     *
+     * Its negative controls are the rest of `instants` and the whole of `timing`: a flash creature
+     * with haste, one whose ETB clears a blocker, and the ambush window itself, where it must
+     * actually cast. A term that only ever says "don't" would score well on a suite by never
+     * playing, which is why `instants-10` asserts the cast.
+     */
+    val holdFlashPermanentsForAmbush: Boolean = false,
+    /**
      * The two `BoardPresence.creatureValue` corrections [PRODUCTION_RACECLOCK]'s KDoc named as the
      * reason its arena win came with a puzzle trade — the damaged-creature discount and the flat
      * multiplier on "can't attack". Both are off by default; see
@@ -945,6 +977,63 @@ data class AiProfile(
         val PRODUCTION_CANDIDATE_COUNTERPATIENCE = PRODUCTION_CANDIDATE_CANTRIP.copy(
             id = "production-candidate-counterpatience",
             holdCountersForBetterSpells = true,
+        )
+
+        /**
+         * [holdFlashPermanentsForAmbush] alone on top of [PRODUCTION], so a puzzle or an arena point
+         * that moves is attributable to it — the same isolation [PRODUCTION_COUNTERPATIENCE] gives
+         * counter patience.
+         *
+         * Unlike that column this one *can* close its own puzzle, because the mistake is not one a
+         * greedy agent declines to make for reasons of its own: `production` already has
+         * [useCardIntent], so it reads Restoration Angel's flash, types it `Speed.INSTANT`, finds no
+         * branch that claims it, and jams it in the main phase exactly as the live agent does.
+         *
+         * **Measured: 78/92 → 79/92**, closing `instants-09` and nothing else, with every other
+         * category byte-identical to [PRODUCTION]'s. A term that fires on one narrow shape and
+         * costs nothing across the other 91 positions is what the isolation column is for.
+         */
+        val PRODUCTION_AMBUSH = PRODUCTION.copy(
+            id = "production-ambush",
+            holdFlashPermanentsForAmbush = true,
+        )
+
+        /**
+         * The promotion candidate: [PRODUCTION_CANDIDATE_COUNTERPATIENCE] plus
+         * [holdFlashPermanentsForAmbush] — the agent that stops dumping its flash creatures into its
+         * own main phase.
+         *
+         * Stacked on [PRODUCTION_CANDIDATE_COUNTERPATIENCE] because that is what
+         * [com.wingedsheep.server.game.EngineAiPlayerController] actually points at, and a candidate
+         * has to be one flag away from what players face — the same rule
+         * [PRODUCTION_CANDIDATE_COUNTERPATIENCE]'s own KDoc states about not stacking on the
+         * manalands experiment.
+         *
+         * **Measured: 89/92 → 90/92**, closing `instants-09` with a failing set that is a strict
+         * subset of [PRODUCTION_CANDIDATE_COUNTERPATIENCE]'s — what is left is `respond-05` and
+         * `timing-03`, the same two that need a horizon rather than a term. The `instants` category
+         * goes 12/13 → **13/13** and every other category is unchanged.
+         *
+         * Its controls are the four positions added alongside it, all of which pass on
+         * [PRODUCTION] already and still pass here: `instants-10` (the ambush itself, at their
+         * declare-attackers), `-11` (flash *and* haste), `-12` (an ETB that taps a blocker before
+         * we attack) and `-13` (past the patience horizon). `instants-10` is not a fix — it passes
+         * everywhere — and it is in the suite for the reason `HoldingInstantsPuzzles`' own header
+         * gives: a category of "don't cast" positions scores 100% for an agent that never casts
+         * anything, so the half that says *do* has to be asserted too.
+         *
+         * **Not yet promoted.** [com.wingedsheep.server.game.EngineAiPlayerController] still points
+         * at [PRODUCTION_CANDIDATE_COUNTERPATIENCE]; the arena half of the standing bar is what
+         * moves it, and until that is run this is a candidate and nothing else.
+         *
+         * If a later arena run comes back below parity, revert the two call sites
+         * (`EngineAiPlayerController` and [AiProfileSelector]'s fallback) rather than the flag: it is
+         * off for every other profile, so backing the promotion out costs nothing and loses no
+         * measurement.
+         */
+        val PRODUCTION_CANDIDATE_AMBUSH = PRODUCTION_CANDIDATE_COUNTERPATIENCE.copy(
+            id = "production-candidate-ambush",
+            holdFlashPermanentsForAmbush = true,
         )
 
         /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -101,6 +101,11 @@ class Strategist(
     /** [AiProfile.cashCantripsInTheEndStep] — passed straight through to [HoldPolicy]. */
     private val cashCantripsInTheEndStep: Boolean = false,
     /**
+     * [AiProfile.holdFlashPermanentsForAmbush] — passed straight through to [HoldPolicy], which
+     * hands it to [com.wingedsheep.ai.engine.knowledge.AmbushWindow].
+     */
+    private val holdFlashPermanentsForAmbush: Boolean = false,
+    /**
      * The profile's `EvaluationWeights.boardPresence`. Only [HoldPolicy] reads it, to quote a
      * patience discount in the same units the leaf score prices board value in.
      */
@@ -125,6 +130,7 @@ class Strategist(
         holdRemovalForBetterTargets = holdRemovalForBetterTargets,
         holdCountersForBetterSpells = holdCountersForBetterSpells,
         cashCantripsInTheEndStep = cashCantripsInTheEndStep,
+        holdFlashPermanentsForAmbush = holdFlashPermanentsForAmbush,
         boardPresenceWeight = boardPresenceWeight,
     )
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/AmbushWindow.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/AmbushWindow.kt
@@ -1,0 +1,177 @@
+package com.wingedsheep.ai.engine.knowledge
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * "Why are you casting that on your own turn?" — the flash creature half of [HoldPolicy].
+ *
+ * A one-ply evaluator scores the board right after the spell resolves, and a 3/4 flier scores the
+ * same there whenever it lands. So a Restoration Angel in hand beats passing in our own precombat
+ * main by roughly its whole board value — measured on the live agent at **+4.06** — and the AI
+ * jams it, throwing away the only thing flash was ever printed for: the option to hold the mana,
+ * see what the opponent does, and ambush an attacker.
+ *
+ * ## Why this is a floor and not a discount
+ *
+ * [RemovalPatience] and [CounterPatience] are discounts, and [HoldPolicy]'s removal branch explains
+ * at length why the *window* half of the same idea was built, measured and removed: holding removal
+ * is a preference between two futures, and the constant large enough to change behaviour was large
+ * enough to veto casting the removal at all.
+ *
+ * Neither argument transfers here, for two reasons that are worth keeping apart:
+ *
+ *  1. **A bonus on the good window cannot fix this.** The removal branch rewards the end step, which
+ *     works because the comparison the AI makes *at* the end step is the one being corrected. Here
+ *     the mistake happens in our own main phase, where the comparison is "cast now vs. pass now" and
+ *     a bonus that exists three steps later is invisible. Removal survives that asymmetry because
+ *     removal held is still removal; a flash creature dumped in main one has already spent the
+ *     entire thing being paid for.
+ *  2. **The claim is provable, not preferential.** Casting a flash permanent now is dominated by
+ *     casting the identical spell at the next free window *unless the permanent does something in
+ *     between* — and the list of things it could do is finite and readable off its [CardIntent].
+ *     That is exactly the standard [TimingVerdict.NoWindow] sets: structurally certain, never a
+ *     preference. So the verdict says the honest thing — whatever the simulation reports, this is
+ *     not better than passing — instead of picking a number to lose an argument with.
+ *
+ * ## What "does something in between" means
+ *
+ * Four ways a permanent cashes in before the window we would otherwise hold it for, and each maps
+ * to something [CardIntent] already carries:
+ *
+ *  - **It attacks**, or taps for an ability — [CardIntent.hasHaste], which is the only one of the
+ *    four that is not a tag.
+ *  - **Its ETB changes a combat** — removal, a tapper, a pump, an anthem, granted evasion.
+ *  - **Its ETB hands us a resource we can still spend this turn** — a card drawn, a tutor, a land.
+ *  - **Something is on the stack** that we might be responding to, which is a window this policy has
+ *    no business overruling.
+ *
+ * [PAYS_OFF_BEFORE_THE_AMBUSH] and [ANSWERS_THEIR_BOARD] are the middle two, split because the
+ * second needs a question the tag cannot answer — *whose* permanents does it point at. The tags
+ * deliberately in neither are the ones that come out identical a step later: a Blood token, a life
+ * total, an opponent's discard, a sacrifice outlet with nothing to feed it yet. A flash permanent
+ * the analyzer reads as doing none of them — an ambush bear, a Pack Guardian, or a Restoration
+ * Angel whose blink only ever touches our own board — is pure body, and pure body is what this is
+ * for.
+ *
+ * ## The releases
+ *
+ * [Patience] owns three of them and they are inherited whole: on a turn where doing nothing loses
+ * the game there is no holding anything, a hand at [com.wingedsheep.engine.core.MaximumHandSize] is
+ * discarding the card anyway, and by [Patience.SPENT_BY_TURN] the bet on a better window has stopped
+ * paying. That reuse is most of why this is worth writing — without it a floor this hard is a brick,
+ * and with it the card cannot rot in hand.
+ *
+ * The fourth release is this file's own and it is [laterWindowIsStillAhead]: once the opponent has
+ * declared attackers the information is in, and holding longer buys nothing.
+ *
+ * Carried on [com.wingedsheep.ai.engine.AiProfile.holdFlashPermanentsForAmbush].
+ */
+internal object AmbushWindow {
+
+    /**
+     * Whether casting this flash permanent **here** is dominated by casting it at a later free
+     * window — the [TimingVerdict.NoWindow] test.
+     *
+     * `false` for everything that is not the narrow shape this reasons about, which is most cards
+     * and every card at all on a profile with the flag off.
+     *
+     * @param intent the *candidate's* intent. Only a [CardIntent.flashPermanent] reaches any of it.
+     */
+    fun holds(state: GameState, playerId: EntityId, intent: CardIntent): Boolean {
+        if (!intent.flashPermanent) return false
+
+        // It can attack, or tap for something, the moment it lands. That is a real payoff this turn
+        // and it is the whole reason flash-and-haste is a printed combination.
+        if (intent.hasHaste) return false
+
+        // Something to respond to is a window in its own right, and one this cannot read well
+        // enough to overrule — the same "silence is not a veto" line [HoldPolicy.responseWindowFor]
+        // takes about a stack object it cannot identify.
+        if (state.stack.isNotEmpty()) return false
+
+        if (intent.tags.any { it in PAYS_OFF_BEFORE_THE_AMBUSH }) return false
+
+        // An ETB that answers *their* board wants to happen before we attack. One that points only
+        // at our own — a blink, a self-bounce — is worth exactly the same a step later, which is
+        // Restoration Angel and is the position that started this. The tag alone cannot tell them
+        // apart; see [CardIntent.targetsOnlyOurPermanents] for why.
+        if (intent.tags.any { it in ANSWERS_THEIR_BOARD } && !intent.targetsOnlyOurPermanents) {
+            return false
+        }
+
+        if (!laterWindowIsStillAhead(state, playerId)) return false
+
+        // Lethal on board, a full hand, or a game gone long — see [Patience], which owns all three
+        // and is shared with the two patience bars so there is one definition of each rather than
+        // three that can drift.
+        return Patience.factorFor(state, state.projectedState, playerId) > 0.0
+    }
+
+    /**
+     * Whether a window at least as good as this one is still coming before the card would have to be
+     * cast anyway.
+     *
+     * **Our own turn: always.** Every step of it is worse than any step of theirs, and the reasoning
+     * does not need to rank them against each other — a no-haste body deployed at any point on our
+     * turn does exactly nothing until we untap, and by then we could have cast it on their turn
+     * instead with a turn of their decisions in hand.
+     *
+     * **Their turn: until attackers are declared.** [Step.DECLARE_ATTACKERS] is the moment the
+     * ambush stops being a guess, and it is the last window where a blocker can still be deployed in
+     * time (CR 509.1 declares blockers in the *next* step). Everything from there on is released,
+     * including [Step.END] — which is the release that matters when they do not attack at all, since
+     * the engine skips the declare-attackers step entirely in that case and a policy that only
+     * released there would hold the card to cleanup.
+     */
+    private fun laterWindowIsStillAhead(state: GameState, playerId: EntityId): Boolean =
+        if (state.activePlayerId == playerId) true else state.step !in RELEASED_ON_THEIR_TURN
+
+    /**
+     * Tags whose payoff is lost, or deferred at a cost, by holding the card — whichever side of the
+     * table they point at.
+     *
+     * Two groups, both about *this turn*:
+     *
+     *  - **Improves our own attack**: [IntentTag.PUMP], [IntentTag.ANTHEM],
+     *    [IntentTag.EVASION_GRANT], [IntentTag.PROTECTION]. An ETB that pumps the team is worth
+     *    having before we swing, and by construction it aims at our own permanents — so unlike
+     *    [ANSWERS_THEIR_BOARD] there is no side-of-the-table question to ask about it.
+     *  - **Hands us something to spend**: [IntentTag.DRAW], [IntentTag.TUTOR], [IntentTag.RAMP],
+     *    [IntentTag.RECURSION]. A card drawn in our main phase can be cast in our main phase; the
+     *    same card drawn on their end step cannot.
+     *
+     * [IntentTag.COUNTERSPELL] and [IntentTag.COMBAT_TRICK] are absent on purpose. They are not
+     * exceptions this set forgot — [HoldPolicy] branches on both *before* it reaches here, so
+     * listing them would imply a guard that lives somewhere else.
+     *
+     * So are [IntentTag.LIFEGAIN], [IntentTag.TOKEN_MAKER], [IntentTag.DISCARD] and
+     * [IntentTag.SACRIFICE_OUTLET], and those are the deliberate inclusions in the floor: a Blood
+     * token, three life, an opponent's discard and an outlet with nothing to feed it are all worth
+     * exactly the same one window later.
+     */
+    private val PAYS_OFF_BEFORE_THE_AMBUSH = setOf(
+        IntentTag.PUMP, IntentTag.ANTHEM, IntentTag.EVASION_GRANT, IntentTag.PROTECTION,
+        IntentTag.DRAW, IntentTag.TUTOR, IntentTag.RAMP, IntentTag.RECURSION,
+    )
+
+    /**
+     * Tags that answer something on the **opponent's** board, and so want to resolve before we
+     * attack rather than after they do.
+     *
+     * Split out from [PAYS_OFF_BEFORE_THE_AMBUSH] because these are the tags the analyzer applies
+     * to a card that only ever touches *our* permanents — a blink, a self-sacrifice, a self-bounce
+     * — and telling those apart takes [CardIntent.targetsOnlyOurPermanents] rather than the tag.
+     */
+    private val ANSWERS_THEIR_BOARD = setOf(
+        IntentTag.REMOVAL, IntentTag.EXILE_REMOVAL, IntentTag.SWEEPER, IntentTag.NEUTRALIZE,
+        IntentTag.TAPPER, IntentTag.FIGHT,
+    )
+
+    /** Their turn, from the moment attackers are known — see [laterWindowIsStillAhead]. */
+    private val RELEASED_ON_THEIR_TURN = setOf(
+        Step.DECLARE_ATTACKERS, Step.DECLARE_BLOCKERS, Step.FIRST_STRIKE_COMBAT_DAMAGE,
+        Step.COMBAT_DAMAGE, Step.END_COMBAT, Step.POSTCOMBAT_MAIN, Step.END,
+    )
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntent.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntent.kt
@@ -88,6 +88,57 @@ data class CardIntent(
      * in the evaluator tells one land from another.
      */
     val entersTapped: Boolean = false,
+    /**
+     * Whether this card is a **permanent with flash** — a body you may deploy on either player's
+     * turn.
+     *
+     * [Speed] cannot answer this on its own: it reports `INSTANT` for a Lightning Bolt and for a
+     * Restoration Angel alike, and the whole of [AmbushWindow]'s argument turns on the difference.
+     * An instant is spent when it resolves and its window is about what it is *answering*; a flash
+     * permanent stays on the battlefield afterwards, so holding it costs the board nothing and buys
+     * the option to ambush.
+     *
+     * Structural like [entersTapped] rather than an [IntentTag], for the reason that enum's own doc
+     * gives: a tag is something the card *does*, and this is a property of when it may be cast.
+     */
+    val flashPermanent: Boolean = false,
+    /**
+     * Whether the card is **printed** with haste — the one reason a [flashPermanent] is worth
+     * deploying on our own turn rather than held for the ambush window.
+     *
+     * Printed, not effective. A creature that would be granted haste by something already on the
+     * battlefield (a Lightning Mauler pairing, an Anger in the graveyard) reads `false` here, and
+     * [AmbushWindow] will hold it a turn it could have attacked. That is the conservative direction
+     * and it is the one this file takes everywhere else it cannot read a card exactly: the
+     * alternative is asking what keywords a card *would* have on resolution, which nothing short of
+     * simulating the cast can answer.
+     */
+    val hasHaste: Boolean = false,
+    /**
+     * Whether every permanent this card targets is one **we control** — and there is at least one.
+     *
+     * This exists because [IntentTag.REMOVAL] cannot answer the question. `hitsAnotherPermanent`
+     * decides "does this take *someone else's* permanent off the battlefield" from the
+     * [com.wingedsheep.sdk.scripting.effects.EffectTarget] alone, and a bound or context target
+     * carries no filter — so it falls through to `else -> true` and every "exile a creature **you
+     * control**" reads as spot removal. Restoration Angel is tagged `REMOVAL, EXILE_REMOVAL` for
+     * blinking our own creature.
+     *
+     * That fail-open is harmless where the tag is only a prior, and wrong where a consumer needs to
+     * know which side of the table an effect points at. [AmbushWindow] is the second kind: "this ETB
+     * clears a blocker before we attack" and "this ETB blinks our own creature" are opposite
+     * answers, and the tag gives the same one for both.
+     *
+     * Fixing `hitsAnotherPermanent` to resolve bound targets against their requirement is the real
+     * repair, and it is deliberately *not* done here: `REMOVAL` feeds `staticPriorValue`'s ladder
+     * and [RemovalPatience]'s bar, so re-tagging every "target creature you control" card is an
+     * evaluation change that needs its own flag and its own arena run. This field is additive, read
+     * by exactly one consumer, and changes nothing for anyone else.
+     *
+     * `false` when the card targets no permanent at all, which keeps a vanilla body — the case the
+     * ambush policy most wants — from being mistaken for one that aims at us.
+     */
+    val targetsOnlyOurPermanents: Boolean = false,
 ) {
     operator fun contains(tag: IntentTag): Boolean = tag in tags
 

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/CardIntentAnalyzer.kt
@@ -21,7 +21,10 @@ import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.effects.*
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.filters.unified.Scope
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import java.util.concurrent.ConcurrentHashMap
 
@@ -212,6 +215,9 @@ object CardIntentAnalyzer {
             anthemBonus = anthemBonus,
             pumpToughness = pumpToughness,
             entersTapped = scripts.any(::alwaysEntersTapped),
+            flashPermanent = card.typeLine.isPermanent && Keyword.FLASH in card.keywords,
+            hasHaste = Keyword.HASTE in card.keywords,
+            targetsOnlyOurPermanents = targetsOnlyOurPermanents(scripts),
         )
         return intent.copy(staticPriorValue = priorValueOf(card, intent))
     }
@@ -432,6 +438,42 @@ object CardIntentAnalyzer {
     // ═════════════════════════════════════════════════════════════════════════
     // Speed / repeatability
     // ═════════════════════════════════════════════════════════════════════════
+
+    /**
+     * [CardIntent.targetsOnlyOurPermanents] — see there for why a consumer cannot get this from
+     * [IntentTag.REMOVAL].
+     *
+     * Requirements are read **flat**, across the spell effect and every triggered and activated
+     * ability, without matching each one back to the effect that consumes it. The question is "could
+     * any of this card's targeting point across the table", and a flat scan answers exactly that;
+     * matching bound variables to requirements would be the beginning of the `hitsAnotherPermanent`
+     * repair this field exists to avoid.
+     *
+     * [TargetObject] is the only requirement kind considered, which is the one that targets a
+     * permanent — [com.wingedsheep.sdk.scripting.targets.TargetCreature] and friends are factory
+     * functions that build one. A player target says nothing about whose board is affected.
+     *
+     * A filter carrying [TargetFilter.alternatives] is declined outright rather than descended into:
+     * "target creature you control **or** artifact an opponent controls" is a real shape, and every
+     * caller of this is better served by a false negative than by a wrong true.
+     */
+    private fun targetsOnlyOurPermanents(scripts: List<CardScript>): Boolean {
+        val permanentTargets = scripts
+            .flatMap(::targetRequirementsOf)
+            .filterIsInstance<TargetObject>()
+        return permanentTargets.isNotEmpty() && permanentTargets.all { requirement ->
+            requirement.filter.alternatives.isEmpty() &&
+                requirement.filter.baseFilter.controllerPredicate == ControllerPredicate.ControlledByYou
+        }
+    }
+
+    /** Every target requirement on [script], wherever it is declared. */
+    private fun targetRequirementsOf(script: CardScript): List<TargetRequirement> =
+        script.targetRequirements +
+            script.triggeredAbilities.flatMap {
+                listOfNotNull(it.targetRequirement) + it.additionalTargetRequirements
+            } +
+            script.activatedAbilities.flatMap { it.targetRequirements }
 
     private fun speedOf(card: CardDefinition, scripts: List<CardScript>, tags: Set<IntentTag>): Speed {
         if (!card.typeLine.isPermanent) {

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/HoldPolicy.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/HoldPolicy.kt
@@ -58,6 +58,12 @@ class HoldPolicy(
      */
     private val cashCantripsInTheEndStep: Boolean = false,
     /**
+     * [AiProfile.holdFlashPermanentsForAmbush][com.wingedsheep.ai.engine.AiProfile.holdFlashPermanentsForAmbush]
+     * — stop deploying a flash creature on our own turn when the ambush window is still ahead. See
+     * [AmbushWindow], which is where the whole idea lives.
+     */
+    private val holdFlashPermanentsForAmbush: Boolean = false,
+    /**
      * The profile's `EvaluationWeights.boardPresence`, so [RemovalPatience] can quote its discount
      * in the same currency as the board value it compares against. The default is the compiled
      * fallback's, which is what every profile that does not opt in would have used anyway.
@@ -150,6 +156,28 @@ class HoldPolicy(
                 state.step in combatWindow -> TimingVerdict.Adjust(COMBAT_WINDOW)
                 else -> responseWindowFor(state, playerId, intent)
             }
+
+            // A permanent with flash, deployed where the ambush window is still ahead of us.
+            //
+            // This is the one branch that returns a verdict on the *wrong* window rather than a
+            // bonus on the right one, and [AmbushWindow] carries the argument for why the removal
+            // branch below does not transfer: a bonus three steps later cannot correct a decision
+            // made now, and unlike "hold the removal" the claim here is provable.
+            //
+            // It sits **above** the removal branch on purpose, and the reason is a bug it has to
+            // route around. `hitsAnotherPermanent` reads "does this take someone else's permanent
+            // off the battlefield" off the effect target alone, which for a bound target carries no
+            // filter and falls through to true — so Restoration Angel, whose ETB blinks a creature
+            // *we control*, is tagged `REMOVAL, EXILE_REMOVAL`. Below the removal branch this
+            // branch would be unreachable for the exact card it was written for.
+            //
+            // Ceding to it costs nothing, because [AmbushWindow]'s own guard is strictly the more
+            // precise of the two: it asks the same question *and* which side of the table the
+            // targeting points at. A flash creature that really does answer their board fails that
+            // guard, this branch's condition goes false, and the removal branch below picks it up
+            // unchanged. Nothing without flash reaches here at all.
+            holdFlashPermanentsForAmbush && AmbushWindow.holds(state, playerId, intent) ->
+                TimingVerdict.NoWindow
 
             // Instant-speed removal: reward the windows that are strictly better than now, and
             // charge nothing for casting it early.

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -123,6 +123,12 @@ object ArenaAgents {
         // today. Expect a rare shape and therefore a wide or degenerate CI, as with patience.
         ArenaAgent("production-counterpatience", AiProfile.PRODUCTION_COUNTERPATIENCE),
         ArenaAgent("production-candidate-counterpatience", AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE),
+        // Flash creatures held for the ambush window instead of dumped in our own main phase.
+        // `just arena production production-ambush 300` prices the term on its own; `just arena
+        // production-candidate-counterpatience production-candidate-ambush 300` is the promotion
+        // gate, against what players face today.
+        ArenaAgent("production-ambush", AiProfile.PRODUCTION_AMBUSH),
+        ArenaAgent("production-candidate-ambush", AiProfile.PRODUCTION_CANDIDATE_AMBUSH),
         ArenaAgent("production-targeted", AiProfile.PRODUCTION_TARGETED),
         // Explicit ECL candidates. Their resource-backed weights fail closed to production's
         // evaluator until a validated artifact is installed; automatic selection is set-gated.

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/AmbushWindowTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/knowledge/AmbushWindowTest.kt
@@ -1,0 +1,216 @@
+package com.wingedsheep.ai.engine.knowledge
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * The one feature, measured on its own rather than through an evaluator.
+ *
+ * `PuzzleSuiteTest` measures the outcome (`instants-09` and `-10`, with the rest of the category as
+ * the control); this pins the *shape* of the floor. Four claims:
+ *
+ *  1. It is **scoped** to a permanent with flash — an instant and an ordinary creature are declined
+ *     before any window reasoning runs.
+ *  2. The window is **our whole turn, and theirs until attackers are known**. That is the entire
+ *     behaviour: hold on ours, hold through their upkeep, release once they have committed.
+ *  3. The **four payoffs** each decline it — haste, a stack object, an ETB that changes a combat,
+ *     an ETB that hands us something to spend.
+ *  4. It **ends**, by [Patience]'s releases rather than by any of its own.
+ *
+ * Where the claim is about the policy's shape the intent is synthesized, so the test says what it
+ * means without depending on which cards a set happens to contain. Where the claim is about
+ * *reading a real card* — the assumption the two puzzles rest on — the intent comes from the
+ * analyzer.
+ */
+class AmbushWindowTest : ScenarioTestBase() {
+
+    private val intents by lazy { IntentCatalog.of(cardRegistry) }
+
+    private fun intentFor(cardName: String) =
+        intents.forName(cardName) ?: error("$cardName is not in the registry")
+
+    /**
+     * A quiet board: seat 1 holds the mana for the flash creature and a creature to defend, seat 2
+     * holds the removal one test needs on the stack.
+     *
+     * [grip] is seat 1's filler only — [Patience]'s hand-size release reads our hand, never theirs.
+     */
+    private fun position(turn: Int = 3, grip: Int = 1, priorityTo: Int = 1) = scenario()
+        .withPlayers()
+        .withActivePlayer(priorityTo)
+        .withTurnNumber(turn)
+        .withLandsOnBattlefield(1, "Plains", 4)
+        .withCardsInHand(1, "Craw Wurm", grip)
+        .withCardOnBattlefield(1, "Grizzly Bears")
+        .withLandsOnBattlefield(2, "Swamp", 4)
+        .withCardInHand(2, "Murder")
+        .build()
+
+    /**
+     * Whether the floor applies to [intent] with seat 1 to act in [step] of [activeSeat]'s turn.
+     *
+     * The step and active player are set on the state directly rather than by advancing the game.
+     * This is a test of one predicate over a position, not of how the position is reached — and
+     * advancing would drag in untaps, draws and triggers that have nothing to do with the claim.
+     */
+    private fun TestGame.floors(
+        intent: CardIntent,
+        step: Step = Step.PRECOMBAT_MAIN,
+        activeSeat: Int = 1,
+    ): Boolean = AmbushWindow.holds(
+        state.copy(
+            step = step,
+            phase = step.phase,
+            activePlayerId = if (activeSeat == 1) player1Id else player2Id,
+        ),
+        player1Id,
+        intent,
+    )
+
+    init {
+
+        // ── 1. Scope ──
+
+        test("Restoration Angel reads as a flash body that only ever touches our own board") {
+            // The card that started this, read by the real analyzer. Three things are load-bearing
+            // for the puzzles, and the third is the surprising one:
+            //
+            //  - `flashPermanent` is what gets it into the policy at all.
+            //  - It carries none of the tags that pay off before the ambush.
+            //  - It IS tagged REMOVAL/EXILE_REMOVAL, for blinking a creature *we control* — the
+            //    `hitsAnotherPermanent` fail-open that [CardIntent.targetsOnlyOurPermanents]
+            //    exists to work around. Pinned here so the workaround's premise is visible: if a
+            //    later analyzer change makes the tag honest, this assertion fails and the field
+            //    can be deleted rather than quietly kept forever.
+            val angel = intentFor("Restoration Angel")
+            angel.flashPermanent shouldBe true
+            angel.hasHaste shouldBe false
+            angel.speed shouldBe Speed.INSTANT
+            angel.tags.filter { it in PAYS_OFF_BEFORE_THE_AMBUSH }.shouldBeEmpty()
+            angel.tags.filter { it in ANSWERS_THEIR_BOARD }.shouldNotBeEmpty()
+            angel.targetsOnlyOurPermanents shouldBe true
+        }
+
+        test("an instant and an ordinary creature are out of scope") {
+            val game = position()
+            // Speed.INSTANT, but spent when it resolves — its window is about what it *answers*,
+            // which is a question [HoldPolicy]'s own branches ask and this one must not re-ask.
+            game.floors(intentFor("Giant Growth")) shouldBe false
+            // A permanent, but castable only in this window anyway: no later window to hold for.
+            game.floors(intentFor("Grizzly Bears")) shouldBe false
+        }
+
+        // ── 2. The window ──
+
+        test("every step of our own turn is floored") {
+            val game = position()
+            val angel = intentFor("Restoration Angel")
+            for (step in Step.entries.filter { it.hasPriority }) {
+                withClue("our own ${step.displayName}") {
+                    game.floors(angel, step = step, activeSeat = 1) shouldBe true
+                }
+            }
+        }
+
+        test("their turn is floored until attackers are declared") {
+            val game = position()
+            val angel = intentFor("Restoration Angel")
+
+            // Before the attack is known, holding still buys information.
+            game.floors(angel, step = Step.UPKEEP, activeSeat = 2) shouldBe true
+            game.floors(angel, step = Step.PRECOMBAT_MAIN, activeSeat = 2) shouldBe true
+            game.floors(angel, step = Step.BEGIN_COMBAT, activeSeat = 2) shouldBe true
+
+            // Attackers are in. This is the ambush, and the last window a blocker can still be
+            // deployed in time — CR 509.1 declares blockers in the *next* step.
+            game.floors(angel, step = Step.DECLARE_ATTACKERS, activeSeat = 2) shouldBe false
+
+            // And the release that matters when they decline to attack at all: the engine skips the
+            // declare-attackers step entirely then, so a policy releasing only there would hold the
+            // card all the way to cleanup.
+            game.floors(angel, step = Step.END, activeSeat = 2) shouldBe false
+        }
+
+        // ── 3. The four payoffs ──
+
+        test("printed haste declines the floor") {
+            // Raging Kavu — flash and haste on one card, which is the combination that exists
+            // precisely so you can deploy it and attack with it.
+            val kavu = intentFor("Raging Kavu")
+            kavu.flashPermanent shouldBe true
+            kavu.hasHaste shouldBe true
+            position().floors(kavu) shouldBe false
+        }
+
+        test("something on the stack declines the floor") {
+            // Seat 2 needs priority to put the spell there, which is why this position hands them
+            // the turn. `floors` overwrites the active player on the state it tests either way, so
+            // the assertions below are about the stack and nothing else.
+            val game = position(priorityTo = 2)
+            val angel = intentFor("Restoration Angel")
+            game.floors(angel) shouldBe true
+
+            game.castSpell(2, "Murder", game.findPermanent("Grizzly Bears")).error shouldBe null
+            game.state.stack.shouldNotBeEmpty()
+            game.floors(angel) shouldBe false
+        }
+
+        test("an ETB that clears a blocker declines the floor") {
+            // Nebelgast Herald — flash, and a trigger that taps a creature an opponent controls.
+            // Tapping a blocker is worth doing *before* we attack, and this policy has no way to
+            // rank that window against the ambush, so it declines rather than guessing.
+            //
+            // The pair with the Restoration Angel case above, and the reason the side-of-the-table
+            // question has to be asked: both cards carry a tag from [ANSWERS_THEIR_BOARD], and only
+            // the Herald's targeting actually points across the table.
+            val herald = intentFor("Nebelgast Herald")
+            herald.flashPermanent shouldBe true
+            herald.tags.filter { it in ANSWERS_THEIR_BOARD }.shouldNotBeEmpty()
+            herald.targetsOnlyOurPermanents shouldBe false
+            position().floors(herald) shouldBe false
+        }
+
+        test("an ETB that hands us a card declines the floor") {
+            // Synthesized rather than taken from a set: the claim is about the tag, and pinning it
+            // to whichever flash cantrip creature happens to be implemented is a worse test.
+            val drawer = intentFor("Restoration Angel").copy(tags = setOf(IntentTag.DRAW))
+            position().floors(drawer) shouldBe false
+        }
+
+        // ── 4. The releases, all inherited from Patience ──
+
+        test("past Patience.SPENT_BY_TURN there is no floor") {
+            val angel = intentFor("Restoration Angel")
+            position(turn = Patience.SPENT_BY_TURN - 1).floors(angel) shouldBe true
+            position(turn = Patience.SPENT_BY_TURN).floors(angel) shouldBe false
+        }
+
+        test("a hand at maximum size has no floor") {
+            val angel = intentFor("Restoration Angel")
+            // The Angel would itself be one of the cards in hand, so the filler is the maximum
+            // minus it — six holds the floor, seven is already discarding something.
+            position(grip = 6).floors(angel) shouldBe true
+            position(grip = 7).floors(angel) shouldBe false
+        }
+    }
+
+    private companion object {
+        /**
+         * The two tag sets [AmbushWindow] declines on. Duplicated here on purpose: the policy's own
+         * copies are private, and a test that imported them could only ever agree with itself.
+         */
+        val PAYS_OFF_BEFORE_THE_AMBUSH = setOf(
+            IntentTag.PUMP, IntentTag.ANTHEM, IntentTag.EVASION_GRANT, IntentTag.PROTECTION,
+            IntentTag.DRAW, IntentTag.TUTOR, IntentTag.RAMP, IntentTag.RECURSION,
+        )
+
+        val ANSWERS_THEIR_BOARD = setOf(
+            IntentTag.REMOVAL, IntentTag.EXILE_REMOVAL, IntentTag.SWEEPER, IntentTag.NEUTRALIZE,
+            IntentTag.TAPPER, IntentTag.FIGHT,
+        )
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -94,6 +94,12 @@ class PuzzleComparisonBenchmark : ScenarioTestBase() {
                 // is zero by construction.
                 AiProfile.PRODUCTION_COUNTERPATIENCE,
                 AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE,
+                // Flash creatures held for the ambush, alone and on top of what is live.
+                // `instants-09` is the verdict that should move; `instants-10` is the ambush itself
+                // and must not, and the three guards (`instants-11`, `-12`, `-13`) are the negative
+                // controls for haste, an ETB that clears a blocker, and the late-game release.
+                AiProfile.PRODUCTION_AMBUSH,
+                AiProfile.PRODUCTION_CANDIDATE_AMBUSH,
                 // Phase 7's rollout evaluator, isolated from Phases 4 and 6 so the column is
                 // attributable to the rollouts alone.
                 AiProfile.PHASE7,

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -36,7 +36,7 @@ class PuzzleSuiteTest : ScenarioTestBase() {
                     PuzzleCatalog.byCategory(category).size shouldBeGreaterThanOrEqual 6
                 }
             }
-            PuzzleCatalog.all.size shouldBe 87
+            PuzzleCatalog.all.size shouldBe 92
         }
 
         test("every KNOWN_FAILURES id names a real puzzle") {
@@ -71,8 +71,9 @@ class PuzzleSuiteTest : ScenarioTestBase() {
          *
          * Baselined 2026-07-27 against `AiProfile.PRODUCTION` at 39/48; **44/48 since Phase 6**
          * (`CardIntent`), which closed noncreature-01/03/04 and instants-01/06; **60/66 since Phase
-         * 2b** added the respond / activate / keywords categories; **71/83** today, after Phase 2c's
-         * timing / lastchance categories and the combat trick window pair. Per-category rates are in
+         * 2b** added the respond / activate / keywords categories; **71/83** after Phase 2c's
+         * timing / lastchance categories and the combat trick window pair; **78/92** today, after
+         * the five ambush-window positions. Per-category rates are in
          * `docs/ai/baseline-metrics.md`.
          */
         val KNOWN_FAILURES: Set<String> = setOf(
@@ -205,6 +206,24 @@ class PuzzleSuiteTest : ScenarioTestBase() {
             // able to cast removal at all competes with that. Its pair, `removal-08`, is the same
             // board with a full hand and passes here and everywhere.
             "removal-07",
+
+            // ── The ambush window ──
+            // Restoration Angel jammed in our own precombat main, off a real game. The leaf scores
+            // a 3/4 flier the same wherever in the turn it lands, so casting beats passing by the
+            // creature's whole board value (+4.06) and every reason flash is printed — hold the
+            // mana, see their attack, ambush a creature — is worth nothing to a one-ply evaluator.
+            // It cannot attack this turn either way.
+            //
+            // **Closed by `AiProfile.holdFlashPermanentsForAmbush`**, and unlike the entries above
+            // it needs nothing else stacked with it: `AiProfile.PRODUCTION_AMBUSH` closes it alone.
+            // Still listed here because [AiProfile.PRODUCTION] is the frozen baseline this set
+            // describes.
+            //
+            // Its four controls all pass on this baseline and must keep passing: `instants-10` (the
+            // ambush itself, at their declare-attackers), `-11` (flash *and* haste), `-12` (an ETB
+            // that taps a blocker before we attack) and `-13` (the same board as this one, past the
+            // patience horizon).
+            "instants-09",
         )
     }
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/HoldingInstantsPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/HoldingInstantsPuzzles.kt
@@ -186,5 +186,107 @@ object HoldingInstantsPuzzles {
             // cast leaks is not on the board.
             check = { shouldNotCast("Giant Growth") },
         ),
+
+        AiPuzzle(
+            id = "instants-09",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Hold Restoration Angel in our own main phase — flash is worth nothing spent here",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Restoration Angel")
+                    // Something to ambush. Without a creature across the table the hold is still
+                    // right, but for a weaker reason, and a puzzle should probe the strong one.
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+            },
+            // Taken from a real game (turn 7, four Plains, precombat main). The leaf sees a 3/4
+            // flier on the battlefield and scores it the same wherever in the turn it landed, so
+            // casting beat passing by +4.06 and the AI jammed it. It cannot attack this turn
+            // either way; what casting now spends is the whole reason flash is printed.
+            check = { shouldNotCast("Restoration Angel") },
+        ),
+
+        AiPuzzle(
+            id = "instants-10",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "They attacked with the 3/3 — flash the Angel in and ambush it",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Restoration Angel")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .build()
+                    .advanceToDeclaration(2, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Hill Giant" to 1)) }
+                    .advanceToPriority(1, Step.DECLARE_ATTACKERS)
+            },
+            // The positive half, and the reason `instants-09` is not just a licence to never cast:
+            // a category made only of "don't cast" positions scores 100% for an AI that never plays
+            // a spell. This is the window the hold was *for* — attackers are committed, and a 3/4
+            // deployed now blocks in the next step (CR 509.1).
+            check = { shouldCast("Restoration Angel") },
+        ),
+
+        AiPuzzle(
+            id = "instants-11",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Raging Kavu has haste — deploy it in our main phase and attack",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Raging Kavu")
+                    .build()
+            },
+            // The haste guard. Flash and haste are printed together precisely so the body can be
+            // deployed and used at once, so the domination argument `instants-09` rests on does not
+            // hold: there *is* a payoff before the ambush window.
+            check = { shouldCast("Raging Kavu") },
+        ),
+
+        AiPuzzle(
+            id = "instants-12",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Nebelgast Herald's ETB taps a blocker — that is worth having before we attack",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInHand(1, "Nebelgast Herald")
+                    // Our attacker, and the blocker the ETB would tap out of its way.
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+            },
+            // The ETB guard. A flash creature whose trigger changes this turn's combat has a real
+            // payoff before the ambush window, and the policy has no way to rank the two — so it
+            // declines rather than guessing, and the ordinary board evaluation decides.
+            check = { shouldCast("Nebelgast Herald") },
+        ),
+
+        AiPuzzle(
+            id = "instants-13",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Past the patience horizon the Angel is just a body — play it",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withTurnNumber(16)
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInHand(1, "Restoration Angel")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+            },
+            // The release guard, and the reason a floor this hard is not a brick: `AmbushWindow`
+            // inherits `Patience`'s three exits whole, and this is the one a long game reaches.
+            // Same position as `instants-09`, nine turns later.
+            check = { shouldCast("Restoration Angel") },
+        ),
     )
 }

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -1964,3 +1964,88 @@ jar, most likely a build race with a parallel agent). Both games were the same p
 out of the comparison. Unrelated to this change, which touches `:ai` only.
 
 **Promoted 2026-08-08** in `EngineAiPlayerController` and `AiProfileSelector`'s fallback.
+
+# The ambush window — flash creatures held for the opponent's turn
+
+Reported from a real game, not found on the suite. Turn 7, the AI's own precombat main, four Plains
+untapped and a Restoration Angel in hand — and it jams it. The decision record says why:
+
+```
+Cast Restoration Angel   score  3.86   advantage +4.06   <- chosen
+Pass priority            score -0.19   baseline
+```
+
+That advantage *is* the creature's board value. A one-ply evaluator scores the board right after the
+spell resolves, and a 3/4 flier scores the same there whichever window it landed in, so every reason
+flash is printed — hold the mana, see their attack, ambush an attacker — is worth exactly zero. The
+Angel cannot attack this turn either way. What casting now spends is the whole card's edge.
+
+## Why the removal branch's shape does not transfer
+
+`HoldPolicy` already has a well-argued answer for "wrong window", and it is a **bonus on the good
+window**: instant-speed removal is paid at the opponent's end step and charged nothing for being cast
+early. That branch's KDoc records that the symmetric penalty was built, measured and removed, because
+holding removal is a preference between two futures and the constant big enough to change behaviour
+was big enough to veto casting the removal at all.
+
+Neither half of that reasoning reaches this case:
+
+1. **A bonus on the good window cannot fix it.** The removal bonus works because the comparison it
+   corrects happens *at* the end step. Here the mistake happens in our own main phase, where the
+   comparison is "cast now vs. pass now" and a bonus three steps later is invisible. Removal survives
+   the asymmetry because removal held is still removal; a flash creature dumped in main one has
+   already spent the thing being paid for.
+2. **The claim is provable, not preferential.** Casting a no-haste flash permanent now is dominated
+   by casting the identical spell at the next free window *unless the permanent does something in
+   between* — and that list is finite and readable off the card. That is exactly the standard
+   `TimingVerdict.NoWindow` sets, so the verdict says the honest thing rather than picking a number
+   to lose an argument with.
+
+`AmbushWindow` declines the floor on any of the four: printed haste, something on the stack, an ETB
+that changes a combat, an ETB that hands us a resource to spend this turn. It inherits `Patience`'s
+three releases whole — lethal on board, hand at the discard limit, decay to nothing by turn 14 — and
+adds one of its own: once attackers are declared, holding longer buys nothing.
+
+## The tag that lied
+
+The first build of this did nothing at all, and the reason is worth recording. `CardIntentAnalyzer`
+tags Restoration Angel **`REMOVAL, EXILE_REMOVAL`** — for blinking a creature *we control*.
+`hitsAnotherPermanent` decides "does this take someone else's permanent off the battlefield" from the
+`EffectTarget` alone, and a bound target carries no filter, so it falls through to `else -> true`.
+
+Two consequences, and both are in the change:
+
+- The branch had to move **above** `HoldPolicy`'s removal branch, or it was unreachable for the exact
+  card it was written for.
+- The guard needed a question the tag cannot answer — *whose* permanents does this point at. That is
+  `CardIntent.targetsOnlyOurPermanents`, computed from the target requirements' controller predicate,
+  and read by exactly one consumer.
+
+Fixing `hitsAnotherPermanent` itself is the real repair and is deliberately **not** here: `REMOVAL`
+feeds `staticPriorValue`'s ladder and `RemovalPatience`'s bar, so re-tagging every "target creature
+you control" card is an evaluation change owed its own flag and its own arena run. `AmbushWindowTest`
+pins the wrong tag on purpose, so that when the repair lands the assertion fails and the workaround
+gets deleted instead of quietly living forever.
+
+## Puzzles — 92 positions, five new
+
+| | `production` | live (`production-candidate-counterpatience`) |
+|---|---|---|
+| baseline | 78/92 | 89/92 |
+| with the term | **79/92** | **90/92** |
+| closes | `instants-09` | `instants-09` |
+| loses | — | — |
+
+The `instants` category goes 10/13 → 11/13 in isolation and 12/13 → **13/13** on the candidate; every
+other category is identical in both columns. Unlike the patience and counter-patience terms, the
+isolation column *can* close its own puzzle here — `production` already reads the card's flash and
+types it `Speed.INSTANT`, it simply had no branch that claimed it.
+
+The candidate's failing set is a strict subset of its baseline's: `respond-05` and `timing-03`, the
+same two that need a horizon rather than a term.
+
+Four of the five new positions are controls that pass on `production` already and must keep passing:
+`instants-10` (the ambush itself, at their declare-attackers), `-11` (flash *and* haste), `-12` (an
+ETB that taps a blocker before we attack) and `-13` (the same board as `-09`, past the patience
+horizon). `instants-10` is not a fix and is not counted as one — it is there because a category made
+only of "don't cast" positions scores 100% for an agent that never casts anything.

--- a/docs/ai/baseline-metrics.md
+++ b/docs/ai/baseline-metrics.md
@@ -2049,3 +2049,25 @@ Four of the five new positions are controls that pass on `production` already an
 ETB that taps a blocker before we attack) and `-13` (the same board as `-09`, past the patience
 horizon). `instants-10` is not a fix and is not counted as one — it is there because a category made
 only of "don't cast" positions scores 100% for an agent that never casts anything.
+
+## The arena half
+
+`just arena production-candidate-counterpatience production-candidate-ambush 100`:
+
+```
+Pair win %:   50.0%  CI [50.0%, 50.0%]   <- the merge gate
+Game score %: 50.0%  Wilson [40.4%, 59.6%]
+Completed:    100 / 100     Illegal acts: 0
+Avg turns:    22.0   avg actions: 526
+Wall clock:   1625s on 8 threads
+```
+
+The **fourth degenerate null** in this sequence, and it reads the same way the patience, cantrip and
+counter-patience promotions did: every scored pair came back 1-1-0, which says the term changes the
+outcome of a real sealed game *rarely*, not that it is worthless. That is what the mechanism
+predicts — it fires only on a turn where the AI holds a flash permanent with the ambush window still
+ahead, and BLB sealed pools are thin in flash creatures. A CI spanning parity is a pass under the
+standing bar, and the puzzle side is the evidence.
+
+Cleaner than the counter-patience run in one respect worth noting: 100/100 completed with 0 illegal
+actions, where that one lost two games to a stale-jar `NoClassDefFoundError` on a test worker.


### PR DESCRIPTION
## The position

From a real game, not from the suite. Turn 7, the AI's own precombat main, four Plains untapped, a Restoration Angel in hand — and it casts it. The decision record says why:

```
Cast Restoration Angel   score  3.86   advantage +4.06   <- chosen
Pass priority            score -0.19   baseline
```

That advantage *is* the creature's board value. A one-ply evaluator scores the board right after the spell resolves, and a 3/4 flier scores the same there whichever window it landed in — so hold the mana, see their attack, ambush an attacker are all worth exactly zero. The Angel can't attack this turn either way. What casting now spends is the whole card's edge.

## Why `HoldPolicy`'s existing shape doesn't reach it

The removal branch answers "wrong window" with a **bonus on the good window**, and its KDoc records that the symmetric penalty was built, measured and removed — holding removal is a preference between two futures, and the constant big enough to change behaviour was big enough to veto casting removal at all.

Neither half transfers:

1. **A bonus can't fix this one.** The removal bonus works because the comparison it corrects happens *at* the end step. Here the mistake is in our main phase, where the comparison is "cast now vs. pass now" and a bonus three steps later is invisible. Removal survives that because removal held is still removal; a flash creature dumped in main one has already spent the thing being paid for.
2. **The claim is provable, not preferential.** Casting a no-haste flash permanent now is dominated by casting the identical spell at the next free window *unless the permanent does something in between* — and that list is finite: it attacks, its ETB changes a combat, its ETB hands us a resource to spend, or something is on the stack. That is exactly the standard `TimingVerdict.NoWindow` sets.

So `AmbushWindow` returns `NoWindow`, guarded on those four. It inherits `Patience`'s three releases whole — lethal on board, hand at the discard limit, decay to nothing by turn 14 — and adds one of its own: once attackers are declared, holding longer buys nothing.

## Two findings from building it

**`hitsAnotherPermanent` fails open, and Restoration Angel is tagged `REMOVAL, EXILE_REMOVAL`** — for blinking a creature *we control*. It reads "does this take someone else's permanent off the battlefield" off the `EffectTarget` alone, and a bound target carries no filter, so it falls through to `else -> true`. Consequences, both in the change:

- The new branch had to move **above** `HoldPolicy`'s removal branch, or it was unreachable for the exact card it was written for. Ceding to it costs nothing: `AmbushWindow`'s guard is strictly the more precise of the two, so a flash creature that really does answer their board fails it and the removal branch picks the card up unchanged.
- The guard needed a question the tag can't answer — *whose* permanents does this point at. `CardIntent.targetsOnlyOurPermanents` reads the target requirements' controller predicate; one consumer, additive, nothing else changes.

**Repairing `hitsAnotherPermanent` is deliberately not here.** `REMOVAL` feeds `staticPriorValue`'s ladder and `RemovalPatience`'s bar, so re-tagging every "target creature you control" card is an evaluation change owed its own flag and its own arena run. `AmbushWindowTest` pins the wrong tag **on purpose**, so when that repair lands the assertion fails and the workaround gets deleted rather than quietly living forever. Worth its own issue.

## Measurement

Puzzles — 92 positions, five new:

| | `production` | live (`production-candidate-counterpatience`) |
|---|---|---|
| baseline | 78/92 | 89/92 |
| with the term | **79/92** | **90/92** |
| closes | `instants-09` | `instants-09` |
| loses | — | — |

`instants` goes 10/13 → 11/13 in isolation and 12/13 → **13/13** on the candidate; every other category is identical in both columns. The candidate's failing set is a strict subset of its baseline's — `respond-05` and `timing-03`, both of which need a horizon rather than a term.

Arena — `just arena production-candidate-counterpatience production-candidate-ambush 100`:

```
Pair win %:   50.0%  CI [50.0%, 50.0%]   <- the merge gate
Completed:    100 / 100     Illegal acts: 0
Wall clock:   1625s on 8 threads
```

The fourth degenerate null in this sequence, same reading as the patience, cantrip and counter-patience promotions: every scored pair 1-1-0, so the term changes the outcome of a real sealed game *rarely*. That is what the mechanism predicts — it fires only on a turn where the AI holds a flash permanent with the ambush window still ahead. A CI spanning parity is a pass under the standing bar; the evidence is the puzzle side, at +1 with nothing traded.

## The controls

Four of the five new positions pass on `production` already and must keep passing:

- `instants-10` — the ambush itself, at their declare-attackers. **Not a fix**: it passes everywhere. It is in the suite because a category made only of "don't cast" positions scores 100% for an agent that never casts anything.
- `instants-11` — flash *and* haste (Raging Kavu). There is a payoff before the ambush window.
- `instants-12` — an ETB that taps a blocker before we attack (Nebelgast Herald). The side-of-the-table pair with Restoration Angel: both carry a tag from `ANSWERS_THEIR_BOARD`, only one actually points across the table.
- `instants-13` — the same board as `-09`, past the patience horizon.

`AmbushWindowTest` adds 10 unit tests pinning the floor's shape directly rather than through an evaluator.

## Not promoted

`EngineAiPlayerController:61` and `AiProfileSelector`'s fallback still point at `PRODUCTION_CANDIDATE_COUNTERPATIENCE`. The standing bar is met, so the promotion is a two-line follow-up — but it changes what every player faces, so I left it as your call rather than folding it into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)