### PR TITLE
Add six The Hobbit cards: tapland cycle tail, Stir Up Trouble, Plunder the Trollshaws

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ElvenkingsHalls.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ElvenkingsHalls.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Elvenking's Halls — The Hobbit #182
+ * Land · Common
+ *
+ * This land enters tapped.
+ * {T}: Add {G} or {U}.
+ * {2}{G}{U}, {T}, Sacrifice this land: Put two +1/+1 counters on target Elf you control.
+ * Activate only as a sorcery.
+ *
+ * The Elf member of the HOB tapland cycle; see [IronHills] for the shape.
+ */
+val ElvenkingsHalls = card("Elvenking's Halls") {
+    manaCost = ""
+    colorIdentity = "GU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {G} or {U}.\n" +
+        "{2}{G}{U}, {T}, Sacrifice this land: Put two +1/+1 counters on target Elf you control. " +
+        "Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{G}{U}"), Costs.Tap, Costs.SacrificeSelf)
+        val elf = target(
+            "target Elf you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.ELF))
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, elf)
+        timing = TimingRule.SorcerySpeed
+        description = "Put two +1/+1 counters on target Elf you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Leon Tukker"
+        flavorText = "Elf-guards sang as they marched along the twisting, crossing, and echoing paths."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd477096-41b1-4907-9cb3-852cb22c9ba2.jpg?1785323590"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GoblinTown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GoblinTown.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Goblin-town — The Hobbit #183
+ * Land · Common
+ *
+ * This land enters tapped.
+ * {T}: Add {B} or {R}.
+ * {2}{B}{R}, {T}, Sacrifice this land: Put two +1/+1 counters on target Goblin or Orc you control.
+ * Activate only as a sorcery.
+ *
+ * The Goblin/Orc member of the HOB tapland cycle; see [IronHills] for the shape. The two-tribe
+ * clause is one target with an OR over subtypes ([GameObjectFilter.withAnySubtype]), not two
+ * targets — a creature that is both still only satisfies the single requirement once.
+ */
+val GoblinTown = card("Goblin-town") {
+    manaCost = ""
+    colorIdentity = "BR"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {B} or {R}.\n" +
+        "{2}{B}{R}, {T}, Sacrifice this land: Put two +1/+1 counters on target Goblin or Orc you " +
+        "control. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}{R}"), Costs.Tap, Costs.SacrificeSelf)
+        val goblinOrOrc = target(
+            "target Goblin or Orc you control",
+            TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.youControl().withAnySubtype("Goblin", "Orc")
+                )
+            )
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, goblinOrOrc)
+        timing = TimingRule.SorcerySpeed
+        description = "Put two +1/+1 counters on target Goblin or Orc you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "183"
+        artist = "Sean Vo"
+        flavorText = "The passages were crossed and tangled in all directions, and it was most " +
+            "horribly stuffy."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d76df9d0-56cf-4351-a5e8-e6ae6fc791d1.jpg?1785323613"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LakeTown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LakeTown.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Lake-town — The Hobbit #186
+ * Land · Common
+ *
+ * This land enters tapped.
+ * {T}: Add {W} or {U}.
+ * {2}{W}{U}, {T}, Sacrifice this land: Put two +1/+1 counters on target Human you control.
+ * Activate only as a sorcery.
+ *
+ * The Human member of the HOB tapland cycle; see [IronHills] for the shape. "Add {W} or {U}" is two
+ * separate mana abilities (one per color) rather than a choice on resolution, matching every other
+ * dual tapland in the engine.
+ */
+val LakeTown = card("Lake-town") {
+    manaCost = ""
+    colorIdentity = "WU"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {W} or {U}.\n" +
+        "{2}{W}{U}, {T}, Sacrifice this land: Put two +1/+1 counters on target Human you control. " +
+        "Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{W}{U}"), Costs.Tap, Costs.SacrificeSelf)
+        val human = target(
+            "target Human you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.HUMAN))
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, human)
+        timing = TimingRule.SorcerySpeed
+        description = "Put two +1/+1 counters on target Human you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Marina Ortega Lorente"
+        flavorText = "The Elves spoke of a strange town built right on the surface of the Long Lake, " +
+            "under the shadow of the Dragon-mountain."
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2fbd0584-81a7-4c47-8af1-1c8635899a97.jpg?1785323601"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/Mirkwood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/Mirkwood.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Mirkwood — The Hobbit #188
+ * Land · Common
+ *
+ * This land enters tapped.
+ * {T}: Add {B} or {G}.
+ * {2}{B}{G}, {T}, Sacrifice this land: Put two +1/+1 counters on target Bear, Spider, or Wolf you
+ * control. Activate only as a sorcery.
+ *
+ * The Bear/Spider/Wolf member of the HOB tapland cycle; see [IronHills] for the shape and
+ * [GoblinTown] for the multi-tribe target.
+ */
+val Mirkwood = card("Mirkwood") {
+    manaCost = ""
+    colorIdentity = "BG"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {B} or {G}.\n" +
+        "{2}{B}{G}, {T}, Sacrifice this land: Put two +1/+1 counters on target Bear, Spider, or " +
+        "Wolf you control. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{B}{G}"), Costs.Tap, Costs.SacrificeSelf)
+        val beast = target(
+            "target Bear, Spider, or Wolf you control",
+            TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.youControl().withAnySubtype("Bear", "Spider", "Wolf")
+                )
+            )
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, beast)
+        timing = TimingRule.SorcerySpeed
+        description = "Put two +1/+1 counters on target Bear, Spider, or Wolf you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "188"
+        artist = "Leon Tukker"
+        flavorText = "\"Stick to the forest-track, keep your spirits up, and hope for the best.\"\n" +
+            "—Gandalf"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/612cf954-f86c-4629-99df-4874d56fded3.jpg?1785323344"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/PlunderTheTrollshaws.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/PlunderTheTrollshaws.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Plunder the Trollshaws — The Hobbit #51
+ * {1}{U} · Instant · Common
+ *
+ * Draw a card. If this spell was cast from a graveyard, draw two cards instead.
+ * Flashback {3}{U}
+ *
+ * "Instead" replaces the whole draw, so this is one branch or the other — a [ConditionalEffect] with
+ * an else branch (draw two / draw one), not "draw one, then draw one more". Flashback is the only
+ * way this card is normally cast from a graveyard, but [Conditions.WasCastFromGraveyard] reads the
+ * cast-time zone stamp rather than the flashback marker, so any other graveyard-cast permission
+ * (Yawgmoth's Will and friends) also turns on the bonus, exactly as printed.
+ */
+val PlunderTheTrollshaws = card("Plunder the Trollshaws") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw a card. If this spell was cast from a graveyard, draw two cards instead.\n" +
+        "Flashback {3}{U} (You may cast this card from your graveyard for its flashback cost. " +
+        "Then exile it.)"
+
+    spell {
+        effect = ConditionalEffect(
+            condition = Conditions.WasCastFromGraveyard,
+            effect = Effects.DrawCards(2),
+            elseEffect = Effects.DrawCards(1)
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{3}{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Alexander Mokhov"
+        flavorText = "The swords caught their eyes particularly, because of their beautiful " +
+            "scabbards and jeweled hilts."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afb73190-b9bd-4744-a011-a37cd9c0148d.jpg?1785496438"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StirUpTrouble.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StirUpTrouble.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stir Up Trouble — The Hobbit #84
+ * {B} · Sorcery · Common
+ *
+ * As an additional cost to cast this spell, sacrifice an artifact or creature or pay {4}.
+ * Destroy target creature.
+ *
+ * The additional cost is the "sacrifice or pay {N}" shape ([Costs.additional.SacrificeOrPay]) — the
+ * cast-path enumerator offers both branches and drops the sacrifice branch when you control no
+ * artifact or creature, so a player with an empty board can still cast this for {4}{B}.
+ */
+val StirUpTrouble = card("Stir Up Trouble") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice an artifact or creature or " +
+        "pay {4}.\n" +
+        "Destroy target creature."
+
+    additionalCost(
+        Costs.additional.SacrificeOrPay(
+            filter = GameObjectFilter.CreatureOrArtifact,
+            alternativeManaCost = "{4}",
+        )
+    )
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Andreia Ugrai"
+        flavorText = "\"I will prepare something particularly uncomfortable for you, Thorin " +
+            "Oakenshield!\"\n—The Great Goblin"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd145e3a-c889-4390-accb-863dbcc845ce.jpg?1785497107"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1253,6 +1253,88 @@
     ]
 }
 
+// Elvenking's Halls
+{
+    "name": "Elvenking's Halls",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {G} or {U}.\n{2}{G}{U}, {T}, Sacrifice this land: Put two +1/+1 counters on target Elf you control. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{G}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Elf you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Elf ctrl:you"
+                        },
+                        "id": "target Elf you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Put two +1/+1 counters on target Elf you control."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Leon Tukker",
+        "flavorText": "Elf-guards sang as they marched along the twisting, crossing, and echoing paths.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd477096-41b1-4907-9cb3-852cb22c9ba2.jpg?1785323590"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Elvenking's Harper
 {
     "name": "Elvenking's Harper",
@@ -1809,6 +1891,88 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Goblin-town
+{
+    "name": "Goblin-town",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {B} or {R}.\n{2}{B}{R}, {T}, Sacrifice this land: Put two +1/+1 counters on target Goblin or Orc you control. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Goblin or Orc you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Goblin|Orc ctrl:you"
+                        },
+                        "id": "target Goblin or Orc you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Put two +1/+1 counters on target Goblin or Orc you control."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "artist": "Sean Vo",
+        "flavorText": "The passages were crossed and tangled in all directions, and it was most horribly stuffy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d76df9d0-56cf-4351-a5e8-e6ae6fc791d1.jpg?1785323613"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -2371,6 +2535,88 @@
     ]
 }
 
+// Lake-town
+{
+    "name": "Lake-town",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {W} or {U}.\n{2}{W}{U}, {T}, Sacrifice this land: Put two +1/+1 counters on target Human you control. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Human you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Human ctrl:you"
+                        },
+                        "id": "target Human you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Put two +1/+1 counters on target Human you control."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Marina Ortega Lorente",
+        "flavorText": "The Elves spoke of a strange town built right on the surface of the Long Lake, under the shadow of the Dragon-mountain.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2fbd0584-81a7-4c47-8af1-1c8635899a97.jpg?1785323601"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Lake-town Toymaker
 {
     "name": "Lake-town Toymaker",
@@ -2683,6 +2929,88 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Mirkwood
+{
+    "name": "Mirkwood",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\n{T}: Add {B} or {G}.\n{2}{B}{G}, {T}, Sacrifice this land: Put two +1/+1 counters on target Bear, Spider, or Wolf you control. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Bear, Spider, or Wolf you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Bear|Spider|Wolf ctrl:you"
+                        },
+                        "id": "target Bear, Spider, or Wolf you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Put two +1/+1 counters on target Bear, Spider, or Wolf you control."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "artist": "Leon Tukker",
+        "flavorText": "\"Stick to the forest-track, keep your spirits up, and hope for the best.\"\n—Gandalf",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/612cf954-f86c-4629-99df-4874d56fded3.jpg?1785323344"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -3393,6 +3721,58 @@
     ]
 }
 
+// Plunder the Trollshaws
+{
+    "name": "Plunder the Trollshaws",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Draw a card. If this spell was cast from a graveyard, draw two cards instead.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{3}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "WasCastFromZone",
+                    "zone": "Graveyard"
+                }
+            },
+            "then": {
+                "type": "DrawCards",
+                "count": {
+                    "type": "Fixed",
+                    "amount": 2
+                }
+            },
+            "otherwise": {
+                "type": "DrawCards",
+                "count": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Alexander Mokhov",
+        "flavorText": "The swords caught their eyes particularly, because of their beautiful scabbards and jeweled hilts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afb73190-b9bd-4744-a011-a37cd9c0148d.jpg?1785496438"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Quarrel
 {
     "name": "Quarrel",
@@ -3869,6 +4249,55 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Stir Up Trouble
+{
+    "name": "Stir Up Trouble",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice an artifact or creature or pay {4}.\nDestroy target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "OrPay",
+                "cost": {
+                    "type": "AdditionalAtom",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature|artifact"
+                    }
+                },
+                "alternativeManaCost": "{4}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Andreia Ugrai",
+        "flavorText": "\"I will prepare something particularly uncomfortable for you, Thorin Oakenshield!\"\n—The Great Goblin",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd145e3a-c889-4390-accb-863dbcc845ce.jpg?1785497107"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinTownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinTownScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Goblin-town (HOB #183) — Land.
+ *
+ * "{T}: Add {B} or {R}.
+ *  {2}{B}{R}, {T}, Sacrifice this land: Put two +1/+1 counters on target Goblin or Orc you control.
+ *  Activate only as a sorcery."
+ *
+ * The sacrifice ability is the only new shape in the HOB tapland cycle: a *single* target with an
+ * OR over two subtypes. This proves both legs are legal and that a creature of neither type is not,
+ * so the OR didn't collapse into "creature you control".
+ */
+class GoblinTownScenarioTest : ScenarioTestBase() {
+
+    // Vanilla proof creatures — nothing that could confound the target check.
+    private val testGoblin = card("Goblin-town Test Goblin") {
+        manaCost = "{R}"
+        typeLine = "Creature — Goblin"
+        power = 1
+        toughness = 1
+    }
+    private val testOrc = card("Goblin-town Test Orc") {
+        manaCost = "{B}"
+        typeLine = "Creature — Orc"
+        power = 1
+        toughness = 1
+    }
+    private val testBear = card("Goblin-town Test Bear") {
+        manaCost = "{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    init {
+        cardRegistry.register(listOf(testGoblin, testOrc, testBear))
+
+        context("Goblin-town") {
+
+            test("the sacrifice ability puts two +1/+1 counters on a Goblin you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Goblin-town")
+                    .withCardOnBattlefield(1, "Goblin-town Test Goblin")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val land = game.findPermanent("Goblin-town")!!
+                val goblin = game.findPermanent("Goblin-town Test Goblin")!!
+                // ability_1 / ability_2 are the two mana abilities; ability_3 is the sacrifice one.
+                val pump = cardRegistry.requireCard("Goblin-town").activatedAbilities.last().id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = land,
+                        abilityId = pump,
+                        targets = listOf(ChosenTarget.Permanent(goblin)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Goblin got two +1/+1 counters") {
+                    game.state.getEntity(goblin)
+                        ?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+                withClue("the sacrifice cost consumed the land") {
+                    game.findPermanent("Goblin-town") shouldBe null
+                    game.isInGraveyard(1, "Goblin-town") shouldBe true
+                }
+            }
+
+            test("an Orc is a legal target but a creature of neither type is not") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Goblin-town")
+                    .withCardOnBattlefield(1, "Goblin-town Test Orc")
+                    .withCardOnBattlefield(1, "Goblin-town Test Bear")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val orc = game.findPermanent("Goblin-town Test Orc")!!
+                val bear = game.findPermanent("Goblin-town Test Bear")!!
+
+                val pumpAction = game.getLegalActions(1)
+                    .first { it.description.contains("+1/+1 counters") }
+                val validTargets = pumpAction.validTargets
+
+                withClue("the Orc leg of the OR is legal") {
+                    validTargets!! shouldContain orc
+                }
+                withClue("a Bear satisfies neither subtype") {
+                    validTargets!! shouldNotContain bear
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlunderTheTrollshawsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlunderTheTrollshawsScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Plunder the Trollshaws (HOB #51) — {1}{U} Instant.
+ *
+ * "Draw a card. If this spell was cast from a graveyard, draw two cards instead.
+ *  Flashback {3}{U}"
+ *
+ * "Instead" replaces the whole draw, so the graveyard cast must draw *two*, not three — the mistake
+ * a "draw one, then draw one more" model would make. The flashback leg also has to exile the card
+ * afterwards rather than return it to the graveyard.
+ */
+class PlunderTheTrollshawsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Plunder the Trollshaws") {
+
+            test("cast from hand draws exactly one card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Plunder the Trollshaws")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.state.getLibrary(game.player1Id).size
+
+                game.castSpell(1, "Plunder the Trollshaws").error shouldBe null
+                game.resolveStack()
+
+                withClue("one card drawn on a hand cast") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libraryBefore - 1
+                    game.handSize(1) shouldBe 1
+                }
+                withClue("a normal cast puts it into the graveyard, not exile") {
+                    game.isInGraveyard(1, "Plunder the Trollshaws") shouldBe true
+                }
+            }
+
+            test("flashback from the graveyard draws two cards instead and exiles the card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Plunder the Trollshaws")
+                    .withLandsOnBattlefield(1, "Island", 4) // Flashback {3}{U}
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libraryBefore = game.state.getLibrary(game.player1Id).size
+
+                game.castSpellFromGraveyard(1, "Plunder the Trollshaws").error shouldBe null
+                game.resolveStack()
+
+                withClue("'instead' means two, not one and not three") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libraryBefore - 2
+                    game.handSize(1) shouldBe 2
+                }
+                withClue("flashback exiles the card afterwards") {
+                    game.isInExile(1, "Plunder the Trollshaws") shouldBe true
+                    game.isInGraveyard(1, "Plunder the Trollshaws") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StirUpTroubleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StirUpTroubleScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Stir Up Trouble (HOB #84) — {B} Sorcery.
+ *
+ * "As an additional cost to cast this spell, sacrifice an artifact or creature or pay {4}.
+ *  Destroy target creature."
+ *
+ * Exercises both legs of the sacrifice-or-pay additional cost. The sacrifice filter is "artifact
+ * **or** creature", so an artifact alone is a legal payment — the case a plain "sacrifice a
+ * creature" model would get wrong — and with no artifact and no creature the pay path must still
+ * be offered so the spell is castable off an empty board.
+ */
+class StirUpTroubleScenarioTest : ScenarioTestBase() {
+
+    private val testRelic = card("Stir Up Test Relic") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+    }
+    private val testBear = card("Stir Up Test Bear") {
+        manaCost = "{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    init {
+        cardRegistry.register(listOf(testRelic, testBear))
+
+        context("sacrifice-or-pay additional cost") {
+
+            test("sacrificing an artifact pays the additional cost and destroys the target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stir Up Trouble")
+                    .withCardOnBattlefield(1, "Stir Up Test Relic")
+                    .withLandsOnBattlefield(1, "Swamp", 1) // only {B} — the pay path is unaffordable
+                    .withCardOnBattlefield(2, "Stir Up Test Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val relic = game.findPermanent("Stir Up Test Relic")!!
+                val bear = game.findPermanent("Stir Up Test Bear")!!
+                val spell = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Stir Up Trouble"
+                }
+
+                val result = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        spell,
+                        listOf(ChosenTarget.Permanent(bear)),
+                        additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(relic)),
+                    )
+                )
+                withClue("an artifact should satisfy 'sacrifice an artifact or creature': ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("the artifact was sacrificed as a cost") {
+                    game.isInGraveyard(1, "Stir Up Test Relic") shouldBe true
+                }
+
+                game.resolveStack()
+
+                withClue("the targeted creature is destroyed") {
+                    game.isOnBattlefield("Stir Up Test Bear") shouldBe false
+                    game.isInGraveyard(2, "Stir Up Test Bear") shouldBe true
+                }
+            }
+
+            test("the pay path casts it off an empty board for {4}{B}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stir Up Trouble")
+                    .withLandsOnBattlefield(1, "Swamp", 5) // {B} + {4}
+                    .withCardOnBattlefield(2, "Stir Up Test Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Stir Up Test Bear")!!
+
+                withClue("no sacrifice payment — the engine adds {4} to the cost") {
+                    game.castSpell(1, "Stir Up Trouble", bear).error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the targeted creature is destroyed") {
+                    game.isInGraveyard(2, "Stir Up Test Bear") shouldBe true
+                }
+            }
+
+            test("one Swamp and nothing to sacrifice leaves it uncastable") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stir Up Trouble")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardOnBattlefield(2, "Stir Up Test Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("neither leg of the additional cost is payable") {
+                    game.getLegalActions(1)
+                        .none { it.description.startsWith("Cast Stir Up Trouble") } shouldBe true
+                }
+
+                val bear = game.findPermanent("Stir Up Test Bear")!!
+                withClue("and casting it anyway is rejected") {
+                    game.castSpell(1, "Stir Up Trouble", bear).error shouldNotBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements six cards from The Hobbit (HOB), all canonical in HOB (brand-new set, no earlier printings — `just check-card-printing` clean for all six).

## The tapland cycle tail

Iron Hills was already in; this completes the cycle. Each land is two separate mana abilities (one per color, matching every other dual tapland in the engine) plus a sorcery-speed `{2}{C}{C}, {T}, Sacrifice this land` ability putting two +1/+1 counters on a tribal target.

| Card | Colors | Target |
|---|---|---|
| Lake-town | {W}/{U} | Human |
| Goblin-town | {B}/{R} | Goblin **or** Orc |
| Mirkwood | {B}/{G} | Bear, Spider, **or** Wolf |
| Elvenking's Halls | {G}/{U} | Elf |

The multi-tribe wording is a *single* target with an OR over subtypes (`GameObjectFilter.withAnySubtype`), not two targets and not a collapsed "creature you control".

## Stir Up Trouble — {B} Sorcery

> As an additional cost to cast this spell, sacrifice an artifact or creature or pay {4}.
> Destroy target creature.

Uses the existing `Costs.additional.SacrificeOrPay` over `GameObjectFilter.CreatureOrArtifact` with alternative `{4}`. The cast-path enumerator offers both legs and drops the sacrifice leg when you control neither, so the spell stays castable for `{4}{B}` off an empty board.

## Plunder the Trollshaws — {1}{U} Instant

> Draw a card. If this spell was cast from a graveyard, draw two cards instead.
> Flashback {3}{U}

"Instead" replaces the whole draw, so this is a `ConditionalEffect` with an else branch (draw two / draw one), not "draw one, then draw one more". The condition is `Conditions.WasCastFromGraveyard`, which reads the cast-time zone stamp rather than the flashback marker — so any other graveyard-cast permission also turns the bonus on, exactly as printed.

## Scope

No new SDK vocabulary — everything composes existing primitives, so `docs/card-sdk-language-reference.md` needs no change. No new decision UI either: the lands use the existing activated-ability button plus battlefield targeting, Stir Up Trouble rides the same two-cast-path rail as Eaten Alive / Louisoix's Sacrifice, and Plunder raises no decisions.

## Tests

Three scenario tests, one per card, covering only the shapes that could silently resolve wrong:

- `GoblinTownScenarioTest` — the sacrifice ability lands two counters and consumes the land; an Orc is a legal target and a Bear is not (the OR didn't collapse).
- `StirUpTroubleScenarioTest` — the artifact leg of the sacrifice pays the cost (the case a "sacrifice a creature" model gets wrong), the pay path works off an empty board, and one Swamp with nothing to sacrifice leaves it uncastable.
- `PlunderTheTrollshawsScenarioTest` — hand cast draws exactly one, flashback draws exactly two (not three) and exiles the card.

## Verification

- `just build` green.
- Card snapshot re-blessed; diff confirms **only these six cards** moved in `HOB.json`.
- `just check-card-printing` clean for all six.
- Every printed field (name, mana cost, type line, oracle text, collector number, artist, flavor text, image URI) re-checked field-by-field against Scryfall; all image URIs return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
