### PR TITLE
Add five The Hobbit cards, with Player.OwnerOfSource support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2717,6 +2717,12 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   `PreventLifeGain` (`LifeGainEvent(player = EnchantedPlayer)`). Resolves to nothing if the source isn't
   an Aura attached to a player. (Grievous Wound.)
 - `Player.ControllerOf(desc)` / `Player.OwnerOf(desc)` — controller/owner of the first chosen target.
+- `Player.OwnerOfSource` — the owner of the effect's **source**, read from the source card's
+  `CardComponent.ownerId`. The source-bound sibling of `Player.OwnerOf(desc)`, which needs a chosen
+  target and so can't express an ability that names its own source without targeting it: *"[This
+  creature]'s owner shuffles it into their library and draws three cards"* (Gandalf, Wandering
+  Wizard). Distinct from `Player.You` precisely when ownership and control diverge — a stolen
+  permanent's ability still acts on its owner. Reach for `Player.You` whenever the text says "you".
 - `Player.OwnersOfLinkedExile` — the **distinct owners** of the cards still in the effect source's
   linked-exile pile (`LinkedExileComponent`, populated by `Effects.ExileUntilLeaves`). A *list*
   reference: reach it only through `Effects.ForEachPlayer(Player.OwnersOfLinkedExile, …)`, typically

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -185,6 +185,22 @@ sealed interface Player {
     }
 
     /**
+     * The owner of the effect's **source** — the card the ability is printed on, not whoever
+     * currently controls it.
+     *
+     * [OwnerOf] reads the owner of the effect's first *chosen target*, so it is unusable for an
+     * ability that names its own source without targeting it. This is that missing case:
+     * *"[This creature]'s owner shuffles it into their library and draws three cards"*
+     * (Gandalf, Wandering Wizard). It matters exactly when control and ownership diverge — a stolen
+     * permanent's ability still acts on the *owner*, per the printed text.
+     */
+    @SerialName("OwnerOfSource")
+    @Serializable
+    data object OwnerOfSource : Player {
+        override val description: String = "its owner"
+    }
+
+    /**
      * The distinct owners of the cards currently in the effect source's *linked-exile pile*
      * (the source's [com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent],
      * populated by [com.wingedsheep.sdk.dsl.Effects.ExileUntilLeaves]). Resolves to one entry
@@ -226,6 +242,7 @@ sealed interface Player {
             EnchantedPlayer -> "enchanted player's"
             is ControllerOf -> "its controller's"
             is OwnerOf -> "its owner's"
+            OwnerOfSource -> "its owner's"
             OwnersOfLinkedExile -> "the exiled card's owner's"
         }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GalionElvenkingsButler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GalionElvenkingsButler.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Galion, Elvenking's Butler — The Hobbit #125
+ * {2}{G}{G} · Legendary Creature — Elf Advisor · Uncommon
+ * 4/4
+ *
+ * Whenever Galion attacks, choose up to one other target creature you control. Its base power and
+ * toughness become equal to Galion's power and toughness until end of turn.
+ *
+ * Modeling notes:
+ *  - "up to one **other** target creature you control" — `optional = true` plus
+ *    `TargetFilter.OtherCreatureYouControl`, so attacking alone is legal and the trigger simply does
+ *    nothing.
+ *  - This is a layer 7b *set* evaluated once on resolution ([Effects.SetBasePowerAndToughness] with
+ *    dynamic amounts), not a continuously-recomputed CDA: the chosen creature keeps the numbers
+ *    Galion had when the trigger resolved even if Galion is later pumped or dies. Because it sets the
+ *    *base* stats, a +1/+1 counter or an Aura still applies on top in layer 7c/7d.
+ */
+val GalionElvenkingsButler = card("Galion, Elvenking's Butler") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Elf Advisor"
+    power = 4
+    toughness = 4
+    oracleText = "Whenever Galion attacks, choose up to one other target creature you control. " +
+        "Its base power and toughness become equal to Galion's power and toughness until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val other = target(
+            "up to one other target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.OtherCreatureYouControl)
+        )
+        effect = Effects.SetBasePowerAndToughness(
+            power = DynamicAmounts.sourcePower(),
+            toughness = DynamicAmounts.sourceToughness(),
+            target = other,
+            duration = Duration.EndOfTurn
+        )
+        description = "Whenever Galion attacks, choose up to one other target creature you control. " +
+            "Its base power and toughness become equal to Galion's power and toughness until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Jarel Threat"
+        flavorText = "\"Here's the old villain with his head on a jug! He's been having a little " +
+            "feast all to himself!\"\n—Elven guard"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/985bd676-58c4-42c7-a570-1b413e9aa94c.jpg?1785152142"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GandalfWanderingWizard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GandalfWanderingWizard.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gandalf, Wandering Wizard — The Hobbit #41
+ * {4}{U} · Legendary Creature — Avatar Wizard · Common
+ * 4/5
+ *
+ * Ward {3}
+ * {6}: Gandalf's owner shuffles him into their library and draws three cards.
+ *
+ * Modeling notes:
+ *  - The ability names its *owner*, not its controller, so the draw uses
+ *    [Player.OwnerOfSource] rather than the ambient controller. The two only diverge when Gandalf has
+ *    been stolen: the thief may pay {6}, but it is Gandalf's owner who shuffles him back and draws.
+ *  - Shuffle first, then draw — the printed order — so the three cards are drawn off a library that
+ *    already contains him and he can genuinely be drawn again.
+ */
+val GandalfWanderingWizard = card("Gandalf, Wandering Wizard") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 4
+    toughness = 5
+    oracleText = "Ward {3} (Whenever this creature becomes the target of a spell or ability an " +
+        "opponent controls, counter it unless that player pays {3}.)\n" +
+        "{6}: Gandalf's owner shuffles him into their library and draws three cards."
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{3}")))
+
+    activatedAbility {
+        cost = Costs.Mana("{6}")
+        effect = Effects.ShuffleIntoLibrary(EffectTarget.Self) then
+            Effects.DrawCards(3, EffectTarget.PlayerRef(Player.OwnerOfSource))
+        description = "{6}: Gandalf's owner shuffles him into their library and draws three cards."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Irvin Rodriguez"
+        flavorText = "\"May the wind under your wings bear you where the sun sails and the moon walks.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f8403a2-849c-4a59-b0ed-c8803995028d.jpg?1785496472"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RageIntoTheValley.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RageIntoTheValley.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rage into the Valley — The Hobbit #79
+ * {2}{B} · Sorcery · Common
+ *
+ * You draw a card and lose 1 life.
+ * Amass Goblins 2.
+ *
+ * "You draw a card and lose 1 life" is one atomic clause aimed at the caster, so both halves target
+ * the controller explicitly rather than leaning on the "target opponent" default of
+ * [Effects.LoseLife]. `Effects.Amass` handles the Army bookkeeping (create a 0/0 black Goblin Army
+ * first if you control none, otherwise add the counters to the Army you already have).
+ */
+val RageIntoTheValley = card("Rage into the Valley") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "You draw a card and lose 1 life.\n" +
+        "Amass Goblins 2. (Put two +1/+1 counters on an Army you control. It's also a Goblin. " +
+        "If you don't control an Army, create a 0/0 black Goblin Army creature token first.)"
+
+    spell {
+        effect = Effects.DrawCards(1) then
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.You)) then
+            Effects.Amass(2, "Goblin")
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Antonio José Manzanedo"
+        flavorText = "The Goblin army poured in, driving wildly between the arms of the Mountain, " +
+            "seeking for the foe."
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/8651958c-3b94-47a9-a751-faf8f6236a42.jpg?1785496290"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SnowslopeHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SnowslopeHunter.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+
+/**
+ * Snowslope Hunter — The Hobbit #112
+ * {2}{R} · Creature — Goblin Ranger · Uncommon
+ * 2/3
+ *
+ * Sacrifice another creature or artifact: Exile the top card of your library. You may play it until
+ * the end of your next turn. Activate only during your turn and only once each turn.
+ *
+ * Modeling notes:
+ *  - The cost is [Costs.SacrificeAnother], so the Hunter can never eat itself.
+ *  - The impulse window is [MayPlayExpiry.UntilEndOfNextTurn] — turn-keyed, so the permission
+ *    survives the end of the turn it was granted on and is revoked at the cleanup of your next turn.
+ *    It also survives the Hunter leaving the battlefield, which is the printed behaviour.
+ *  - Both printed restrictions are activation restrictions rather than a timing rule: the ability is
+ *    still instant-speed *within* your turn (you may sacrifice in response during your own combat),
+ *    it just can't be activated on someone else's turn, and only once each turn.
+ */
+val SnowslopeHunter = card("Snowslope Hunter") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Ranger"
+    power = 2
+    toughness = 3
+    oracleText = "Sacrifice another creature or artifact: Exile the top card of your library. " +
+        "You may play it until the end of your next turn. Activate only during your turn and " +
+        "only once each turn."
+
+    activatedAbility {
+        cost = Costs.SacrificeAnother(GameObjectFilter.CreatureOrArtifact)
+        effect = Patterns.Exile.impulse(count = 1, expiry = MayPlayExpiry.UntilEndOfNextTurn)
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.OncePerTurn
+        )
+        description = "Sacrifice another creature or artifact: Exile the top card of your library. " +
+            "You may play it until the end of your next turn. Activate only during your turn and " +
+            "only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Adrián Rodríguez Pérez"
+        flavorText = "Goblins did not usually venture very far from their mountains except to go " +
+            "on raids or hunt for food."
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/47666099-ffb2-4d07-a801-70524dba0837.jpg?1785497147"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheNotaryHobbits.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheNotaryHobbits.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * The Notary Hobbits — The Hobbit #131
+ * {3}{G}{G} · Legendary Creature — Halfling Advisor · Rare
+ * 1/1
+ *
+ * When The Notary Hobbits enter, if they're not a token, create two tokens that are copies of them,
+ * except the tokens aren't legendary.
+ * {T}: Add {C} for each Halfling you control.
+ *
+ * Modeling notes:
+ *  - The "if they're not a token" clause is an intervening-if (CR 603.4), so it is a
+ *    `triggerCondition` rather than a guard inside the effect — the ability never goes on the stack
+ *    at all for the copies. That gate is what stops the copies from recursing: each token copy
+ *    carries the same ETB trigger, and without it two tokens would make four, and so on.
+ *  - `removeLegendary = true` is what "except the tokens aren't legendary" means, and it is also what
+ *    keeps the legend rule (CR 704.5j) from immediately eating them.
+ *  - The mana ability counts Halflings you control including The Notary Hobbits themself and the two
+ *    tokens, so the printed card taps for {C}{C}{C} on an otherwise empty board.
+ */
+val TheNotaryHobbits = card("The Notary Hobbits") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Halfling Advisor"
+    power = 1
+    toughness = 1
+    oracleText = "When The Notary Hobbits enter, if they're not a token, create two tokens that " +
+        "are copies of them, except the tokens aren't legendary.\n" +
+        "{T}: Add {C} for each Halfling you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.SourceMatches(GameObjectFilter.Any.nontoken())
+        effect = Effects.CreateTokenCopyOfSelf(count = 2, removeLegendary = true)
+        description = "When The Notary Hobbits enter, if they're not a token, create two tokens " +
+            "that are copies of them, except the tokens aren't legendary."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Creature.withSubtype("Halfling")
+            ).count()
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {C} for each Halfling you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "131"
+        artist = "Jarel Threat"
+        flavorText = "Since Bilbo was presumed dead, his belongings were auctioned by three of the " +
+            "town's best lawyers: Messrs. Grubb, Grubb, and Burrowes."
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d876315f-b269-4254-a517-905c6e927462.jpg?1785412540"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1577,6 +1577,64 @@
     ]
 }
 
+// Galion, Elvenking's Butler
+{
+    "name": "Galion, Elvenking's Butler",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Creature — Elf Advisor",
+    "oracleText": "Whenever Galion attacks, choose up to one other target creature you control. Its base power and toughness become equal to Galion's power and toughness until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "SetBaseStats",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one other target creature you control"
+                    },
+                    "power": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "toughness": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Toughness"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "up to one other target creature you control"
+                },
+                "descriptionOverride": "Whenever Galion attacks, choose up to one other target creature you control. Its base power and toughness become equal to Galion's power and toughness until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Jarel Threat",
+        "flavorText": "\"Here's the old villain with his head on a jug! He's been having a little feast all to himself!\"\n—Elven guard",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/985bd676-58c4-42c7-a570-1b413e9aa94c.jpg?1785152142"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Gandalf, Spark Starter
 {
     "name": "Gandalf, Spark Starter",
@@ -1620,6 +1678,76 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Gandalf, Wandering Wizard
+{
+    "name": "Gandalf, Wandering Wizard",
+    "manaCost": "{4}{U}",
+    "typeLine": "Legendary Creature — Avatar Wizard",
+    "oracleText": "Ward {3} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {3}.)\n{6}: Gandalf's owner shuffles him into their library and draws three cards.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{3}"
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{6}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Library",
+                            "placement": "Shuffled"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "OwnerOfSource"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{6}: Gandalf's owner shuffles him into their library and draws three cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Irvin Rodriguez",
+        "flavorText": "\"May the wind under your wings bear you where the sun sails and the moon walks.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f8403a2-849c-4a59-b0ed-c8803995028d.jpg?1785496472"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -3824,6 +3952,56 @@
     ]
 }
 
+// Rage into the Valley
+{
+    "name": "Rage into the Valley",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "You draw a card and lose 1 life.\nAmass Goblins 2. (Put two +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "You"
+                    }
+                },
+                {
+                    "type": "Amass",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "subtype": "Goblin"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "artist": "Antonio José Manzanedo",
+        "flavorText": "The Goblin army poured in, driving wildly between the arms of the Mountain, seeking for the foe.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/8651958c-3b94-47a9-a751-faf8f6236a42.jpg?1785496290"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Ragged Short Spear
 {
     "name": "Ragged Short Spear",
@@ -4252,6 +4430,81 @@
     ]
 }
 
+// Snowslope Hunter
+{
+    "name": "Snowslope Hunter",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Ranger",
+    "oracleText": "Sacrifice another creature or artifact: Exile the top card of your library. You may play it until the end of your next turn. Activate only during your turn and only once each turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature|artifact",
+                        "excludeSelf": true
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled",
+                            "expiry": {
+                                "type": "UntilControllerStep",
+                                "step": "CLEANUP",
+                                "includeCurrentTurn": false
+                            }
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    "OncePerTurn"
+                ],
+                "descriptionOverride": "Sacrifice another creature or artifact: Exile the top card of your library. You may play it until the end of your next turn. Activate only during your turn and only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Adrián Rodríguez Pérez",
+        "flavorText": "Goblins did not usually venture very far from their mountains except to go on raids or hunt for food.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/47666099-ffb2-4d07-a801-70524dba0837.jpg?1785497147"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Stir Up Trouble
 {
     "name": "Stir Up Trouble",
@@ -4623,6 +4876,67 @@
     },
     "colorIdentityOverride": [
         "BLACK",
+        "GREEN"
+    ]
+}
+
+// The Notary Hobbits
+{
+    "name": "The Notary Hobbits",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Legendary Creature — Halfling Advisor",
+    "oracleText": "When The Notary Hobbits enter, if they're not a token, create two tokens that are copies of them, except the tokens aren't legendary.\n{T}: Add {C} for each Halfling you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateTokenCopyOfSource",
+                    "count": 2,
+                    "removeLegendary": true
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "nontoken"
+                },
+                "descriptionOverride": "When The Notary Hobbits enter, if they're not a token, create two tokens that are copies of them, except the tokens aren't legendary."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Halfling"
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {C} for each Halfling you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "RARE",
+        "artist": "Jarel Threat",
+        "flavorText": "Since Bilbo was presumed dead, his belongings were auctioned by three of the town's best lawyers: Messrs. Grubb, Grubb, and Burrowes.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d876315f-b269-4254-a517-905c6e927462.jpg?1785412540"
+    },
+    "colorIdentityOverride": [
         "GREEN"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -1049,7 +1049,7 @@ class DynamicAmountEvaluator(
             // resolver (parity with resolvePlayerRef), so aggregates like "creatures that target's
             // controller controls" work (Skulking Killer's "if that opponent controls no other
             // creatures" = AggregateBattlefield(ControllerOf("target"), Creature) == 1).
-            is Player.ControllerOf, is Player.OwnerOf -> listOfNotNull(
+            is Player.ControllerOf, is Player.OwnerOf, is Player.OwnerOfSource -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
             is Player.TriggeringPlayer -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -161,6 +161,11 @@ object TargetResolutionUtils {
             Player.EnchantedPlayer -> enchantedPlayer(context, state)
             is Player.OwnerOf -> context.targets.firstOrNull()?.toEntityId()
                 ?.let { state.getEntity(it)?.get<CardComponent>()?.ownerId }
+            // The owner of the ability's own source, which is NOT context.controllerId once the
+            // permanent has been stolen — "its owner shuffles it into their library and draws"
+            // still acts on the owner (Gandalf, Wandering Wizard).
+            Player.OwnerOfSource -> context.sourceId
+                ?.let { state.getEntity(it)?.get<CardComponent>()?.ownerId }
             is Player.ControllerOf -> context.targets.firstOrNull()?.toEntityId()
                 ?.let { controllerOf(state, it) }
             // Multi-player / list-only references have no single resolution here.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GalionElvenkingsButlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GalionElvenkingsButlerScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Galion, Elvenking's Butler (HOB) — "Whenever Galion attacks, choose up to one other target
+ * creature you control. Its base power and toughness become equal to Galion's power and toughness
+ * until end of turn."
+ *
+ * Two things worth pinning: the dynamic amounts read *Galion*, not the creature being changed (a
+ * source-vs-affected-entity mix-up would silently make the target copy its own stats and look like a
+ * no-op), and "up to one" means attacking with no other creature out is still legal.
+ */
+class GalionElvenkingsButlerScenarioTest : ScenarioTestBase() {
+
+    private fun power(game: TestGame, id: EntityId): Int? = game.state.projectedState.getPower(id)
+    private fun toughness(game: TestGame, id: EntityId): Int? = game.state.projectedState.getToughness(id)
+
+    init {
+        test("the chosen creature's base power and toughness become Galion's 4/4") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Galion, Elvenking's Butler", summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Galion, Elvenking's Butler" to 2)).error shouldBe null
+
+            val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+            game.selectTargets(listOf(bears))
+            game.resolveStack()
+
+            withClue("Grizzly Bears is printed 2/2 and should now be Galion's 4/4") {
+                power(game, bears) shouldBe 4
+                toughness(game, bears) shouldBe 4
+            }
+        }
+
+        test("attacking with nothing else on board is legal — the target is 'up to one'") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Galion, Elvenking's Butler", summoningSickness = false)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Galion, Elvenking's Butler" to 2)).error shouldBe null
+            game.resolveStack()
+
+            val galion = game.findPermanent("Galion, Elvenking's Butler").shouldNotBeNull()
+            power(game, galion) shouldBe 4
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfWanderingWizardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfWanderingWizardScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gandalf, Wandering Wizard (HOB) — "{6}: Gandalf's owner shuffles him into their library and draws
+ * three cards."
+ *
+ * The card that motivated `Player.OwnerOfSource`. The ability names its *own source's owner*, which
+ * no existing player reference could express: `Player.You` is the ability's controller and
+ * `Player.OwnerOf(desc)` reads the owner of the first chosen *target*, of which this ability has
+ * none. The second test is the one that would fail under either substitute — it splits ownership
+ * from control and checks that the owner, not the activating thief, refills.
+ */
+class GandalfWanderingWizardScenarioTest : ScenarioTestBase() {
+
+    /** Activate Gandalf's only activated ability, letting the engine auto-pay the {6}. */
+    private fun TestGame.activateGandalf(playerNumber: Int) = execute(
+        ActivateAbility(
+            playerId = if (playerNumber == 1) player1Id else player2Id,
+            sourceId = findPermanent("Gandalf, Wandering Wizard")
+                ?: error("Gandalf is not on the battlefield"),
+            abilityId = cardRegistry.getCard("Gandalf, Wandering Wizard")!!
+                .activatedAbilities[0].id,
+            paymentStrategy = PaymentStrategy.AutoPay,
+        )
+    )
+
+    init {
+        test("the owner shuffles Gandalf into their library and draws three") {
+            val game = scenario()
+                .withPlayers("Owner", "Opponent")
+                .withCardOnBattlefield(1, "Gandalf, Wandering Wizard")
+                .withLandsOnBattlefield(1, "Island", 6)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handBefore = game.handSize(1)
+
+            game.activateGandalf(1).error.shouldBeNull()
+            game.resolveStack()
+
+            game.findPermanent("Gandalf, Wandering Wizard").shouldBeNull()
+            game.handSize(1) shouldBe handBefore + 3
+            // Five Forests, plus Gandalf shuffled in, minus the three cards drawn.
+            game.librarySize(1) shouldBe 3
+        }
+
+        test("a thief may pay the {6}, but it is the owner who shuffles and draws") {
+            val game = scenario()
+                .withPlayers("Owner", "Thief")
+                .withCardOnBattlefield(1, "Gandalf, Wandering Wizard")
+                .withLandsOnBattlefield(2, "Island", 6)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(2)
+                .withPriorityPlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            // Simulate a Mind Control effect: control moves to player 2, ownership stays with 1.
+            val stolen = game.findPermanent("Gandalf, Wandering Wizard")
+                ?: error("Gandalf is not on the battlefield")
+            game.state = game.state.updateEntity(stolen) { container ->
+                container.with(ControllerComponent(game.player2Id))
+            }
+
+            val ownerHandBefore = game.handSize(1)
+            val thiefHandBefore = game.handSize(2)
+
+            game.activateGandalf(2).error.shouldBeNull()
+            game.resolveStack()
+
+            game.findPermanent("Gandalf, Wandering Wizard").shouldBeNull()
+            game.handSize(1) shouldBe ownerHandBefore + 3
+            game.librarySize(1) shouldBe 3
+
+            // The thief paid, but drew nothing and kept their own library intact.
+            game.handSize(2) shouldBe thiefHandBefore
+            game.librarySize(2) shouldBe 5
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheNotaryHobbitsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheNotaryHobbitsScenarioTest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Notary Hobbits (HOB) — "When The Notary Hobbits enter, if they're not a token, create two
+ * tokens that are copies of them, except the tokens aren't legendary."
+ *
+ * The interesting claim is the intervening-if (CR 603.4): every token copy carries the same enters
+ * trigger, so without the "if they're not a token" gate two tokens would each make two more and the
+ * board would never stop growing. The count assertions below are what pins that down.
+ */
+class TheNotaryHobbitsScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("casting them makes exactly two nonlegendary token copies, and the copies don't recurse") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "The Notary Hobbits")
+                .withLandsOnBattlefield(1, "Forest", 5)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "The Notary Hobbits").error shouldBe null
+            game.resolveStack()
+
+            val copies = game.findPermanents("The Notary Hobbits")
+            withClue("the printed card plus two token copies — and no runaway recursion") {
+                copies.size shouldBe 3
+            }
+            copies.count { game.state.getEntity(it)?.has<TokenComponent>() == true } shouldBe 2
+
+            // Legend rule (CR 704.5j) would eat a legendary duplicate; the tokens survive it.
+            game.checkStateBasedActions()
+            game.findPermanents("The Notary Hobbits").size shouldBe 3
+        }
+    }
+}


### PR DESCRIPTION
Five cards from The Hobbit (HOB), each canonical in `hob` — none is a reprint.

| Card | Cost | Notes |
|---|---|---|
| Rage into the Valley | `{2}{B}` | Draw + lose 1, then Amass Goblins 2 |
| Galion, Elvenking's Butler | `{2}{G}{G}` | Attack trigger sets an "up to one **other**" creature's base P/T to Galion's |
| Snowslope Hunter | `{2}{R}` | Sacrifice-another impulse, `UntilEndOfNextTurn`, `OnlyDuringYourTurn` + `OncePerTurn` |
| Gandalf, Wandering Wizard | `{4}{U}` | Ward {3}; `{6}`: owner shuffles him in and draws three |
| The Notary Hobbits | `{3}{G}{G}` | Two nonlegendary token copies + a `{C}`-per-Halfling mana ability |

Set selection avoided HOB's unimplemented mechanics (recruit, storied) — those are `add-feature` work, not card work.

## New SDK vocabulary: `Player.OwnerOfSource`

`Player.OwnerOf(desc)` resolves the owner of the effect's first **chosen target**, so it cannot express an ability that names its own source without targeting it. That is exactly Gandalf: *"Gandalf's owner shuffles him into their library and draws three cards."* Using `Player.You` instead would be an approximation that only holds while ownership and control agree.

`Player.OwnerOfSource` reads `CardComponent.ownerId` off `context.sourceId`. Wired into `TargetResolutionUtils.resolvePlayerRef` and `DynamicAmountEvaluator.resolveUnifiedPlayerIds` (`ForEachExecutor` already routes unknown single-player refs through `resolvePlayerRef`), and documented in `docs/card-sdk-language-reference.md`.

## Modeling notes worth a second look

- **The Notary Hobbits** — "if they're not a token" is an intervening-if (CR 603.4), so it is a `triggerCondition`, not a guard inside the effect. Without it each token copy would make two more and the board would never stop growing; the scenario test asserts exactly three permanents after resolution and re-checks after SBAs.
- **Galion** — `SetBasePowerAndToughness` with `sourcePower()`/`sourceToughness()` is a layer 7b *set* evaluated once on resolution, not a continuously-recomputed CDA. The chosen creature keeps the numbers Galion had at resolution, and counters/Auras still apply on top in 7c/7d.
- **Snowslope Hunter** — both printed restrictions are `ActivationRestriction`s rather than a timing rule, so the ability stays instant-speed *within* your own turn.

## Tests

Scenario tests for Gandalf, Galion, and The Notary Hobbits. The Gandalf test includes the case that motivated the new reference: a thief pays the `{6}`, but the owner shuffles and draws while the thief's hand and library are untouched.

HOB card snapshot re-blessed — the diff is pure additions, only these five cards.

## Verification

- `just build` — green
- `just test` — green
- `just check` — green
- `just check-card-printing` — clean for all five
- All five `image_uris.normal` return HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)