### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AlleyAssailant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AlleyAssailant.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Alley Assailant — Murders at Karlov Manor #76
+ * {2}{B} · Creature — Vampire Rogue · 3/3
+ *
+ * This creature enters tapped.
+ * Disguise {4}{B}{B}
+ * When this creature is turned face up, target opponent loses 3 life and you gain 3 life.
+ *
+ * The two lines are in tension by design, and the tension is the card. Hard-cast for {2}{B} it is a
+ * tapped 3/3 with no payoff — the drain only ever comes off the *disguise* route (CR 702.168d:
+ * turning face up is not entering the battlefield, so an enters trigger would never fire, and this
+ * one isn't an enters trigger to begin with).
+ *
+ * "Enters tapped" is a self-replacement (`EntersTapped`) carried by the card's own abilities, so
+ * casting it face down dodges it entirely: a face-down permanent has no abilities at all
+ * (CR 702.168a / 708.2), so the 2/2 with ward {2} arrives untapped and can attack the turn it comes
+ * down given haste, or block immediately. Flipping it later for {4}{B}{B} likewise leaves its
+ * tapped status alone (CR 701.34c), so the 3/3 that appears mid-combat is untapped.
+ *
+ * The drain is two independent fixed amounts, not a linked `DrainLife`: the opponent loses 3 and
+ * you gain 3 regardless of how much life they actually had to lose.
+ */
+val AlleyAssailant = card("Alley Assailant") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Rogue"
+    oracleText = "This creature enters tapped.\n" +
+        "Disguise {4}{B}{B} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, target opponent loses 3 life and you gain 3 life."
+    power = 3
+    toughness = 3
+    disguise = "{4}{B}{B}"
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        val victim = target("target opponent", TargetOpponent())
+        effect = Effects.Composite(
+            Effects.LoseLife(3, target = victim),
+            Effects.GainLife(3)
+        )
+        description = "When this creature is turned face up, target opponent loses 3 life and you gain 3 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edf238c9-61de-4f3a-b82f-05af46e5e81b.jpg?1783912903"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "Turning a permanent face up or face down doesn't change whether that permanent is " +
+                "tapped or untapped."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BasilicaStalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BasilicaStalker.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Basilica Stalker — Murders at Karlov Manor #78
+ * {5}{B} · Creature — Vampire Detective · 3/4
+ *
+ * Flying
+ * Whenever this creature deals combat damage to a player, you gain 1 life and surveil 1.
+ * Disguise {4}{B}
+ *
+ * Disguise here is a *rate* fix, not an evasion trick: {3} face down beats {5}{B} on curve, and the
+ * {4}{B} flip is paid later, at instant speed, out of the same mana you'd otherwise hold up. While
+ * face down it's a vanilla 2/2 with ward {2} (CR 702.168a) — the flying and the damage trigger are
+ * both suppressed (CR 708.2) until it's turned face up.
+ *
+ * The trigger is SELF-bound and combat-only, so pinging a player with a non-combat damage effect
+ * doesn't fire it. Its two clauses resolve in the printed order under one composite: the life comes
+ * in before the surveil, which matters only for anything watching lifegain mid-resolution.
+ */
+val BasilicaStalker = card("Basilica Stalker") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Detective"
+    oracleText = "Flying\n" +
+        "Whenever this creature deals combat damage to a player, you gain 1 life and surveil 1. " +
+        "(Look at the top card of your library. You may put it into your graveyard.)\n" +
+        "Disguise {4}{B} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)"
+    power = 3
+    toughness = 4
+    keywords(Keyword.FLYING)
+    disguise = "{4}{B}"
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Composite(
+            Effects.GainLife(1),
+            Effects.Surveil(1)
+        )
+        description = "Whenever this creature deals combat damage to a player, you gain 1 life and surveil 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Nicholas Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fdafea8f-283d-4f19-a74a-669bfbdfed98.jpg?1783912901"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LoxodonEavesdropper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LoxodonEavesdropper.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Loxodon Eavesdropper — Murders at Karlov Manor #168
+ * {3}{G} · Creature — Elephant Detective · 3/3
+ *
+ * When this creature enters, investigate.
+ * Whenever you draw your second card each turn, this creature gets +1/+1 and gains vigilance
+ * until end of turn.
+ *
+ * The two halves are deliberately linked: the Clue the enters trigger leaves behind is itself a
+ * draw, so cracking it on a turn you've already drawn for the turn is what turns the second clause
+ * on. `Triggers.NthCardDrawn(2)` counts *draws* (CR 121.2) — a card put into hand without the word
+ * "draw" (CR 121.5) doesn't advance it, and a single multi-card draw that crosses two still fires
+ * the trigger exactly once.
+ *
+ * The payoff names the source rather than a target, so both halves are `EffectTarget.Self` under
+ * one composite: the +1/+1 and the vigilance are one ability's effect and share the end-of-turn
+ * duration. Vigilance arriving *after* attackers are declared does nothing, which is why the
+ * interesting line is drawing at instant speed during the opponent's turn or in your first main
+ * phase — not after combat.
+ */
+val LoxodonEavesdropper = card("Loxodon Eavesdropper") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elephant Detective"
+    oracleText = "When this creature enters, investigate. (Create a Clue token. It's an artifact " +
+        "with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "Whenever you draw your second card each turn, this creature gets +1/+1 and gains " +
+        "vigilance until end of turn."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Investigate()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 1, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self)
+        )
+        description = "Whenever you draw your second card each turn, this creature gets +1/+1 " +
+            "and gains vigilance until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Jesper Ejsing"
+        flavorText = "He's all ears."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbbf8c3a-6c74-42fd-bb8d-61e3f0a77848.jpg?1783912865"
+
+        ruling(
+            "2024-02-02",
+            "Clue is an artifact type. Even though it appears on some cards with other permanent " +
+                "types, it's never a creature type, a land type, or anything but an artifact type."
+        )
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MuseumNightwatch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MuseumNightwatch.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Museum Nightwatch — Murders at Karlov Manor #25
+ * {3}{W} · Creature — Centaur Soldier · 3/2
+ *
+ * When this creature dies, create a 2/2 white and blue Detective creature token.
+ * Disguise {1}{W}
+ *
+ * A body that trades and then leaves a body behind, so it's never a bad block. The dies trigger is
+ * unconditional — it fires on a combat trade, on removal, and on a sacrifice, and the Detective is
+ * created even though the Nightwatch is already in the graveyard when it resolves.
+ *
+ * Disguise interacts with the death trigger the way it does with every ability on a face-down card:
+ * a face-down Museum Nightwatch is a 2/2 with ward {2} and *no* abilities (CR 702.168a / 708.2), so
+ * if it dies while face down no Detective arrives. Flipping it for {1}{W} is cheap precisely
+ * because turning it face up is what arms the trigger.
+ *
+ * The token's art comes from the MKM `tokenArt` layer (a 2/2 white-and-blue Detective is one of the
+ * set's printed tokens), so no `imageUri` is baked in here — same as Person of Interest.
+ */
+val MuseumNightwatch = card("Museum Nightwatch") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Centaur Soldier"
+    oracleText = "When this creature dies, create a 2/2 white and blue Detective creature token.\n" +
+        "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)"
+    power = 3
+    toughness = 2
+    disguise = "{1}{W}"
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE, Color.BLUE),
+            creatureTypes = setOf("Detective")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Alix Branwyn"
+        flavorText = "\"You there, halt! The gallery is closed. Wait—what are you doing?\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37860682-4973-4a0f-a43a-3056037bd2dc.jpg?1783912921"
+
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "If a face-down permanent leaves the battlefield, you must reveal it."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RepeatOffender.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RepeatOffender.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Repeat Offender — Murders at Karlov Manor #101
+ * {1}{B} · Creature — Human Assassin · 2/1
+ *
+ * {2}{B}: If this creature is suspected, put a +1/+1 counter on it. Otherwise, suspect it.
+ *
+ * One ability with a branch, not two abilities: the first activation suspects it (menace, can't
+ * block — CR 701.60a), and every activation after that grows it. The branch is a *state test*, so
+ * `ConditionalEffect` (which lowers to `GatedEffect` + `Gate.WhenCondition`) is the right shape —
+ * no prompt, no pause, both branches resolve synchronously in the executor.
+ *
+ * The condition is checked on **resolution**, not activation, which is the interaction worth
+ * knowing: holding priority and activating twice in response to itself resolves the second copy
+ * first, and since the creature is not yet suspected at that point, *both* copies take the
+ * "suspect it" branch — CR 701.60d makes the second one a no-op rather than a second counter.
+ * `Conditions.SourceIsSuspected` reads the projected suspected designation rather than probing for
+ * menace, so a creature that gained menace some other way doesn't trip the counter branch.
+ *
+ * "It" names the source in both branches, so both are `EffectTarget.Self` — there is no target and
+ * the ability can't be fizzled by removing something else.
+ */
+val RepeatOffender = card("Repeat Offender") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Assassin"
+    oracleText = "{2}{B}: If this creature is suspected, put a +1/+1 counter on it. Otherwise, " +
+        "suspect it. (A suspected creature has menace and can't block.)"
+    power = 2
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = ConditionalEffect(
+            condition = Conditions.SourceIsSuspected,
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            elseEffect = Effects.Suspect(EffectTarget.Self)
+        )
+        description = "If this creature is suspected, put a +1/+1 counter on it. Otherwise, suspect it."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Joshua Cairos"
+        flavorText = "\"Blasted sketch artist did too good a job. Looks like it's time for me to " +
+            "lie low for a little while.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c2ca1e7-e0de-4d29-a81b-62185ccd295f.jpg?1783912892"
+
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until it " +
+                "leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+        ruling("2024-02-02", "If a creature is already suspected, suspecting it again won't have any effect.")
+        ruling(
+            "2024-02-02",
+            "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected " +
+                "creature, it won't be suspected."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1,3 +1,84 @@
+// Alley Assailant
+{
+    "name": "Alley Assailant",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire Rogue",
+    "oracleText": "This creature enters tapped.\nDisguise {4}{B}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, target opponent loses 3 life and you gain 3 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{B}{B}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature is turned face up, target opponent loses 3 life and you gain 3 life."
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edf238c9-61de-4f3a-b82f-05af46e5e81b.jpg?1783912903",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Auspicious Arrival
 {
     "name": "Auspicious Arrival",
@@ -47,6 +128,80 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Basilica Stalker
+{
+    "name": "Basilica Stalker",
+    "manaCost": "{5}{B}",
+    "typeLine": "Creature — Vampire Detective",
+    "oracleText": "Flying\nWhenever this creature deals combat damage to a player, you gain 1 life and surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\nDisguise {4}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{B}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Surveil",
+                            "count": 1
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, you gain 1 life and surveil 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Nicholas Gregory",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fdafea8f-283d-4f19-a74a-669bfbdfed98.jpg?1783912901",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -1620,6 +1775,83 @@
     ]
 }
 
+// Loxodon Eavesdropper
+{
+    "name": "Loxodon Eavesdropper",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elephant Detective",
+    "oracleText": "When this creature enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\nWhenever you draw your second card each turn, this creature gets +1/+1 and gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you draw your second card each turn, this creature gets +1/+1 and gains vigilance until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Jesper Ejsing",
+        "flavorText": "He's all ears.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbbf8c3a-6c74-42fd-bb8d-61e3f0a77848.jpg?1783912865",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Clue is an artifact type. Even though it appears on some cards with other permanent types, it's never a creature type, a land type, or anything but an artifact type."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Lush Portico
 {
     "name": "Lush Portico",
@@ -1870,6 +2102,73 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Museum Nightwatch
+{
+    "name": "Museum Nightwatch",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Centaur Soldier",
+    "oracleText": "When this creature dies, create a 2/2 white and blue Detective creature token.\nDisguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{W}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE",
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Detective"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Alix Branwyn",
+        "flavorText": "\"You there, halt! The gallery is closed. Wait—what are you doing?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/37860682-4973-4a0f-a43a-3056037bd2dc.jpg?1783912921",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a face-down permanent leaves the battlefield, you must reveal it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -2394,6 +2693,98 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Repeat Offender
+{
+    "name": "Repeat Offender",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Assassin",
+    "oracleText": "{2}{B}: If this creature is suspected, put a +1/+1 counter on it. Otherwise, suspect it. (A suspected creature has menace and can't block.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": {
+                                "statePredicates": [
+                                    "IsSuspected"
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SetSuspected",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "MENACE",
+                                "target": "Self",
+                                "duration": "Permanent"
+                            },
+                            {
+                                "type": "CantBlockTargetCreatures",
+                                "target": "Self",
+                                "duration": "Permanent"
+                            }
+                        ],
+                        "descriptionOverride": "this creature becomes suspected"
+                    }
+                },
+                "descriptionOverride": "If this creature is suspected, put a +1/+1 counter on it. Otherwise, suspect it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Joshua Cairos",
+        "flavorText": "\"Blasted sketch artist did too good a job. Looks like it's time for me to lie low for a little while.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c2ca1e7-e0de-4d29-a81b-62185ccd295f.jpg?1783912892",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature is already suspected, suspecting it again won't have any effect."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected creature, it won't be suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LoxodonEavesdropperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LoxodonEavesdropperScenarioTest.kt
@@ -1,0 +1,164 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.LoxodonEavesdropper
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Loxodon Eavesdropper (MKM) — {3}{G} 3/3 Creature — Elephant Detective.
+ *
+ * "When this creature enters, investigate.
+ *  Whenever you draw your second card each turn, this creature gets +1/+1 and gains vigilance
+ *  until end of turn."
+ *
+ * The enters half is a plain `Effects.Investigate()`; the interesting half is the
+ * [com.wingedsheep.sdk.dsl.Triggers.NthCardDrawn]`(2)` payoff landing on the source itself, so
+ * these cover: the Clue arriving on entry, the second draw (and only the second) pumping it, and
+ * the bonus being end-of-turn rather than permanent.
+ */
+class LoxodonEavesdropperScenarioTest : ScenarioTestBase() {
+
+    // Free instants so a cast costs no mana and the only thing under test is the draw count.
+    private val drawOne = card("Draw One Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Draw a card."
+        spell { effect = Effects.DrawCards(1) }
+    }
+
+    private val drawThree = card("Draw Three Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Draw three cards."
+        spell { effect = Effects.DrawCards(3) }
+    }
+
+    init {
+        cardRegistry.register(LoxodonEavesdropper)
+        cardRegistry.register(drawOne)
+        cardRegistry.register(drawThree)
+
+        context("Loxodon Eavesdropper") {
+
+            test("entering the battlefield investigates — a Clue token arrives") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Loxodon Eavesdropper")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.isOnBattlefield("Clue") shouldBe false
+
+                game.castSpell(1, "Loxodon Eavesdropper").error shouldBe null
+                game.resolveStack()
+
+                withClue("the enters trigger must create a Clue token") {
+                    game.findAllPermanents("Clue").size shouldBe 1
+                }
+            }
+
+            test("the second draw of the turn pumps it and grants vigilance; the first does not") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Loxodon Eavesdropper", summoningSickness = false)
+                    .withCardsInHand(1, "Draw One Test", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardsDrawnThisTurn(1, 0)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val loxodon = game.findPermanent("Loxodon Eavesdropper")!!
+
+                game.castSpell(1, "Draw One Test").error shouldBe null
+                game.resolveStack()
+
+                withClue("the first draw of the turn advances no NthCardDrawn(2)") {
+                    val projected = StateProjector().project(game.state)
+                    projected.getPower(loxodon) shouldBe 3
+                    projected.getToughness(loxodon) shouldBe 3
+                    projected.hasKeyword(loxodon, Keyword.VIGILANCE) shouldBe false
+                }
+
+                game.castSpell(1, "Draw One Test").error shouldBe null
+                game.resolveStack()
+
+                withClue("the second draw pumps it and grants vigilance") {
+                    val projected = StateProjector().project(game.state)
+                    projected.getPower(loxodon) shouldBe 4
+                    projected.getToughness(loxodon) shouldBe 4
+                    projected.hasKeyword(loxodon, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+
+            test("a single multi-card draw crossing the second card fires the trigger exactly once") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Loxodon Eavesdropper", summoningSickness = false)
+                    .withCardInHand(1, "Draw Three Test")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardsDrawnThisTurn(1, 0)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val loxodon = game.findPermanent("Loxodon Eavesdropper")!!
+
+                game.castSpell(1, "Draw Three Test").error shouldBe null
+                game.resolveStack()
+
+                withClue("draws #1 and #3 fire nothing; only #2 does, for a single +1/+1") {
+                    val projected = StateProjector().project(game.state)
+                    projected.getPower(loxodon) shouldBe 4
+                    projected.getToughness(loxodon) shouldBe 4
+                    projected.hasKeyword(loxodon, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+
+            test("the bonus is until end of turn, not permanent") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Loxodon Eavesdropper", summoningSickness = false)
+                    .withCardInHand(1, "Draw Three Test")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardsDrawnThisTurn(1, 0)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val loxodon = game.findPermanent("Loxodon Eavesdropper")!!
+
+                game.castSpell(1, "Draw Three Test").error shouldBe null
+                game.resolveStack()
+                StateProjector().project(game.state).getPower(loxodon) shouldBe 4
+
+                game.passUntilPhase(Phase.ENDING, Step.CLEANUP)
+
+                withClue("cleanup wipes the end-of-turn buff and the granted vigilance") {
+                    val projected = StateProjector().project(game.state)
+                    projected.getPower(loxodon) shouldBe 3
+                    projected.getToughness(loxodon) shouldBe 3
+                    projected.hasKeyword(loxodon, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RepeatOffenderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RepeatOffenderScenarioTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.RepeatOffender
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Repeat Offender (MKM) — {1}{B} 2/1 Creature — Human Assassin.
+ *
+ * "{2}{B}: If this creature is suspected, put a +1/+1 counter on it. Otherwise, suspect it."
+ *
+ * The branch is a resolution-time state test, so these cover both arms and the hinge between them:
+ * the first activation suspects (designation + menace + can't block, no counter), and every
+ * activation afterwards takes the other arm and grows it instead of re-suspecting a no-op.
+ */
+class RepeatOffenderScenarioTest : FunSpec({
+
+    val abilityId = RepeatOffender.script.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RepeatOffender)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun activate(driver: GameTestDriver, player: EntityId, offender: EntityId) {
+        driver.giveMana(player, Color.BLACK, 3)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = offender, abilityId = abilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+    }
+
+    test("the first activation suspects it — designation, menace and can't block, no counter") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val offender = driver.putCreatureOnBattlefield(player, "Repeat Offender")
+
+        withClue("a freshly-played Repeat Offender is not suspected") {
+            StateProjector().project(driver.state).isSuspected(offender) shouldBe false
+        }
+
+        activate(driver, player, offender)
+
+        val projected = StateProjector().project(driver.state)
+        withClue("the else arm applies the suspected designation (CR 701.60a)") {
+            projected.isSuspected(offender) shouldBe true
+        }
+        withClue("suspected grants menace (CR 701.60c)") {
+            projected.hasKeyword(offender, Keyword.MENACE) shouldBe true
+        }
+        withClue("suspected can't block (CR 701.60c)") {
+            projected.cantBlock(offender) shouldBe true
+        }
+        withClue("the counter arm must not have run — it wasn't suspected yet") {
+            plusOneCounters(driver, offender) shouldBe 0
+            projected.getPower(offender) shouldBe 2
+            projected.getToughness(offender) shouldBe 1
+        }
+    }
+
+    test("once suspected, further activations add +1/+1 counters instead") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val offender = driver.putCreatureOnBattlefield(player, "Repeat Offender")
+
+        activate(driver, player, offender)
+        activate(driver, player, offender)
+
+        withClue("the second activation takes the counter arm") {
+            plusOneCounters(driver, offender) shouldBe 1
+            val projected = StateProjector().project(driver.state)
+            projected.getPower(offender) shouldBe 3
+            projected.getToughness(offender) shouldBe 2
+            projected.isSuspected(offender) shouldBe true
+        }
+
+        activate(driver, player, offender)
+
+        withClue("and keeps taking it — the counters accumulate") {
+            plusOneCounters(driver, offender) shouldBe 2
+            val projected = StateProjector().project(driver.state)
+            projected.getPower(offender) shouldBe 4
+            projected.getToughness(offender) shouldBe 3
+        }
+    }
+
+    test("suspecting stays permanent — the designation survives into a later turn") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val offender = driver.putCreatureOnBattlefield(player, "Repeat Offender")
+
+        activate(driver, player, offender)
+        StateProjector().project(driver.state).isSuspected(offender) shouldBe true
+
+        // Round the table back to the same player.
+        do {
+            driver.passPriorityUntil(Step.END)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        } while (driver.activePlayer != player)
+
+        withClue("suspected is not an until-end-of-turn effect (CR 701.60a)") {
+            StateProjector().project(driver.state).isSuspected(offender) shouldBe true
+        }
+
+        activate(driver, player, offender)
+
+        withClue("so a later-turn activation takes the counter arm") {
+            plusOneCounters(driver, offender) shouldBe 1
+        }
+    }
+})


### PR DESCRIPTION
Five MKM commons, all built entirely from existing SDK vocabulary — no new effects, triggers, keywords, or conditions, so `docs/card-sdk-language-reference.md` needs no update.

## Cards

| Card | Cost | Shape |
|---|---|---|
| **Loxodon Eavesdropper** | `{3}{G}` 3/3 | Enters → investigate; `Triggers.NthCardDrawn(2)` gives the source +1/+1 and vigilance UEOT |
| **Basilica Stalker** | `{5}{B}` 3/4 | Flying; combat damage to a player → gain 1 life + surveil 1; disguise `{4}{B}` |
| **Alley Assailant** | `{2}{B}` 3/3 | `EntersTapped` self-replacement; disguise `{4}{B}{B}`; turned-face-up → target opponent loses 3, you gain 3 |
| **Museum Nightwatch** | `{3}{W}` 3/2 | Dies → 2/2 white-and-blue Detective token; disguise `{1}{W}` |
| **Repeat Offender** | `{1}{B}` 2/1 | `{2}{B}`: branch on `Conditions.SourceIsSuspected` — +1/+1 counter if suspected, otherwise suspect it |

## Notes worth a reviewer's eye

- **Alley Assailant's drain is two independent fixed amounts**, not `DrainLife`. The oracle is "loses 3 … you gain 3" unconditionally, so a linked drain would wrongly cap the gain at the life actually lost.
- **Alley Assailant's "enters tapped" is deliberately dodgeable.** It's a self-replacement carried by the card's own abilities, so casting it face down (CR 702.168a / 708.2 — no abilities at all) lands an untapped 2/2, and flipping it later leaves its tapped status alone (CR 701.34c). That is the card's whole design tension.
- **Repeat Offender's branch is checked at resolution, not activation.** Two activations held in response to each other both take the "suspect it" arm, and CR 701.60d makes the second a no-op rather than a second counter. `Conditions.SourceIsSuspected` reads the projected designation, not a probe for menace.
- **Museum Nightwatch's token carries no `imageUri`** — the MKM `tokenArt` layer supplies the 2/2 white-and-blue Detective, same as Person of Interest.

## Tests

Scenario tests for the two cards whose behaviour isn't a flat composition (one card per file):

- `LoxodonEavesdropperScenarioTest` — Clue on entry; the second draw and only the second pumps; a single three-card draw crossing #2 fires exactly once; the buff and vigilance expire at cleanup.
- `RepeatOffenderScenarioTest` — both branch arms, counters accumulating across activations, and the suspected designation surviving into a later turn.

The other three are flat compositions of existing primitives, covered by the snapshot and lint nets.

## Verification

- `just test-class RepeatOffenderScenarioTest` — 3/3 pass
- `just test-class LoxodonEavesdropperScenarioTest` — 4/4 pass
- `just build` — green
- `just rebless-cards` — the `MKM.json` golden diff is purely additive; only these five card trees appear, no unrelated card moved
- `just check-card-printing` — clean for all five (each is an MKM-only printing, canonical sits in the earliest real printing)

MKM coverage: 67 → 72 of 276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)