### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MagnifyingGlassReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MagnifyingGlassReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Magnifying Glass reprint in Jumpstart 2022. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shadows over Innistrad (the earliest real
+ * printing); this file contributes only presentation data.
+ */
+val MagnifyingGlassReprint = Printing(
+    oracleId = "f2ce9e55-07c0-4f36-a59e-127693fc0f62",
+    name = "Magnifying Glass",
+    setCode = "J22",
+    collectorNumber = "95",
+    scryfallId = "5db997a7-d54c-4821-9e9f-56292f9e7e5a",
+    artist = "Yukihiro Maruo",
+    imageUri = "https://cards.scryfall.io/normal/front/5/d/5db997a7-d54c-4821-9e9f-56292f9e7e5a.jpg?1783919156",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DefenestratedPhantom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DefenestratedPhantom.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Defenestrated Phantom — Murders at Karlov Manor #11
+ * {4}{W}{W} · Creature — Spirit · 4/3
+ *
+ * Flying
+ * Disguise {4}{W}
+ *
+ * A pure vanilla-plus-disguise body: the whole card is two keywords, so there is no script block at
+ * all. Face down it is the standard 2/2 with ward {2} and no abilities (CR 702.168a / 708.2) — it
+ * doesn't fly until it's turned face up. Note the disguise cost {4}{W} is a *worse* rate than just
+ * hard-casting it for {4}{W}{W}, so disguise here is about timing (a surprise blocker that flips
+ * mid-combat) rather than about cheating on mana.
+ */
+val DefenestratedPhantom = card("Defenestrated Phantom") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\n" +
+        "Disguise {4}{W} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)"
+    power = 4
+    toughness = 3
+    keywords(Keyword.FLYING)
+    disguise = "{4}{W}"
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Never parley near high windows.\"\n—Teysa"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b284304-c3bf-4413-9fd3-b44eb4eb642a.jpg?1783912926"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "The resulting creature is a 2/2 creature with ward {2} that has no name, mana cost, " +
+                "or creature types. Both the spell and the resulting creature are colorless and " +
+                "have a mana value of 0."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DueDiligence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DueDiligence.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Due Diligence — Murders at Karlov Manor #14
+ * {2}{W} · Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, target creature you control other than enchanted creature gets +2/+2 and
+ * gains vigilance until end of turn.
+ * Enchanted creature gets +2/+2 and has vigilance.
+ *
+ * Two bodies get the buff, but only one keeps it: the static half rides the attachment for as long
+ * as the Aura stays put, while the enters trigger is a one-shot on a *second*, separately-targeted
+ * creature that wears off at cleanup.
+ *
+ * "other than enchanted creature" is the source-relative
+ * [GameObjectFilter.notAttachedToBySource] exclusion, evaluated against the Aura's own attachment
+ * at the moment targets are chosen and again on resolution — which is exactly what the printed
+ * ruling describes: if the Aura somehow moves onto the creature its own trigger is targeting
+ * before that trigger resolves, the target is no longer legal, the ability is removed from the
+ * stack, and *none* of its effects happen (CR 608.2b).
+ *
+ * Note that the Aura may legally enchant a creature an opponent controls (the enchant restriction
+ * is just "creature"), but the trigger's target is restricted to a creature *you* control.
+ */
+val DueDiligence = card("Due Diligence") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, target creature you control other than enchanted creature gets " +
+        "+2/+2 and gains vigilance until end of turn.\n" +
+        "Enchanted creature gets +2/+2 and has vigilance."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val other = target(
+            "target creature you control other than enchanted creature",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.youControl().notAttachedToBySource())
+            )
+        )
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, other),
+            Effects.GrantKeyword(Keyword.VIGILANCE, other)
+        )
+        description = "When this Aura enters, target creature you control other than enchanted " +
+            "creature gets +2/+2 and gains vigilance until end of turn."
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 2, Filters.EnchantedCreature)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EnchantedCreature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/076d9f76-a247-4727-9e0f-a0289c51059e.jpg?1783912925"
+
+        ruling(
+            "2024-02-02",
+            "In the unusual case where Due Diligence's second ability triggers and then Due " +
+                "Diligence becomes attached to the target of its own triggered ability before " +
+                "that ability resolves, when the triggered ability tries to resolve, it won't " +
+                "resolve and none of its effects will happen."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LeadPipe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LeadPipe.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lead Pipe — Murders at Karlov Manor #90
+ * {B} · Artifact — Clue Equipment
+ *
+ * Equipped creature gets +2/+0.
+ * Whenever equipped creature dies, each opponent loses 1 life.
+ * {2}, Sacrifice this Equipment: Draw a card.
+ * Equip {2}
+ *
+ * One of the set's "murder weapon" Equipment — an Equipment that is also a Clue, so it carries the
+ * standard Clue sacrifice-to-draw *and* the Clue subtype, which matters for the set's "sacrifice a
+ * Clue" payoffs (Scryfall's ruling: "If an effect refers to a Clue, it means any Clue artifact,
+ * not just a Clue artifact token"). The subtype is on the type line, so nothing extra is needed
+ * for those payoffs to see it.
+ *
+ * The death trigger is [TriggerBinding.ATTACHED] over a battlefield→graveyard zone change, which
+ * is the engine's "equipped creature dies" idiom. The Equipment stays on the battlefield when its
+ * host dies (it just becomes unattached, CR 704.5m), so it can be re-equipped or cashed in for the
+ * card afterwards — the two halves of the card don't compete.
+ */
+val LeadPipe = card("Lead Pipe") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Clue Equipment"
+    oracleText = "Equipped creature gets +2/+0.\n" +
+        "Whenever equipped creature dies, each opponent loses 1 life.\n" +
+        "{2}, Sacrifice this Equipment: Draw a card.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = ModifyStats(+2, +0, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(to = Zone.GRAVEYARD, binding = TriggerBinding.ATTACHED)
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        description = "Whenever equipped creature dies, each opponent loses 1 life."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Igor Krstic"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87f69249-c6e4-40c1-9870-b9c45ce24c39.jpg?1783912896"
+
+        ruling(
+            "2016-04-08",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token."
+        )
+        ruling(
+            "2016-04-08",
+            "You can't sacrifice a Clue to pay multiple costs."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MagnifyingGlassReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MagnifyingGlassReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Magnifying Glass reprint in Murders at Karlov Manor. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Shadows over Innistrad (the earliest real
+ * printing); this file contributes only presentation data.
+ */
+val MagnifyingGlassReprint = Printing(
+    oracleId = "f2ce9e55-07c0-4f36-a59e-127693fc0f62",
+    name = "Magnifying Glass",
+    setCode = "MKM",
+    collectorNumber = "255",
+    scryfallId = "c606a71f-8fb0-486b-955f-727ebf436946",
+    artist = "Paolo Puggioni",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c606a71f-8fb0-486b-955f-727ebf436946.jpg?1783912827",
+    releaseDate = "2024-02-09",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SliceFromTheShadows.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SliceFromTheShadows.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Slice from the Shadows — Murders at Karlov Manor #103
+ * {X}{B} · Instant
+ *
+ * This spell can't be countered.
+ * Target creature gets -X/-X until end of turn.
+ *
+ * A Death Wind that dodges counterspells. The reminder text calls out the interesting case: ward is a
+ * *counter* the spell, so the ward trigger still goes on the stack and still asks you to pay, but if
+ * you decline, the counter attempt simply does nothing and Slice resolves anyway (CR 702.21b — the
+ * ward ability counters the spell, and `cantBeCountered` beats it).
+ *
+ * X is locked in on cast, so shrinking the target after announcement doesn't change the -X/-X, and a
+ * responding pump spell can still save the creature. -X/-X is a stat modification in Layer 7c, not
+ * damage, so it kills through indestructible and doesn't count as damage for lifelink or triggers.
+ */
+val SliceFromTheShadows = card("Slice from the Shadows") {
+    manaCost = "{X}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "This spell can't be countered. (This includes by the ward ability.)\n" +
+        "Target creature gets -X/-X until end of turn."
+    cantBeCountered = true
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        val negX = DynamicAmount.Multiply(DynamicAmount.XValue, -1)
+        effect = Effects.ModifyStats(negX, negX, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Lie Setiawan"
+        flavorText = "\"Proft has been poking his nose where it doesn't belong. " +
+            "I want him out of the way.\"\n—Judith, to Massacre Girl"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/317800b3-6b2d-4de6-8e44-7e54dd623055.jpg?1783912894"
+
+        ruling(
+            "2024-02-02",
+            "If you target a creature with ward, you may still pay the ward cost, but Slice from " +
+                "the Shadows won't be countered even if you don't."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MagnifyingGlass.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MagnifyingGlass.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Magnifying Glass — Shadows over Innistrad #258
+ * {3} · Artifact
+ *
+ * {T}: Add {C}.
+ * {4}, {T}: Investigate.
+ *
+ * Canonical definition lives in Shadows over Innistrad, the earliest real printing (2016-04-08),
+ * where Clues debuted. Reprinted in Murders at Karlov Manor — see MKM `MagnifyingGlassReprint`.
+ *
+ * The two abilities share the tap symbol, so they compete: each turn the Glass either ramps or
+ * (much later) starts turning mana into Clues, never both. Only the first is a mana ability — the
+ * investigate line costs {4} on top of the tap and uses the stack, so it can be responded to,
+ * which is why `manaAbility`/`TimingRule.ManaAbility` is set on the first activation and not the
+ * second.
+ */
+val MagnifyingGlass = card("Magnifying Glass") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {C}.\n" +
+        "{4}, {T}: Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this " +
+        "token: Draw a card.\")"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}"), Costs.Tap)
+        effect = Effects.Investigate()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "258"
+        artist = "Dan Murayama Scott"
+        flavorText = "Knight-Inquisitors of Saint Raban delve deep into mysteries best left unexplored."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7a708d5-f757-4fcf-a167-5b5920c6adeb.jpg?1783937707"
+
+        ruling(
+            "2016-04-08",
+            "Clue is an artifact type. Even though it appears on some cards with other permanent " +
+                "types, it's never a creature type, a land type, or anything but an artifact type."
+        )
+        ruling(
+            "2016-04-08",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -738,6 +738,52 @@
     ]
 }
 
+// Defenestrated Phantom
+{
+    "name": "Defenestrated Phantom",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nDisguise {4}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{W}"
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Never parley near high windows.\"\n—Teysa",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b284304-c3bf-4413-9fd3-b44eb4eb642a.jpg?1783912926",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "The resulting creature is a 2/2 creature with ward {2} that has no name, mana cost, or creature types. Both the spell and the resulting creature are colorless and have a mana value of 0."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Demand Answers
 {
     "name": "Demand Answers",
@@ -838,6 +884,103 @@
     },
     "colorIdentityOverride": [
         "RED",
+        "WHITE"
+    ]
+}
+
+// Due Diligence
+{
+    "name": "Due Diligence",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, target creature you control other than enchanted creature gets +2/+2 and gains vigilance until end of turn.\nEnchanted creature gets +2/+2 and has vigilance.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control other than enchanted creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control other than enchanted creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                {
+                                    "type": "StateNot",
+                                    "predicate": "IsAttachedToBySource"
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    },
+                    "id": "target creature you control other than enchanted creature"
+                },
+                "descriptionOverride": "When this Aura enters, target creature you control other than enchanted creature gets +2/+2 and gains vigilance until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/076d9f76-a247-4727-9e0f-a0289c51059e.jpg?1783912925",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "In the unusual case where Due Diligence's second ability triggers and then Due Diligence becomes attached to the target of its own triggered ability before that ability resolves, when the triggered ability tries to resolve, it won't resolve and none of its effects will happen."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
         "WHITE"
     ]
 }
@@ -1895,6 +2038,119 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Lead Pipe
+{
+    "name": "Lead Pipe",
+    "manaCost": "{B}",
+    "typeLine": "Artifact — Clue Equipment",
+    "oracleText": "Equipped creature gets +2/+0.\nWhenever equipped creature dies, each opponent loses 1 life.\n{2}, Sacrifice this Equipment: Draw a card.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                "descriptionOverride": "Whenever equipped creature dies, each opponent loses 1 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Krstic",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87f69249-c6e4-40c1-9870-b9c45ce24c39.jpg?1783912896",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+            },
+            {
+                "date": "2016-04-08",
+                "text": "You can't sacrifice a Clue to pay multiple costs."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -3599,6 +3855,58 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Slice from the Shadows
+{
+    "name": "Slice from the Shadows",
+    "manaCost": "{X}{B}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be countered. (This includes by the ward ability.)\nTarget creature gets -X/-X until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Multiply",
+                "amount": "XValue",
+                "multiplier": -1
+            },
+            "toughnessModifier": {
+                "type": "Multiply",
+                "amount": "XValue",
+                "multiplier": -1
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Lie Setiawan",
+        "flavorText": "\"Proft has been poking his nose where it doesn't belong. I want him out of the way.\"\n—Judith, to Massacre Girl",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/317800b3-6b2d-4de6-8e44-7e54dd623055.jpg?1783912894",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you target a creature with ward, you may still pay the ward cost, but Slice from the Shadows won't be countered even if you don't."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -2406,6 +2406,69 @@
     ]
 }
 
+// Magnifying Glass
+{
+    "name": "Magnifying Glass",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {C}.\n{4}, {T}: Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Knight-Inquisitors of Saint Raban delve deep into mysteries best left unexplored.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7a708d5-f757-4fcf-a167-5b5920c6adeb.jpg?1783937707",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "Clue is an artifact type. Even though it appears on some cards with other permanent types, it's never a creature type, a land type, or anything but an artifact type."
+            },
+            {
+                "date": "2016-04-08",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Moonlight Hunt
 {
     "name": "Moonlight Hunt",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -20,7 +20,10 @@ import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
  * this detector checks if general events (DamageDealtEvent, AttackersDeclaredEvent, etc.)
  * match ATTACHED-bound triggers on auras/equipment attached to the event's entity.
  */
-class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
+class AttachmentTriggerDetector(
+    private val abilityResolver: TriggerAbilityResolver,
+    private val matcher: TriggerMatcher,
+) {
 
     /**
      * Unified detection for all ATTACHED-bound triggers on battlefield auras/equipment.
@@ -39,7 +42,11 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
         val isZoneChange = event is ZoneChangeEvent
 
         for (entityId in relevantIds) {
-            for (entry in index.aurasByTarget[entityId].orEmpty()) {
+            val live = index.aurasByTarget[entityId].orEmpty()
+            // When the attached permanent left the battlefield, the live links may already be torn
+            // down — see [lastKnownAttachments].
+            val entries = live + lastKnownAttachments(state, event, index, live)
+            for (entry in entries) {
                 for (ability in entry.abilities) {
                     if (ability.binding != TriggerBinding.ATTACHED) continue
                     // For zone-change events on the attached creature (e.g., creature dies),
@@ -61,6 +68,63 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * The Equipment that was attached to a permanent leaving the battlefield but is no longer
+     * linked to it in [TriggerIndex.aurasByTarget] — CR 608.2h last-known information.
+     *
+     * Needed because the timing of the unattach depends on *how* the host left. A destroy or
+     * bounce effect emits the [ZoneChangeEvent] during resolution, and triggers are detected
+     * while the link is still live. A death by state-based action does not: `LETHAL_DAMAGE`
+     * (CR 704.5g) and `UNATTACHED_AURAS` (CR 704.5m) run in the *same* SBA pass, so by the time
+     * the batch's events reach trigger detection the Equipment is already unattached and the
+     * index no longer connects it to its dead host. Without this fallback, "whenever equipped
+     * creature dies" would fire on removal but silently no-op on combat damage — the far more
+     * common way a creature actually dies.
+     *
+     * Only Equipment is reconstructed: an Aura goes to the graveyard along with its host and is
+     * handled from its own [ZoneChangeEvent] by
+     * [DeathAndLeaveTriggerDetector.detectDeadAuraAttachmentTriggers].
+     *
+     * [live] entries are excluded so an attachment the index still knows about is never counted
+     * twice.
+     */
+    private fun lastKnownAttachments(
+        state: GameState,
+        event: EngineGameEvent,
+        index: TriggerIndex,
+        live: List<TriggerIndex.IndexedEntity>,
+    ): List<TriggerIndex.IndexedEntity> {
+        if (event !is ZoneChangeEvent) return emptyList()
+        val attachmentIds = event.lastKnown?.attachmentIds.orEmpty()
+        if (attachmentIds.isEmpty()) return emptyList()
+
+        val alreadyLive = live.mapTo(mutableSetOf()) { it.entityId }
+        val battlefield = state.getBattlefield()
+        return attachmentIds.mapNotNull { attachmentId ->
+            if (attachmentId in alreadyLive) return@mapNotNull null
+            // The Equipment must still be on the battlefield for its ability to function.
+            if (attachmentId !in battlefield) return@mapNotNull null
+            val container = state.getEntity(attachmentId) ?: return@mapNotNull null
+            val cardComponent = container
+                .get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                ?: return@mapNotNull null
+            if (!cardComponent.typeLine.isEquipment) return@mapNotNull null
+            val controllerId = container
+                .get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                ?.playerId ?: return@mapNotNull null
+            val abilities = abilityResolver.getTriggeredAbilities(
+                attachmentId, cardComponent.cardDefinitionId, state, index.statics
+            )
+            if (abilities.isEmpty()) return@mapNotNull null
+            TriggerIndex.IndexedEntity(
+                entityId = attachmentId,
+                cardComponent = cardComponent,
+                controllerId = controllerId,
+                abilities = abilities,
+            )
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -80,7 +80,7 @@ class TriggerDetector(
     private val abilityResolver = TriggerAbilityResolver(cardRegistry, abilityRegistry)
     private val deathAndLeaveDetector = DeathAndLeaveTriggerDetector(abilityResolver, matcher)
     private val damageDetector = DamageTriggerDetector(abilityResolver, matcher)
-    private val attachmentDetector = AttachmentTriggerDetector(matcher)
+    private val attachmentDetector = AttachmentTriggerDetector(abilityResolver, matcher)
 
     /**
      * Build a trigger index for the current game state.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -284,16 +284,16 @@ object ZoneTransitionService {
         // Was this permanent equipped / enchanted as it left? The live attachment links are torn
         // down by the exit cleanup below (CR 704.5m/n), so "modified/equipped/enchanted creature
         // leaves the battlefield" triggers must freeze it here as last-known information (CR 608.2h).
-        val lastKnownAttachedTypeLines = if (leavingBattlefield) {
+        val lastKnownAttachmentIds = if (leavingBattlefield) {
             state.getEntity(entityId)
                 ?.get<com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent>()
                 ?.attachedIds
-                ?.mapNotNull { attachId ->
-                    state.getEntity(attachId)
-                        ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.typeLine
-                }
                 ?: emptyList()
         } else emptyList()
+        val lastKnownAttachedTypeLines = lastKnownAttachmentIds.mapNotNull { attachId ->
+            state.getEntity(attachId)
+                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.typeLine
+        }
         val lastKnownWasEquipped = lastKnownAttachedTypeLines.any { it.isEquipment }
         val lastKnownWasEnchanted = lastKnownAttachedTypeLines.any { it.isAura }
 
@@ -315,6 +315,7 @@ object ZoneTransitionService {
                 cardDefinitionId = cardComponent.cardDefinitionId,
                 attachedTo = lastKnownAttachedTo,
                 wasEquipped = lastKnownWasEquipped,
+                attachmentIds = lastKnownAttachmentIds,
                 wasEnchanted = lastKnownWasEnchanted,
                 blockingOrBlockedByIds = lastKnownBlockingOrBlockedByIds,
                 wasAttacking = lastKnownWasAttacking,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
@@ -116,6 +116,19 @@ data class EntitySnapshot(
      */
     val wasEquipped: Boolean = false,
     /**
+     * The Auras/Equipment that were attached to this permanent when it left the battlefield, in
+     * attachment order. [wasEquipped]/[wasEnchanted] answer "was it attached to *anything* of this
+     * kind"; this field answers "by *what*", which is what an ATTACHED-bound leaves/dies trigger
+     * borne by a still-on-the-battlefield Equipment needs to find itself again.
+     *
+     * The live links are torn down by the exit cleanup (CR 704.5m/n), and when the permanent dies
+     * to a state-based action the unattach runs in the *same* SBA pass as the death — so by the
+     * time triggers are detected, the attachment index no longer connects the Equipment to its
+     * dead host. Freezing the ids here is the last-known information (CR 608.2h) that lets
+     * `AttachmentTriggerDetector` still fire "whenever equipped creature dies".
+     */
+    val attachmentIds: List<EntityId> = emptyList(),
+    /**
      * True if this permanent had at least one Aura attached when it left the battlefield (CR 303.4).
      * Last-known counterpart to [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsEnchanted];
      * a leg of the last-known [com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsModified].

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DueDiligenceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DueDiligenceScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Due Diligence (MKM #14) — {2}{W} Enchantment — Aura.
+ * "Enchant creature / When this Aura enters, target creature you control other than enchanted
+ * creature gets +2/+2 and gains vigilance until end of turn. / Enchanted creature gets +2/+2
+ * and has vigilance."
+ *
+ * The load-bearing part is "other than enchanted creature": the trigger's target filter is the
+ * source-relative `notAttachedToBySource()` exclusion, and a fail-open filter would silently let
+ * the player stack both buffs onto the enchanted creature. Both tests below pin that down — one
+ * on the legal-target list the engine offers, one on the resulting stats.
+ */
+class DueDiligenceScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Due Diligence") {
+
+            test("the enters trigger cannot target the enchanted creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardInHand(1, "Due Diligence")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                // Enchant the Bears.
+                game.castSpell(1, "Due Diligence", targetId = bears).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val decision = game.getPendingDecision() as ChooseTargetsDecision
+                val legal = decision.legalTargets[0].orEmpty()
+                withClue("the other creature you control is offered") {
+                    legal shouldContain courser
+                }
+                withClue("the enchanted creature is excluded — 'other than enchanted creature'") {
+                    legal shouldNotContain bears
+                }
+            }
+
+            test("the static buffs the host and the trigger buffs a second creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardInHand(1, "Due Diligence")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.castSpell(1, "Due Diligence", targetId = bears).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                game.selectTargets(listOf(courser)).error shouldBe null
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("enchanted Grizzly Bears is 2/2 + 2/+2 = 4/4 with vigilance") {
+                    projected.getPower(bears) shouldBe 4
+                    projected.getToughness(bears) shouldBe 4
+                    projected.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+                }
+                withClue("the triggered target Centaur Courser is 3/3 + 2/+2 = 5/5 with vigilance") {
+                    projected.getPower(courser) shouldBe 5
+                    projected.getToughness(courser) shouldBe 5
+                    projected.hasKeyword(courser, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ForebearsBladeTriggerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ForebearsBladeTriggerTest.kt
@@ -174,4 +174,46 @@ class ForebearsBladeTriggerTest : FunSpec({
         driver.getPermanents(activePlayer).contains(equipment) shouldBe true
         driver.state.getEntity(equipment)?.get<AttachedToComponent>() shouldBe null
     }
+
+    /**
+     * Regression: the dies trigger must fire the same way whether the host was destroyed by an
+     * effect or died to lethal damage as a state-based action.
+     *
+     * The two paths unattach the Equipment at different moments. A destroy effect emits the zone
+     * change during resolution, so the attachment link is still live when triggers are detected.
+     * Lethal damage does not — CR 704.5g (lethal damage) and CR 704.5m (unattach) are both
+     * state-based actions applied in the *same* pass, so the link is already gone. The detector
+     * falls back to the host's last-known attachment ids (CR 608.2h) to cover it; before that
+     * fallback existed, every "whenever equipped creature dies" Equipment silently no-opped on
+     * the combat-damage path.
+     */
+    test("the dies trigger also fires when the equipped creature dies to lethal damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 10, "Mountain" to 10),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature1 = driver.putCreatureOnBattlefield(activePlayer, "Test Soldier")
+        val creature2 = driver.putCreatureOnBattlefield(activePlayer, "Test Knight")
+        val equipment = driver.putEquipmentAttached(activePlayer, "Forebear's Blade", creature1)
+
+        // Bolt the 2/2 host — it dies to state-based actions, not to a destroy effect.
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(creature1)))
+        driver.bothPass()
+
+        driver.getPermanents(activePlayer).contains(creature1) shouldBe false
+
+        // The trigger still fired and is asking for its target.
+        driver.pendingDecision shouldNotBe null
+        driver.submitTargetSelection(activePlayer, listOf(creature2))
+        driver.bothPass()
+
+        driver.state.getEntity(equipment)?.get<AttachedToComponent>()?.targetId shouldBe creature2
+    }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeadPipeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeadPipeScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lead Pipe (MKM #90) — {B} Artifact — Clue Equipment.
+ * "Equipped creature gets +2/+0. / Whenever equipped creature dies, each opponent loses 1 life. /
+ * {2}, Sacrifice this Equipment: Draw a card. / Equip {2}"
+ *
+ * The death trigger is an ATTACHED-bound battlefield→graveyard zone change, which reads its
+ * subject through the attachment rather than off the source — the shape that silently no-ops if
+ * the binding is wrong. Covered here alongside the static buff and the Clue half.
+ */
+class LeadPipeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lead Pipe") {
+
+            test("equipped creature gets +2/+0 and its death drains each opponent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Lead Pipe", "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val pipe = game.findPermanent("Lead Pipe")!!
+
+                withClue("2/2 base + 2/+0 from the Equipment") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+
+                // Bolt the equipped creature — 3 damage to a 4/2 kills it.
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the equipped creature died") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+
+                // The dies trigger goes on the stack; resolve it.
+                game.resolveStack()
+
+                withClue("each opponent lost 1 life; the Equipment's controller did not") {
+                    game.getLifeTotal(2) shouldBe 19
+                    game.getLifeTotal(1) shouldBe 20
+                }
+                withClue("the Equipment stays on the battlefield, just unattached (CR 704.5m)") {
+                    game.findPermanent("Lead Pipe") shouldBe pipe
+                }
+            }
+
+            test("the Clue half sacrifices for a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lead Pipe")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                val pipe = game.findPermanent("Lead Pipe")!!
+                // activatedAbilities[0] is the Clue sacrifice; [1] is equip.
+                val sacrifice = cardRegistry.getCard("Lead Pipe")!!.script.activatedAbilities[0]
+
+                game.execute(ActivateAbility(game.player1Id, pipe, sacrifice.id)).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the Equipment was sacrificed and a card was drawn") {
+                    game.findPermanent("Lead Pipe") shouldBe null
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five MKM cards, chosen to spread across the set's mechanics without any single card being complex.

## Cards

| Card | Cost | Notes |
|---|---|---|
| **Defenestrated Phantom** (MKM #11) | `{4}{W}{W}` | 4/3 flier, disguise `{4}{W}`. Pure keywords — no script block. |
| **Due Diligence** (MKM #14) | `{2}{W}` | Aura. Static +2/+2 + vigilance on the host; enters trigger buffs a **second** creature. |
| **Lead Pipe** (MKM #90) | `{B}` | Clue Equipment: +2/+0, equipped-creature-dies drain, `{2}`+sac to draw, equip `{2}`. |
| **Slice from the Shadows** (MKM #103) | `{X}{B}` | Can't be countered (including by ward); -X/-X until end of turn. |
| **Magnifying Glass** | `{3}` | Mana rock + `{4},{T}: Investigate`. |

**Magnifying Glass placement**: its earliest real printing is Shadows over Innistrad (2016-04-08), so the canonical `CardDefinition` went to `soi/cards/`, with `Printing` rows in J22 and MKM. `just check-card-printing` is clean for all five.

MKM coverage: 77 → 82 of 276.

## Engine fix (surfaced by Lead Pipe)

An `ATTACHED`-bound *"whenever equipped creature dies"* trigger fired when the host was **destroyed by an effect** but silently no-opped when the host **died to lethal damage** — the far more common case.

The two paths unattach at different moments:

- A destroy effect emits the `ZoneChangeEvent` during resolution, so the attachment link is still live when triggers are detected.
- Lethal damage does not. CR 704.5g (lethal damage) and CR 704.5m (unattach) are both state-based actions applied in the **same** pass, so by the time the batch's events reach trigger detection, `TriggerIndex.aurasByTarget` no longer connects the Equipment to its dead host.

Fix: `EntitySnapshot` now freezes the host's attachment ids as last-known information (CR 608.2h) — the site already read `attachedIds` to compute `wasEquipped`, it just discarded them. `AttachmentTriggerDetector` falls back to those ids for Equipment still on the battlefield, deduped against the live index so nothing double-fires. Auras are deliberately excluded: they go to the graveyard with the host and are already handled from their own zone-change event.

This was pre-existing and not caused by these cards — it equally affected **Forebear's Blade**, **Angelic Destiny**, **Demonic Vigor**, **Fungal Fortitude** and every other card of that shape. Their existing tests only covered the destroy path, which is why it went unnoticed.

## Verification

- `just build` — green.
- `just test` — full suite green, no regressions.
- `LeadPipeScenarioTest` (2 cases: static + death drain on the damage path; the Clue half).
- `DueDiligenceScenarioTest` (2 cases: the "other than enchanted creature" target filter genuinely excludes the host; both creatures end at the right stats).
- `ForebearsBladeTriggerTest` gains a case proving the engine fix generalizes beyond the new card.
- Card snapshots re-blessed — only the new cards moved in the golden.
- All six image URIs verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)