### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BilboBagginsBurglar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BilboBagginsBurglar.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bilbo Baggins, Burglar // Take a Glance — The Hobbit #34
+ * {2}{U} · Legendary Creature — Halfling Rogue · Common
+ * 2/1
+ *
+ * When Bilbo Baggins enters, draw a card.
+ *
+ * Adventure: Take a Glance — {U}, Sorcery — Adventure
+ * Scry 2.
+ *
+ * The Adventure is the cheap look-ahead you cast on turn one; the creature half is the same card
+ * cast later from exile, replaying its enters trigger. Both halves are existing facades — the scry
+ * is [Patterns.Library.scry], not a hand-rolled reorder.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val BilboBagginsBurglar = card("Bilbo Baggins, Burglar") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Halfling Rogue"
+    power = 2
+    toughness = 1
+    oracleText = "When Bilbo Baggins enters, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When Bilbo Baggins enters, draw a card."
+    }
+
+    adventure("Take a Glance") {
+        manaCost = "{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Scry 2. (Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Patterns.Library.scry(2)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Kieran Yanner"
+        flavorText = "\"Now it is the burglar's turn. You must go on and find out if all is " +
+            "perfectly safe and canny.\"\n—Thorin"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a109b3e-9f5b-4625-abb7-6b992c10530b.jpg?1785323194"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GollumSilentSlinker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GollumSilentSlinker.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gollum, Silent Slinker // Meager Meal — The Hobbit #71
+ * {3}{B} · Legendary Creature — Halfling Horror · Common
+ * 4/3
+ *
+ * Menace
+ *
+ * Adventure: Meager Meal — {B}, Sorcery — Adventure
+ * Put a +1/+1 counter on up to one target creature. Target player gains 2 life.
+ *
+ * The Adventure takes two targets: the creature is "up to one" ([Targets.UpToCreatures]) so the
+ * spell is castable with no creatures on the battlefield, while the player is a required target —
+ * declaring no creature never makes the life gain optional. Named targets keep the two apart, so a
+ * creature that becomes illegal by resolution only skips the counter; the life gain still happens.
+ *
+ * The **required player target is declared first** and the optional creature second, which is the
+ * reverse of the oracle sentence order. That is deliberate: cast-time targets are matched to
+ * requirements by fixed-width positional slots, so a declined *leading* optional target would let
+ * the player slide into the creature's slot and be rejected. A declined *trailing* optional target
+ * is simply an absent slot. CR 601.2c fixes no order between separate instances of "target", and
+ * the effects bind by name rather than by index, so nothing else moves.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val GollumSilentSlinker = card("Gollum, Silent Slinker") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Halfling Horror"
+    power = 4
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)"
+
+    keywords(Keyword.MENACE)
+
+    adventure("Meager Meal") {
+        manaCost = "{B}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Put a +1/+1 counter on up to one target creature. Target player gains 2 life. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val player = target("player", Targets.Player)
+            val creature = target("creature", Targets.UpToCreatures(1))
+            effect = Effects.Composite(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature),
+                Effects.GainLife(2, player)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Miklós Ligeti"
+        flavorText = "He rowed about quietly on the lake. Never a ripple did he make, not he."
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6cfaa182-3fec-4907-8814-b4d29c33cec3.jpg?1785323234"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SmaugTheGreatCalamity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SmaugTheGreatCalamity.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Smaug, the Great Calamity // Spew Flame — The Hobbit #109
+ * {5}{R}{R} · Legendary Creature — Dragon · Common
+ * 5/5
+ *
+ * Flying
+ *
+ * Adventure: Spew Flame — {4}{R}, Sorcery — Adventure
+ * Spew Flame deals 5 damage to target creature.
+ *
+ * A vanilla flier on the front and a plain burn spell on the Adventure, so both halves are pure
+ * facade composition. The damage is dealt by the Adventure card itself (`EffectTarget.Source` is
+ * implied by [Effects.DealDamage]'s default source), which matters only for damage-source-triggered
+ * abilities on the target.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val SmaugTheGreatCalamity = card("Smaug, the Great Calamity") {
+    manaCost = "{5}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dragon"
+    power = 5
+    toughness = 5
+    oracleText = "Flying"
+
+    keywords(Keyword.FLYING)
+
+    adventure("Spew Flame") {
+        manaCost = "{4}{R}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Spew Flame deals 5 damage to target creature. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            target = Targets.Creature
+            effect = Effects.DealDamage(5, EffectTarget.ContextTarget(0))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Chris Cold"
+        flavorText = "\"My armor is like tenfold shields, my teeth are swords, my wings a hurricane, " +
+            "and my breath death!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/419ca9e5-8413-4378-a4ef-eda5a1024218.jpg?1785497136"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheBlackArrow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheBlackArrow.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Black Arrow — The Hobbit #171
+ * {3} · Legendary Artifact — Equipment · Uncommon
+ *
+ * Flash
+ * When The Black Arrow enters, it deals 1 damage to any target. If a Dragon is dealt damage this
+ * way, destroy it.
+ * Equipped creature gets +1/+1 and has reach.
+ * Equip {1}
+ *
+ * Flash plus the enters trigger is the whole point: held up during the opponent's turn, it answers
+ * an attacking Dragon for {3} regardless of the Dragon's toughness. The conditional destroy follows
+ * the Sonic Shrieker convention — "is dealt damage this way" is modeled as a check on what the
+ * chosen target *was*, since the engine deals the damage unconditionally to a legal target.
+ * [Conditions.TargetMatchesFilter] returns false for a player target, so a player hit by the arrow
+ * never trips the destroy.
+ *
+ * The Dragon check is `GameObjectFilter.Any.withSubtype(DRAGON)` rather than `Creature.withSubtype`
+ * so a noncreature permanent that is a Dragon (a Dragon planeswalker, a Dragon Vehicle) is still
+ * caught by the destroy — the card says "a Dragon", not "a Dragon creature".
+ */
+val TheBlackArrow = card("The Black Arrow") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Flash\n" +
+        "When The Black Arrow enters, it deals 1 damage to any target. If a Dragon is dealt " +
+        "damage this way, destroy it.\n" +
+        "Equipped creature gets +1/+1 and has reach.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.DealDamage(1, anyTarget),
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(
+                    GameObjectFilter.Any.withSubtype(Subtype.DRAGON),
+                    targetIndex = 0
+                ),
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+            )
+        )
+        description = "When The Black Arrow enters, it deals 1 damage to any target. " +
+            "If a Dragon is dealt damage this way, destroy it."
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.REACH, Filters.EquippedCreature)
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Kevin Sidharta"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab181190-d53d-4972-8cd5-8e54b45f2276.jpg?1785496386"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/VowToErebor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/VowToErebor.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vow to Erebor — The Hobbit #31
+ * {1}{W} · Instant · Common
+ *
+ * Untap target creature you control. It gets +2/+2 until end of turn. If it's a Dwarf, you may
+ * attach an Equipment you control to it.
+ *
+ * The Dwarf rider is a resolution-time check on the one target ([Conditions.TargetMatchesFilter]),
+ * so a creature that only becomes a Dwarf in response still gets the attach, and a non-Dwarf target
+ * skips it silently rather than fizzling the untap and the pump.
+ *
+ * The Equipment is **chosen, not targeted** — the oracle text says "an Equipment you control", not
+ * "target Equipment". So it is gathered from the battlefield and picked with `chooseUpTo(1)`, whose
+ * "up to" shape *is* the "you may": declining selects nothing and the attach is a no-op. The gather
+ * passes `includeAttachments = true` because an Equipment already attached to another creature is
+ * still one you control, and moving it is the main reason to cast this in combat.
+ */
+val VowToErebor = card("Vow to Erebor") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Untap target creature you control. It gets +2/+2 until end of turn. " +
+        "If it's a Dwarf, you may attach an Equipment you control to it."
+
+    spell {
+        target = Targets.CreatureYouControl
+        effect = Effects.Composite(
+            Effects.Untap(EffectTarget.ContextTarget(0)),
+            Effects.ModifyStats(2, 2, EffectTarget.ContextTarget(0), Duration.EndOfTurn),
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(
+                    GameObjectFilter.Creature.withSubtype(Subtype.DWARF),
+                    targetIndex = 0
+                ),
+                effect = Effects.Pipeline {
+                    val equipment = gather(
+                        filter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT),
+                        player = Player.You,
+                        includeAttachments = true
+                    )
+                    val chosen = chooseUpTo(
+                        count = 1,
+                        from = equipment,
+                        useTargetingUI = true,
+                        prompt = "You may attach an Equipment you control to the Dwarf",
+                        selectedLabel = "Attach"
+                    )
+                    run(
+                        Effects.AttachTargetEquipmentToCreature(
+                            equipmentTarget = EffectTarget.PipelineTarget(chosen.key),
+                            creatureTarget = EffectTarget.ContextTarget(0)
+                        )
+                    )
+                }
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Andreia Ugrai"
+        flavorText = "\"We shall soon, before the break of day, start on our long journey—a journey " +
+            "from which some of us, or perhaps all of us, may never return.\"\n—Thorin"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d4f3eb5-fedf-45d6-8bd8-aacbe0ce33b2.jpg?1785497034"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -117,6 +117,61 @@
     ]
 }
 
+// Bilbo Baggins, Burglar
+{
+    "name": "Bilbo Baggins, Burglar",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Halfling Rogue",
+    "oracleText": "When Bilbo Baggins enters, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When Bilbo Baggins enters, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"Now it is the burglar's turn. You must go on and find out if all is perfectly safe and canny.\"\n—Thorin",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a109b3e-9f5b-4625-abb7-6b992c10530b.jpg?1785323194"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Take a Glance",
+            "manaCost": "{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Scry 2. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        }
+    ]
+}
+
 // Bilbo's Deadly Slice
 {
     "name": "Bilbo's Deadly Slice",
@@ -2242,6 +2297,80 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Gollum, Silent Slinker
+{
+    "name": "Gollum, Silent Slinker",
+    "manaCost": "{3}{B}",
+    "typeLine": "Legendary Creature — Halfling Horror",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Miklós Ligeti",
+        "flavorText": "He rowed about quietly on the lake. Never a ripple did he make, not he.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6cfaa182-3fec-4907-8814-b4d29c33cec3.jpg?1785323234"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Meager Meal",
+            "manaCost": "{B}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Put a +1/+1 counter on up to one target creature. Target player gains 2 life. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "player"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "player"
+                    },
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -4430,6 +4559,60 @@
     ]
 }
 
+// Smaug, the Great Calamity
+{
+    "name": "Smaug, the Great Calamity",
+    "manaCost": "{5}{R}{R}",
+    "typeLine": "Legendary Creature — Dragon",
+    "oracleText": "Flying",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Chris Cold",
+        "flavorText": "\"My armor is like tenfold shields, my teeth are swords, my wings a hurricane, and my breath death!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/419ca9e5-8413-4378-a4ef-eda5a1024218.jpg?1785497136"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Spew Flame",
+            "manaCost": "{4}{R}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Spew Flame deals 5 damage to target creature. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Snowslope Hunter
 {
     "name": "Snowslope Hunter",
@@ -4816,6 +4999,121 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// The Black Arrow
+{
+    "name": "The Black Arrow",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Flash\nWhen The Black Arrow enters, it deals 1 damage to any target. If a Dragon is dealt damage this way, destroy it.\nEquipped creature gets +1/+1 and has reach.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any target"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "Dragon"
+                                }
+                            },
+                            "then": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "descriptionOverride": "When The Black Arrow enters, it deals 1 damage to any target. If a Dragon is dealt damage this way, destroy it."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "REACH"
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Kevin Sidharta",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab181190-d53d-4972-8cd5-8e54b45f2276.jpg?1785496386"
+    },
+    "colorIdentityOverride": []
 }
 
 // The Chief Warg
@@ -5625,6 +5923,116 @@
                 ]
             }
         }
+    ]
+}
+
+// Vow to Erebor
+{
+    "name": "Vow to Erebor",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Untap target creature you control. It gets +2/+2 until end of turn. If it's a Dwarf, you may attach an Equipment you control to it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": "creature Dwarf"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "artifact Equipment",
+                                    "player": "You",
+                                    "includeAttachments": true
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "selected1",
+                                "prompt": "You may attach an Equipment you control to the Dwarf",
+                                "selectedLabel": "Attach",
+                                "useTargetingUI": true
+                            },
+                            {
+                                "type": "AttachTargetEquipmentToCreature",
+                                "equipmentTarget": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "selected1"
+                                },
+                                "creatureTarget": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Andreia Ugrai",
+        "flavorText": "\"We shall soon, before the break of day, start on our long journey—a journey from which some of us, or perhaps all of us, may never return.\"\n—Thorin",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d4f3eb5-fedf-45d6-8bd8-aacbe0ce33b2.jpg?1785497034"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GollumSilentSlinkerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GollumSilentSlinkerScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gollum, Silent Slinker // Meager Meal (HOB #71).
+ *
+ * The Adventure takes two targets of different kinds — a required "target player" and "up to one
+ * target creature" — so the risk is the two getting crossed, or the optional one swallowing the
+ * required one when it is declined. These tests pin that both land where they belong, and that
+ * declining the creature still gains the life.
+ */
+class GollumSilentSlinkerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Meager Meal (the Adventure)") {
+
+            test("puts the counter on the chosen creature and gains the chosen player 2 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gollum, Silent Slinker")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val gollum = game.findCardsInHand(1, "Gollum, Silent Slinker").single()
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = gollum,
+                        faceIndex = 0, // the Adventure face
+                        // Required player target first, optional creature second — see the card's
+                        // KDoc for why the slot order is the reverse of the oracle sentence.
+                        targets = listOf(
+                            ChosenTarget.Player(game.player1Id),
+                            ChosenTarget.Permanent(bears)
+                        )
+                    )
+                )
+                withClue("Casting Meager Meal should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the creature target got the +1/+1 counter") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 3
+                }
+                withClue("the player target gained 2 life") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("the Adventure exiles itself rather than going to the graveyard") {
+                    game.isInExile(1, "Gollum, Silent Slinker") shouldBe true
+                }
+            }
+
+            test("the creature is 'up to one' — declining it still gains the life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gollum, Silent Slinker")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gollum = game.findCardsInHand(1, "Gollum, Silent Slinker").single()
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = gollum,
+                        faceIndex = 0,
+                        // No creature on the battlefield at all — only the required player target.
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("Meager Meal is castable with no creature to counter: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the chosen player still gains 2 life") {
+                    game.getLifeTotal(2) shouldBe 22
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheBlackArrowScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheBlackArrowScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Black Arrow (HOB #171) — {3} Legendary Artifact — Equipment.
+ *
+ * "Flash. When The Black Arrow enters, it deals 1 damage to any target. If a Dragon is dealt damage
+ * this way, destroy it. Equipped creature gets +1/+1 and has reach. Equip {1}."
+ *
+ * The whole card hangs on the Dragon rider: 1 damage is nothing to a 5/5 flier, so the destroy has
+ * to fire off the *type* of the damaged permanent, not off lethal damage. These tests pin both
+ * sides of that gate — a Dragon dies, a same-sized non-Dragon shrugs it off.
+ */
+class TheBlackArrowScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Black Arrow ETB") {
+
+            test("a Dragon dealt the 1 damage is destroyed regardless of its toughness") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Black Arrow")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(2, "Shivan Dragon") // 5/5 — survives 1 damage on its own
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "The Black Arrow")
+                withClue("Casting The Black Arrow should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack() // Equipment enters → ETB trigger asks for its "any target"
+
+                val dragon = game.findPermanent("Shivan Dragon")!!
+                val targeted = game.selectTargets(listOf(dragon))
+                withClue("Targeting the Dragon should be legal: ${targeted.error}") { targeted.error shouldBe null }
+                game.resolveStack()
+
+                withClue("1 damage is not lethal to a 5/5, but the Dragon rider destroys it anyway") {
+                    game.isOnBattlefield("Shivan Dragon") shouldBe false
+                    game.isInGraveyard(2, "Shivan Dragon") shouldBe true
+                }
+            }
+
+            test("a non-Dragon dealt the 1 damage survives") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Black Arrow")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3 — not a Dragon
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "The Black Arrow")
+                withClue("Casting The Black Arrow should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val targeted = game.selectTargets(listOf(giant))
+                withClue("Targeting the Hill Giant should be legal: ${targeted.error}") { targeted.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Not a Dragon, so only the 1 damage lands — the 3/3 lives") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                }
+            }
+
+            test("a player dealt the 1 damage just loses a life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Black Arrow")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "The Black Arrow").error shouldBe null
+                game.resolveStack()
+
+                game.selectTargets(listOf(game.player2Id)).error shouldBe null
+                game.resolveStack()
+
+                withClue("A player target takes 1 damage and never trips the Dragon rider") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+            }
+        }
+
+        context("The Black Arrow equipped bonus") {
+
+            test("equipped creature gets +1/+1 and reach") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Black Arrow")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2, no reach
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val arrow = game.findPermanent("The Black Arrow")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val equip = cardRegistry.requireCard("The Black Arrow").activatedAbilities.single().id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = arrow,
+                        abilityId = equip,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("Equipped creature gets +1/+1") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 3
+                }
+                withClue("Equipped creature has reach") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.REACH) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VowToEreborScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VowToEreborScenarioTest.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vow to Erebor (HOB #31) — {1}{W} Instant.
+ *
+ * "Untap target creature you control. It gets +2/+2 until end of turn. If it's a Dwarf, you may
+ * attach an Equipment you control to it."
+ *
+ * Three things worth pinning: the Dwarf rider is gated on the *target's* type (a non-Dwarf gets the
+ * untap and the pump but is never offered the attach), the attach is a chosen-not-targeted
+ * selection whose "up to one" shape carries the "you may", and an Equipment already attached
+ * elsewhere can be moved — that is the combat trick this card is for.
+ */
+class VowToEreborScenarioTest : ScenarioTestBase() {
+
+    private fun isTapped(game: TestGame, id: EntityId): Boolean =
+        game.state.getEntity(id)?.get<TappedComponent>() != null
+
+    /** Cast the spell at [target] and settle the mana payment, leaving the spell mid-resolution. */
+    private fun castAndResolve(game: TestGame, target: EntityId) {
+        val cast = game.castSpell(1, "Vow to Erebor", target)
+        withClue("Casting Vow to Erebor should succeed: ${cast.error}") { cast.error shouldBe null }
+        if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+        game.resolveStack()
+    }
+
+    init {
+        context("Vow to Erebor") {
+
+            test("a Dwarf target is untapped, pumped, and may take an Equipment you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Vow to Erebor")
+                    .withCardOnBattlefield(1, "Dwarven Provisioner", tapped = true) // 2/2 Dwarf
+                    .withCardOnBattlefield(1, "Bonesplitter")                       // +2/+0, unattached
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dwarf = game.findPermanent("Dwarven Provisioner")!!
+                val bonesplitter = game.findPermanent("Bonesplitter")!!
+
+                castAndResolve(game, dwarf)
+
+                withClue("resolution pauses to offer the Equipment attach") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(listOf(bonesplitter)).error shouldBe null
+
+                withClue("the Dwarf is untapped") { isTapped(game, dwarf) shouldBe false }
+                withClue("the Bonesplitter moved onto the Dwarf") {
+                    game.state.getEntity(bonesplitter)?.get<AttachedToComponent>()?.targetId shouldBe dwarf
+                }
+                withClue("2/2 base, +2/+2 from the spell, +2/+0 from the Bonesplitter") {
+                    game.state.projectedState.getPower(dwarf) shouldBe 6
+                    game.state.projectedState.getToughness(dwarf) shouldBe 4
+                }
+            }
+
+            test("the attach is optional — declining still leaves the untap and the pump") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Vow to Erebor")
+                    .withCardOnBattlefield(1, "Dwarven Provisioner", tapped = true)
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dwarf = game.findPermanent("Dwarven Provisioner")!!
+                val bonesplitter = game.findPermanent("Bonesplitter")!!
+
+                castAndResolve(game, dwarf)
+
+                game.hasPendingDecision() shouldBe true
+                game.skipSelection().error shouldBe null
+
+                withClue("declining attaches nothing") {
+                    game.state.getEntity(bonesplitter)?.get<AttachedToComponent>() shouldBe null
+                }
+                withClue("the untap and the +2/+2 happened anyway") {
+                    isTapped(game, dwarf) shouldBe false
+                    game.state.projectedState.getPower(dwarf) shouldBe 4
+                    game.state.projectedState.getToughness(dwarf) shouldBe 4
+                }
+            }
+
+            test("a non-Dwarf target is untapped and pumped but never offered the attach") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Vow to Erebor")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = true) // 2/2, not a Dwarf
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val bonesplitter = game.findPermanent("Bonesplitter")!!
+
+                castAndResolve(game, bears)
+
+                withClue("no Dwarf, so no Equipment prompt at all") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("untap and pump still resolve") {
+                    isTapped(game, bears) shouldBe false
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 4
+                }
+                game.state.getEntity(bonesplitter)?.get<AttachedToComponent>() shouldBe null
+            }
+
+            test("an Equipment already attached elsewhere can be moved onto the Dwarf") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Vow to Erebor")
+                    .withCardOnBattlefield(1, "Dwarven Provisioner", tapped = true)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Bonesplitter", "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dwarf = game.findPermanent("Dwarven Provisioner")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val bonesplitter = game.findPermanent("Bonesplitter")!!
+
+                withClue("the Bonesplitter starts on the Bears") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                }
+
+                castAndResolve(game, dwarf)
+
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(listOf(bonesplitter)).error shouldBe null
+
+                withClue("the Equipment left the Bears and landed on the Dwarf") {
+                    game.state.getEntity(bonesplitter)?.get<AttachedToComponent>()?.targetId shouldBe dwarf
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                    game.state.projectedState.getPower(dwarf) shouldBe 6
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five HOB cards, all pure composition over existing SDK primitives — no new effect, trigger, condition, or keyword.

| Card | # | Text |
|---|---|---|
| Smaug, the Great Calamity // Spew Flame | 109 | {5}{R}{R} 5/5 flier; Adventure {4}{R} deals 5 damage to target creature |
| Gollum, Silent Slinker // Meager Meal | 71 | {3}{B} 4/3 menace; Adventure {B} puts a +1/+1 counter on up to one target creature, target player gains 2 life |
| Bilbo Baggins, Burglar // Take a Glance | 34 | {2}{U} 2/1, ETB draw a card; Adventure {U} scries 2 |
| Vow to Erebor | 31 | {1}{W} instant — untap + +2/+2 target creature you control; if it's a Dwarf, you may attach an Equipment you control to it |
| The Black Arrow | 171 | {3} flash Equipment — ETB deals 1 damage to any target, destroying it if it's a Dragon; equipped creature gets +1/+1 and reach; equip {1} |

## Modeling notes

**Vow to Erebor's Equipment is chosen, not targeted.** The oracle says "an Equipment you control", not "target Equipment", so it runs through a `gather → chooseUpTo(1) → AttachTargetEquipmentToCreature` pipeline rather than a second target requirement. The "up to one" shape *is* the "you may" — declining selects nothing and the attach is a graceful no-op. `useTargetingUI = true` routes the pick to the battlefield instead of an overlay, and the gather passes `includeAttachments = true` so an Equipment already on another creature can be moved (the main reason to cast this in combat).

**Meager Meal declares its required player target before its optional creature target**, reversing the oracle sentence order. Cast-time targets are matched to requirements by fixed-width positional slots (`TargetValidator.validateTargets`), so a declined *leading* optional target lets the next target slide into its slot and get rejected as the wrong kind; a declined *trailing* optional target is simply an absent slot. CR 601.2c fixes no order between separate instances of the word "target", and the effects bind by name rather than index, so nothing else moves. This is documented in the card's KDoc and pinned by a test.

**The Black Arrow's Dragon rider** follows the existing Sonic Shrieker convention: "is dealt damage this way" is modeled as a check on what the chosen target *was*, since the engine deals the damage unconditionally to a legal target. The filter is `GameObjectFilter.Any.withSubtype(DRAGON)` rather than `Creature.withSubtype` — the card says "a Dragon", not "a Dragon creature".

## Verification

- `just build` — green (full compile + all module tests + kover verify).
- `just rebless-cards` — only `snapshots/cards/HOB.json` moved, and only with these five cards' trees added.
- `just check-card-printing` — all five report `canonical is in the card's earliest real printing`.
- Scenario tests for the three cards with real resolution logic (one file per card, all passing):
  - `VowToEreborScenarioTest` — Dwarf gets the attach; declining leaves untap + pump intact; a non-Dwarf is never offered the prompt at all; an Equipment attached elsewhere moves onto the Dwarf.
  - `TheBlackArrowScenarioTest` — a 5/5 Dragon dies to 1 damage; a 3/3 non-Dragon survives; a player target just loses a life; equipped creature gets +1/+1 and reach.
  - `GollumSilentSlinkerScenarioTest` — both targets land where they belong and the Adventure self-exiles; declining the creature still gains the life.
- Smaug and Bilbo are single-facade compositions covered by the snapshot and lint nets, per the `add-card` skill's "tests only if new SDK vocabulary" rule.
- All five `imageUri` values verified HTTP 200 against `cards.scryfall.io`; every mechanical field re-checked against Scryfall (`&set=hob`). No rulings exist yet for this set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)