### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BardTheBowman.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BardTheBowman.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bard the Bowman
+ * {1}{W}{U}
+ * Legendary Creature — Human Archer
+ * 1/3
+ * Reach
+ * Whenever you draw your second card each turn, put a +1/+1 counter on target creature. It gains
+ * lifelink until end of turn.
+ *
+ *  - **"Whenever you draw your second card each turn"** is [Triggers.NthCardDrawn]`(2)`, whose default
+ *    scope is the controller. The per-turn tally lives on `CardsDrawnThisTurnComponent` and resets each
+ *    turn, so the ability fires at most once per turn without needing `oncePerTurn`; a single multi-card
+ *    draw that crosses the threshold fires it exactly once (CR 121.2), and cards put into hand without
+ *    the word "draw" (CR 121.5) never advance the count.
+ *  - **"target creature"** is unrestricted — any creature, not just one you control — so a bare
+ *    [TargetCreature] with no filter. The counter and the lifelink grant share the one target `t`, so
+ *    if it becomes illegal the whole ability fizzles and neither half happens.
+ */
+val BardTheBowman = card("Bard the Bowman") {
+    manaCost = "{1}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Archer"
+    oracleText = "Reach\n" +
+        "Whenever you draw your second card each turn, put a +1/+1 counter on target creature. " +
+        "It gains lifelink until end of turn."
+    power = 1
+    toughness = 3
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        val t = target("target creature to get a +1/+1 counter and lifelink", TargetCreature())
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+            .then(Effects.GrantKeyword(Keyword.LIFELINK, t))
+        description = "Whenever you draw your second card each turn, put a +1/+1 counter on " +
+            "target creature. It gains lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Miklós Ligeti"
+        flavorText = "No one had dared to face the Dragon for many an age; nor would they have " +
+            "dared now, if it hadn't been for the grim-voiced Bard urging them on."
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b84e232-428c-424a-848c-ef95debc6e50.jpg?1784377009"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DancingFromDarkToDawn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DancingFromDarkToDawn.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Dancing from Dark to Dawn
+ * {3}{G}{G}
+ * Enchantment
+ * Whenever you cast a creature spell, put X +1/+1 counters on target creature you control, where X
+ * is that spell's mana value.
+ * Landfall — Whenever a land you control enters, create a 2/2 green Bear creature token.
+ *
+ *  - **"that spell's mana value"** is [DynamicAmounts.triggeringManaValue] — the triggering entity of
+ *    [Triggers.YouCastCreature] is the spell on the stack, so the amount is read at resolution off the
+ *    spell itself. It reads the spell's mana value on the stack, which for an X spell includes the
+ *    chosen X (CR 202.3b), and cost reductions never change it.
+ *  - The counters go on **target creature you control**, a different object from the spell that
+ *    triggered the ability. The trigger goes on the stack above the creature spell and resolves first,
+ *    so the creature being cast is not yet on the battlefield and can't be chosen.
+ *  - **Landfall** is [Triggers.LandYouControlEnters] — any land, not just one played for the turn, and
+ *    it fires for lands put onto the battlefield by other effects too.
+ */
+val DancingFromDarkToDawn = card("Dancing from Dark to Dawn") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a creature spell, put X +1/+1 counters on target creature you " +
+        "control, where X is that spell's mana value.\n" +
+        "Landfall — Whenever a land you control enters, create a 2/2 green Bear creature token."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        val t = target(
+            "target creature you control to get +1/+1 counters",
+            TargetCreature(filter = TargetFilter.CreatureYouControl)
+        )
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmounts.triggeringManaValue(),
+            t
+        )
+        description = "Whenever you cast a creature spell, put X +1/+1 counters on target creature " +
+            "you control, where X is that spell's mana value."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Bear"),
+            controller = EffectTarget.Controller,
+            imageUri = "https://cards.scryfall.io/normal/front/3/1/31661af9-a40a-418c-82e3-b74aa14cc7c4.jpg?1785497718",
+        )
+        description = "Landfall — Whenever a land you control enters, create a 2/2 green Bear " +
+            "creature token."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "123"
+        artist = "Leesha Hannigan"
+        flavorText = "\"There must have been a regular bears' meeting outside here last night.\"\n—Gandalf"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/550cd0b6-ca61-4db7-9d20-0b68c48066f9.jpg?1785236704"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DownDownToGoblinTown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DownDownToGoblinTown.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Down, Down to Goblin-town
+ * {2}{B}
+ * Enchantment — Saga
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+ * I — Target opponent reveals their hand. You choose a nonland card from it. That player discards
+ *     that card.
+ * II — Amass Goblins 1.
+ * III, IV — Target opponent loses 1 life and you gain 1 life.
+ *
+ *  - **Chapter I** is the Ego Drain idiom: reveal, gather the revealed hand, `chooseExactly(1)`
+ *    filtered to [GameObjectFilter.Nonland], then move with [MoveType.Discard] so discard triggers
+ *    (madness, "whenever you discard") actually see it. A hand with no nonland card simply strips
+ *    nothing. Note chapters I, III and IV each target independently — the opponent is chosen fresh
+ *    when each chapter ability goes on the stack, so a chapter fizzles on its own if its opponent
+ *    becomes an illegal target.
+ *  - **Chapter II** is [Effects.Amass]`(1, "Goblin")`. Amass is not a target, so it never fizzles;
+ *    it mints the 0/0 Goblin Army first if you control no Army.
+ *  - **Chapters III and IV** are one ability declared twice. It is *not* a drain: "and you gain
+ *    1 life" is a flat gain, so the life gain still happens even if the loss is prevented or the
+ *    opponent's life total can't change — hence [Effects.LoseLife] `.then(` [Effects.GainLife] `)`
+ *    rather than [Effects.DrainLife], which would tie the gain to the life actually lost.
+ */
+val DownDownToGoblinTown = card("Down, Down to Goblin-town") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\n" +
+        "I — Target opponent reveals their hand. You choose a nonland card from it. That player " +
+        "discards that card.\n" +
+        "II — Amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. " +
+        "If you don't control an Army, create a 0/0 black Goblin Army creature token first.)\n" +
+        "III, IV — Target opponent loses 1 life and you gain 1 life."
+
+    // I — Target opponent reveals their hand. You choose a nonland card from it. That player
+    //     discards that card.
+    sagaChapter(1) {
+        val opponent = target("target opponent to strip a card from", TargetOpponent())
+        effect = Effects.Pipeline {
+            run(RevealHandEffect(opponent))
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)), name = "opponentHand")
+            val chosen = chooseExactly(
+                1, from = hand,
+                filter = GameObjectFilter.Nonland,
+                prompt = "Choose a nonland card to discard",
+                alwaysPrompt = true,
+                showAllCards = true,
+                name = "toDiscard"
+            )
+            move(
+                chosen,
+                CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                moveType = MoveType.Discard
+            )
+        }
+    }
+
+    // II — Amass Goblins 1.
+    sagaChapter(2) {
+        effect = Effects.Amass(1, "Goblin")
+    }
+
+    // III, IV — Target opponent loses 1 life and you gain 1 life.
+    sagaChapter(3) {
+        val opponent = target("target opponent to lose 1 life", TargetOpponent())
+        effect = goblinTownDrain(opponent)
+    }
+    sagaChapter(4) {
+        val opponent = target("target opponent to lose 1 life", TargetOpponent())
+        effect = goblinTownDrain(opponent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b72e193c-e030-4936-9b79-c636eff750e1.jpg?1784733900"
+    }
+}
+
+/** The chapter III / IV ability: the named opponent loses 1 life, then you gain 1 life. */
+private fun goblinTownDrain(opponent: EffectTarget): Effect =
+    Effects.LoseLife(1, opponent).then(Effects.GainLife(1))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheMistyMountainsCold.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheMistyMountainsCold.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Misty Mountains Cold
+ * {2}{R}
+ * Enchantment — Saga
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+ * I, II, III, IV — Create a Treasure token. Then if you control four or more Treasures, sacrifice
+ * this Saga. If you do, create a 6/6 red Dragon creature token with flying.
+ *
+ *  - **All four chapters are the same ability**, so [mistyMountainsChapter] is declared once and
+ *    wired to chapters I–IV. The Saga's own "sacrifice after IV" state trigger still applies if the
+ *    Dragon never comes: reaching IV without four Treasures just ends the Saga the ordinary way
+ *    (CR 714.4).
+ *  - **Two gates, not one.** "Then if you control four or more Treasures" is a state check at
+ *    resolution ([ConditionalEffect] over [Conditions.YouControlAtLeast]) — and it counts *after*
+ *    this chapter's Treasure is created, so the fourth Treasure the chapter itself mints turns it
+ *    on. "If you do" is a second gate on the sacrifice actually happening
+ *    ([SuccessCriterion.PermanentsSacrificed]): if the Saga has already left the battlefield, or
+ *    can't be sacrificed, there is no Dragon. `SuccessCriterion.Always` here would fail open and
+ *    mint a free Dragon.
+ *  - The count is every Treasure you control, not just the ones this Saga made.
+ */
+val TheMistyMountainsCold = card("The Misty Mountains Cold") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\n" +
+        "I, II, III, IV — Create a Treasure token. Then if you control four or more Treasures, " +
+        "sacrifice this Saga. If you do, create a 6/6 red Dragon creature token with flying. " +
+        "(A Treasure token is an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    sagaChapter(1) { effect = mistyMountainsChapter() }
+    sagaChapter(2) { effect = mistyMountainsChapter() }
+    sagaChapter(3) { effect = mistyMountainsChapter() }
+    sagaChapter(4) { effect = mistyMountainsChapter() }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "104"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d5f35ff-4146-4844-9da5-031461cc8c05.jpg?1784673451"
+    }
+}
+
+/** The one chapter ability shared by I, II, III and IV. */
+private fun mistyMountainsChapter(): Effect =
+    Effects.CreateTreasure()
+        .then(
+            ConditionalEffect(
+                condition = Conditions.YouControlAtLeast(
+                    4,
+                    GameObjectFilter.Artifact.withSubtype(Subtype.TREASURE)
+                ),
+                effect = Effects.IfYouDo(
+                    action = Effects.SacrificeTarget(EffectTarget.Self),
+                    ifYouDo = Effects.CreateToken(
+                        power = 6,
+                        toughness = 6,
+                        colors = setOf(Color.RED),
+                        creatureTypes = setOf("Dragon"),
+                        keywords = setOf(Keyword.FLYING),
+                        controller = EffectTarget.Controller,
+                        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
+                    ),
+                    successCriterion = SuccessCriterion.PermanentsSacrificed,
+                )
+            )
+        )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilsCompany.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilsCompany.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantAdditionalLandDrop
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Thranduil's Company
+ * {2}{G}{U}
+ * Creature — Elf Soldier
+ * 3/4
+ * As long as you control another Elf, you may play an additional land on each of your turns.
+ * Landfall — Whenever a land you control enters, put two +1/+1 counters on target creature you
+ * control. It gains vigilance until end of turn.
+ *
+ *  - The land-drop clause is a **continuous static gated on a different Elf** — the Bolg's Company
+ *    shape: [GrantAdditionalLandDrop] wrapped in the builder's `condition`, evaluated continuously.
+ *    Lose the other Elf after playing the extra land and nothing is taken back, but lose it before
+ *    and the extra drop is simply unavailable. [Conditions.YouControl]`(excludeSelf = true)` is what
+ *    makes it *another* Elf; this card is itself an Elf and must not satisfy its own condition.
+ *  - **Landfall** is [Triggers.LandYouControlEnters] — every land entering under your control, not
+ *    just the ones you play, and it fires for the extra land drop this card grants too.
+ *  - The counters and the vigilance share one target `t`, so an illegal target fizzles both halves.
+ */
+val ThranduilsCompany = card("Thranduil's Company") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Elf Soldier"
+    oracleText = "As long as you control another Elf, you may play an additional land on each of " +
+        "your turns.\n" +
+        "Landfall — Whenever a land you control enters, put two +1/+1 counters on target creature " +
+        "you control. It gains vigilance until end of turn."
+    power = 3
+    toughness = 4
+
+    staticAbility {
+        ability = GrantAdditionalLandDrop(count = 1)
+        condition = Conditions.YouControl(
+            GameObjectFilter.Creature.withSubtype(Subtype.ELF),
+            excludeSelf = true
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        val t = target(
+            "target creature you control to get two +1/+1 counters and vigilance",
+            TargetCreature(filter = TargetFilter.CreatureYouControl)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, t)
+            .then(Effects.GrantKeyword(Keyword.VIGILANCE, t))
+        description = "Landfall — Whenever a land you control enters, put two +1/+1 counters on " +
+            "target creature you control. It gains vigilance until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "168"
+        artist = "Irina Nordsol"
+        flavorText = "They escaped at times to ride or run over open lands by moonlight or starlight."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abdb9d4e-e6ca-409b-b589-0cf71724340b.jpg?1785412736"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -48,6 +48,74 @@
     ]
 }
 
+// Bard the Bowman
+{
+    "name": "Bard the Bowman",
+    "manaCost": "{1}{W}{U}",
+    "typeLine": "Legendary Creature — Human Archer",
+    "oracleText": "Reach\nWhenever you draw your second card each turn, put a +1/+1 counter on target creature. It gains lifelink until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature to get a +1/+1 counter and lifelink"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature to get a +1/+1 counter and lifelink"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature to get a +1/+1 counter and lifelink"
+                },
+                "descriptionOverride": "Whenever you draw your second card each turn, put a +1/+1 counter on target creature. It gains lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Miklós Ligeti",
+        "flavorText": "No one had dared to face the Dragon for many an age; nor would they have dared now, if it hadn't been for the grim-voiced Bard urging them on.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b84e232-428c-424a-848c-ef95debc6e50.jpg?1784377009"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Bejeweled Warg
 {
     "name": "Bejeweled Warg",
@@ -762,6 +830,84 @@
     ]
 }
 
+// Dancing from Dark to Dawn
+{
+    "name": "Dancing from Dark to Dawn",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a creature spell, put X +1/+1 counters on target creature you control, where X is that spell's mana value.\nLandfall — Whenever a land you control enters, create a 2/2 green Bear creature token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": "ManaValue"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control to get +1/+1 counters"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control to get +1/+1 counters"
+                },
+                "descriptionOverride": "Whenever you cast a creature spell, put X +1/+1 counters on target creature you control, where X is that spell's mana value."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Bear"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/1/31661af9-a40a-418c-82e3-b74aa14cc7c4.jpg?1785497718",
+                    "controller": "Controller"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, create a 2/2 green Bear creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "MYTHIC",
+        "artist": "Leesha Hannigan",
+        "flavorText": "\"There must have been a regular bears' meeting outside here last night.\"\n—Gandalf",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/550cd0b6-ca61-4db7-9d20-0b68c48066f9.jpg?1785236704"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Desolation Prowler
 {
     "name": "Desolation Prowler",
@@ -849,6 +995,154 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Down, Down to Goblin-town
+{
+    "name": "Down, Down to Goblin-town",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.\nII — Amass Goblins 1. (Put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)\nIII, IV — Target opponent loses 1 life and you gain 1 life.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "RevealHand",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent to strip a card from"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "opponentHand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "opponentHand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "nonland",
+                            "storeSelected": "toDiscard",
+                            "prompt": "Choose a nonland card to discard",
+                            "showAllCards": true,
+                            "alwaysPrompt": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toDiscard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent to strip a card from"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "Amass",
+                    "subtype": "Goblin"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent to lose 1 life"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent to lose 1 life"
+                }
+            },
+            {
+                "chapter": 4,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent to lose 1 life"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent to lose 1 life"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Rovina Cai",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b72e193c-e030-4936-9b79-c636eff750e1.jpg?1784733900"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -5178,6 +5472,259 @@
     ]
 }
 
+// The Misty Mountains Cold
+{
+    "name": "The Misty Mountains Cold",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III, IV — Create a Treasure token. Then if you control four or more Treasures, sacrifice this Saga. If you do, create a 6/6 red Dragon creature token with flying. (A Treasure token is an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "artifact Treasure"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.DoAction",
+                                    "action": {
+                                        "type": "SacrificeTarget",
+                                        "target": "Self"
+                                    },
+                                    "successCriterion": "SuccessCriterion.PermanentsSacrificed"
+                                },
+                                "then": {
+                                    "type": "CreateToken",
+                                    "power": 6,
+                                    "toughness": 6,
+                                    "colors": [
+                                        "RED"
+                                    ],
+                                    "creatureTypes": [
+                                        "Dragon"
+                                    ],
+                                    "keywords": [
+                                        "FLYING"
+                                    ],
+                                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
+                                    "controller": "Controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "artifact Treasure"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.DoAction",
+                                    "action": {
+                                        "type": "SacrificeTarget",
+                                        "target": "Self"
+                                    },
+                                    "successCriterion": "SuccessCriterion.PermanentsSacrificed"
+                                },
+                                "then": {
+                                    "type": "CreateToken",
+                                    "power": 6,
+                                    "toughness": 6,
+                                    "colors": [
+                                        "RED"
+                                    ],
+                                    "creatureTypes": [
+                                        "Dragon"
+                                    ],
+                                    "keywords": [
+                                        "FLYING"
+                                    ],
+                                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
+                                    "controller": "Controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "artifact Treasure"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.DoAction",
+                                    "action": {
+                                        "type": "SacrificeTarget",
+                                        "target": "Self"
+                                    },
+                                    "successCriterion": "SuccessCriterion.PermanentsSacrificed"
+                                },
+                                "then": {
+                                    "type": "CreateToken",
+                                    "power": 6,
+                                    "toughness": 6,
+                                    "colors": [
+                                        "RED"
+                                    ],
+                                    "creatureTypes": [
+                                        "Dragon"
+                                    ],
+                                    "keywords": [
+                                        "FLYING"
+                                    ],
+                                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
+                                    "controller": "Controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 4,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "artifact Treasure"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.DoAction",
+                                    "action": {
+                                        "type": "SacrificeTarget",
+                                        "target": "Self"
+                                    },
+                                    "successCriterion": "SuccessCriterion.PermanentsSacrificed"
+                                },
+                                "then": {
+                                    "type": "CreateToken",
+                                    "power": 6,
+                                    "toughness": 6,
+                                    "colors": [
+                                        "RED"
+                                    ],
+                                    "creatureTypes": [
+                                        "Dragon"
+                                    ],
+                                    "keywords": [
+                                        "FLYING"
+                                    ],
+                                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
+                                    "controller": "Controller"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "104",
+        "rarity": "RARE",
+        "artist": "Rovina Cai",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d5f35ff-4146-4844-9da5-031461cc8c05.jpg?1784673451"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // The Notary Hobbits
 {
     "name": "The Notary Hobbits",
@@ -5411,6 +5958,85 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Thranduil's Company
+{
+    "name": "Thranduil's Company",
+    "manaCost": "{2}{G}{U}",
+    "typeLine": "Creature — Elf Soldier",
+    "oracleText": "As long as you control another Elf, you may play an additional land on each of your turns.\nLandfall — Whenever a land you control enters, put two +1/+1 counters on target creature you control. It gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 2,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control to get two +1/+1 counters and vigilance"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control to get two +1/+1 counters and vigilance"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control to get two +1/+1 counters and vigilance"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, put two +1/+1 counters on target creature you control. It gains vigilance until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": "GrantAdditionalLandDrop",
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Elf",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "rarity": "RARE",
+        "artist": "Irina Nordsol",
+        "flavorText": "They escaped at times to ride or run over open lands by moonlight or starlight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abdb9d4e-e6ca-409b-b589-0cf71724340b.jpg?1785412736"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -75,7 +75,8 @@ class PlayLandHandler(
         // Check land drop availability (accounts for static ability bonuses)
         val landDrops = state.getEntity(action.playerId)?.get<LandDropsComponent>()
             ?: LandDropsComponent()
-        val staticBonus = LandDropUtils.getAdditionalLandDrops(state, action.playerId, cardRegistry)
+        val staticBonus =
+            LandDropUtils.getAdditionalLandDrops(state, action.playerId, cardRegistry, conditionEvaluator)
         if (landDrops.remaining + staticBonus <= 0) {
             return "You have already played a land this turn"
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -1095,7 +1095,7 @@ class CastPermissionUtils(
      * Multiple sources are additive.
      */
     fun getAdditionalLandDrops(state: GameState, playerId: EntityId): Int {
-        return LandDropUtils.getAdditionalLandDrops(state, playerId, cardRegistry)
+        return LandDropUtils.getAdditionalLandDrops(state, playerId, cardRegistry, conditionEvaluator)
     }
 
     fun getMaxLoyaltyActivations(state: GameState, playerId: EntityId): Int {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/LandDropUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/LandDropUtils.kt
@@ -1,9 +1,12 @@
 package com.wingedsheep.engine.legalactions.utils
 
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.GrantAdditionalLandDrop
 
 /**
@@ -14,15 +17,33 @@ object LandDropUtils {
     /**
      * Count additional land drops granted by [GrantAdditionalLandDrop] static abilities
      * on permanents controlled by the given player. Multiple sources are additive.
+     *
+     * A [ConditionalStaticAbility] wrapper is unwrapped and its condition evaluated against the
+     * source permanent, so "as long as …" gates are honored — Thranduil's Company only grants the
+     * extra drop while you control another Elf. Without the unwrap the grant silently no-ops, the
+     * same trap [com.wingedsheep.engine.core.MaximumHandSize] documents for `SetMaximumHandSize`.
      */
-    fun getAdditionalLandDrops(state: GameState, playerId: EntityId, cardRegistry: CardRegistry): Int {
+    fun getAdditionalLandDrops(
+        state: GameState,
+        playerId: EntityId,
+        cardRegistry: CardRegistry,
+        conditionEvaluator: ConditionEvaluator = ConditionEvaluator(),
+    ): Int {
         var bonus = 0
         for (entityId in state.getBattlefield(playerId)) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             for (ability in cardDef.script.staticAbilities) {
-                if (ability is GrantAdditionalLandDrop) {
-                    bonus += ability.count
+                when (ability) {
+                    is GrantAdditionalLandDrop -> bonus += ability.count
+                    is ConditionalStaticAbility -> {
+                        val inner = ability.ability as? GrantAdditionalLandDrop ?: continue
+                        val context = EffectContext(sourceId = entityId, controllerId = playerId)
+                        if (conditionEvaluator.evaluate(state, ability.condition, context)) {
+                            bonus += inner.count
+                        }
+                    }
+                    else -> {}
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BardTheBowmanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BardTheBowmanScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bard the Bowman — {1}{W}{U} 1/3 Legendary Human Archer (HOB #145).
+ *
+ * "Reach. Whenever you draw your second card each turn, put a +1/+1 counter on target creature.
+ *  It gains lifelink until end of turn."
+ *
+ * The trigger is [com.wingedsheep.sdk.dsl.Triggers.NthCardDrawn]`(2)`; both halves ride the one
+ * target, so an illegal target has to fizzle the whole ability.
+ */
+class BardTheBowmanScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, name: String): Int {
+        val id = game.findPermanent(name) ?: error("$name not on battlefield")
+        return game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Bard the Bowman's second-draw trigger") {
+
+            test("drawing a second card puts a +1/+1 counter on the target and gives it lifelink") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bard the Bowman")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Divination")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardsDrawnThisTurn(1, 0)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // Divination draws two; the 2nd crosses N=2 and fires the trigger once.
+                game.castSpell(1, "Divination").error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("target got exactly one +1/+1 counter") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 1
+                }
+                withClue("target gained lifelink until end of turn") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.LIFELINK) shouldBe true
+                }
+                withClue("Bard itself was not the target and got no counter") {
+                    plusOneCounters(game, "Bard the Bowman") shouldBe 0
+                }
+            }
+
+            test("no trigger when the second draw already happened earlier this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bard the Bowman")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Divination")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    // Already five draws deep this turn — these become the 6th and 7th.
+                    .withCardsDrawnThisTurn(1, 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Divination").error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing is waiting on a target — the ability never triggered") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("no counter and no lifelink") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 0
+                    game.state.projectedState.hasKeyword(bears, Keyword.LIFELINK) shouldBe false
+                }
+            }
+
+            test("Bard can target a creature an opponent controls — 'target creature' is unrestricted") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bard the Bowman")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Divination")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Island")
+                    .withCardsDrawnThisTurn(1, 0)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Divination").error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the opponent's creature got the counter and the lifelink") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 1
+                    game.state.projectedState.hasKeyword(bears, Keyword.LIFELINK) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DancingFromDarkToDawnScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DancingFromDarkToDawnScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.DancingFromDarkToDawn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dancing from Dark to Dawn — {3}{G}{G} Enchantment (HOB #123).
+ *
+ * "Whenever you cast a creature spell, put X +1/+1 counters on target creature you control, where
+ *  X is that spell's mana value.
+ *  Landfall — Whenever a land you control enters, create a 2/2 green Bear creature token."
+ *
+ * X is read off the *triggering spell*, and the trigger resolves above the creature spell — so the
+ * creature being cast is still on the stack and can't be the target.
+ */
+class DancingFromDarkToDawnScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DancingFromDarkToDawn))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Drain the stack, pointing any target prompt at [preferredTarget] (null: none expected). */
+    fun GameTestDriver.settle(preferredTarget: EntityId? = null) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 40) {
+            val pending = state.pendingDecision
+            when {
+                pending is ChooseTargetsDecision && preferredTarget != null ->
+                    submitTargetSelection(pending.playerId, listOf(preferredTarget))
+                pending != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+            guard++
+        }
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("casting a creature spell puts counters equal to its mana value on a creature you control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(me, "Dancing from Dark to Dawn")
+        val lions = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+
+        // Centaur Courser is {2}{G} — mana value 3.
+        driver.giveMana(me, Color.GREEN, 3)
+        val courser = driver.putCardInHand(me, "Centaur Courser")
+        driver.castSpell(me, courser).error shouldBe null
+        driver.settle(lions)
+
+        withClue("three counters — Centaur Courser's mana value") {
+            driver.plusOneCounters(lions) shouldBe 3
+        }
+        withClue("the creature spell itself still resolved onto the battlefield") {
+            (driver.findPermanent(me, "Centaur Courser") != null) shouldBe true
+        }
+        withClue("and it did not receive the counters — it was on the stack when the trigger resolved") {
+            driver.plusOneCounters(driver.findPermanent(me, "Centaur Courser")!!) shouldBe 0
+        }
+    }
+
+    test("landfall creates a 2/2 green Bear token") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(me, "Dancing from Dark to Dawn")
+
+        val forest = driver.putCardInHand(me, "Forest")
+        driver.playLand(me, forest).isSuccess shouldBe true
+        driver.settle()
+
+        val bears = driver.getPermanents(me).filter { driver.getCardName(it) == "Bear Token" }
+        withClue("exactly one Bear token") {
+            bears.size shouldBe 1
+        }
+        withClue("it is a 2/2") {
+            driver.state.projectedState.getPower(bears.single()) shouldBe 2
+            driver.state.projectedState.getToughness(bears.single()) shouldBe 2
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DownDownToGoblinTownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DownDownToGoblinTownScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.DownDownToGoblinTown
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Down, Down to Goblin-town — {2}{B} Enchantment — Saga (HOB #65).
+ *
+ * I — Target opponent reveals their hand. You choose a nonland card from it. That player discards
+ *     that card.
+ * II — Amass Goblins 1.
+ * III, IV — Target opponent loses 1 life and you gain 1 life.
+ *
+ * Chapter I is the interesting one: each chapter targets an opponent independently, and the chosen
+ * card must be a *nonland* — a hand of nothing but lands strips nothing.
+ */
+class DownDownToGoblinTownScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + PredefinedTokens.allTokens + listOf(DownDownToGoblinTown))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Drain the stack, auto-answering anything that pauses. */
+    fun GameTestDriver.drain() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    /** Cast the Saga targeting [opponent] with chapter I, and let chapter I resolve. */
+    fun GameTestDriver.castSaga(me: EntityId, opponent: EntityId) {
+        giveMana(me, Color.BLACK, 3)
+        val card = putCardInHand(me, "Down, Down to Goblin-town")
+        submit(
+            CastSpell(
+                playerId = me,
+                cardId = card,
+                targets = listOf(ChosenTarget.Player(opponent)),
+            )
+        ).error shouldBe null
+        drain()
+    }
+
+    test("chapter I strips a nonland card from the targeted opponent's hand") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putCardInHand(opponent, "Grizzly Bears")
+        val handBefore = driver.getHandSize(opponent)
+
+        driver.castSaga(me, opponent)
+
+        withClue("the Saga entered and chapter I resolved") {
+            (driver.findPermanent(me, "Down, Down to Goblin-town") != null) shouldBe true
+        }
+        withClue("the nonland card is the only legal pick, so it goes to the graveyard") {
+            driver.getGraveyardCardNames(opponent).contains("Grizzly Bears") shouldBe true
+            driver.getHandSize(opponent) shouldBe handBefore - 1
+        }
+        withClue("the Saga is at lore I — chapter II has not happened yet") {
+            val saga = driver.findPermanent(me, "Down, Down to Goblin-town")!!
+            driver.state.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe 1
+        }
+        withClue("no Army yet — amass is chapter II") {
+            driver.getPermanents(me).none { driver.getCardName(it) == "Goblin Army" } shouldBe true
+        }
+    }
+
+    test("chapter I strips nothing when the opponent's hand is all lands") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // The deck is all Swamps, so the opening hand has no nonland card to strip.
+        withClue("precondition: the opponent's hand is lands only") {
+            driver.getHand(opponent).all { driver.getCardName(it) == "Swamp" } shouldBe true
+        }
+        val handBefore = driver.getHandSize(opponent)
+
+        driver.castSaga(me, opponent)
+
+        withClue("a nonland-only filter finds nothing, so no card is discarded") {
+            driver.getHandSize(opponent) shouldBe handBefore
+            driver.getGraveyard(opponent).isEmpty() shouldBe true
+        }
+        withClue("the chapter still resolved and the Saga is on the battlefield") {
+            (driver.findPermanent(me, "Down, Down to Goblin-town") != null) shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMistyMountainsColdScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMistyMountainsColdScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.TheMistyMountainsCold
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Misty Mountains Cold — {2}{R} Enchantment — Saga (HOB #104).
+ *
+ * I, II, III, IV — Create a Treasure token. Then if you control four or more Treasures, sacrifice
+ * this Saga. If you do, create a 6/6 red Dragon creature token with flying.
+ *
+ * The two gates are what these tests pin down: the state check ("four or more Treasures", counted
+ * *after* the chapter's own Treasure is minted) and the "If you do" gate on the sacrifice actually
+ * happening. Getting either wrong hands out a free Dragon or never hands one out at all.
+ */
+class TheMistyMountainsColdScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + PredefinedTokens.allTokens + listOf(TheMistyMountainsCold))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Drain the stack, auto-answering anything that pauses. */
+    fun GameTestDriver.drain() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    fun GameTestDriver.treasures(playerId: EntityId): List<EntityId> =
+        getPermanents(playerId).filter { getCardName(it) == "Treasure" }
+
+    fun GameTestDriver.dragons(playerId: EntityId): List<EntityId> =
+        getPermanents(playerId).filter { getCardName(it) == "Dragon Token" }
+
+    /** Cast the Saga and let chapter I resolve. */
+    fun GameTestDriver.castSaga(playerId: EntityId): GameTestDriver {
+        giveMana(playerId, Color.RED, 3)
+        val card = putCardInHand(playerId, "The Misty Mountains Cold")
+        castSpell(playerId, card).error shouldBe null
+        drain()
+        return this
+    }
+
+    test("chapter I under four Treasures: makes a Treasure, keeps the Saga, no Dragon") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.castSaga(me)
+
+        withClue("chapter I minted exactly one Treasure") {
+            driver.treasures(me).size shouldBe 1
+        }
+        withClue("only one Treasure — the Saga is not sacrificed") {
+            (driver.findPermanent(me, "The Misty Mountains Cold") != null) shouldBe true
+        }
+        withClue("no Dragon without the sacrifice") {
+            driver.dragons(me).size shouldBe 0
+        }
+        withClue("the Saga is at lore I") {
+            val saga = driver.findPermanent(me, "The Misty Mountains Cold")!!
+            driver.state.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) shouldBe 1
+        }
+    }
+
+    test("chapter I with three Treasures already out: the fourth triggers the sacrifice and the Dragon") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        repeat(3) { driver.putPermanentOnBattlefield(me, "Treasure") }
+        driver.castSaga(me)
+
+        withClue("the chapter's own Treasure is counted, so three on board is enough") {
+            driver.treasures(me).size shouldBe 4
+        }
+        withClue("the Saga sacrificed itself") {
+            driver.findPermanent(me, "The Misty Mountains Cold") shouldBe null
+            driver.getGraveyardCardNames(me).contains("The Misty Mountains Cold") shouldBe true
+        }
+        withClue("and 'if you do' paid off with a 6/6 flying Dragon") {
+            driver.dragons(me).size shouldBe 1
+        }
+    }
+
+    test("opponent Treasures do not count — 'you control four or more'") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        repeat(3) { driver.putPermanentOnBattlefield(opponent, "Treasure") }
+        driver.castSaga(me)
+
+        withClue("only my own single Treasure counts") {
+            driver.treasures(me).size shouldBe 1
+        }
+        withClue("so the Saga survives and no Dragon appears") {
+            (driver.findPermanent(me, "The Misty Mountains Cold") != null) shouldBe true
+            driver.dragons(me).size shouldBe 0
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThranduilsCompanyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThranduilsCompanyScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.ThranduilsCompany
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thranduil's Company — {2}{G}{U} 3/4 Elf Soldier (HOB #168).
+ *
+ * "As long as you control another Elf, you may play an additional land on each of your turns.
+ *  Landfall — Whenever a land you control enters, put two +1/+1 counters on target creature you
+ *  control. It gains vigilance until end of turn."
+ *
+ * The land-drop half is gated on *another* Elf, so the card must never satisfy its own condition.
+ */
+class ThranduilsCompanyScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ThranduilsCompany))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Play a land, then settle the landfall trigger onto [preferredTarget] if it asks. */
+    fun GameTestDriver.playLandAndSettle(playerId: EntityId, landId: EntityId, preferredTarget: EntityId) {
+        playLand(playerId, landId)
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 40) {
+            val pending = state.pendingDecision
+            when {
+                pending is ChooseTargetsDecision -> submitTargetSelection(pending.playerId, listOf(preferredTarget))
+                pending != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+            guard++
+        }
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("landfall puts two +1/+1 counters on the target and grants it vigilance") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val company = driver.putCreatureOnBattlefield(me, "Thranduil's Company")
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        val forest = driver.putCardInHand(me, "Forest")
+        driver.playLandAndSettle(me, forest, bears)
+
+        withClue("two counters, not one") {
+            driver.plusOneCounters(bears) shouldBe 2
+        }
+        withClue("and vigilance until end of turn") {
+            driver.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+        }
+        withClue("the untargeted Company got nothing") {
+            driver.plusOneCounters(company) shouldBe 0
+        }
+    }
+
+    test("no other Elf: the card does not satisfy its own 'another Elf' condition") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val company = driver.putCreatureOnBattlefield(me, "Thranduil's Company")
+
+        val forest1 = driver.putCardInHand(me, "Forest")
+        driver.playLandAndSettle(me, forest1, company)
+
+        val forest2 = driver.putCardInHand(me, "Forest")
+        withClue("only the base land drop — the Company is the only Elf") {
+            driver.submitExpectFailure(PlayLand(me, forest2)).isSuccess shouldBe false
+        }
+    }
+
+    test("with another Elf out, a second land drop is legal") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val company = driver.putCreatureOnBattlefield(me, "Thranduil's Company")
+        driver.putCreatureOnBattlefield(me, "Llanowar Elves")
+
+        val forest1 = driver.putCardInHand(me, "Forest")
+        driver.playLandAndSettle(me, forest1, company)
+
+        val forest2 = driver.putCardInHand(me, "Forest")
+        driver.playLandAndSettle(me, forest2, company)
+
+        withClue("both lands are on the battlefield") {
+            driver.getLands(me).size shouldBe 2
+        }
+        withClue("two landfall triggers resolved, two counters each") {
+            driver.plusOneCounters(company) shouldBe 4
+        }
+
+        val forest3 = driver.putCardInHand(me, "Forest")
+        withClue("but only one extra drop — a third land is still illegal") {
+            driver.submitExpectFailure(PlayLand(me, forest3)).isSuccess shouldBe false
+        }
+    }
+})


### PR DESCRIPTION
Five cards from The Hobbit (HOB), each canonical in `hob` (all are HOB-first printings — `just check-card-printing` clean for all five).

| Card | # | What it needed |
|---|---|---|
| **Bard the Bowman** | 145 | `Triggers.NthCardDrawn(2)`; the counter and the lifelink grant share one target, so an illegal target fizzles both halves. |
| **Dancing from Dark to Dawn** | 123 | `DynamicAmounts.triggeringManaValue()` off a `YouCastCreature` trigger; landfall Bear token. |
| **The Misty Mountains Cold** | 104 | Four identical Saga chapters. Two gates: the "four or more Treasures" state check (counted *after* the chapter's own Treasure), and an `IfYouDo` gate on the self-sacrifice actually happening. |
| **Down, Down to Goblin-town** | 65 | Saga with per-chapter opponent targets — reveal-and-strip a nonland (Ego Drain idiom), amass Goblins 1, then drain 1 on III and IV. |
| **Thranduil's Company** | 168 | Conditional `GrantAdditionalLandDrop` (`excludeSelf` — it must not satisfy its own "another Elf"), plus landfall counters and vigilance. |

### Engine fix

`LandDropUtils.getAdditionalLandDrops` only matched a bare `GrantAdditionalLandDrop`, so a `ConditionalStaticAbility` wrapping one **silently no-opped** — Thranduil's Company granted nothing even with another Elf out. It now unwraps the conditional and evaluates the condition against the source permanent; both call sites (`PlayLandHandler`, `CastPermissionUtils`) thread their existing `ConditionEvaluator` through instead of allocating one. This is the same trap `MaximumHandSize` already documents for `SetMaximumHandSize`.

### Fidelity notes

- `SuccessCriterion.PermanentsSacrificed` rather than `Always` on the Misty Mountains Cold gate — `Always` would fail open and mint a free Dragon when the Saga has already left the battlefield.
- Down, Down to Goblin-town's III/IV is `LoseLife` + `GainLife`, **not** `DrainLife`: "and you gain 1 life" is a flat gain, not life equal to the life lost.

### Verification

- `just build` ✅
- `just test` — full suite green ✅
- `just rebless-cards` — only the five new cards moved in the HOB golden ✅
- One scenario test per card (12 tests total), all passing; the Thranduil test is what caught the land-drop bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
