### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CorneredCrook.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CorneredCrook.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Cornered Crook — Murders at Karlov Manor #120
+ * {4}{R} · Creature — Lizard Warrior · 5/4
+ *
+ * When this creature enters, you may sacrifice an artifact. When you do, this creature deals 3
+ * damage to any target.
+ *
+ * A [ReflexiveTriggerEffect], and the reflexive half genuinely matters here — the Scryfall ruling is
+ * explicit that no target is chosen when the enters ability triggers. The damage is a *second*
+ * ability (CR 603.12) that goes on the stack only after the artifact is actually sacrificed, picks
+ * its target then, and can be responded to on its own. Resolving the damage inline would let the
+ * Crook's controller see the target before committing the artifact and would deny opponents the
+ * priority window, both of which the rules forbid.
+ *
+ * The sacrifice is a resolution-time *choice*, not a target — `SelectTargetEffect` prompts for an
+ * artifact its controller owns and `SacrificeTarget` sacrifices it. Any artifact qualifies, including
+ * an artifact creature and including Clue tokens, which is the intended Karlov Manor synergy; the
+ * Crook itself is not an artifact, so no `.other()` guard is needed.
+ *
+ * `optional = true` carries the "you may". With no artifact on the battlefield
+ * `ReflexiveTriggerEffectExecutor.isActionFeasible` skips the whole thing rather than asking a
+ * question that could only produce a vacuous yes.
+ */
+val CorneredCrook = card("Cornered Crook") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard Warrior"
+    oracleText = "When this creature enters, you may sacrifice an artifact. When you do, this " +
+        "creature deals 3 damage to any target."
+    power = 5
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Composite(
+                listOf(
+                    SelectTargetEffect(
+                        requirement = TargetObject(filter = TargetFilter.Artifact.youControl()),
+                        storeAs = "toSacrifice"
+                    ),
+                    Effects.SacrificeTarget(EffectTarget.PipelineTarget("toSacrifice"))
+                )
+            ),
+            optional = true,
+            reflexiveEffect = Effects.DealDamage(3, EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(Targets.Any),
+            descriptionOverride = "You may sacrifice an artifact. When you do, this creature deals " +
+                "3 damage to any target."
+        )
+        description = "When this creature enters, you may sacrifice an artifact. When you do, this " +
+            "creature deals 3 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "120"
+        artist = "Gabor Szikszai"
+        flavorText = "Monax knew attacking the detective was a reckless move, but he was at the end " +
+            "of his rope."
+        imageUri = "https://cards.scryfall.io/normal/front/a/3/a3aff1ea-1d25-49c3-a2d9-f435124a5969.jpg?1783912883"
+
+        ruling(
+            "2024-02-02",
+            "You don't choose a target for Cornered Crook's ability at the time it triggers. Rather, " +
+                "a second \"reflexive\" ability triggers when you sacrifice an artifact this way. You " +
+                "choose a target for that ability as it goes on the stack. Each player may respond to " +
+                "this triggered ability as normal."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CrimeNovelist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CrimeNovelist.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Crime Novelist — Murders at Karlov Manor #121
+ * {2}{R} · Creature — Goblin Bard · 1/3
+ *
+ * Whenever you sacrifice an artifact, put a +1/+1 counter on this creature and add {R}.
+ *
+ * `YouSacrificeA` is the per-permanent form: "whenever you sacrifice **an** artifact" is one trigger
+ * per artifact, so sacrificing three at once grows the Novelist by three and produces {R}{R}{R} — the
+ * batch form would give one of each. The Novelist is not itself an artifact, so `YouSacrificeA` and
+ * `YouSacrificeAnother` would behave identically here; the printed wording is the non-"another" one.
+ *
+ * Sacrifices made to *pay a cost* count. Costs are paid while the spell or ability is being put on
+ * the stack, so cracking a Clue for its own "{2}, Sacrifice this token: Draw a card" triggers this,
+ * and — the reason the card is playable at all — the {R} arrives in time to help cast whatever comes
+ * next, not the spell whose cost caused it.
+ *
+ * This is a *triggered* ability that produces mana, not a mana ability: it uses the stack (it has an
+ * effect other than producing mana, CR 605.1a), so opponents get priority and the mana lands in the
+ * pool during that trigger's resolution. It therefore empties at the end of the step or phase like
+ * any other unspent mana.
+ */
+val CrimeNovelist = card("Crime Novelist") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Bard"
+    oracleText = "Whenever you sacrifice an artifact, put a +1/+1 counter on this creature and add {R}."
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Artifact)
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            Effects.AddMana(Color.RED)
+        )
+        description = "Whenever you sacrifice an artifact, put a +1/+1 counter on this creature and add {R}."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "121"
+        artist = "Izzy"
+        flavorText = "\"But then he peeled off the mask, revealing a sight that made Groja's blood " +
+            "run cold—Brulu was actually Vogos in disguise!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14a5cd7c-b0b1-4ffa-a806-bb0e73baffad.jpg?1783912882"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FaerieSnoop.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FaerieSnoop.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faerie Snoop — Murders at Karlov Manor #203
+ * {1}{U}{B} · Creature — Faerie Detective · 1/4
+ *
+ * Flying
+ * Disguise {1}{U/B}{U/B}
+ * When this creature is turned face up, look at the top two cards of your library. Put one into your
+ * hand and the other into your graveyard.
+ *
+ * Face down it is a colorless, typeless 2/2 with ward {2} (CR 708.2) — no flying, no Detective type,
+ * no trigger — so the Snoop only pays off through the disguise route. Turning face up is a special
+ * action, not entering the battlefield (CR 701.34c), which is why this is a `TurnedFaceUp` trigger and
+ * not an enters trigger.
+ *
+ * The look is *not* impulse card selection: both cards leave the top, one to hand and one to the
+ * graveyard, so `lookAtTopAndKeep(count = 2, keepCount = 1)` with its default HAND / GRAVEYARD
+ * destinations is the literal reading. `ChooseExactly(1)` is right rather than "up to" — the oracle
+ * text has no "may", and with a one-card library the selection just runs over whatever was gathered.
+ *
+ * The cards are looked at, not revealed, so the graveyard half is only public once it lands there.
+ */
+val FaerieSnoop = card("Faerie Snoop") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Faerie Detective"
+    oracleText = "Flying\n" +
+        "Disguise {1}{U/B}{U/B} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, look at the top two cards of your library. Put one " +
+        "into your hand and the other into your graveyard."
+    power = 1
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+    disguise = "{1}{U/B}{U/B}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        effect = Patterns.Library.lookAtTopAndKeep(count = 2, keepCount = 1)
+        description = "When this creature is turned face up, look at the top two cards of your " +
+            "library. Put one into your hand and the other into your graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "203"
+        artist = "Dallas Williams"
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20267dab-8898-4b44-8ef4-8a239967662c.jpg?1783912849"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "The resulting creature is a 2/2 creature with ward {2} that has no name, mana cost, or " +
+                "creature types. Other effects that apply to the creature can still grant it any " +
+                "characteristics it doesn't have."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/NervousGardener.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/NervousGardener.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Nervous Gardener — Murders at Karlov Manor #169
+ * {1}{G} · Creature — Dryad · 2/2
+ *
+ * Disguise {G}
+ * When this creature is turned face up, search your library for a land card with a basic land type,
+ * reveal it, put it into your hand, then shuffle.
+ *
+ * The whole card is the disguise line: hard-cast for {1}{G} it's a vanilla 2/2, because turning face
+ * up is a special action and not entering the battlefield (CR 701.34), so nothing about a normal cast
+ * ever reaches the trigger. The intended curve is {3} face down on turn three, then {G} to flip and
+ * fetch — cheapest flip cost in the set.
+ *
+ * "A land card **with a basic land type**" is broader than a basic land card: it's any land whose
+ * subtypes include one of the five basic land types (CR 305.6), so shocklands, triomes, and Karlov
+ * Manor's own surveil duals all qualify — this is a subtype test, not a supertype test, and using
+ * [Filters.BasicLand] here would silently narrow it to actual basics. Composed off
+ * [Subtype.ALL_BASIC_LAND_TYPES] so it tracks the canonical list rather than a second hand-written one.
+ *
+ * The search is `ChooseUpTo(1)`, which is how the rules read it anyway: you're never forced to find
+ * (CR 701.19c), and choosing nothing is the legal "fail to find".
+ */
+val NervousGardener = card("Nervous Gardener") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dryad"
+    oracleText = "Disguise {G} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, search your library for a land card with a basic land " +
+        "type, reveal it, put it into your hand, then shuffle."
+    power = 2
+    toughness = 2
+
+    disguise = "{G}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        effect = Patterns.Library.searchLibrary(
+            filter = Filters.Land.withAnyOfSubtypes(Subtype.ALL_BASIC_LAND_TYPES.map { Subtype(it) }),
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+        description = "When this creature is turned face up, search your library for a land card with " +
+            "a basic land type, reveal it, put it into your hand, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93b747c7-b342-47f8-a190-16c393b20607.jpg?1783912862"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face up, " +
+                "turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SanctuaryWall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SanctuaryWall.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sanctuary Wall — Murders at Karlov Manor #32
+ * {1}{W} · Artifact Creature — Wall · 0/4
+ *
+ * Defender
+ * {2}{W}, {T}: Tap target creature. You may put a stun counter on it. If you do, put a stun counter
+ * on this creature.
+ *
+ * A tapper that pays for the upgrade in its own untap step. The stun counter is the *whole* choice:
+ * without it the target simply untaps next turn, and with it the target skips an untap (CR 122.6d)
+ * but so does the Wall, meaning the ability can only be used every other turn. Declining is often
+ * right, which is why the "may" is real and not decorative.
+ *
+ * Modelled as `Tap` followed by a `MayEffect` over both counter placements. The two counters go
+ * together — the printed "if you do" only comes apart in the corner case where the target genuinely
+ * can't receive the counter (an effect like Solemnity, or a permanent that can't have counters put
+ * on it): the rules would then skip the Wall's counter too, while this script places it. There is no
+ * "counters were added" `SuccessCriterion` to gate on today, so that corner is knowingly unmodelled
+ * rather than silently assumed away.
+ *
+ * The Wall taps as part of the cost, so it is already tapped when the ability resolves; the stun
+ * counter it takes therefore bites on its controller's very next untap step.
+ *
+ * Defender is only on the printed card — nothing here grants or removes it, and the Wall's 0 power
+ * makes the "tap an attacker before blocks" line the point rather than a combat trick.
+ */
+val SanctuaryWall = card("Sanctuary Wall") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Wall"
+    oracleText = "Defender\n" +
+        "{2}{W}, {T}: Tap target creature. You may put a stun counter on it. If you do, put a stun " +
+        "counter on this creature. (If a permanent with a stun counter would become untapped, remove " +
+        "one from it instead.)"
+    power = 0
+    toughness = 4
+
+    keywords(Keyword.DEFENDER)
+
+    activatedAbility {
+        val creature = target("target creature", Targets.Creature)
+        cost = Costs.Composite(
+            Costs.Mana("{2}{W}"),
+            Costs.Tap
+        )
+        effect = Effects.Composite(
+            Effects.Tap(creature),
+            MayEffect(
+                Effects.Composite(
+                    Effects.AddCounters(Counters.STUN, 1, creature),
+                    Effects.AddCounters(Counters.STUN, 1, EffectTarget.Self)
+                ),
+                descriptionOverride = "Put a stun counter on it? (Sanctuary Wall also gets one.)"
+            )
+        )
+        description = "Tap target creature. You may put a stun counter on it. If you do, put a stun " +
+            "counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "32"
+        artist = "Josu Solano"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a009ba2-c7b9-4cf6-bb90-9d6fd589e932.jpg?1783912918"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -381,6 +381,137 @@
     ]
 }
 
+// Cornered Crook
+{
+    "name": "Cornered Crook",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Lizard Warrior",
+    "oracleText": "When this creature enters, you may sacrifice an artifact. When you do, this creature deals 3 damage to any target.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectTarget",
+                                "requirement": {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact ctrl:you"
+                                    }
+                                },
+                                "storeAs": "toSacrifice"
+                            },
+                            {
+                                "type": "SacrificeTarget",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "toSacrifice"
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "reflexiveTargetRequirements": [
+                        "AnyTarget"
+                    ],
+                    "descriptionOverride": "You may sacrifice an artifact. When you do, this creature deals 3 damage to any target."
+                },
+                "descriptionOverride": "When this creature enters, you may sacrifice an artifact. When you do, this creature deals 3 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "UNCOMMON",
+        "artist": "Gabor Szikszai",
+        "flavorText": "Monax knew attacking the detective was a reckless move, but he was at the end of his rope.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/3/a3aff1ea-1d25-49c3-a2d9-f435124a5969.jpg?1783912883",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You don't choose a target for Cornered Crook's ability at the time it triggers. Rather, a second \"reflexive\" ability triggers when you sacrifice an artifact this way. You choose a target for that ability as it goes on the stack. Each player may respond to this triggered ability as normal."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Crime Novelist
+{
+    "name": "Crime Novelist",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Bard",
+    "oracleText": "Whenever you sacrifice an artifact, put a +1/+1 counter on this creature and add {R}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "RED"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you sacrifice an artifact, put a +1/+1 counter on this creature and add {R}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "flavorText": "\"But then he peeled off the mask, revealing a sight that made Groja's blood run cold—Brulu was actually Vogos in disguise!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14a5cd7c-b0b1-4ffa-a806-bb0e73baffad.jpg?1783912882"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Crimestopper Sprite
 {
     "name": "Crimestopper Sprite",
@@ -894,6 +1025,108 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Faerie Snoop
+{
+    "name": "Faerie Snoop",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Creature — Faerie Detective",
+    "oracleText": "Flying\nDisguise {1}{U/B}{U/B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, look at the top two cards of your library. Put one into your hand and the other into your graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{U/B}{U/B}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put in graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature is turned face up, look at the top two cards of your library. Put one into your hand and the other into your graveyard."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "artist": "Dallas Williams",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20267dab-8898-4b44-8ef4-8a239967662c.jpg?1783912849",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "The resulting creature is a 2/2 creature with ward {2} that has no name, mana cost, or creature types. Other effects that apply to the creature can still grant it any characteristics it doesn't have."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 
@@ -2229,6 +2462,108 @@
     ]
 }
 
+// Nervous Gardener
+{
+    "name": "Nervous Gardener",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Dryad",
+    "oracleText": "Disguise {G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{G}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsLand",
+                                        {
+                                            "type": "HasAnyOfSubtypes",
+                                            "subtypes": [
+                                                "Plains",
+                                                "Island",
+                                                "Swamp",
+                                                "Mountain",
+                                                "Forest"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "descriptionOverride": "When this creature is turned face up, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/93b747c7-b342-47f8-a190-16c393b20607.jpg?1783912862",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Nightdrinker Moroii
 {
     "name": "Nightdrinker Moroii",
@@ -2995,6 +3330,97 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Sanctuary Wall
+{
+    "name": "Sanctuary Wall",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact Creature — Wall",
+    "oracleText": "Defender\n{2}{W}, {T}: Tap target creature. You may put a stun counter on it. If you do, put a stun counter on this creature. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "AddCounters",
+                                        "counterType": "stun",
+                                        "count": 1,
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target creature"
+                                        }
+                                    },
+                                    {
+                                        "type": "AddCounters",
+                                        "counterType": "stun",
+                                        "count": 1,
+                                        "target": "Self"
+                                    }
+                                ]
+                            },
+                            "descriptionOverride": "Put a stun counter on it? (Sanctuary Wall also gets one.)"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "Tap target creature. You may put a stun counter on it. If you do, put a stun counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Solano",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a009ba2-c7b9-4cf6-bb90-9d6fd589e932.jpg?1783912918"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CorneredCrookScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CorneredCrookScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CorneredCrook
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Cornered Crook (MKM) — {4}{R} 5/4 Lizard Warrior.
+ *
+ * "When this creature enters, you may sacrifice an artifact. When you do, this creature deals 3
+ *  damage to any target."
+ *
+ * The damage is a CR 603.12 reflexive ability, so the flow under test is: enters trigger → yes/no →
+ * pick the artifact → *then* pick the damage target. These cover the happy path, the decline, and
+ * the infeasible case where no artifact exists and the question must not be asked at all.
+ */
+class CorneredCrookScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CorneredCrook))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun castCrook(driver: GameTestDriver, player: EntityId) {
+        val card = driver.putCardInHand(player, "Cornered Crook")
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveColorlessMana(player, 4)
+        driver.castSpell(player, card).error shouldBe null
+        driver.bothPass() // resolve the creature spell
+        driver.bothPass() // enters trigger goes on the stack and resolves
+    }
+
+    test("sacrificing an artifact deals 3 damage to the chosen target") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val artifact = driver.putCreatureOnBattlefield(me, "Artifact Creature")
+
+        castCrook(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+        driver.submitTargetSelection(me, listOf(artifact))
+
+        withClue("the artifact is gone before the reflexive ability picks a target") {
+            driver.getGraveyard(me).contains(artifact) shouldBe true
+        }
+
+        // "When you do" — a second ability, targeted only now.
+        driver.submitTargetSelection(me, listOf(opponent))
+        driver.bothPass()
+
+        driver.assertLifeTotal(opponent, 17)
+    }
+
+    test("declining the sacrifice deals no damage and keeps the artifact") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val artifact = driver.putCreatureOnBattlefield(me, "Artifact Creature")
+
+        castCrook(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, false)
+
+        withClue("no sacrifice means the reflexive ability never triggers") {
+            driver.state.getBattlefield(me).contains(artifact) shouldBe true
+            driver.assertLifeTotal(opponent, 20)
+        }
+    }
+
+    test("with no artifact to sacrifice, the question is never asked") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        castCrook(driver, me)
+
+        withClue("an impossible action must not prompt — a 'yes' could only no-op") {
+            driver.pendingDecision shouldBe null
+            driver.assertLifeTotal(opponent, 20)
+        }
+    }
+
+    test("the damage can be aimed at a creature instead of a player") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val artifact = driver.putCreatureOnBattlefield(me, "Artifact Creature")
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser") // 3/3
+
+        castCrook(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+        driver.submitTargetSelection(me, listOf(artifact))
+        driver.submitTargetSelection(me, listOf(victim))
+        driver.bothPass()
+
+        withClue("3 damage kills a 3/3") {
+            driver.state.getBattlefield(opponent).contains(victim) shouldBe false
+            driver.assertLifeTotal(opponent, 20)
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrimeNovelistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrimeNovelistScenarioTest.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CrimeNovelist
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Crime Novelist (MKM) — {2}{R} 1/3 Goblin Bard.
+ *
+ * "Whenever you sacrifice an artifact, put a +1/+1 counter on this creature and add {R}."
+ *
+ * Two things are worth proving. First that both halves happen — the counter *and* the mana, since a
+ * triggered ability producing mana is the unusual half. Second that the trigger is per-artifact
+ * rather than per-event: sacrificing two artifacts to a single effect must grow it twice and produce
+ * {R}{R}, which is what separates `YouSacrificeA` from the batch `YouSacrificeOneOrMore`.
+ */
+class CrimeNovelistScenarioTest : ScenarioTestBase() {
+
+    // Free sorceries so nothing but the sacrifice is under test.
+    private val sacrificeOneArtifact = card("Sacrifice One Test") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "You sacrifice an artifact."
+        spell {
+            effect = Effects.Sacrifice(
+                Filters.Unified.artifact,
+                count = 1,
+                target = EffectTarget.PlayerRef(Player.You)
+            )
+        }
+    }
+
+    private val sacrificeTwoArtifacts = card("Sacrifice Two Test") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "You sacrifice two artifacts."
+        spell {
+            effect = Effects.Sacrifice(
+                Filters.Unified.artifact,
+                count = 2,
+                target = EffectTarget.PlayerRef(Player.You)
+            )
+        }
+    }
+
+    private val sacrificeTargetCreature = card("Sacrifice Creature Test") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Sacrifice target creature you control."
+        spell {
+            val victim = target("target creature you control", Targets.CreatureYouControl)
+            effect = Effects.SacrificeTarget(victim)
+        }
+    }
+
+    init {
+        cardRegistry.register(CrimeNovelist)
+        cardRegistry.register(sacrificeOneArtifact)
+        cardRegistry.register(sacrificeTwoArtifacts)
+        cardRegistry.register(sacrificeTargetCreature)
+
+        fun counters(game: TestGame, id: EntityId): Int =
+            game.state.getEntity(id)?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+        fun redMana(game: TestGame): Int =
+            game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.red ?: 0
+
+        context("Crime Novelist") {
+
+            test("sacrificing one artifact grows it and adds {R}") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Crime Novelist", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Artifact Creature", summoningSickness = false)
+                    .withCardInHand(1, "Sacrifice One Test")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val novelist = game.findPermanent("Crime Novelist")!!
+
+                game.castSpell(1, "Sacrifice One Test").error shouldBe null
+                game.resolveStack()
+
+                withClue("the artifact is gone") {
+                    game.isOnBattlefield("Artifact Creature") shouldBe false
+                }
+                withClue("one +1/+1 counter, reflected in the projected stats") {
+                    counters(game, novelist) shouldBe 1
+                    val projected = StateProjector().project(game.state)
+                    projected.getPower(novelist) shouldBe 2
+                    projected.getToughness(novelist) shouldBe 4
+                }
+                withClue("and exactly one red mana in the pool") {
+                    redMana(game) shouldBe 1
+                }
+            }
+
+            test("sacrificing two artifacts at once triggers twice, not once") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Crime Novelist", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Artifact Creature", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Artifact Creature", summoningSickness = false)
+                    .withCardInHand(1, "Sacrifice Two Test")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val novelist = game.findPermanent("Crime Novelist")!!
+
+                game.castSpell(1, "Sacrifice Two Test").error shouldBe null
+                game.resolveStack()
+
+                withClue("both artifacts are gone") {
+                    game.findAllPermanents("Artifact Creature").size shouldBe 0
+                }
+                withClue("\"whenever you sacrifice an artifact\" is one trigger per artifact") {
+                    counters(game, novelist) shouldBe 2
+                    redMana(game) shouldBe 2
+                }
+            }
+
+            test("sacrificing a nonartifact creature does nothing") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Crime Novelist", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Centaur Courser", summoningSickness = false)
+                    .withCardInHand(1, "Sacrifice Creature Test")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val novelist = game.findPermanent("Crime Novelist")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.castSpell(1, "Sacrifice Creature Test", courser).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Courser is not an artifact, so the Novelist is untouched") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                    counters(game, novelist) shouldBe 0
+                    redMana(game) shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaerieSnoopScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaerieSnoopScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.FaerieSnoop
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Faerie Snoop (MKM) — {1}{U}{B} 1/4 Faerie Detective with flying and Disguise {1}{U/B}{U/B}.
+ *
+ * "When this creature is turned face up, look at the top two cards of your library. Put one into your
+ *  hand and the other into your graveyard."
+ *
+ * Two named cards are seeded on top of an otherwise-uniform library so the split is observable: the
+ * chosen card must land in hand and the *other* one — not some third card — in the graveyard.
+ */
+class FaerieSnoopScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FaerieSnoop))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun nameOf(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    /** Cast the Snoop face down for {3} and return the resulting face-down permanent. */
+    fun castFaceDown(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Faerie Snoop")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    fun flipFaceUp(driver: GameTestDriver, player: EntityId, snoop: EntityId) {
+        driver.giveColorlessMana(player, 1)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = snoop,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+    }
+
+    test("turning it face up splits the top two — one to hand, the other to the graveyard") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        // Seeded last, so "Lightning Bolt" is the top card and "Giant Growth" is second.
+        driver.putCardOnTopOfLibrary(player, "Giant Growth")
+        driver.putCardOnTopOfLibrary(player, "Lightning Bolt")
+
+        val snoop = castFaceDown(driver, player)
+        flipFaceUp(driver, player, snoop)
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+
+        withClue("exactly the top two cards are looked at") {
+            decision.options.mapNotNull { nameOf(driver, it) }.sorted() shouldBe
+                listOf("Giant Growth", "Lightning Bolt")
+        }
+
+        val bolt = decision.options.single { nameOf(driver, it) == "Lightning Bolt" }
+        driver.submitCardSelection(player, listOf(bolt))
+
+        withClue("the kept card goes to hand and the remainder to the graveyard") {
+            driver.findCardInHand(player, "Lightning Bolt").shouldNotBeNull()
+            driver.getGraveyardCardNames(player) shouldBe listOf("Giant Growth")
+        }
+        withClue("both cards left the library") {
+            driver.state.getLibrary(player).map { nameOf(driver, it) }
+                .none { it == "Lightning Bolt" || it == "Giant Growth" } shouldBe true
+        }
+    }
+
+    test("face up it is the printed 1/4 flier; face down it is a vanilla 2/2") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val snoop = castFaceDown(driver, player)
+
+        withClue("CR 708.2: a face-down permanent has no name, types, keywords or abilities") {
+            driver.state.projectedState.getPower(snoop) shouldBe 2
+            driver.state.projectedState.getToughness(snoop) shouldBe 2
+            driver.state.projectedState.hasKeyword(snoop, Keyword.FLYING) shouldBe false
+        }
+
+        flipFaceUp(driver, player, snoop)
+
+        withClue("flipped, it is the real card") {
+            driver.state.projectedState.getPower(snoop) shouldBe 1
+            driver.state.projectedState.getToughness(snoop) shouldBe 4
+            driver.state.projectedState.hasKeyword(snoop, Keyword.FLYING) shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NervousGardenerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NervousGardenerScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.EscapeTunnel
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.LushPortico
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.NervousGardener
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Nervous Gardener (MKM) — {1}{G} 2/2 Dryad, Disguise {G}.
+ *
+ * "When this creature is turned face up, search your library for a land card with a basic land type,
+ *  reveal it, put it into your hand, then shuffle."
+ *
+ * The library here is deliberately mixed: a deck of **Escape Tunnel** (`Land`, no subtypes) with a
+ * **Forest** and a **Lush Portico** (`Land — Forest Plains`) seeded on top. That makes the filter
+ * falsifiable — a plain "land card" filter would offer the whole library, and a "basic land card"
+ * filter would offer only the Forest. The card wants exactly the two carrying a basic land *type*.
+ */
+class NervousGardenerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(NervousGardener, EscapeTunnel, LushPortico))
+        driver.initMirrorMatch(deck = Deck.of("Escape Tunnel" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun nameOf(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    /** Cast the Gardener face down for {3} and return the resulting face-down permanent. */
+    fun castFaceDown(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Nervous Gardener")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    /** Pay {G} to flip it, then let the turned-face-up trigger reach its decision. */
+    fun flipFaceUp(driver: GameTestDriver, player: EntityId, gardener: EntityId) {
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = gardener,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+    }
+
+    test("turning it face up searches — and only lands with a basic land type are offered") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCardOnTopOfLibrary(player, "Forest")
+        driver.putCardOnTopOfLibrary(player, "Lush Portico")
+
+        val gardener = castFaceDown(driver, player)
+        flipFaceUp(driver, player, gardener)
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+
+        withClue("Escape Tunnel is a land with no basic land type and must not be searchable") {
+            decision.options.mapNotNull { nameOf(driver, it) }.sorted() shouldBe
+                listOf("Forest", "Lush Portico")
+        }
+
+        // Lush Portico is a nonbasic land that *has* basic land types — the case the filter exists for.
+        val portico = decision.options.single { nameOf(driver, it) == "Lush Portico" }
+        driver.submitCardSelection(player, listOf(portico))
+
+        withClue("the found card goes to hand, not the battlefield") {
+            driver.findCardInHand(player, "Lush Portico").shouldNotBeNull()
+            driver.findPermanent(player, "Lush Portico") shouldBe null
+        }
+    }
+
+    test("failing to find is legal — the search may take nothing") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCardOnTopOfLibrary(player, "Forest")
+
+        val gardener = castFaceDown(driver, player)
+        val librarySizeBefore = driver.state.getLibrary(player).size
+
+        flipFaceUp(driver, player, gardener)
+
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(player, emptyList())
+
+        withClue("nothing was taken, so the Forest stays in a library of unchanged size") {
+            driver.findCardInHand(player, "Forest") shouldBe null
+            driver.state.getLibrary(player).size shouldBe librarySizeBefore
+        }
+    }
+
+    test("hard-casting it never searches — turning face up is not entering the battlefield") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCardOnTopOfLibrary(player, "Forest")
+
+        val card = driver.putCardInHand(player, "Nervous Gardener")
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 1)
+        driver.castSpell(player, card).error shouldBe null
+        driver.bothPass()
+
+        withClue("the 2/2 is on the battlefield") {
+            driver.findPermanent(player, "Nervous Gardener").shouldNotBeNull()
+        }
+        withClue("CR 701.34c: no trigger fired, so no search and the Forest is still in the library") {
+            driver.pendingDecision shouldBe null
+            driver.findCardInHand(player, "Forest") shouldBe null
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SanctuaryWallScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SanctuaryWallScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.SanctuaryWall
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Sanctuary Wall (MKM) — {1}{W} 0/4 Artifact Creature — Wall with defender.
+ *
+ * "{2}{W}, {T}: Tap target creature. You may put a stun counter on it. If you do, put a stun counter
+ *  on this creature."
+ *
+ * The optional half is the card: the counter is a real trade, taking the target off its next untap
+ * step at the cost of the Wall skipping its own. These cover both answers plus the untap step that
+ * makes the counters matter.
+ */
+class SanctuaryWallScenarioTest : FunSpec({
+
+    val abilityId = SanctuaryWall.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SanctuaryWall))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun stunCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    fun activate(driver: GameTestDriver, player: EntityId, wall: EntityId, victim: EntityId) {
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.giveColorlessMana(player, 2)
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = wall,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        ).error shouldBe null
+        driver.bothPass()
+    }
+
+    test("accepting the counter stuns the target and the Wall alike") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val wall = driver.putCreatureOnBattlefield(me, "Sanctuary Wall")
+        driver.removeSummoningSickness(wall)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        activate(driver, me, wall, victim)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+
+        withClue("the target is tapped by the effect, the Wall by its own cost") {
+            driver.isTapped(victim) shouldBe true
+            driver.isTapped(wall) shouldBe true
+        }
+        withClue("\"if you do\" means the Wall takes one too") {
+            stunCounters(driver, victim) shouldBe 1
+            stunCounters(driver, wall) shouldBe 1
+        }
+    }
+
+    test("declining leaves the target merely tapped and the Wall counter-free") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val wall = driver.putCreatureOnBattlefield(me, "Sanctuary Wall")
+        driver.removeSummoningSickness(wall)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        activate(driver, me, wall, victim)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, false)
+
+        withClue("the tap is not optional — only the counter is") {
+            driver.isTapped(victim) shouldBe true
+        }
+        withClue("no counter on either permanent") {
+            stunCounters(driver, victim) shouldBe 0
+            stunCounters(driver, wall) shouldBe 0
+        }
+    }
+
+    test("the stun counter is spent instead of untapping (CR 122.6d)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val wall = driver.putCreatureOnBattlefield(me, "Sanctuary Wall")
+        driver.removeSummoningSickness(wall)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        activate(driver, me, wall, victim)
+        driver.submitYesNo(me, true)
+
+        // Round to the opponent's untap step.
+        driver.passPriorityUntil(Step.END)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        withClue("the opponent's untap step removed the counter rather than untapping the Courser") {
+            driver.activePlayer shouldBe opponent
+            driver.isTapped(victim) shouldBe true
+            stunCounters(driver, victim) shouldBe 0
+        }
+        withClue("the Wall keeps its own counter until its controller's untap step") {
+            stunCounters(driver, wall) shouldBe 1
+            driver.isTapped(wall) shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
Five more Murders at Karlov Manor cards, spanning the set's mechanics — disguise, artifact sacrifice, and stun counters. All five are MKM-only printings, so each canonical `CardDefinition` lives in `definitions/mkm/cards/`.

| Card | Cost | Line |
|---|---|---|
| Nervous Gardener | `{1}{G}` | Disguise `{G}`; turned face up → fetch a land with a basic land type |
| Faerie Snoop | `{1}{U}{B}` | Flying, Disguise `{1}{U/B}{U/B}`; turned face up → top two split hand/graveyard |
| Cornered Crook | `{4}{R}` | Enters: may sacrifice an artifact → 3 damage to any target |
| Crime Novelist | `{2}{R}` | Whenever you sacrifice an artifact: +1/+1 counter and add `{R}` |
| Sanctuary Wall | `{1}{W}` | Defender; `{2}{W}, {T}`: tap a creature, optionally trade stun counters |

No new SDK vocabulary — all five compose existing facades, so `docs/card-sdk-language-reference.md` is unchanged.

## Two that needed care

**Nervous Gardener** searches for "a land card with a **basic land type**". That's a subtype test, not a supertype one: shocklands, triomes and Karlov Manor's own surveil duals all qualify. Using `Filters.BasicLand` would have silently narrowed it to actual basics, so the filter is composed off `Subtype.ALL_BASIC_LAND_TYPES` and tracks that canonical list. The scenario test makes this falsifiable — a library of Escape Tunnels (`Land`, no subtypes) with a Forest and a Lush Portico (`Land — Forest Plains`) seeded on top, asserting the search offers exactly those two.

**Cornered Crook**'s damage is a genuine CR 603.12 reflexive ability (`ReflexiveTriggerEffect`), not an inline resolution. Per the card's own Scryfall ruling, no target is chosen when the enters ability triggers; a second ability goes on the stack once the artifact is actually sacrificed, picks its target then, and can be responded to. `optional = true` carries the "you may", and with no artifact on the battlefield the feasibility check skips the question rather than asking one whose only answer would no-op.

## Tests

One scenario test file per card, 15 tests total, all passing:

- `NervousGardenerScenarioTest` — the filter, failing to find, and the hard-cast line firing nothing (CR 701.34c).
- `FaerieSnoopScenarioTest` — the top-two split lands one in hand and the *other* in the graveyard; face-down vanilla 2/2 vs. the printed 1/4 flier.
- `CorneredCrookScenarioTest` — happy path, decline, no-artifact-so-no-prompt, and damage aimed at a creature.
- `CrimeNovelistScenarioTest` — counter *and* mana; two artifacts in one event trigger twice (per-artifact, not per-batch); a nonartifact sacrifice does nothing.
- `SanctuaryWallScenarioTest` — both answers, plus the stun counter being spent instead of untapping (CR 122.6d).

## Known gap

There is no "counters were added" `SuccessCriterion` today, so Sanctuary Wall's "You may put a stun counter on it. **If you do**, put a stun counter on this creature" is modelled as one `MayEffect` over both placements. That diverges from the rules only in the corner where the target genuinely can't receive a counter (Solemnity and friends), where the rules would skip the Wall's counter too. Documented in the card's KDoc rather than silently assumed away.

## Verification

`just build` green. MKM card snapshot re-blessed — additions only, no existing card moved. `just check-card-printing` clean for all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)