### PR TITLE
Stop the AI paying for expiring grants in windows that cannot spend them

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -251,6 +251,7 @@ class AIPlayer(
                     holdCountersForBetterSpells = profile.holdCountersForBetterSpells,
                     cashCantripsInTheEndStep = profile.cashCantripsInTheEndStep,
                     holdFlashPermanentsForAmbush = profile.holdFlashPermanentsForAmbush,
+                    holdExpiringGrantsForCombat = profile.holdExpiringGrantsForCombat,
                     // Same seam as `CombatAdvisor`'s `lifeWeight`: a raw Phase 9 profile resolves
                     // to the compiled fallback here, which is the right answer for a policy that
                     // only needs to know what a point of board value trades against.

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AiProfile.kt
@@ -299,6 +299,48 @@ data class AiProfile(
      */
     val holdFlashPermanentsForAmbush: Boolean = false,
     /**
+     * Stop paying for an **activated ability whose whole payoff expires at cleanup** in a window
+     * where nothing can spend it.
+     *
+     * The target is `instants-14`, taken from a real game: turn 4, the *opponent's* precombat main,
+     * an Olivia's Dragoon (`Discard a card: This creature gains flying until end of turn`) that
+     * entered last turn, and the AI discards a Battleground Geist to give it flying. A card, for a
+     * keyword that is gone at cleanup, on a turn where the opponent controls no flier for it to
+     * block and no combat it can attack in.
+     *
+     * The leaf scores it at **+2.35**, and both halves of that are the evaluator working as
+     * designed. `BoardPresence.creatureBodyValue` prices flying at `1.5 + power × 0.3` = 2.1 (× the
+     * 1.5 board weight = 3.15) with no reading of whether it is evasive against *this* board — the
+     * same fact `ThreatAssessment.evasivePower` reads correctly two features over, where the
+     * summoning-sick Dragoon contributes zero. And `CardAdvantage` charges the discarded card the
+     * 4th-card marginal, 0.8. Neither number is defensibly wrong on its own; the position is.
+     *
+     * [com.wingedsheep.ai.engine.knowledge.ExpiringGrantWindow] answers it the way
+     * [holdFlashPermanentsForAmbush] answers its own — a
+     * [com.wingedsheep.ai.engine.knowledge.TimingVerdict.NoWindow] rather than a discount — and its
+     * KDoc carries the argument. The short version is that the dominance claim is *stronger* here
+     * than for a card in hand: an ability is not a resource that can be stripped, so it is provably
+     * still available at `DECLARE_ATTACKERS`, at the same cost, with strictly more information.
+     *
+     * **This is also the first window verdict an activated ability has ever received.**
+     * `HoldPolicy.verdictFor` resolves an activation to its source permanent's name, and
+     * `CardIntentAnalyzer` types any permanent carrying a non-mana activated ability as
+     * `Speed.ACTIVATED`, which `windowVerdictFor` declines at its first line. So the `COMBAT_TRICK`
+     * branch — whose subject is exactly "a pump wears off at cleanup" — was unreachable for every
+     * ability in the catalog, and the mistake `instants-06` pins for an instant went unmeasured for
+     * the identical text printed on a creature.
+     *
+     * Three guards keep the floor honest, any one of which failing hands the decision back to the
+     * leaf: every payoff in the effect tree is an until-end-of-turn grant, the ability is
+     * instant-speed with a window still ahead, and nothing on the stack points at a permanent we
+     * control. It inherits
+     * [com.wingedsheep.ai.engine.knowledge.Patience]'s three releases on top — and the hand-size one
+     * matters more here than anywhere else, because the commonest cost on this ability shape is a
+     * discard, which is free at a full hand. Needs [useCardIntent], like everything else the policy
+     * reads.
+     */
+    val holdExpiringGrantsForCombat: Boolean = false,
+    /**
      * The two `BoardPresence.creatureValue` corrections [PRODUCTION_RACECLOCK]'s KDoc named as the
      * reason its arena win came with a puzzle trade — the damaged-creature discount and the flat
      * multiplier on "can't attack". Both are off by default; see
@@ -1038,6 +1080,64 @@ data class AiProfile(
         val PRODUCTION_CANDIDATE_AMBUSH = PRODUCTION_CANDIDATE_COUNTERPATIENCE.copy(
             id = "production-candidate-ambush",
             holdFlashPermanentsForAmbush = true,
+        )
+
+        /**
+         * [holdExpiringGrantsForCombat] alone on top of [PRODUCTION], so a puzzle or an arena point
+         * that moves is attributable to it — the same isolation [PRODUCTION_AMBUSH] gives the
+         * ambush window.
+         *
+         * Like that column this one can close its own puzzle unaided: `production` already has
+         * [useCardIntent], so the catalog resolves Olivia's Dragoon's ability and the flag is the
+         * only thing standing between the position and a floor.
+         *
+         * **Measured: 81/96 → 82/96**, closing `instants-14` and nothing else, with every other
+         * category byte-identical to [PRODUCTION]'s. A term that fires on one narrow shape and
+         * costs nothing across the other 95 positions is what the isolation column is for.
+         */
+        val PRODUCTION_EXPIRING = PRODUCTION.copy(
+            id = "production-expiring",
+            holdExpiringGrantsForCombat = true,
+        )
+
+        /**
+         * The promotion candidate: [PRODUCTION_CANDIDATE_COUNTERPATIENCE] plus
+         * [holdExpiringGrantsForCombat] — the agent that stops pitching cards for keywords it has
+         * nothing to spend them on.
+         *
+         * Stacked on [PRODUCTION_CANDIDATE_COUNTERPATIENCE], **not** on
+         * [PRODUCTION_CANDIDATE_AMBUSH], because that is what
+         * [com.wingedsheep.ai.engine.EngineAiPlayerController] actually points at: the ambush
+         * flag's own promotion never reached the call site, so stacking on it would make this
+         * candidate two flags from what players face and its arena number unattributable.
+         *
+         * Its controls are the two positions added alongside it: `instants-15` (the same ability at
+         * the opponent's declare-attackers, where the window is released and the block it buys is
+         * real) and `instants-16` (the same board at a full hand, where the discard is the card
+         * cleanup was taking anyway). A term that only ever says "don't" scores well on a suite by
+         * never playing, which is why the half that says *do* is asserted too.
+         *
+         * **Measured: 91/96 → 92/96**, closing `instants-14` with a failing set that is a strict
+         * subset of [PRODUCTION_CANDIDATE_COUNTERPATIENCE]'s. The `instants` category goes 14/17 →
+         * 15/17 and every other category is byte-identical; what is left is `instants-08`,
+         * `respond-05`, `timing-01` and `timing-03`, none of which this term is about.
+         *
+         * The arena half returned another **degenerate null**: `just arena
+         * production-candidate-counterpatience production-candidate-expiring 100` measured **50.0%,
+         * CI [50.0%, 50.0%]**, 100/100 completed, 0 illegal actions, and *every* scored pair 1-1-0.
+         * Pairs that identical mean the term did not fire at all across 100 BLB sealed games, which
+         * the mechanism predicts — it needs a permanent with an instant-speed ability whose only
+         * payoff expires, held in a pre-combat window, and BLB is not a set full of those. Read the
+         * arena as **no regression**, not as evidence of gain; the evidence for the gain is the
+         * puzzle side and the game it was taken from, which was neither BLB nor sealed.
+         *
+         * If a later arena run comes back below parity, revert the one call site
+         * ([com.wingedsheep.ai.engine.EngineAiPlayerController]) rather than the flag: it is off for
+         * every other profile, so backing the promotion out costs nothing and loses no measurement.
+         */
+        val PRODUCTION_CANDIDATE_EXPIRING = PRODUCTION_CANDIDATE_COUNTERPATIENCE.copy(
+            id = "production-candidate-expiring",
+            holdExpiringGrantsForCombat = true,
         )
 
         /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/EngineAiPlayerController.kt
@@ -22,16 +22,18 @@ private val logger = LoggerFactory.getLogger(EngineAiPlayerController::class.jav
  *
  * Runs entirely locally with no API calls. Uses the engine's ActionProcessor, board evaluator,
  * [Strategist] and [CombatAdvisor] directly, configured by
- * [AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE]
+ * [AiProfile.PRODUCTION_CANDIDATE_EXPIRING]
  * — rollout candidate evaluation over a determinized state, on a four-tier decision budget, with a
  * land drop priced as the card conversion it is, land *order* priced by the mana it makes usable,
  * a combat trick held until blocks are in and searched properly once they are, the race scored
  * in urgency rather than in turns, removal held for a target worth a card, and a creature priced by
  * what it can still do — marked damage wearing off at cleanup, "can't attack" costing the power —
- * a cantrip cashed in the window where its mana was going to evaporate anyway, and a counterspell
- * held while the caster still has the mana for something bigger.
+ * a cantrip cashed in the window where its mana was going to evaporate anyway, a counterspell
+ * held while the caster still has the mana for something bigger, and an activated ability whose
+ * whole payoff expires at cleanup held for a window that can actually spend it.
  * Each superseded configuration is kept as the baseline its successor was measured against:
- * [AiProfile.PRODUCTION_CANDIDATE_CANTRIP] ran immediately before it,
+ * [AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE] ran immediately before it,
+ * [AiProfile.PRODUCTION_CANDIDATE_CANTRIP] before it,
  * [AiProfile.PRODUCTION_CANDIDATE_BOARDVALUE] before it,
  * [AiProfile.PRODUCTION_CANDIDATE_PATIENCE] before it,
  * [AiProfile.PRODUCTION_CANDIDATE_RACECLOCK] before it,
@@ -58,7 +60,7 @@ class EngineAiPlayerController(
 
     private val aiPlayer =
         AIPlayer.create(
-            cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_COUNTERPATIENCE, insightSink = insightSink,
+            cardRegistry, playerId, AiProfile.PRODUCTION_CANDIDATE_EXPIRING, insightSink = insightSink,
         )
 
     override fun chooseAction(

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -106,6 +106,11 @@ class Strategist(
      */
     private val holdFlashPermanentsForAmbush: Boolean = false,
     /**
+     * [AiProfile.holdExpiringGrantsForCombat] — passed straight through to [HoldPolicy], which
+     * hands it to [com.wingedsheep.ai.engine.knowledge.ExpiringGrantWindow].
+     */
+    private val holdExpiringGrantsForCombat: Boolean = false,
+    /**
      * The profile's `EvaluationWeights.boardPresence`. Only [HoldPolicy] reads it, to quote a
      * patience discount in the same units the leaf score prices board value in.
      */
@@ -131,6 +136,7 @@ class Strategist(
         holdCountersForBetterSpells = holdCountersForBetterSpells,
         cashCantripsInTheEndStep = cashCantripsInTheEndStep,
         holdFlashPermanentsForAmbush = holdFlashPermanentsForAmbush,
+        holdExpiringGrantsForCombat = holdExpiringGrantsForCombat,
         boardPresenceWeight = boardPresenceWeight,
     )
 
@@ -588,7 +594,14 @@ class Strategist(
         // other half is whether this was the window — and, for removal, whether this was the target
         // worth spending the card on. The materialized action is what carries the committed
         // targets, so the hold policy is asked about the same spell the processor would receive.
-        val timing = holdPolicy.verdictFor(state, playerId, cardName, action.action as? CastSpell)
+        //
+        // The activation is handed over for the same reason: an ability's window is a question about
+        // the *ability*, and `cardName` only ever names the permanent it is printed on.
+        val timing = holdPolicy.verdictFor(
+            state, playerId, cardName,
+            cast = action.action as? CastSpell,
+            activation = action.action as? ActivateAbility,
+        )
         if (timing is TimingVerdict.NoWindow) {
             // The card does nothing here, so nothing the simulation reports should make it beat
             // passing. See [TimingVerdict.NoWindow] for why this is a floor and not a penalty.

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/ExpiringGrantWindow.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/ExpiringGrantWindow.kt
@@ -1,0 +1,258 @@
+package com.wingedsheep.ai.engine.knowledge
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TargetsComponent
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GrantEvasionKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * "Why are you paying for that now?" — the **activated ability** half of [HoldPolicy].
+ *
+ * [AmbushWindow] is the same argument about a card in hand, and everything below is the shape it
+ * established applied one zone over. The mistake it answers is a real one, off a live game: turn 4,
+ * the *opponent's* precombat main, an Olivia's Dragoon (`Discard a card: This creature gains flying
+ * until end of turn`) freshly deployed and summoning sick, and the AI discards a Battleground Geist
+ * to give it flying. There is no combat this turn it can use, the opponent controls no flier for it
+ * to block, and the keyword is gone at cleanup. A card for nothing.
+ *
+ * ## Why the existing window machinery never sees it
+ *
+ * [HoldPolicy.verdictFor] resolves an activation to its *source permanent's* name, and
+ * [CardIntentAnalyzer] types any permanent carrying a non-mana activated ability as
+ * [Speed.ACTIVATED]. `windowVerdictFor` opens by declining everything that is not [Speed.INSTANT],
+ * so the [IntentTag.COMBAT_TRICK] branch — whose whole subject is "a pump wears off at cleanup, so
+ * it is worth casting only when something will use it before then" — is unreachable for an ability.
+ * The identical mistake, printed on a creature instead of on an instant, was unmeasured.
+ *
+ * ## Why this is a floor and not a discount
+ *
+ * The same two reasons [AmbushWindow] gives, and the second is stronger here:
+ *
+ *  1. **A bonus on the good window cannot fix this.** The comparison being corrected happens in the
+ *     wrong window, where a reward three steps later is invisible.
+ *  2. **The claim is provable.** Activating now is dominated by activating the identical ability at
+ *     the next window *unless something happens in between that needs it* — and unlike a card in
+ *     hand there is no "it might get discarded / countered" residue to argue about, because the
+ *     ability is not a resource that can be stripped. It is still there at
+ *     [Step.DECLARE_ATTACKERS], at the same cost, with strictly more information.
+ *
+ * What the floor deliberately does **not** claim is that the grant is worthless — that is the
+ * evaluator's question, and it keeps it. This says only that *here* is not where it gets asked.
+ *
+ * ## What "expires with nothing to spend it on" means
+ *
+ * Three guards, each of which must hold, and any one of which failing hands the decision straight
+ * back to the leaf score:
+ *
+ *  - **Every payoff expires at end of turn** — see [everyPayoffExpiresThisTurn]. One permanent
+ *    effect anywhere in the tree (a +1/+1 counter, a card drawn, a token) and the ability is buying
+ *    something that survives the turn, so waiting is no longer free.
+ *  - **A later activation is available** — [TimingRule.InstantSpeed], and a window still ahead. A
+ *    sorcery-speed ability has only our own main phases, and the postcombat one is worse than this,
+ *    so there is nothing to hold for. "Still ahead" stops one step earlier on our own turn than on
+ *    theirs; [laterWindowIsStillAhead] carries why, and it is the guard that keeps the floor from
+ *    talking the AI out of the attack the grant was for.
+ *  - **Nothing on the stack threatens our board** — [somethingOnTheStackThreatensUs]. A grant is
+ *    often the response (indestructible against a wrath, protection from a burn spell, evasion out
+ *    of a "target creature without flying gets -3/-3"), and this policy cannot rank those. It reads
+ *    both where a stack object points *and* what it is, because the shape that most needs the
+ *    release — a sweeper — names no target at all.
+ *
+ * Plus [Patience]'s three releases, inherited whole — see [holds].
+ *
+ * Carried on [com.wingedsheep.ai.engine.AiProfile.holdExpiringGrantsForCombat].
+ */
+internal object ExpiringGrantWindow {
+
+    /**
+     * Whether activating [ability] **here** is dominated by activating it at a later window this
+     * turn — the [TimingVerdict.NoWindow] test.
+     *
+     * `false` for everything that is not the narrow shape this reasons about, which is the
+     * overwhelming majority of abilities and every ability at all on a profile with the flag off.
+     */
+    fun holds(
+        state: GameState,
+        playerId: EntityId,
+        ability: ActivatedAbility,
+        intents: IntentCatalog,
+    ): Boolean {
+        if (ability.isManaAbility) return false
+
+        // A sorcery-speed ability has no later window worth holding for: our own main phases are
+        // the only ones it gets, and the postcombat one is strictly worse than this.
+        if (ability.timing != TimingRule.InstantSpeed) return false
+
+        if (!everyPayoffExpiresThisTurn(ability.effect)) return false
+
+        if (!laterWindowIsStillAhead(state, playerId)) return false
+
+        if (somethingOnTheStackThreatensUs(state, playerId, intents)) return false
+
+        // Lethal on board, a hand at maximum size, a game gone long — see [Patience], which owns all
+        // three and is shared with the patience bars and [AmbushWindow] so there is one definition
+        // of each rather than four that can drift.
+        //
+        // The hand-size release earns its keep twice over here, because the commonest cost on this
+        // ability shape is a discard: at a full hand the card being pitched is the one the cleanup
+        // step was going to take anyway, so the activation is free and the floor has no business
+        // stopping it.
+        return Patience.factorFor(state, state.projectedState, playerId) > 0.0
+    }
+
+    /**
+     * Whether **everything** [effect] does is gone at cleanup.
+     *
+     * The test is over [EffectWalker.leaves], so a composite, a gate and a "you may" are all seen
+     * through to the leaves that actually do something — and both branches of a conditional count,
+     * which is the conservative reading: an ability that *might* make a token is an ability that
+     * buys something permanent.
+     *
+     * Only the three duration-carrying grant leaves are recognized as expiring. Everything else —
+     * including an unrecognized effect — fails the test, so a shape this cannot read keeps the
+     * pre-flag behaviour rather than earning a veto. That is the same fail-safe direction
+     * [IntentCatalog] takes about a card it has never seen.
+     *
+     * [Duration.EndOfTurn] specifically, not "any bounded duration": [Duration.UntilYourNextTurn]
+     * spans the opponent's whole turn, which is precisely a payoff that outlives the window this
+     * policy would defer past.
+     *
+     * And a [ModifyStatsEffect] counts only when it **pumps**. "Target creature gets -2/-2 until end
+     * of turn" is removal with a duration on it: the modifier expires, the creature it killed does
+     * not, so its payoff is permanent and waiting is not free. `CardIntentAnalyzer` draws the same
+     * line one file over, tagging a negative toughness modifier `REMOVAL` rather than `PUMP`. A
+     * modifier this cannot read as a number at all — anything but a [DynamicAmount.Fixed] — fails
+     * for the same fail-safe reason an unrecognized leaf does.
+     */
+    private fun everyPayoffExpiresThisTurn(effect: Effect): Boolean {
+        val leaves = EffectWalker.leaves(effect)
+        return leaves.isNotEmpty() && leaves.all { leaf ->
+            when (leaf) {
+                is GrantKeywordEffect -> leaf.duration == Duration.EndOfTurn
+                is GrantEvasionKeywordEffect -> leaf.duration == Duration.EndOfTurn
+                is ModifyStatsEffect ->
+                    leaf.duration == Duration.EndOfTurn && isPump(leaf)
+                else -> false
+            }
+        }
+    }
+
+    /** Whether [effect] only ever adds stats — see [everyPayoffExpiresThisTurn]. */
+    private fun isPump(effect: ModifyStatsEffect): Boolean {
+        val power = (effect.powerModifier as? DynamicAmount.Fixed)?.amount ?: return false
+        val toughness = (effect.toughnessModifier as? DynamicAmount.Fixed)?.amount ?: return false
+        return power >= 0 && toughness >= 0
+    }
+
+    /**
+     * Whether a window at least as good as this one is still coming this turn.
+     *
+     * **The deadline is one step earlier on our own turn than on theirs**, and the asymmetry is
+     * load-bearing rather than fussy — it is the difference between holding a grant and throwing
+     * away the attack it was for.
+     *
+     * *Their turn* releases at [Step.DECLARE_ATTACKERS]. That is the last window an evasion grant
+     * can still change a block (CR 509.1a — a creature with flying can be blocked only by a
+     * creature with flying or reach, and blockers are declared in the next step), and by then the
+     * attack is known, which is the whole reason to wait.
+     *
+     * *Our turn* releases at [Step.BEGIN_COMBAT], one step sooner, because our attack is declared
+     * *in* `DECLARE_ATTACKERS` and the AI receives priority there only after declaring. `CombatAdvisor`
+     * reads the board as it stands, so a grant held past begin-combat is not in force when the
+     * attack is chosen: the 2/2 that would have attacked as a flier stays home, and the floor has
+     * cost the line it was protecting. Begin-combat is the last window that is still strictly better
+     * than the main phase (a flash blocker may have appeared) *and* still ahead of the declaration.
+     *
+     * Both are the earliest of the last-useful windows across the grants this covers rather than the
+     * latest — a raw +3/+0 could honestly wait until after blocks — and releasing early is the
+     * conservative direction: from there on this policy says nothing and the leaf score decides, so
+     * it can cost the AI a slightly early activation but can never make it miss the payoff.
+     *
+     * A turn where no attackers are declared skips the declare-attackers step entirely, so on the
+     * opponent's turn the floor then stands to cleanup — correctly. With no combat the grant had
+     * nothing to buy in the first place, and paying a card to watch it expire in the end step is the
+     * mistake, not the missed window.
+     */
+    private fun laterWindowIsStillAhead(state: GameState, playerId: EntityId): Boolean =
+        if (state.activePlayerId == playerId) state.step in BEFORE_OUR_ATTACK
+        else state.step in BEFORE_THEIR_ATTACK
+
+    /**
+     * Whether anything on the stack is a reason to spend the grant *now* rather than later.
+     *
+     * Three ways to be one, and they are ordered from the cheapest question to the most
+     * information-hungry:
+     *
+     *  1. **It points at a permanent we control.** No intent needed and it catches the whole shape
+     *     of spot removal, a fight, a bounce, a tapper — anything that names one of our permanents
+     *     is something a grant might answer, and this policy has no business ranking those.
+     *  2. **We cannot read it, and it is not ours.** The same "silence is not a veto" line
+     *     [HoldPolicy.responseWindowFor] takes: an unknown opposing spell is not evidence that
+     *     waiting is safe.
+     *  3. **We can read it, it is not ours, and it answers a board.** This is the clause a sweeper
+     *     needs. A Wrath of God names no targets at all, so clause 1 never sees it, and an ability
+     *     that grants indestructible until end of turn is exactly the thing you activate in
+     *     response to one — a floor that deferred past it would be actively losing the board.
+     *
+     * Our own spells and abilities are excluded throughout: an ETB trigger of ours resolving is not
+     * a deadline, and treating it as one would release the floor on most turns for no reason.
+     *
+     * The position that motivated this file has an opposing *creature spell* on the stack — read,
+     * not ours, and carrying none of [THREATENS_A_BOARD] — so the floor correctly stands there.
+     */
+    private fun somethingOnTheStackThreatensUs(
+        state: GameState,
+        playerId: EntityId,
+        intents: IntentCatalog,
+    ): Boolean {
+        if (state.stack.isEmpty()) return false
+        val projected = state.projectedState
+        return state.stack.any { stackId ->
+            val container = state.getEntity(stackId) ?: return@any false
+
+            val aimedAtUs = container.get<TargetsComponent>()?.targets.orEmpty().any { target ->
+                target is ChosenTarget.Permanent && projected.getController(target.entityId) == playerId
+            }
+            if (aimedAtUs) return@any true
+
+            // Ours, and pointed at nothing of ours: not a deadline. Read off the base state —
+            // the projected-state rule is about battlefield permanents, and this is the stack.
+            if (container.get<ControllerComponent>()?.playerId == playerId) return@any false
+
+            val intent = intents.forStackObject(container) ?: return@any true
+            intent.tags.any { it in THREATENS_A_BOARD }
+        }
+    }
+
+    /**
+     * Tags that answer a board rather than build one — the stack objects a grant is plausibly a
+     * response to even when they name no target.
+     *
+     * The same set [AmbushWindow.ANSWERS_THEIR_BOARD] names, and for a mirrored reason: there it is
+     * "this ETB wants to happen before we attack", here it is "this is a deadline we must not defer
+     * past". [IntentTag.SWEEPER] is the member that earns the set — it is the one shape that cannot
+     * be caught by looking at targets, because a wrath has none.
+     */
+    private val THREATENS_A_BOARD = setOf(
+        IntentTag.REMOVAL, IntentTag.EXILE_REMOVAL, IntentTag.SWEEPER, IntentTag.NEUTRALIZE,
+        IntentTag.TAPPER, IntentTag.FIGHT,
+    )
+
+    /** Every step before we choose our attackers — see [laterWindowIsStillAhead]. */
+    private val BEFORE_OUR_ATTACK = setOf(
+        Step.UNTAP, Step.UPKEEP, Step.DRAW, Step.PRECOMBAT_MAIN,
+    )
+
+    /** [BEFORE_OUR_ATTACK] plus the step where their attack is not yet known. */
+    private val BEFORE_THEIR_ATTACK = BEFORE_OUR_ATTACK + Step.BEGIN_COMBAT
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/HoldPolicy.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/HoldPolicy.kt
@@ -1,17 +1,14 @@
 package com.wingedsheep.ai.engine.knowledge
 
 import com.wingedsheep.ai.engine.evaluation.EvaluationWeights
+import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
-import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
-import com.wingedsheep.engine.state.components.stack.AbilityOnStackComponent
-import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.TargetsComponent
-import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.EntityId
 
@@ -64,6 +61,12 @@ class HoldPolicy(
      */
     private val holdFlashPermanentsForAmbush: Boolean = false,
     /**
+     * [AiProfile.holdExpiringGrantsForCombat][com.wingedsheep.ai.engine.AiProfile.holdExpiringGrantsForCombat]
+     * — stop paying for an activated ability whose whole payoff expires at cleanup, in a window
+     * where nothing can spend it. See [ExpiringGrantWindow], which is where the whole idea lives.
+     */
+    private val holdExpiringGrantsForCombat: Boolean = false,
+    /**
      * The profile's `EvaluationWeights.boardPresence`, so [RemovalPatience] can quote its discount
      * in the same currency as the board value it compares against. The default is the compiled
      * fallback's, which is what every profile that does not opt in would have used anyway.
@@ -86,13 +89,24 @@ class HoldPolicy(
      *
      * @param cast the materialized spell, when this action is one. Null for an activated ability,
      *   which spends no card and so is never charged for patience.
+     * @param activation the materialized activation, when this action is one. The window half below
+     *   reads the *card*, which for an activation is its source permanent — a different and much
+     *   broader question than what the ability does, and the reason [activationVerdictFor] exists.
      */
     fun verdictFor(
         state: GameState,
         playerId: EntityId,
         cardName: String,
         cast: CastSpell? = null,
+        activation: ActivateAbility? = null,
     ): TimingVerdict {
+        // Asked first, and it can only ever return [TimingVerdict.NoWindow] or [TimingVerdict.
+        // Neutral], so with the flag off — or on any action that is not an activation — everything
+        // below is reached exactly as it was.
+        activationVerdictFor(state, playerId, cardName, activation)
+            .takeIf { it is TimingVerdict.NoWindow }
+            ?.let { return it }
+
         val intent = intents.forName(cardName) ?: return TimingVerdict.Neutral
 
         val window = windowVerdictFor(state, playerId, intent)
@@ -134,6 +148,33 @@ class HoldPolicy(
             0.0
         }
         return removal + counter
+    }
+
+    /**
+     * The window half for an **activated ability**, which the card-driven one below cannot ask.
+     *
+     * Kept as its own entry point rather than as a branch in [windowVerdictFor] because the two
+     * read different objects. That one reads the card, and for an activation the card is the source
+     * permanent — [CardIntentAnalyzer] types anything with a non-mana activated ability as
+     * [Speed.ACTIVATED], which the window half declines outright, so no branch there has ever seen
+     * an activation. This reads the *ability*: what it does, how long it lasts, and whether it can
+     * be paid for again later.
+     *
+     * A null lookup — the flag off, no card knowledge, or an ability granted by something other
+     * than the card itself — is "no information" and returns [TimingVerdict.Neutral], leaving the
+     * leaf score in charge exactly as before.
+     */
+    private fun activationVerdictFor(
+        state: GameState,
+        playerId: EntityId,
+        cardName: String,
+        activation: ActivateAbility?,
+    ): TimingVerdict {
+        if (!holdExpiringGrantsForCombat || activation == null) return TimingVerdict.Neutral
+        val ability = intents.activatedAbility(cardName, activation.abilityId)
+            ?: return TimingVerdict.Neutral
+        return if (ExpiringGrantWindow.holds(state, playerId, ability, intents)) TimingVerdict.NoWindow
+        else TimingVerdict.Neutral
     }
 
     /** The window half — "is this the moment?", which only an instant-speed card can get wrong. */
@@ -247,8 +288,8 @@ class HoldPolicy(
      * is only honest where "does nothing" is structurally certain, so a stack object this policy
      * cannot read — an unknown card, or a fight, whose reach is the other creature's power and not
      * a property of the card — keeps the old bonus rather than earning a veto. Which makes it
-     * load-bearing that [threatOn] reads *abilities* too, since a trigger on the stack is the
-     * commonest stack object there is.
+     * load-bearing that [IntentCatalog.forStackObject] reads *abilities* too, since a trigger on the
+     * stack is the commonest stack object there is.
      */
     private fun responseWindowFor(state: GameState, playerId: EntityId, pump: CardIntent): TimingVerdict {
         val projected = state.projectedState
@@ -256,7 +297,7 @@ class HoldPolicy(
 
         for (stackId in state.stack) {
             val container = state.getEntity(stackId) ?: continue
-            val threat = threatOn(container)
+            val threat = intents.forStackObject(container)
             if (threat == null || IntentTag.FIGHT in threat.tags) {
                 unreadable = true
                 continue
@@ -280,27 +321,6 @@ class HoldPolicy(
         }
 
         return if (unreadable) TimingVerdict.Adjust(RESPONSE_WINDOW) else TimingVerdict.NoWindow
-    }
-
-    /**
-     * What the stack object [container] threatens, or null when nothing here can be read.
-     *
-     * A spell is its card. An **ability** is its effect, which the stack object carries itself —
-     * it has no [CardComponent] at all — so it has to be read from there rather than from the
-     * permanent that produced it, which is a different and much broader question.
-     *
-     * Reading abilities is what keeps [responseWindowFor]'s "silence is not a veto" fallback
-     * honest. Without it every ability on the stack fell through as unreadable and bought a trick
-     * the full response bonus, so an ETB token trigger — or a "you may pay {B} to transform this"
-     * on the opponent's own main phase — paid the AI to dump a combat trick in a window where the
-     * pump provably wears off before any combat.
-     */
-    private fun threatOn(container: ComponentContainer): CardIntent? {
-        val ability = container.get<TriggeredAbilityOnStackComponent>()?.effect
-            ?: container.get<ActivatedAbilityOnStackComponent>()?.effect
-            ?: container.get<AbilityOnStackComponent>()?.effect
-        if (ability != null) return intents.forEffect(ability)
-        return container.get<CardComponent>()?.name?.let { intents.forName(it) }
     }
 
     /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/IntentCatalog.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/knowledge/IntentCatalog.kt
@@ -2,9 +2,15 @@ package com.wingedsheep.ai.engine.knowledge
 
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.state.components.stack.AbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.effects.Effect
 
 /**
@@ -83,6 +89,50 @@ class IntentCatalog private constructor(private val registry: CardRegistry?) {
 
     /** The intent of a definition already in hand. Always answers, even on [NONE]. */
     fun forCard(card: CardDefinition): CardIntent = CardIntentAnalyzer.analyze(card)
+
+    /**
+     * What the stack object [container] is doing, or null when nothing here can be read.
+     *
+     * A spell is its card. An **ability** is its effect, which the stack object carries itself — it
+     * has no [com.wingedsheep.engine.state.components.identity.CardComponent] at all — so it has to
+     * be read from there rather than from the permanent that produced it, which is a different and
+     * much broader question.
+     *
+     * Both readers of the stack want exactly this: [HoldPolicy]'s response window, to decide whether
+     * a trick has something it can answer, and [ExpiringGrantWindow]'s, to decide whether the thing
+     * on the stack is a reason not to defer. Null is "no information", and both treat it as a reason
+     * to decline rather than as "this object is harmless" — see each of their "silence is not a
+     * veto" notes.
+     */
+    fun forStackObject(container: ComponentContainer): CardIntent? {
+        val ability = container.get<TriggeredAbilityOnStackComponent>()?.effect
+            ?: container.get<ActivatedAbilityOnStackComponent>()?.effect
+            ?: container.get<AbilityOnStackComponent>()?.effect
+        if (ability != null) return forEffect(ability)
+        return container.get<CardComponent>()?.name?.let(::forName)
+    }
+
+    /**
+     * The ability with [abilityId] printed on the card called [cardName], or null when the catalog
+     * is off, the name is not a real card, or no face of it carries that ability.
+     *
+     * The one reader that wants the ability *itself* rather than a [CardIntent] of it, because
+     * [ExpiringGrantWindow] asks two questions no tag carries: how long the effect lasts, and
+     * whether the ability can be activated again later this turn.
+     *
+     * **Printed abilities only.** An ability *granted* to this permanent by something else — an
+     * Equipment, an Aura, a `GrantActivatedAbility` — is not on the card definition and answers
+     * null, as does a Class whose level gates which abilities exist. Both are the same "no
+     * information" every other lookup here returns, and every consumer must keep its pre-flag
+     * behaviour on it rather than reading it as "this ability does nothing".
+     */
+    fun activatedAbility(cardName: String, abilityId: AbilityId): ActivatedAbility? {
+        val definition = registry?.getCard(cardName) ?: return null
+        definition.script.activatedAbilities.find { it.id == abilityId }?.let { return it }
+        return definition.cardFaces.firstNotNullOfOrNull { face ->
+            face.script.activatedAbilities.find { it.id == abilityId }
+        }
+    }
 
     /**
      * The intent of one ability's [effect] — what a triggered or activated ability sitting on the

--- a/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/arena/ArenaAgent.kt
@@ -129,6 +129,12 @@ object ArenaAgents {
         // gate, against what players face today.
         ArenaAgent("production-ambush", AiProfile.PRODUCTION_AMBUSH),
         ArenaAgent("production-candidate-ambush", AiProfile.PRODUCTION_CANDIDATE_AMBUSH),
+        // Activated abilities whose payoff expires at cleanup, held for a window that can spend it.
+        // `just arena production production-expiring 300` prices the term on its own; `just arena
+        // production-candidate-counterpatience production-candidate-expiring 300` is the promotion
+        // gate, against what players face today.
+        ArenaAgent("production-expiring", AiProfile.PRODUCTION_EXPIRING),
+        ArenaAgent("production-candidate-expiring", AiProfile.PRODUCTION_CANDIDATE_EXPIRING),
         ArenaAgent("production-targeted", AiProfile.PRODUCTION_TARGETED),
         // Explicit ECL candidates. Their resource-backed weights fail closed to production's
         // evaluator until a validated artifact is installed; automatic selection is set-gated.

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/AiPuzzle.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/AiPuzzle.kt
@@ -179,6 +179,13 @@ class PuzzleMove internal constructor(
         }
     }
 
+    /** The "don't pay for it here" half of [shouldActivate] — see `instants-14`. */
+    fun shouldNotActivate(cardName: String) {
+        if (action is ActivateAbility && playedCard == cardName) {
+            fail("Expected NOT to activate $cardName")
+        }
+    }
+
     fun shouldPlayLand(landName: String? = null) {
         if (action !is PlayLand) fail("Expected to play a land")
         if (landName != null && playedCard != landName) fail("Expected to play $landName")

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleComparisonBenchmark.kt
@@ -100,6 +100,12 @@ class PuzzleComparisonBenchmark : ScenarioTestBase() {
                 // controls for haste, an ETB that clears a blocker, and the late-game release.
                 AiProfile.PRODUCTION_AMBUSH,
                 AiProfile.PRODUCTION_CANDIDATE_AMBUSH,
+                // Expiring grants held for a window that can spend them, alone and on top of what
+                // is live. `instants-14` is the verdict that should move; `instants-15` (the
+                // released window) and `instants-16` (a payoff that outlives the turn) are the
+                // negative controls and must not.
+                AiProfile.PRODUCTION_EXPIRING,
+                AiProfile.PRODUCTION_CANDIDATE_EXPIRING,
                 // Phase 7's rollout evaluator, isolated from Phases 4 and 6 so the column is
                 // attributable to the rollouts alone.
                 AiProfile.PHASE7,

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -36,7 +36,7 @@ class PuzzleSuiteTest : ScenarioTestBase() {
                     PuzzleCatalog.byCategory(category).size shouldBeGreaterThanOrEqual 6
                 }
             }
-            PuzzleCatalog.all.size shouldBe 92
+            PuzzleCatalog.all.size shouldBe 96
         }
 
         test("every KNOWN_FAILURES id names a real puzzle") {
@@ -224,6 +224,30 @@ class PuzzleSuiteTest : ScenarioTestBase() {
             // that taps a blocker before we attack) and `-13` (the same board as this one, past the
             // patience horizon).
             "instants-09",
+
+            // ── The expiring-grant window ──
+            // Olivia's Dragoon on the opponent's precombat main, off a real game: a card discarded
+            // to give a 2/2 flying, on a turn with no combat it can use and against a board with no
+            // flier to block. `BoardPresence` prices flying at `1.5 + power × 0.3` with no reading
+            // of whether it is evasive *now*, so the leaf scored the activation +2.35 over passing.
+            //
+            // Structurally it is `instants-06` — an expiring pump bought in a window that cannot
+            // spend it — with the text printed on a creature instead of an instant, and that is why
+            // the AI gets one right and the other wrong: `HoldPolicy` resolves an activation to its
+            // source permanent, `CardIntentAnalyzer` types that permanent `Speed.ACTIVATED`, and
+            // `windowVerdictFor` declines everything that is not `Speed.INSTANT` at its first line.
+            // No branch there has ever seen an activated ability.
+            //
+            // **Closed by `AiProfile.holdExpiringGrantsForCombat`**, unaided —
+            // `AiProfile.PRODUCTION_EXPIRING` closes it alone. Still listed here because
+            // [AiProfile.PRODUCTION] is the frozen baseline this set describes.
+            //
+            // Its three controls pass on this baseline and must keep passing: `instants-15` (the
+            // same ability at their declare-attackers, where the window is released and the block
+            // it buys is real), `instants-16` (the same board at a full hand, where the discard is
+            // the card cleanup was taking anyway) and `instants-17` (our own begin combat, the
+            // release that keeps the floor from talking the AI out of the attack).
+            "instants-14",
         )
     }
 }

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/HoldingInstantsPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/HoldingInstantsPuzzles.kt
@@ -288,5 +288,110 @@ object HoldingInstantsPuzzles {
             // Same position as `instants-09`, nine turns later.
             check = { shouldCast("Restoration Angel") },
         ),
+
+        AiPuzzle(
+            id = "instants-14",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Don't pitch a card for flying on their main phase — it expires before any combat",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withCardOnBattlefield(1, "Olivia's Dragoon")
+                    // The card the ability's cost would eat. No lands, so it is uncastable and the
+                    // activation is the only thing on offer besides passing.
+                    .withCardInHand(1, "Hill Giant")
+                    // A ground board across the table, so flying reads as real evasion to the
+                    // evaluator — `ThreatAssessment.evasivePower` pays for it against a defender
+                    // with no flier or reach. That is what makes this the strong version of the
+                    // position: the keyword is genuinely good, and still cannot be spent here.
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .build()
+                    .advanceToPriority(1, Step.PRECOMBAT_MAIN)
+            },
+            // Taken from a real game (turn 4, their precombat main, a Battleground Geist discarded
+            // to give a summoning-sick 2/2 flying). `BoardPresence` prices flying at 1.5 + power ×
+            // 0.3 with no reading of whether it is evasive *now*, so the leaf scored the activation
+            // +2.35 over passing. The identical text on an instant is `instants-06`, which the AI
+            // already gets right — the ability path had no window verdict at all.
+            check = { shouldNotActivate("Olivia's Dragoon") },
+        ),
+
+        AiPuzzle(
+            id = "instants-15",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "They attacked with a flier — now the flying is worth a card, so buy it",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withCardOnBattlefield(1, "Olivia's Dragoon")
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Wind Drake")
+                    .withLandsOnBattlefield(2, "Island", 4)
+                    .build()
+                    .advanceToDeclaration(2, Step.DECLARE_ATTACKERS)
+                    .also { it.declareAttackers(mapOf("Wind Drake" to 1)) }
+                    .advanceToPriority(1, Step.DECLARE_ATTACKERS)
+            },
+            // The positive half, and the same argument `instants-10` makes for the ambush: a
+            // category of "don't activate" positions scores 100% for an agent that never activates
+            // anything. This is the window the floor releases at, and the last one that can still
+            // change a block (CR 509.1a) — the 2/2 blocks the Drake only if it has flying now.
+            check = { shouldActivate("Olivia's Dragoon") },
+        ),
+
+        AiPuzzle(
+            id = "instants-16",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "At a full hand the discard is free — the cleanup step was taking that card anyway",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withActivePlayer(2)
+                    .withCardOnBattlefield(1, "Olivia's Dragoon")
+                    .withCardInHand(1, "Hill Giant")
+                    .withCardInHand(1, "Craw Wurm")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Llanowar Elves")
+                    .withCardInHand(1, "Trained Armodon")
+                    .withCardInHand(1, "Wind Drake")
+                    .withCardInHand(1, "Giant Spider")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .build()
+                    .advanceToPriority(1, Step.PRECOMBAT_MAIN)
+            },
+            // `instants-14`'s board with a hand at `MaximumHandSize.DEFAULT`, which is the release
+            // that matters most for this shape: the commonest cost on an expiring grant is a
+            // discard, and at seven cards the card being pitched is the one cleanup takes. Held
+            // apart from the other two `Patience` exits because those are shared with every policy
+            // and this is the one that turns *this* ability's cost to zero.
+            check = { shouldActivate("Olivia's Dragoon") },
+        ),
+
+        AiPuzzle(
+            id = "instants-17",
+            category = PuzzleCategory.HOLDING_INSTANTS,
+            expectation = "Our own begin-combat: buy the flying now, or the attack is declared without it",
+            aiSeat = 1,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Olivia's Dragoon")
+                    .withCardInHand(1, "Hill Giant")
+                    // The blocker the flying is for: a 3/3 eats the 2/2 on the ground and cannot
+                    // touch it in the air.
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .build()
+                    .advanceToPriority(1, Step.BEGIN_COMBAT)
+            },
+            // The asymmetry guard, and the reason the deadline is a step earlier on our own turn:
+            // we declare attackers *in* `DECLARE_ATTACKERS` and only get priority there afterwards,
+            // and `CombatAdvisor` reads the board as it stands. A floor that held to the same step
+            // it holds to on their turn would keep the 2/2 home and then have nothing to spend the
+            // grant on — the line thrown away by protecting it.
+            check = { shouldActivate("Olivia's Dragoon") },
+        ),
     )
 }


### PR DESCRIPTION
## The position

Off a real game (AI insight sample, turn 4): the **opponent's** precombat main, an Olivia's Dragoon
(`Discard a card: This creature gains flying until end of turn`) that entered last turn, and the AI
discards a Battleground Geist to give it flying. No combat it can attack in, no flier across the
table to block, keyword gone at cleanup. A card for nothing — scored **+2.35 over passing**.

## Why it happened

Two separate things, and only one of them is a bad number.

**1. The structural gap.** `HoldPolicy.verdictFor` resolves an activation to its *source permanent's*
name, and `CardIntentAnalyzer` types any permanent carrying a non-mana activated ability as
`Speed.ACTIVATED` — which `windowVerdictFor` declines at its first line. So the `COMBAT_TRICK`
branch, whose entire subject is *"a pump wears off at cleanup, so it is worth casting only when
something will use it before then"*, has been **unreachable for every ability in the catalog**. The
AI gets `instants-06` right for a Giant Growth and wrong for the identical text printed on a
creature.

**2. The score.** `BoardPresence.creatureBodyValue` prices flying at `1.5 + power × 0.3` (2.1 raw,
×1.5 board weight = 3.15) with no reading of whether it is evasive *now* — the same fact
`ThreatAssessment.evasivePower` reads correctly two features over, where the summoning-sick Dragoon
contributes zero — and `CardAdvantage` charges the discarded card the 4th-card marginal, 0.8.
Neither constant is defensibly wrong on its own, so this PR leaves the weights alone and fixes the
window.

## The change

`ExpiringGrantWindow` follows `AmbushWindow`'s shape: a `TimingVerdict.NoWindow` floor on a
**dominance** claim rather than a discount. The claim is stronger here than for a card in hand — an
ability is not a resource that can be stripped, so it is provably still available later at the same
cost with strictly more information.

Three guards, any one of which hands the decision straight back to the leaf score:

- **Every payoff expires at end of turn.** A `-2/-2` is removal with a duration on it — the modifier
  expires, the creature it killed does not — so it counts as permanent, the same line
  `CardIntentAnalyzer` draws one file over.
- **Instant-speed, with a window still ahead.** The deadline is **one step earlier on our own turn
  than on theirs**: we declare attackers *in* `DECLARE_ATTACKERS` and only receive priority there
  afterwards, so a floor held past begin-combat would throw away the attack it was protecting.
- **Nothing on the stack threatens our board** — reading both where stack objects point *and* what
  they are, because the shape that most needs the release (a sweeper) names no target at all.

Plus `Patience`'s three releases inherited whole; the hand-size one matters most here, since the
commonest cost on this ability shape is a discard.

`IntentCatalog.forStackObject` is extracted from `HoldPolicy.threatOn`, now that both stack readers
want it.

## Measurement

Behind `AiProfile.holdExpiringGrantsForCombat`, measured on both the isolation and promotion columns:

| | puzzles | delta |
|---|---|---|
| `production` → `production-expiring` | 81/96 → **82/96** | +1 (`instants-14`), every other category byte-identical |
| live `…counterpatience` → `…expiring` | 91/96 → **92/96** | +1, every other category byte-identical |
| arena, 100 games BLB sealed | **50.0%, CI [50.0%, 50.0%]** | 100/100 completed, 0 illegal actions, every pair 1-1-0 |

Four puzzles: `instants-14` is the blunder, `-15` the released window at their declare-attackers,
`-16` the full-hand release, `-17` our own begin-combat release that keeps the attack.

Promoted to `EngineAiPlayerController` (stacked on `PRODUCTION_CANDIDATE_COUNTERPATIENCE`, what
players actually face — the ambush flag's own promotion never reached that call site, so it stays
off and unchanged).

## Two things to be straight about

- **The arena is evidence of no regression, not of gain.** Every pair returning exactly 1-1-0 means
  the term never fired across 100 BLB sealed games — it needs an instant-speed expiring-grant ability
  held in a pre-combat window, and BLB has few. The evidence for the gain is the puzzle side and the
  game it was taken from, which was neither BLB nor sealed. Same degenerate null the ambush term got.
- **The sweeper clause has no puzzle.** It needs a card granting indestructible via a cheap
  instant-speed ability (Selfless Spirit shape), which is not in the catalog. It rests on its
  rationale plus the `respond` category as a regression net.

## Verification

`just test-ai` green, `just arena-puzzles` green (failing set equals `KNOWN_FAILURES`),
`:game-server:compileKotlin` green. No SDK, engine, card or client changes, so no card snapshots or
lint to re-bless and no `card-sdk-language-reference.md` update is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)