### PR TITLE
Add five Murders at Karlov Manor cards with suspected-status support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3298,6 +3298,14 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   doesn't matter who controlled the permanent when the damage landed, or whether it was on the battlefield
   then. Same lifetime and source-relative caveats as its mirror.
 - `.saddled()` — permanent is saddled (CR 702.171b); backed by `StatePredicate.IsSaddled`.
+- `.suspected()` — permanent is suspected (CR 701.60a); backed by `StatePredicate.IsSuspected`. Unlike
+  saddled it has **no duration** — a suspected permanent stays suspected until it changes zones. The
+  designation is a Layer-ability floating effect (`SerializableModification.SetSuspected`) surfaced as
+  `ProjectedState.isSuspected`, not a component, so it is read from the projection; trigger gating and
+  `SetSuspectedExecutor`'s CR 701.60d dedup share the raw-state reading in
+  `handlers/predicates/SuspectedPredicate.kt`. Asks specifically "is it suspected", not "does it have
+  menace" — the menace and can't-block halves of `Effects.Suspect` are separate sub-effects, so a
+  creature given menace some other way does not match.
 - `.crewedOrSaddledSourceThisTurn()` — source-relative: creature crewed (CR 702.122) or saddled
   (CR 702.171) the effect's source permanent this turn; backed by
   `StatePredicate.CrewedOrSaddledSourceThisTurn` (see Object-state predicates). For
@@ -7283,6 +7291,11 @@ that works in both resolution and static-ability (projection) contexts.
 - `SourceEnteredThisTurn` — source entered the battlefield this turn.
 - `SourceIsSaddled` — source is saddled (CR 702.171b). Gates Mount payoffs on "while saddled" /
   "as long as it's saddled"; evaluates identically at resolution and during projection.
+- `SourceIsSuspected` — source is suspected (CR 701.60a). Wrap in `Conditions.Not(…)` for the
+  "if it's **not** suspected" intervening-if on MKM's self-suspecting attack triggers
+  (**Rubblebelt Braggart**) — because a suspected permanent can't become suspected again
+  (CR 701.60d), the check is what stops the trigger going on the stack, rather than letting the
+  player click through a "may" that could never do anything.
 - `SourceAttackedThisTurn` — source was declared as an attacker at least once during the
   current turn (per-creature, derived from the controller's `PlayerAttackersThisTurnComponent`).
   Negate via `Conditions.Not(...)` for Erg Raiders-style "if it didn't attack this turn".

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1052,6 +1052,15 @@ object Conditions {
     val SourceIsSaddled: ConditionInterface =
         SourceMatches(com.wingedsheep.sdk.scripting.GameObjectFilter.Any.saddled())
 
+    /**
+     * If this permanent is suspected (CR 701.60a). Negate it with [Not] for the "if it's **not**
+     * suspected" intervening-if that guards MKM's self-suspecting attack triggers (Rubblebelt
+     * Braggart) — a suspected permanent can't become suspected again (CR 701.60d), so the check
+     * is what stops the trigger from going on the stack at all.
+     */
+    val SourceIsSuspected: ConditionInterface =
+        SourceMatches(com.wingedsheep.sdk.scripting.GameObjectFilter.Any.suspected())
+
     /** If this creature is soulbond-paired with another creature (CR 702.95b). */
     val SourceIsPaired: ConditionInterface =
         SourceMatches(com.wingedsheep.sdk.scripting.GameObjectFilter.Any.paired())

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -919,6 +919,11 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.IsSaddled
     )
 
+    /** Must be suspected (CR 701.60a) — see [StatePredicate.IsSuspected]. */
+    fun suspected() = copy(
+        statePredicates = statePredicates + StatePredicate.IsSuspected
+    )
+
     /**
      * Must have crewed (CR 702.122) or saddled (CR 702.171) the effect's source permanent this
      * turn. Source-relative — see [StatePredicate.CrewedOrSaddledSourceThisTurn].

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -574,6 +574,30 @@ sealed interface StatePredicate {
     }
 
     // =============================================================================
+    // Suspect (Entity)
+    // =============================================================================
+
+    /**
+     * Permanent that is currently suspected (CR 701.60a, Murders at Karlov Manor). A named
+     * designation applied by `Effects.Suspect`; unlike saddled it has **no duration** — a
+     * suspected permanent stays suspected until it loses the designation or changes zones.
+     *
+     * Projected, not component-backed: the designation rides a Layer-ability floating effect
+     * (`SerializableModification.SetSuspected`) and surfaces as `ProjectedState.isSuspected`,
+     * so evaluators must read the projection rather than probing for a component.
+     *
+     * Menace and "can't block" are separate sub-effects of the same composite, so this predicate
+     * asks specifically "is it suspected", not "does it have menace" — which is what cards that
+     * read the designation back need ("if it's not suspected", "target suspected creature you
+     * control", "if the sacrificed creature was suspected").
+     */
+    @SerialName("IsSuspected")
+    @Serializable
+    data object IsSuspected : Entity {
+        override val description: String = "suspected"
+    }
+
+    // =============================================================================
     // Saddle (Entity)
     // =============================================================================
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CuriousCadaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CuriousCadaver.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Curious Cadaver — Murders at Karlov Manor #194
+ * {2}{U}{B} · Creature — Zombie Detective · 3/1
+ *
+ * Flying
+ * When you sacrifice a Clue, return this card from your graveyard to your hand.
+ *
+ * The recursion ability functions **only** from the graveyard (`triggerZone = Zone.GRAVEYARD`,
+ * the Pyre Zombie / Shambling Cie'th shape) — the printed wording says "return this card from
+ * your graveyard", so it does nothing while Curious Cadaver is on the battlefield.
+ *
+ * `YouSacrificeA` is the per-permanent form (`perPermanent = true`): sacrificing two Clues at
+ * once triggers twice, matching CR 603.2's per-event reading of "when you sacrifice a Clue".
+ * The second instance finds the card already in hand and does nothing.
+ *
+ * Sacrificing a Clue for a *cost* (its own "{2}, Sacrifice this token: Draw a card", or Demand
+ * Answers' additional cost) still triggers this — costs are paid before the spell or ability
+ * goes on the stack, and the trigger fires off the sacrifice event either way.
+ */
+val CuriousCadaver = card("Curious Cadaver") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Zombie Detective"
+    oracleText = "Flying\nWhen you sacrifice a Clue, return this card from your graveyard to your hand."
+    power = 3
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Artifact.withSubtype("Clue"))
+        triggerZone = Zone.GRAVEYARD
+        effect = Effects.ReturnToHand(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "194"
+        artist = "Peter Polach"
+        flavorText = "\"When you said I could learn a lot from a corpse, I have to admit I wasn't " +
+            "expecting it to lecture me on forensic procedure.\"\n—Kellan, to Ezrim"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/2893aef8-835d-4935-b532-d8670585e489.jpg?1783912854"
+
+        ruling(
+            "2024-02-02",
+            "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger " +
+                "whenever you sacrifice a Clue for any reason, not just to activate a Clue's " +
+                "activated ability."
+        )
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token. For example, you can sacrifice Wrench to pay for Alquist Proft, Master " +
+                "Sleuth's activated ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DemandAnswers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DemandAnswers.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Demand Answers — Murders at Karlov Manor #122
+ * {1}{R} · Instant
+ *
+ * As an additional cost to cast this spell, sacrifice an artifact or discard a card.
+ * Draw two cards.
+ *
+ * Cost-vs-cost additional cost (`Costs.additional.Choice`, the Souls of the Lost shape): each
+ * branch surfaces as its own cast action, so the player picks the sub-cost by picking which
+ * action to play, and a branch with nothing to pay it with simply isn't offered. Because it's
+ * an *additional cost*, it is paid on casting — countering the spell doesn't give the artifact
+ * or the discarded card back. Sacrificing a Clue to it is a real sacrifice, so "when you
+ * sacrifice a Clue" payoffs (Curious Cadaver) see it.
+ */
+val DemandAnswers = card("Demand Answers") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice an artifact or discard a card.\n" +
+        "Draw two cards."
+
+    additionalCost(
+        Costs.additional.Choice(
+            Costs.additional.SacrificePermanent(GameObjectFilter.Artifact),
+            Costs.additional.DiscardCards()
+        )
+    )
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Justyna Dura"
+        flavorText = "After the attempt on Aurelia's life, she gave the Agency an ultimatum: solve " +
+            "the case in twenty-four hours, or the Boros Legion would declare war on the Cult of Rakdos."
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/eca092fc-7c67-4a73-989e-5297bbaaea76.jpg?1783912883"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PersonOfInterest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PersonOfInterest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Person of Interest — Murders at Karlov Manor #139
+ * {3}{R} · Creature — Human Rogue · 2/2
+ *
+ * When this creature enters, suspect it. Create a 2/2 white and blue Detective creature token.
+ *
+ * One trigger with two sentences, so both happen on the same resolution. "Suspect it" is not a
+ * target — it names the source itself (`EffectTarget.Self`), which is why the Detective still
+ * arrives if Person of Interest has already left the battlefield by resolution.
+ *
+ * Suspecting itself is a real drawback traded for the body: CR 701.60a gives it menace *and*
+ * "can't block", permanently. The Detective token is the untainted blocker of the pair.
+ *
+ * The token's art comes from the MKM `tokenArt` layer (a 2/2 white-and-blue Detective is one of
+ * the set's printed tokens), so no `imageUri` is baked in here.
+ */
+val PersonOfInterest = card("Person of Interest") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue"
+    oracleText = "When this creature enters, suspect it. Create a 2/2 white and blue Detective " +
+        "creature token. (A suspected creature has menace and can't block.)"
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Effects.Suspect(EffectTarget.Self),
+            Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.WHITE, Color.BLUE),
+                creatureTypes = setOf("Detective")
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Justyna Dura"
+        flavorText = "\"Maybe they're following someone else,\" Alvis thought to himself, despite " +
+            "mounting evidence to the contrary."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d56ebff-67c8-4bc7-a533-ddde4ce0c2af.jpg?1783912876"
+
+        ruling(
+            "2024-02-02",
+            "If Person of Interest is no longer on the battlefield when its triggered ability " +
+                "resolves, you'll still create a Detective token."
+        )
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until it " +
+                "leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RubblebeltBraggart.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RubblebeltBraggart.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rubblebelt Braggart — Murders at Karlov Manor #143
+ * {4}{R} · Creature — Lizard Warrior · 5/5
+ *
+ * Whenever this creature attacks, if it's not suspected, you may suspect it.
+ *
+ * "if it's not suspected" is an **intervening-if** (CR 603.4), modelled as
+ * `triggerCondition = Conditions.Not(Conditions.SourceIsSuspected)` — which reads the projected
+ * suspected designation rather than probing for menace. An already-suspected Braggart never puts
+ * the trigger on the stack at all, so the player isn't asked a question that couldn't do anything.
+ *
+ * The engine checks `triggerCondition` at trigger time but not again at resolution, which CR 603.4
+ * also requires. That gap is inert here: suspect is idempotent by CR 701.60d ("a suspected
+ * permanent can't become suspected again"), and `SetSuspectedExecutor` enforces exactly that, so a
+ * Braggart that somehow became suspected between trigger and resolution just resolves to a no-op.
+ *
+ * "Suspect it" names the source, not a target, so it is `EffectTarget.Self`; the "you may" is a
+ * plain yes/no decision on resolution. Saying yes is a real cost — the Braggart gains menace but
+ * permanently loses the ability to block, and there is no way to shed the designation later.
+ */
+val RubblebeltBraggart = card("Rubblebelt Braggart") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard Warrior"
+    oracleText = "Whenever this creature attacks, if it's not suspected, you may suspect it. " +
+        "(A suspected creature has menace and can't block.)"
+    power = 5
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.Not(Conditions.SourceIsSuspected)
+        // `Effects.Suspect`'s own description is the sentence "this creature becomes suspected",
+        // which reads as gibberish under the gate's "You may …" prefix. Spell the question out so
+        // the yes/no prompt names the trade the player is actually making.
+        effect = MayEffect(
+            Effects.Suspect(EffectTarget.Self),
+            descriptionOverride = "Suspect Rubblebelt Braggart? (It gains menace but can't block.)"
+        )
+        description = "Whenever this creature attacks, if it's not suspected, you may suspect it."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Leonardo Santanna"
+        flavorText = "\"I did it! Double—no, triple homicide! In a building I set on fire. Yep, all me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f90f8691-210a-4bf0-9fc2-fb2efcf057fb.jpg?1783912875"
+
+        ruling("2024-02-02", "If a creature is already suspected, suspecting it again won't have any effect.")
+        ruling(
+            "2024-02-02",
+            "If a suspected creature loses all abilities, it will lose menace and \"This creature " +
+                "can't block\", but it won't stop being suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected " +
+                "creature, it won't be suspected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ToxinAnalysis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ToxinAnalysis.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Toxin Analysis — Murders at Karlov Manor #107
+ * {B} · Instant
+ *
+ * Target creature gains deathtouch and lifelink until end of turn. Investigate.
+ *
+ * The Clue is not conditional on the target surviving: investigate happens on resolution
+ * regardless. If the single target is illegal by then the whole spell is countered on
+ * resolution (CR 608.2b) and no Clue is created.
+ */
+val ToxinAnalysis = card("Toxin Analysis") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gains deathtouch and lifelink until end of turn. Investigate. " +
+        "(Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        val t = target("target creature", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.DEATHTOUCH, t),
+            Effects.GrantKeyword(Keyword.LIFELINK, t),
+            Effects.Investigate()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Irina Nordsol"
+        flavorText = "\"Poison this deadly is only used by the Ochran. Either the Golgari are behind " +
+            "this, or someone wants us to think they are.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0eda1aff-c1f4-4171-a800-605396cc8168.jpg?1783912889"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -260,6 +260,63 @@
     ]
 }
 
+// Curious Cadaver
+{
+    "name": "Curious Cadaver",
+    "manaCost": "{2}{U}{B}",
+    "typeLine": "Creature — Zombie Detective",
+    "oracleText": "Flying\nWhen you sacrifice a Clue, return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact Clue",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                },
+                "activeZones": [
+                    "Graveyard"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "UNCOMMON",
+        "artist": "Peter Polach",
+        "flavorText": "\"When you said I could learn a lot from a corpse, I have to admit I wasn't expecting it to lecture me on forensic procedure.\"\n—Kellan, to Ezrim",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/2893aef8-835d-4935-b532-d8670585e489.jpg?1783912854",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger whenever you sacrifice a Clue for any reason, not just to activate a Clue's activated ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token. For example, you can sacrifice Wrench to pay for Alquist Proft, Master Sleuth's activated ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Curious Inquiry
 {
     "name": "Curious Inquiry",
@@ -340,6 +397,50 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Demand Answers
+{
+    "name": "Demand Answers",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice an artifact or discard a card.\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "ChoiceCost",
+                "options": [
+                    {
+                        "type": "AdditionalAtom",
+                        "atom": {
+                            "type": "AtomSacrifice",
+                            "filter": "artifact"
+                        }
+                    },
+                    {
+                        "type": "AdditionalAtom",
+                        "atom": "AtomDiscard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Justyna Dura",
+        "flavorText": "After the attempt on Aurelia's life, she gave the Agency an ultimatum: solve the case in twenty-four hours, or the Boros Legion would declare war on the Cult of Rakdos.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/eca092fc-7c67-4a73-989e-5297bbaaea76.jpg?1783912883"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1895,6 +1996,86 @@
     ]
 }
 
+// Person of Interest
+{
+    "name": "Person of Interest",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "When this creature enters, suspect it. Create a 2/2 white and blue Detective creature token. (A suspected creature has menace and can't block.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "SetSuspected",
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "MENACE",
+                                    "target": "Self",
+                                    "duration": "Permanent"
+                                },
+                                {
+                                    "type": "CantBlockTargetCreatures",
+                                    "target": "Self",
+                                    "duration": "Permanent"
+                                }
+                            ],
+                            "descriptionOverride": "this creature becomes suspected"
+                        },
+                        {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "WHITE",
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Detective"
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Justyna Dura",
+        "flavorText": "\"Maybe they're following someone else,\" Alvis thought to himself, despite mounting evidence to the contrary.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d56ebff-67c8-4bc7-a533-ddde4ce0c2af.jpg?1783912876",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If Person of Interest is no longer on the battlefield when its triggered ability resolves, you'll still create a Detective token."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Pick Your Poison
 {
     "name": "Pick Your Poison",
@@ -2104,6 +2285,88 @@
         "artist": "Iris Compiet",
         "flavorText": "\"Thopters are but one option in our suite of autonomous surveillance solutions.\"\n—Kylox",
         "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c137a44-9ab6-4e59-8324-34d9dca8f5a6.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rubblebelt Braggart
+{
+    "name": "Rubblebelt Braggart",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Lizard Warrior",
+    "oracleText": "Whenever this creature attacks, if it's not suspected, you may suspect it. (A suspected creature has menace and can't block.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetSuspected",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "MENACE",
+                                "target": "Self",
+                                "duration": "Permanent"
+                            },
+                            {
+                                "type": "CantBlockTargetCreatures",
+                                "target": "Self",
+                                "duration": "Permanent"
+                            }
+                        ],
+                        "descriptionOverride": "this creature becomes suspected"
+                    },
+                    "descriptionOverride": "Suspect Rubblebelt Braggart? (It gains menace but can't block.)"
+                },
+                "triggerCondition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "EntityMatches",
+                        "entity": "Self",
+                        "filter": {
+                            "statePredicates": [
+                                "IsSuspected"
+                            ]
+                        }
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, if it's not suspected, you may suspect it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Leonardo Santanna",
+        "flavorText": "\"I did it! Double—no, triple homicide! In a building I set on fire. Yep, all me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f90f8691-210a-4bf0-9fc2-fb2efcf057fb.jpg?1783912875",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If a creature is already suspected, suspecting it again won't have any effect."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a suspected creature loses all abilities, it will lose menace and \"This creature can't block\", but it won't stop being suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected creature, it won't be suspected."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "RED"
@@ -2513,6 +2776,59 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Toxin Analysis
+{
+    "name": "Toxin Analysis",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gains deathtouch and lifelink until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Irina Nordsol",
+        "flavorText": "\"Poison this deadly is only used by the Ochran. Either the Golgari are behind this, or someone wants us to think they are.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0eda1aff-c1f4-4171-a800-605396cc8168.jpg?1783912889"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -525,6 +525,7 @@ class BeginningPhaseManager(
         StatePredicate.IsEnchanted,
         StatePredicate.IsModified,
         StatePredicate.IsSaddled,
+        StatePredicate.IsSuspected,
         StatePredicate.HasLockedDoor,
         StatePredicate.CrewedOrSaddledSourceThisTurn,
         StatePredicate.CrewedOrSaddledBySourceThisTurn,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1946,6 +1946,10 @@ class TriggerMatcher(
             val entity = state.getEntity(entityId) ?: return false
             entity.has<FaceDownComponent>()
         }
+        // Suspected (CR 701.60a) reads off the floating-effect list, which is available here, so a
+        // "whenever a suspected creature …" trigger filter gates exactly instead of failing open.
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsSuspected ->
+            com.wingedsheep.engine.handlers.predicates.isSuspected(state, entityId)
         // Soulbond pairing (CR 702.95b) — plain per-entity state, evaluable here, so a
         // "whenever a paired creature …" trigger filter gates correctly instead of failing open.
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsPaired ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1385,6 +1385,10 @@ class PredicateEvaluator {
             // (CR 702.171b). Cleared at end-of-turn cleanup or when the permanent leaves play.
             StatePredicate.IsSaddled -> container.has<SaddledComponent>()
 
+            // Suspected designation (CR 701.60a) — a Layer-ability floating effect, so the answer
+            // lives in the projection rather than on a component. Unlike saddled it never expires.
+            StatePredicate.IsSuspected -> projected.isSuspected(entityId)
+
             // Zone-specific marker — set by WarpExileExecutor when a warped
             // permanent is exiled at end of turn (CR 702.185b).
             StatePredicate.IsWarpExiled ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/SetSuspectedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/SetSuspectedExecutor.kt
@@ -39,11 +39,7 @@ class SetSuspectedExecutor : EffectExecutor<SetSuspectedEffect> {
         state.getEntity(entityId)?.get<CardComponent>()
             ?: return EffectResult.success(state)
 
-        val alreadySuspected = state.floatingEffects.any { fx ->
-            fx.effect.modification is SerializableModification.SetSuspected
-                && entityId in fx.effect.affectedEntities
-        }
-        if (alreadySuspected) {
+        if (com.wingedsheep.engine.handlers.predicates.isSuspected(state, entityId)) {
             return EffectResult.success(state)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/predicates/SuspectedPredicate.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/predicates/SuspectedPredicate.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.engine.handlers.predicates
+
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Whether [entityId] currently carries the suspected designation (CR 701.60a).
+ *
+ * The designation is a Layer-ability floating effect rather than a component, so the normal
+ * read is `ProjectedState.isSuspected`. This raw-state form exists for the callers that have no
+ * projection in hand — trigger gating, and `SetSuspectedExecutor`'s CR 701.60d "can't become
+ * suspected again" check, which has to answer the question *while* building the next state.
+ *
+ * Both readings agree: the projection's `isSuspected` is set from exactly these floating
+ * effects, and suspect has no duration to expire out from under it.
+ */
+fun isSuspected(state: GameState, entityId: EntityId): Boolean =
+    state.floatingEffects.any { fx ->
+        fx.effect.modification is SerializableModification.SetSuspected &&
+            entityId in fx.effect.affectedEntities
+    }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -558,6 +558,10 @@ internal class AffectsFilterResolver {
         }
         StatePredicate.IsSaddled ->
             container.has<com.wingedsheep.engine.state.components.battlefield.SaddledComponent>()
+        // Suspected (CR 701.60a) is itself a Layer-ability modification, so it is read off the
+        // values accumulated so far in this projection pass — the same source `ProjectedState`
+        // exposes as `isSuspected`, and the same self-referential caveat as IsModified above.
+        StatePredicate.IsSuspected -> projectedValues[entityId]?.isSuspected == true
         StatePredicate.IsWarpExiled ->
             container.has<com.wingedsheep.engine.state.components.identity.WarpExiledComponent>()
         StatePredicate.WasCastForWarp ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RubblebeltBraggartScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RubblebeltBraggartScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.RubblebeltBraggart
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Rubblebelt Braggart — "Whenever this creature attacks, if it's not suspected, you may suspect it."
+ *
+ * Covers the new `StatePredicate.IsSuspected` / `Conditions.SourceIsSuspected` vocabulary through
+ * the card that needs it:
+ *  - accepting the "may" applies the whole suspect composite (designation + menace + can't block);
+ *  - declining leaves it untouched, and the offer comes back on a later attack;
+ *  - once suspected, the intervening-if (CR 603.4) stops the trigger firing at all — which is what
+ *    keeps CR 701.60d ("a suspected permanent can't become suspected again") from being a silent
+ *    no-op the player still has to click through.
+ */
+class RubblebeltBraggartScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RubblebeltBraggart)
+        return driver
+    }
+
+    /** Advance whole turns until [player] is the active player again, stopping in precombat main. */
+    fun advanceToNextTurnOf(driver: GameTestDriver, player: com.wingedsheep.sdk.model.EntityId) {
+        do {
+            driver.passPriorityUntil(Step.END)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        } while (driver.activePlayer != player)
+    }
+
+    test("accepting the attack trigger suspects it — designation, menace and can't block") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val braggart = driver.putCreatureOnBattlefield(active, "Rubblebelt Braggart")
+        driver.removeSummoningSickness(braggart)
+
+        withClue("a freshly-played Braggart is not suspected") {
+            StateProjector().project(driver.state).isSuspected(braggart) shouldBe false
+        }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(braggart), opponent)
+
+        // The trigger goes on the stack; resolving it asks the controller whether to suspect.
+        driver.bothPass()
+        withClue("attacking unsuspected must offer the may-suspect decision") {
+            driver.pendingDecision shouldNotBe null
+        }
+        driver.submitYesNo(active, true)
+
+        val projected = StateProjector().project(driver.state)
+        withClue("accepting applies the suspected designation (CR 701.60a)") {
+            projected.isSuspected(braggart) shouldBe true
+        }
+        withClue("suspected grants menace (CR 701.60c)") {
+            projected.hasKeyword(braggart, Keyword.MENACE) shouldBe true
+        }
+        withClue("suspected can't block (CR 701.60c)") {
+            projected.cantBlock(braggart) shouldBe true
+        }
+    }
+
+    test("declining leaves it unsuspected, and the offer returns on the next attack") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val braggart = driver.putCreatureOnBattlefield(active, "Rubblebelt Braggart")
+        driver.removeSummoningSickness(braggart)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(braggart), opponent)
+        driver.bothPass()
+        driver.pendingDecision shouldNotBe null
+        driver.submitYesNo(active, false)
+
+        withClue("declining the may must leave it unsuspected") {
+            val projected = StateProjector().project(driver.state)
+            projected.isSuspected(braggart) shouldBe false
+            projected.cantBlock(braggart) shouldBe false
+        }
+
+        // Still not suspected, so the intervening-if is satisfied again next turn.
+        advanceToNextTurnOf(driver, active)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(braggart), opponent)
+        driver.bothPass()
+        withClue("a declined offer is not consumed — it comes back on the next attack") {
+            driver.pendingDecision shouldNotBe null
+        }
+        driver.submitYesNo(active, true)
+        StateProjector().project(driver.state).isSuspected(braggart) shouldBe true
+    }
+
+    test("already suspected — the intervening-if stops the trigger firing at all") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val braggart = driver.putCreatureOnBattlefield(active, "Rubblebelt Braggart")
+        driver.removeSummoningSickness(braggart)
+
+        // Attack once and accept, so it is suspected going into the second attack.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(braggart), opponent)
+        driver.bothPass()
+        driver.submitYesNo(active, true)
+        StateProjector().project(driver.state).isSuspected(braggart) shouldBe true
+
+        advanceToNextTurnOf(driver, active)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(braggart), opponent)
+        driver.bothPass()
+
+        withClue("an already-suspected Braggart must not put the trigger on the stack (CR 603.4)") {
+            driver.pendingDecision shouldBe null
+        }
+        withClue("and it stays suspected exactly once") {
+            StateProjector().project(driver.state).isSuspected(braggart) shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
Five more Murders at Karlov Manor cards — MKM goes **57/276 → 62/276**.

## Cards

Four build purely on existing SDK vocabulary:

| Card | Notes |
|---|---|
| **Toxin Analysis** `{B}` | Deathtouch + lifelink until end of turn, then investigate. |
| **Demand Answers** `{1}{R}` | Cost-vs-cost additional cost via `Costs.additional.Choice` (the Souls of the Lost shape) — each branch surfaces as its own cast action labelled with the cost it pays, so no new client UI. |
| **Curious Cadaver** `{2}{U}{B}` | Flying; the recursion trigger functions *only* from the graveyard (`triggerZone = Zone.GRAVEYARD`) and uses the per-permanent `Triggers.YouSacrificeA`, so two Clues sacrificed at once trigger it twice. |
| **Person of Interest** `{3}{R}` | One trigger, two sentences: suspect itself (`EffectTarget.Self` — not a target) and create a Detective token, so the token still arrives if it has already left the battlefield (per its ruling). |

## New SDK vocabulary: reading the suspected designation

**Rubblebelt Braggart** `{4}{R}` — "Whenever this creature attacks, **if it's not suspected**, you may suspect it." — needed a way to read the suspected designation back, which the SDK had no vocabulary for. Added:

- `StatePredicate.IsSuspected`
- `GameObjectFilter.suspected()`
- `Conditions.SourceIsSuspected`

This makes "if it's not suspected" the real intervening-if (CR 603.4) rather than a menace lookalike: an already-suspected Braggart never puts the trigger on the stack, instead of asking a yes/no that CR 701.60d guarantees can do nothing. The rulings confirm the distinction matters — a suspected creature that loses all abilities loses menace and "can't block" but *stays suspected*.

Several other MKM cards read the same designation (Deadly Complication, Agency Coroner, Repeat Offender), so this is not a one-off.

### Wiring

Suspect rides a Layer-ability floating effect rather than a component, so each of the four exhaustive dispatch sites reads it from whatever source it has:

| Site | Reads |
|---|---|
| `PredicateEvaluator` | `projected.isSuspected(entityId)` |
| `AffectsFilterResolver` | `projectedValues[entityId]?.isSuspected` (group-static projection) |
| `TriggerMatcher` | new shared `handlers/predicates/SuspectedPredicate.kt` — exact, so a "whenever a suspected creature…" filter gates instead of failing open |
| `BeginningPhaseManager` untap filtering | keeps the documented no-constraint default |

`SetSuspectedExecutor`'s CR 701.60d dedup now shares `SuspectedPredicate` instead of duplicating the scan, so there is one definition.

`docs/card-sdk-language-reference.md` updated in the same change (filter + condition sections).

## UX

The only new decision is Rubblebelt Braggart's yes/no. `Effects.Suspect`'s own description is the sentence *"this creature becomes suspected"*, which reads as gibberish under the gate's "You may …" prefix, so the card supplies a `descriptionOverride`: **"Suspect Rubblebelt Braggart? (It gains menace but can't block.)"** Everything else routes through existing components.

## Verification

- `just build` and `just test` — green.
- `RubblebeltBraggartScenarioTest` — accepting, declining and being re-offered on a later attack, and the already-suspected case producing no trigger at all. All 3 pass.
- `just check-card-printing` — all five confirmed canonical in MKM (none is a reprint).
- `just rebless-cards` — MKM golden diff is additions only, exactly these five cards.
- All five `imageUri`s verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)