### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AuspiciousArrival.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AuspiciousArrival.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auspicious Arrival — Murders at Karlov Manor #5
+ * {1}{W} · Instant
+ *
+ * Target creature gets +2/+2 until end of turn. Investigate.
+ *
+ * Single-target spell, so the Clue rides on the whole spell resolving: if the creature is an
+ * illegal target by resolution the spell is countered on resolution (CR 608.2b) and nothing
+ * happens at all — no pump *and* no Clue. That's the shape [ToxinAnalysis] already documents;
+ * modelling investigate as a separate sentence in a [Effects.Composite] keeps that behaviour
+ * because both halves live inside one spell resolution.
+ */
+val AuspiciousArrival = card("Auspicious Arrival") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn. Investigate. " +
+        "(Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, creature),
+            Effects.Investigate()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Lie Setiawan"
+        flavorText = "Proft brushed past the guards and introduced himself as \"the great Detective " +
+            "Proft\" without a hint of irony, then identified the culprit within minutes."
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/5180c85c-6add-4066-83c4-27fb1fd4de16.jpg?1783912929"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FaeFlight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FaeFlight.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fae Flight — Murders at Karlov Manor #56
+ * {1}{U} · Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * When this Aura enters, enchanted creature gains hexproof until end of turn.
+ * Enchanted creature gets +1/+0 and has flying.
+ *
+ * The hexproof is a *one-shot* on the enters trigger, not a static — that's the whole trick of
+ * the card: flashed in response to removal, the Aura is already attached when the trigger
+ * resolves, so [EffectTarget.EnchantedCreature] resolves through the attachment and the
+ * creature dodges the spell already on the stack. Modelling it as a fourth static ability would
+ * be wrong twice over — it would persist past this turn, and it would come back if the Aura
+ * were ever re-attached.
+ *
+ * Note the trigger targets nothing (CR 702.155a "enchanted creature" is not a target), so
+ * shroud/hexproof on the enchanted creature can't stop it.
+ *
+ * `AuraEntersGrantsHexproofTest` already proves this exact wiring end-to-end: removal on the
+ * stack, Aura flashed in, ETB trigger resolves, removal is countered on resolution (CR 608.2b).
+ */
+val FaeFlight = card("Fae Flight") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature\n" +
+        "When this Aura enters, enchanted creature gains hexproof until end of turn.\n" +
+        "Enchanted creature gets +1/+0 and has flying."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GrantHexproof(EffectTarget.EnchantedCreature)
+        description = "When this Aura enters, enchanted creature gains hexproof until end of turn."
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "56"
+        artist = "Durion"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d9caa4eb-ed8c-4d05-8029-2a42163938a7.jpg?1783912911"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SeasonedConsultant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SeasonedConsultant.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.YouAttackEvent
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Seasoned Consultant — Murders at Karlov Manor #33
+ * {1}{W} · Creature — Human Detective · 1/3
+ *
+ * Whenever you attack with three or more creatures, this creature gets +2/+0 until end of turn.
+ *
+ * `YouAttackEvent(minAttackers = 3)` with an ANY binding, the Armasaur Guide shape — the
+ * Consultant does *not* have to be one of the three attackers, so it pumps even while sitting
+ * back on defense. Counted once per declare-attackers, not once per attacker.
+ *
+ * Per the MKM ruling, the count is locked in at declaration: removing an attacker in response
+ * doesn't stop the +2/+0, which falls out of the trigger reading the event rather than
+ * re-counting the battlefield on resolution.
+ */
+val SeasonedConsultant = card("Seasoned Consultant") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Detective"
+    power = 1
+    toughness = 3
+    oracleText = "Whenever you attack with three or more creatures, this creature gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = TriggerSpec(YouAttackEvent(minAttackers = 3), TriggerBinding.ANY)
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+        description = "Whenever you attack with three or more creatures, this creature gets +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Andreas Zafiratos"
+        flavorText = "\"I appreciate working with associates whose greatest loyalty is to the job at hand.\"\n" +
+            "—Skurad of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0ebfe5d-8819-495d-bf72-b9c28c6fd23e.jpg?1783912918"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ShadyInformant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ShadyInformant.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shady Informant — Murders at Karlov Manor #231
+ * {3}{B}{R} · Creature — Ogre Rogue · 4/2
+ *
+ * When this creature dies, it deals 2 damage to any target.
+ * Disguise {2}{B/R}{B/R}
+ *
+ * The dies trigger and the disguise cost don't interact beyond CR 708.2: a face-down Informant is
+ * a vanilla 2/2 with ward {2} and has no dies trigger at all, so it must be face up when it dies
+ * for the 2 damage to happen. Turning it face up is a special action, not a cast, and per
+ * CR 702.168d is not entering the battlefield — nothing here keys on entering, so that's a no-op
+ * for this card either way.
+ *
+ * The damage source is the Informant itself, read from last-known information (the permanent is
+ * already in the graveyard when the ability resolves).
+ */
+val ShadyInformant = card("Shady Informant") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Ogre Rogue"
+    power = 4
+    toughness = 2
+    oracleText = "When this creature dies, it deals 2 damage to any target.\n" +
+        "Disguise {2}{B/R}{B/R} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)"
+
+    disguise = "{2}{B/R}{B/R}"
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, anyTarget)
+        description = "When this creature dies, it deals 2 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "231"
+        artist = "Caio Monteiro"
+        flavorText = "Rakdos snitches rarely survive to get stitches."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0de36e63-8190-415f-b65b-bae1e595845d.jpg?1783912840"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TopiaryPanther.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TopiaryPanther.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Topiary Panther — Murders at Karlov Manor #179
+ * {4}{G}{G} · Creature — Plant Cat · 6/5
+ *
+ * Trample
+ * Basic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card,
+ * reveal it, put it into your hand, then shuffle.)
+ *
+ * Basic landcycling is the [KeywordAbility.basicLandcycling] variant of cycling — the shared
+ * typecycling machinery narrows the search to *basic* land cards (not merely lands with a basic
+ * land type), so a nonbasic dual like Undercity Sewers is not a legal fetch.
+ */
+val TopiaryPanther = card("Topiary Panther") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Cat"
+    power = 6
+    toughness = 5
+    oracleText = "Trample\n" +
+        "Basic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land " +
+        "card, reveal it, put it into your hand, then shuffle.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    keywordAbility(KeywordAbility.basicLandcycling(ManaCost.parse("{1}{G}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "179"
+        artist = "Xabi Gaztelua"
+        flavorText = "The gardens around Karlov Manor are oddly bereft of birdsong."
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03d0365e-6dee-4236-a997-6761e3cde90d.jpg?1783912860"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1,3 +1,55 @@
+// Auspicious Arrival
+{
+    "name": "Auspicious Arrival",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "artist": "Lie Setiawan",
+        "flavorText": "Proft brushed past the guards and introduced himself as \"the great Detective Proft\" without a hint of irony, then identified the culprit within minutes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/5180c85c-6add-4066-83c4-27fb1fd4de16.jpg?1783912929"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Bite Down on Crime
 {
     "name": "Bite Down on Crime",
@@ -634,6 +686,60 @@
         "imageUri": "https://cards.scryfall.io/normal/front/9/3/93ddde4f-d35e-4128-8f43-d0eadbd715de.jpg?1706242339"
     },
     "colorIdentityOverride": []
+}
+
+// Fae Flight
+{
+    "name": "Fae Flight",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nWhen this Aura enters, enchanted creature gains hexproof until end of turn.\nEnchanted creature gets +1/+0 and has flying.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GrantEvasionKeyword",
+                    "keyword": "HEXPROOF",
+                    "target": "EnchantedCreature"
+                },
+                "descriptionOverride": "When this Aura enters, enchanted creature gains hexproof until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "UNCOMMON",
+        "artist": "Durion",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d9caa4eb-ed8c-4d05-8029-2a42163938a7.jpg?1783912911"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Fanatical Strength
@@ -2535,6 +2641,52 @@
     "colorIdentityOverride": []
 }
 
+// Seasoned Consultant
+{
+    "name": "Seasoned Consultant",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Whenever you attack with three or more creatures, this creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "minAttackers": 3
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you attack with three or more creatures, this creature gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "\"I appreciate working with associates whose greatest loyalty is to the job at hand.\"\n—Skurad of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0ebfe5d-8819-495d-bf72-b9c28c6fd23e.jpg?1783912918"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Shadowy Backstreet
 {
     "name": "Shadowy Backstreet",
@@ -2568,6 +2720,68 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Shady Informant
+{
+    "name": "Shady Informant",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Creature — Ogre Rogue",
+    "oracleText": "When this creature dies, it deals 2 damage to any target.\nDisguise {2}{B/R}{B/R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{B/R}{B/R}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "descriptionOverride": "When this creature dies, it deals 2 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "artist": "Caio Monteiro",
+        "flavorText": "Rakdos snitches rarely survive to get stitches.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0de36e63-8190-415f-b65b-bae1e595845d.jpg?1783912840"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -2776,6 +2990,42 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Topiary Panther
+{
+    "name": "Topiary Panther",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Plant Cat",
+    "oracleText": "Trample\nBasic landcycling {1}{G} ({1}{G}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{G}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "179",
+        "artist": "Xabi Gaztelua",
+        "flavorText": "The gardens around Karlov Manor are oddly bereft of birdsong.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03d0365e-6dee-4236-a997-6761e3cde90d.jpg?1783912860"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Five MKM commons/uncommons, chosen to span different mechanics rather than to be uniform. MKM goes **62/276 → 67/276**.

All five compose existing SDK vocabulary — no new effects, triggers, or keywords — so the snapshot, lint, and facade-boundary nets are the coverage.

| Card | Cost | What it needed |
|---|---|---|
| Auspicious Arrival | `{1}{W}` Instant | `ModifyStats` + `Investigate` in one `Composite` |
| Fae Flight | `{1}{U}` Aura | Flash, `EffectTarget.EnchantedCreature` on the enters trigger |
| Seasoned Consultant | `{1}{W}` 1/3 | `YouAttackEvent(minAttackers = 3)`, ANY binding |
| Topiary Panther | `{4}{G}{G}` 6/5 | `KeywordAbility.basicLandcycling` |
| Shady Informant | `{3}{B}{R}` 4/2 | `disguise` cost + dies-damage trigger |

### The two worth a second look

**Fae Flight** — the hexproof is a *one-shot on the enters trigger*, not a fourth static ability. That's the whole point of the card: flashed in response to removal, the Aura is already attached when the trigger resolves, so `EffectTarget.EnchantedCreature` resolves through the attachment and the removal is countered on resolution (CR 608.2b). Modelling it as a static would be wrong twice over — it would outlive the turn, and it would come back if the Aura were ever re-attached. `AuraEntersGrantsHexproofTest` already proves this exact wiring end to end, which is why no new test ships here.

**Seasoned Consultant** — ANY binding, so the Consultant does not have to be one of the three attackers; it pumps while sitting back on defense. The count is once per declare-attackers, not once per attacker, and it is locked in at declaration — matching the MKM ruling that removing an attacker in response doesn't undo the +2/+0.

The other three are the plain shapes: Auspicious Arrival keeps pump and Clue inside one spell resolution so an illegal target counters the whole thing and produces no Clue either (the Toxin Analysis shape); Topiary Panther's basic landcycling narrows the shared typecycling search to basic land *cards*, so a nonbasic dual is not a legal fetch; Shady Informant is face down a vanilla 2/2 with ward {2} (CR 708.2) and so has no dies trigger at all until turned face up.

### Verification

- `just build` green.
- Snapshot re-blessed — only these five cards move in `MKM.json`.
- Every mechanical field re-checked against Scryfall (mana cost, P/T, rarity, collector number, artist, flavor text, oracle text); all five `image_uris.normal` return HTTP 200.
- MKM is the earliest real-expansion printing for all five, so each is canonical here — no `Printing` rows needed.
- No new decision types or UI: targeting, library search (landcycling), and the disguise cast/turn-face-up flow are all already-exercised paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)