### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1755,7 +1755,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   the rest of the animate at cleanup; `null` keeps the permanent's own art. The optional
   `dynamicPower`/`dynamicToughness` (`DynamicAmount`, supplied together) instead make the Layer 7b base-P/T a
   *dynamic* `SetPowerToughnessDynamic` recomputed at projection rather than locked in at resolution — the
-  single-target companion to `MassAnimateEffect`. Facade
+  single-target companion to `MassAnimateEffect`. The amounts are evaluated with the **animating source's
+  controller** as `you`, so a controller-scoped count works: **Beorn's Hospitality**
+  ("{5}{G}{G}: This enchantment becomes a Bear creature in addition to its other types and gains 'This
+  creature's power and toughness are each equal to the number of lands you control.' (This effect doesn't
+  end.)") is `BecomeCreature(EffectTarget.Self, power = Fixed(0), toughness = Fixed(0),
+  creatureTypes = {"Bear"}, duration = Duration.Permanent, dynamicPower = dynamicToughness =
+  DynamicAmounts.landsYouControl())` — the printed `power`/`toughness` are only the rules-text display
+  (rendered `*/*`), and the enchantment keeps its Enchantment type. Facade
   `Effects.BecomeCreatureWithManaValueStats(target, addTypes, keywords, creatureTypes, duration)` wires P/T = the
   animated permanent's own mana value (`EntityProperty(AffectedEntity, ManaValue)`) for **Xenic Poltergeist**
   ("Until your next upkeep, target noncreature artifact becomes an artifact creature with power and toughness
@@ -5296,7 +5303,16 @@ staticAbility {
   `<property>` among `<filter>` you control", parameterized over `EntityNumericProperty`:
   `ManaValue` (Sunderflock — "greatest mana value among Elementals you control", read from the card
   definition), `Power` (The Skullspore Nexus — "greatest power among creatures you control", read
-  from projected state so counters and buffs count); empty match → 0. … — see `CostStaticAbilities.kt`
+  from projected state so counters and buffs count); empty match → 0,
+  `TotalPropertyAmongPermanentsYouControl(property, filter)` — the sum twin of the above: "{X} less,
+  where X is the total `<property>` of `<filter>` you control", over the same `EntityNumericProperty`
+  axis and the same read rules. The filtered generalization of `TotalPowerYouControl` (Ghalta's
+  unfiltered "total power of creatures you control") the way `PermanentsYouControlMatching`
+  generalizes `CreaturesYouControl`: The Lord of the Eagles is
+  `TotalPropertyAmongPermanentsYouControl(Power, Creature.withKeyword(FLYING))`. The filter runs
+  through `PredicateEvaluator` against projected state, so granted flying and animated permanents
+  count; negative power subtracts from the total (Ghalta's ruling on the same wording) and only the
+  finished sum is floored at 0. … — see `CostStaticAbilities.kt`
   for the full list.
 - `gating: CostGating` — gates whether/how often the modifier fires:
   - `None` (default) — applies to every matching cast.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -4515,6 +4515,14 @@ object Effects {
      * power/toughness. More general than AnimateLand — can remove types, grant keywords, set
      * subtypes, change color. The base P/T amounts are evaluated once when the effect resolves
      * (CR 613.4c) — e.g. `DynamicAmount.Add(XValue, Fixed(1))` for Fractalize's "X plus 1" Fractal.
+     *
+     * Pass [dynamicPower] / [dynamicToughness] (both or neither) when the animated permanent gains a
+     * **characteristic-defining P/T that keeps recomputing** rather than a value frozen at
+     * resolution — "it gains 'This creature's power and toughness are each equal to the number of
+     * lands you control'" (Beorn's Hospitality). Those amounts are re-evaluated at Layer 7b on every
+     * projection, with the animating source's controller as `you`; [power]/[toughness] then serve
+     * only as the rules-text display. [BecomeCreatureWithManaValueStats] is the pre-baked
+     * "equal to its mana value" case.
      */
     fun BecomeCreature(
         target: EffectTarget = EffectTarget.Self,
@@ -4526,8 +4534,13 @@ object Effects {
         addTypes: Set<String> = emptySet(),
         colors: Set<String>? = null,
         imageUri: String? = null,
-        duration: Duration = Duration.EndOfTurn
-    ): Effect = BecomeCreatureEffect(target, power, toughness, keywords, creatureTypes, removeTypes, addTypes, colors, imageUri, duration)
+        duration: Duration = Duration.EndOfTurn,
+        dynamicPower: DynamicAmount? = null,
+        dynamicToughness: DynamicAmount? = null
+    ): Effect = BecomeCreatureEffect(
+        target, power, toughness, keywords, creatureTypes, removeTypes, addTypes, colors, imageUri,
+        duration, dynamicPower, dynamicToughness
+    )
 
     /** Fixed-P/T sugar for [BecomeCreature] — Sarkhan's "4/4 Dragon" and similar constant animates. */
     fun BecomeCreature(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -572,6 +572,34 @@ sealed interface CostReductionSource {
     }
 
     /**
+     * Reduces cost by the *sum* of a numeric [property] over the permanents the caster controls
+     * matching a [filter] — "{X} less, where X is the total <property> of <filter> you control".
+     * Empty matches yield 0 reduction.
+     *
+     * The sum twin of [GreatestPropertyAmongPermanentsYouControl], sharing its `(property, filter)`
+     * axes and its read rules: power/toughness come from projected state (CR 613) so counters and
+     * lords count, and mana value comes from the card definition (X-cost permanents contribute
+     * X = 0). Negative power subtracts from the total, per Ghalta's ruling on the same "total
+     * power" wording; only the finished sum is floored at 0.
+     *
+     * The filtered generalization of [TotalPowerYouControl], the same way
+     * [PermanentsYouControlMatching] generalizes [CreaturesYouControl]:
+     *  - `TotalPropertyAmongPermanentsYouControl(EntityNumericProperty.Power, Filters.Creature.withKeyword(FLYING))`
+     *    — The Lord of the Eagles ("the total power of creatures you control with flying").
+     *
+     * @property property Which numeric characteristic to sum
+     * @property filter The filter that controlled permanents must match
+     */
+    @SerialName("TotalPropertyAmongPermanentsYouControl")
+    @Serializable
+    data class TotalPropertyAmongPermanentsYouControl(
+        val property: EntityNumericProperty,
+        val filter: GameObjectFilter
+    ) : CostReductionSource {
+        override val description: String = "the total ${property.description} of ${filter.description} you control"
+    }
+
+    /**
      * Reduces cost by a fixed amount if a creature is currently attacking the caster.
      * Used for cards like Swat Away ("This spell costs {2} less to cast if a creature
      * is attacking you").

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BeornsHospitality.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BeornsHospitality.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Beorn's Hospitality
+ * {1}{G}
+ * Enchantment
+ *
+ * Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control.
+ * {5}{G}{G}: This enchantment becomes a Bear creature in addition to its other types and gains
+ * "This creature's power and toughness are each equal to the number of lands you control."
+ * (This effect doesn't end.)
+ *
+ * The landfall half is the plain [Triggers.LandYouControlEnters] shape — an enchantment can never be
+ * the entering land, so the trigger's OTHER binding costs nothing here.
+ *
+ * The activated half animates the enchantment *itself* with `Duration.Permanent` ("This effect
+ * doesn't end") and, crucially, a **characteristic-defining** P/T rather than a value frozen at
+ * resolution: `dynamicPower`/`dynamicToughness` are re-evaluated at Layer 7b on every projection, so
+ * playing another land immediately grows the Bear, and a Wasteland shrinks it. The printed
+ * `power`/`toughness` are only the rules-text display (rendered as a star P/T). `creatureTypes` adds Bear
+ * and CREATURE without touching the existing Enchantment type, matching "in addition to its other
+ * types" — the permanent stays an enchantment creature.
+ *
+ * Activating twice is harmless: the second animation is a second Layer 4/7b effect setting the same
+ * types and the same CDA, so the later timestamp simply wins with an identical result.
+ */
+val BeornsHospitality = card("Beorn's Hospitality") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Landfall — Whenever a land you control enters, put a +1/+1 counter on target " +
+        "creature you control.\n" +
+        "{5}{G}{G}: This enchantment becomes a Bear creature in addition to its other types and " +
+        "gains \"This creature's power and toughness are each equal to the number of lands you " +
+        "control.\" (This effect doesn't end.)"
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        description = "Landfall — Whenever a land you control enters, put a +1/+1 counter on " +
+            "target creature you control."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}{G}")
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = DynamicAmount.Fixed(0),
+            toughness = DynamicAmount.Fixed(0),
+            creatureTypes = setOf("Bear"),
+            duration = Duration.Permanent,
+            dynamicPower = DynamicAmounts.landsYouControl(),
+            dynamicToughness = DynamicAmounts.landsYouControl()
+        )
+        description = "{5}{G}{G}: This enchantment becomes a Bear creature in addition to its " +
+            "other types and gains \"This creature's power and toughness are each equal to the " +
+            "number of lands you control.\""
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "120"
+        artist = "Harkalé Linaï"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/153ca57e-30f0-4ad7-ae9d-c55cbf0fd4c9.jpg?1785152153"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BurnBurnTreeAndFern.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BurnBurnTreeAndFern.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Burn, Burn, Tree and Fern
+ * {3}{R}
+ * Enchantment — Saga
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+ * I — This Saga deals 6 damage to target creature an opponent controls.
+ * II — Destroy target artifact an opponent controls.
+ * III, IV — Add {R}.
+ *
+ * Three plain chapters. Chapters I and II each declare their own target, chosen fresh as that
+ * chapter ability goes on the stack, so either can fizzle on its own without affecting the rest of
+ * the Saga. Chapters III and IV are the same ability declared twice — the engine keys chapter
+ * abilities by lore-counter number, so a shared "III, IV" line is two `sagaChapter` blocks.
+ *
+ * The mana from III / IV lands in the controller's pool during their precombat main phase (the
+ * chapter trigger resolves there, CR 714.3c) and empties as that step ends like any other mana.
+ */
+val BurnBurnTreeAndFern = card("Burn, Burn, Tree and Fern") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\n" +
+        "I — This Saga deals 6 damage to target creature an opponent controls.\n" +
+        "II — Destroy target artifact an opponent controls.\n" +
+        "III, IV — Add {R}."
+
+    // I — This Saga deals 6 damage to target creature an opponent controls.
+    sagaChapter(1) {
+        val creature = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.DealDamage(6, creature)
+    }
+
+    // II — Destroy target artifact an opponent controls.
+    sagaChapter(2) {
+        val artifact = target(
+            "target artifact an opponent controls",
+            TargetPermanent(filter = TargetFilter.Artifact.opponentControls())
+        )
+        effect = Effects.Destroy(artifact)
+    }
+
+    // III, IV — Add {R}.
+    sagaChapter(3) {
+        effect = Effects.AddMana(Color.RED, 1)
+    }
+    sagaChapter(4) {
+        effect = Effects.AddMana(Color.RED, 1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fceb1a2d-121e-49ad-acf2-1bb5aebec116.jpg?1784376970"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RollRollRollRoll.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RollRollRollRoll.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.SagaChapterBuilder
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Roll-Roll-Roll-Roll
+ * {2}{U}
+ * Enchantment — Saga
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+ * I, II, III, IV — Exile up to one target creature or land you control. If you do, return it to
+ * the battlefield under its owner's control at the beginning of the next end step.
+ *
+ * The same blink ability on all four chapters, so it is declared four times — the engine keys
+ * chapter abilities by lore-counter number. Each chapter picks its own target as it goes on the
+ * stack, so a permanent blinked by chapter I is back (and re-targetable) long before chapter II.
+ *
+ * "Up to one target" is [TargetPermanent] with `optional = true`: declining to choose, or the
+ * chosen permanent having left the battlefield by resolution, leaves the chapter with nothing to
+ * exile — and the delayed end-step return then has nothing to bring back, which is exactly the
+ * "If you do" clause. [Patterns.Exile.exileUntilEndStep] returns the card under its owner's
+ * control, matching the printed wording, so a permanent you'd stolen goes home rather than
+ * returning under your control.
+ */
+val RollRollRollRoll = card("Roll-Roll-Roll-Roll") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\n" +
+        "I, II, III, IV — Exile up to one target creature or land you control. If you do, return " +
+        "it to the battlefield under its owner's control at the beginning of the next end step."
+
+    // I, II, III, IV — Exile up to one target creature or land you control. If you do, return it
+    //                  to the battlefield under its owner's control at the beginning of the next
+    //                  end step.
+    sagaChapter(1) { blinkOneOfYours() }
+    sagaChapter(2) { blinkOneOfYours() }
+    sagaChapter(3) { blinkOneOfYours() }
+    sagaChapter(4) { blinkOneOfYours() }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "54"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2e4099e-86bd-461f-87fa-7f7850ae7eec.jpg?1785152396"
+    }
+}
+
+/** The chapter ability shared by all four chapters: blink up to one of your creatures or lands. */
+private fun SagaChapterBuilder.blinkOneOfYours() {
+    val permanent = target(
+        "up to one target creature or land you control",
+        TargetPermanent(
+            optional = true,
+            filter = TargetFilter.CreatureOrLandPermanent.youControl()
+        )
+    )
+    effect = Patterns.Exile.exileUntilEndStep(permanent)
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SettleTheWreckageReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SettleTheWreckageReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Settle the Wreckage reprint in The Hobbit. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val SettleTheWreckageReprint = Printing(
+    oracleId = "2a2ea189-b663-4f4a-bb23-ff7a4af25f71",
+    name = "Settle the Wreckage",
+    setCode = "HOB",
+    collectorNumber = "26",
+    scryfallId = "31a7a5e2-4cb8-48fc-8351-18344b4a7560",
+    artist = "Chris Cold",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/31a7a5e2-4cb8-48fc-8351-18344b4a7560.jpg?1785496349",
+    releaseDate = "2026-08-14",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheLordOfTheEagles.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheLordOfTheEagles.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+
+/**
+ * The Lord of the Eagles
+ * {7}{U}{U}
+ * Legendary Creature — Bird Noble
+ * 8/8
+ *
+ * Flash
+ * This spell costs {X} less to cast, where X is the total power of creatures you control with flying.
+ * Flying
+ *
+ * A filtered Ghalta: the same [SpellCostTarget.SelfCast] +
+ * [CostModification.ReduceGenericBy] rail, sourced from
+ * [CostReductionSource.TotalPropertyAmongPermanentsYouControl] over flying creatures. The filter is
+ * evaluated against projected state, so a creature that only has flying from a granted keyword (or
+ * an animated flying artifact) counts, and Ghalta's rulings carry over: the total is locked in
+ * before payment, the reduction never eats the coloured `{U}{U}`, and this creature's own 8 power
+ * doesn't count because it is still on the stack while its cost is calculated.
+ */
+val TheLordOfTheEagles = card("The Lord of the Eagles") {
+    manaCost = "{7}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Bird Noble"
+    power = 8
+    toughness = 8
+    oracleText = "Flash\n" +
+        "This spell costs {X} less to cast, where X is the total power of creatures you control " +
+        "with flying.\n" +
+        "Flying"
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.TotalPropertyAmongPermanentsYouControl(
+                    property = EntityNumericProperty.Power,
+                    filter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+                )
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "46"
+        artist = "Zezhou Chen"
+        flavorText = "The ancient Eagles of the northern mountains were proud, strong, and " +
+            "noble-hearted—the greatest of all birds."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa0554fc-9448-4ae2-8712-4f4f7af3c7b4.jpg?1784636060"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SettleTheWreckage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/SettleTheWreckage.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Settle the Wreckage
+ * {2}{W}{W}
+ * Instant
+ *
+ * Exile all attacking creatures target player controls. That player may search their library for
+ * that many basic land cards, put those cards onto the battlefield tapped, then shuffle.
+ *
+ * The spell targets **only the player** (CR ruling 2017-09-29), so hexproof/protected attackers are
+ * still exiled — the attackers are gathered as a group at resolution rather than targeted. The
+ * gather is scoped by [GameObjectFilter.targetPlayerControls] against the declared player target
+ * so a stolen attacker follows its *controller*, matching the printed wording.
+ *
+ * "That many" counts the attacking creatures that were **exiled**, which per the third ruling
+ * includes tokens and any creature that never actually reached exile — so the count reads off the
+ * gathered collection, not off what landed in the exile zone. The fetch itself is a `ChooseUpTo`,
+ * so the player may find fewer basics than that (ruling two).
+ *
+ * The search is spelled out inline rather than reusing `Patterns.Library.searchLibrary` under an
+ * [Effects.ForEachPlayer] rebinding, because **`ForEach` over players deliberately wipes
+ * `storedCollections`** for each iteration — the `attackers` count would read 0 inside the loop and
+ * the fetch would silently find nothing. Everything therefore stays in one pipeline scope, and the
+ * target player is named explicitly instead: [Player.TargetPlayer] scopes the library gather, the
+ * battlefield destination, and the shuffle, while [Chooser.TargetPlayer] makes *them* pick the
+ * cards. The `may` is a [MayEffect] whose `decisionMaker` is the target player (only the prompt is
+ * delegated — the effect still resolves under the caster, which is why every step names its player).
+ *
+ * Deviation, deliberate: with zero attackers exiled the search is skipped instead of prompting.
+ * "Search for zero basic lands, then shuffle" can find nothing, and a no-op library-search prompt
+ * on every empty resolution is worse than losing the theoretical free shuffle.
+ */
+val SettleTheWreckage = card("Settle the Wreckage") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Exile all attacking creatures target player controls. That player may search " +
+        "their library for that many basic land cards, put those cards onto the battlefield " +
+        "tapped, then shuffle."
+
+    spell {
+        val player = target("target player", Targets.Player)
+        effect = Effects.Pipeline {
+            val attackers = gather(
+                GameObjectFilter.Creature.attacking().targetPlayerControls(player),
+                name = "attackers"
+            )
+            exile(attackers)
+            ifNotEmpty(attackers) {
+                run(
+                    MayEffect(
+                        Effects.Pipeline {
+                            val library = gather(
+                                CardSource.FromZone(
+                                    Zone.LIBRARY,
+                                    Player.TargetPlayer,
+                                    GameObjectFilter.BasicLand
+                                ),
+                                name = "searchable"
+                            )
+                            val found = chooseUpTo(
+                                DynamicAmounts.distinctEntitiesIn(attackers.key),
+                                from = library,
+                                chooser = Chooser.TargetPlayer,
+                                prompt = "Search your library for basic land cards",
+                                name = "found"
+                            )
+                            move(
+                                found,
+                                CardDestination.ToZone(
+                                    Zone.BATTLEFIELD,
+                                    Player.TargetPlayer,
+                                    ZonePlacement.Tapped
+                                )
+                            )
+                            run(ShuffleLibraryEffect(EffectTarget.PlayerRef(Player.TargetPlayer)))
+                        },
+                        decisionMaker = EffectTarget.PlayerRef(Player.TargetPlayer),
+                        descriptionOverride = "That player may search their library for that many " +
+                            "basic land cards, put those cards onto the battlefield tapped, then shuffle."
+                    )
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "34"
+        artist = "Dimitar Marinski"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cbd346e-098a-4cf6-a72f-468376fd2e8f.jpg?1783935791"
+        ruling(
+            "2017-09-29",
+            "Settle the Wreckage targets only the player. Creatures with hexproof that player " +
+                "controls will be exiled as this spell resolves."
+        )
+        ruling(
+            "2017-09-29",
+            "That player can find fewer basic land cards than the number of exiled creatures, " +
+                "whether because they want to or because they don't have that many basic land " +
+                "cards left."
+        )
+        ruling(
+            "2017-09-29",
+            "The number of lands that player may find is the number of attacking creatures that " +
+                "were exiled, even if some of those creatures were tokens, weren't creature " +
+                "cards, or didn't end up in exile."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -185,6 +185,91 @@
     ]
 }
 
+// Beorn's Hospitality
+{
+    "name": "Beorn's Hospitality",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control.\n{5}{G}{G}: This enchantment becomes a Bear creature in addition to its other types and gains \"This creature's power and toughness are each equal to the number of lands you control.\" (This effect doesn't end.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "creatureTypes": [
+                        "Bear"
+                    ],
+                    "duration": "Permanent",
+                    "dynamicPower": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    },
+                    "dynamicToughness": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    }
+                },
+                "descriptionOverride": "{5}{G}{G}: This enchantment becomes a Bear creature in addition to its other types and gains \"This creature's power and toughness are each equal to the number of lands you control.\""
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "UNCOMMON",
+        "artist": "Harkalé Linaï",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/153ca57e-30f0-4ad7-ae9d-c55cbf0fd4c9.jpg?1785152153"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Bilbo Baggins, Burglar
 {
     "name": "Bilbo Baggins, Burglar",
@@ -500,6 +585,81 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Burn, Burn, Tree and Fern
+{
+    "name": "Burn, Burn, Tree and Fern",
+    "manaCost": "{3}{R}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — This Saga deals 6 damage to target creature an opponent controls.\nII — Destroy target artifact an opponent controls.\nIII, IV — Add {R}.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target creature an opponent controls"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact an opponent controls"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact ctrl:opponent"
+                    },
+                    "id": "target artifact an opponent controls"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                }
+            },
+            {
+                "chapter": 4,
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Rovina Cai",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fceb1a2d-121e-49ad-acf2-1bb5aebec116.jpg?1784376970"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -4728,6 +4888,171 @@
     ]
 }
 
+// Roll-Roll-Roll-Roll
+{
+    "name": "Roll-Roll-Roll-Roll",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II, III, IV — Exile up to one target creature or land you control. If you do, return it to the battlefield under its owner's control at the beginning of the next end step.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature or land you control"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature or land you control"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|land ctrl:you"
+                    },
+                    "id": "up to one target creature or land you control"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature or land you control"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature or land you control"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|land ctrl:you"
+                    },
+                    "id": "up to one target creature or land you control"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature or land you control"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature or land you control"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|land ctrl:you"
+                    },
+                    "id": "up to one target creature or land you control"
+                }
+            },
+            {
+                "chapter": 4,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature or land you control"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one target creature or land you control"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|land ctrl:you"
+                    },
+                    "id": "up to one target creature or land you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "rarity": "RARE",
+        "artist": "Rovina Cai",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2e4099e-86bd-461f-87fa-7f7850ae7eec.jpg?1785152396"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Smaug the Magnificent
 {
     "name": "Smaug the Magnificent",
@@ -5469,6 +5794,48 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// The Lord of the Eagles
+{
+    "name": "The Lord of the Eagles",
+    "manaCost": "{7}{U}{U}",
+    "typeLine": "Legendary Creature — Bird Noble",
+    "oracleText": "Flash\nThis spell costs {X} less to cast, where X is the total power of creatures you control with flying.\nFlying",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "TotalPropertyAmongPermanentsYouControl",
+                        "property": "Power",
+                        "filter": "creature kw:flying"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "RARE",
+        "artist": "Zezhou Chen",
+        "flavorText": "The ancient Eagles of the northern mountains were proud, strong, and noble-hearted—the greatest of all birds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa0554fc-9448-4ae2-8712-4f4f7af3c7b4.jpg?1784636060"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -835,6 +835,141 @@
     ]
 }
 
+// Settle the Wreckage
+{
+    "name": "Settle the Wreckage",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Exile all attacking creatures target player controls. That player may search their library for that many basic land cards, put those cards onto the battlefield tapped, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "IsAttacking"
+                            ],
+                            "controllerPredicate": {
+                                "type": "ControlledByReferencedPlayer",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target player"
+                                }
+                            }
+                        }
+                    },
+                    "storeAs": "attackers"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "attackers",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "ConditionalOnCollection",
+                    "collection": "attackers",
+                    "ifNotEmpty": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "player": "TargetPlayer",
+                                        "filter": "basicland"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "DistinctEntitiesInCollections",
+                                            "collections": [
+                                                "attackers"
+                                            ]
+                                        }
+                                    },
+                                    "chooser": "TargetPlayer",
+                                    "storeSelected": "found",
+                                    "prompt": "Search your library for basic land cards"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield",
+                                        "player": "TargetPlayer",
+                                        "placement": "Tapped"
+                                    }
+                                },
+                                {
+                                    "type": "ShuffleLibrary",
+                                    "target": {
+                                        "type": "PlayerRef",
+                                        "player": "TargetPlayer"
+                                    }
+                                }
+                            ]
+                        },
+                        "decisionMaker": {
+                            "type": "PlayerRef",
+                            "player": "TargetPlayer"
+                        },
+                        "descriptionOverride": "That player may search their library for that many basic land cards, put those cards onto the battlefield tapped, then shuffle."
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "RARE",
+        "artist": "Dimitar Marinski",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cbd346e-098a-4cf6-a72f-468376fd2e8f.jpg?1783935791",
+        "rulings": [
+            {
+                "date": "2017-09-29",
+                "text": "Settle the Wreckage targets only the player. Creatures with hexproof that player controls will be exiled as this spell resolves."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "That player can find fewer basic land cards than the number of exiled creatures, whether because they want to or because they don't have that many basic land cards left."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "The number of lands that player may find is the number of attacking creatures that were exiled, even if some of those creatures were tokens, weren't creature cards, or didn't end up in exile."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Skulduggery
 {
     "name": "Skulduggery",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.state.components.battlefield.chosenColor
 import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
 import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
@@ -445,6 +446,9 @@ class CostCalculator(
             is CostReductionSource.GreatestPropertyAmongPermanentsYouControl -> {
                 greatestPropertyAmongMatching(state, playerId, source.filter, source.property)
             }
+            is CostReductionSource.TotalPropertyAmongPermanentsYouControl -> {
+                totalPropertyAmongMatching(state, playerId, source.filter, source.property)
+            }
             is CostReductionSource.FixedIfCreatureDiedThisTurn -> {
                 if (anyCreatureDiedThisTurn(state)) source.amount else 0
             }
@@ -573,19 +577,63 @@ class CostCalculator(
                 matchesBattlefieldPredicate(entityId, cardDef, predicate, projectedState)
             }
             if (!matches) continue
-            val value = when (property) {
-                EntityNumericProperty.Power ->
-                    projectedState.getPower(entityId) ?: baseCharacteristic(card.baseStats?.power)
-                EntityNumericProperty.Toughness ->
-                    projectedState.getToughness(entityId) ?: baseCharacteristic(card.baseStats?.toughness)
-                EntityNumericProperty.BasePower -> baseCharacteristic(card.baseStats?.power)
-                EntityNumericProperty.BaseToughness -> baseCharacteristic(card.baseStats?.toughness)
-                EntityNumericProperty.ManaValue -> cardDef.manaCost.cmc
-                else -> 0
-            }
+            val value = numericProperty(projectedState, entityId, card, cardDef, property)
             if (value > maxValue) maxValue = value
         }
         return maxValue
+    }
+
+    /**
+     * Sum [property] over the permanents the player controls matching a filter — the sum twin of
+     * [greatestPropertyAmongMatching] (The Lord of the Eagles: "the total power of creatures you
+     * control with flying"). Returns 0 if none match.
+     *
+     * Iterates the projected-control view and evaluates the filter through [PredicateEvaluator]
+     * against projected state, exactly like [countControlledPermanentsMatching], so stolen
+     * permanents, granted keywords, and type-changing effects are all honored. Negative power
+     * subtracts from the total (Ghalta's 2018-01-19 ruling on the same "total power" wording), and
+     * only the finished sum is floored at 0 — a net-negative board reduces nothing rather than
+     * taxing the spell.
+     */
+    private fun totalPropertyAmongMatching(
+        state: GameState,
+        playerId: EntityId,
+        filter: GameObjectFilter,
+        property: EntityNumericProperty
+    ): Int {
+        val projected = state.projectedState
+        val context = PredicateContext(controllerId = playerId)
+        var total = 0
+        for (entityId in state.controlledBattlefield(playerId)) {
+            if (!predicateEvaluator.matches(state, projected, entityId, filter, context)) continue
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            total += numericProperty(projected, entityId, card, cardDef, property)
+        }
+        return total.coerceAtLeast(0)
+    }
+
+    /**
+     * One battlefield permanent's value for [property]. Power/toughness read projected state
+     * (CR 613) and fall back to the printed base when a permanent has no projected P/T; base
+     * power/toughness read the printed base directly; mana value comes from
+     * `CardDefinition.manaCost.cmc` (X-costs contribute X = 0 per CR 202.3b on the battlefield).
+     */
+    private fun numericProperty(
+        projectedState: ProjectedState,
+        entityId: EntityId,
+        card: CardComponent,
+        cardDef: CardDefinition,
+        property: EntityNumericProperty
+    ): Int = when (property) {
+        EntityNumericProperty.Power ->
+            projectedState.getPower(entityId) ?: baseCharacteristic(card.baseStats?.power)
+        EntityNumericProperty.Toughness ->
+            projectedState.getToughness(entityId) ?: baseCharacteristic(card.baseStats?.toughness)
+        EntityNumericProperty.BasePower -> baseCharacteristic(card.baseStats?.power)
+        EntityNumericProperty.BaseToughness -> baseCharacteristic(card.baseStats?.toughness)
+        EntityNumericProperty.ManaValue -> cardDef.manaCost.cmc
+        else -> 0
     }
 
     /** Printed base P/T from a [CharacteristicValue] — the fixed value, a CDA's offset, or 0. */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeornsHospitalityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeornsHospitalityScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.BeornsHospitality
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Beorn's Hospitality (HOB #120) — {1}{G} Enchantment.
+ *
+ * Oracle: "Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature
+ * you control. / {5}{G}{G}: This enchantment becomes a Bear creature in addition to its other types
+ * and gains 'This creature's power and toughness are each equal to the number of lands you
+ * control.' (This effect doesn't end.)"
+ *
+ * These cover the new dynamic-P/T path through the `Effects.BecomeCreature` facade. The case that
+ * matters is the third one: a naive animate freezes the P/T at resolution, so the Bear would stay
+ * at its activation-time size when a land later enters or leaves.
+ */
+class BeornsHospitalityScenarioTest : ScenarioTestBase() {
+
+    /** The enchantment's only activated ability — "{5}{G}{G}: … becomes a Bear creature …". */
+    private val animateAbilityId = BeornsHospitality.activatedAbilities.first { !it.isManaAbility }.id
+
+    init {
+        context("Beorn's Hospitality — {5}{G}{G} animate") {
+
+            test("becomes a Bear creature that is still an enchantment, sized by your lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Beorn's Hospitality")
+                    .withLandsOnBattlefield(1, "Forest", 7)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hospitality = game.findPermanent("Beorn's Hospitality")!!
+
+                withClue("before activation it is a plain noncreature enchantment") {
+                    game.state.projectedState.isCreature(hospitality) shouldBe false
+                }
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = hospitality,
+                        abilityId = animateAbilityId,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("it is now a Bear creature, and keeps its enchantment type") {
+                    game.state.projectedState.isCreature(hospitality) shouldBe true
+                    game.state.projectedState.hasType(hospitality, "ENCHANTMENT") shouldBe true
+                    game.state.projectedState.hasSubtype(hospitality, "BEAR") shouldBe true
+                }
+
+                withClue("P/T equals the seven lands you control") {
+                    game.state.projectedState.getPower(hospitality) shouldBe 7
+                    game.state.projectedState.getToughness(hospitality) shouldBe 7
+                }
+            }
+
+            test("only your own lands count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Beorn's Hospitality")
+                    .withLandsOnBattlefield(1, "Forest", 7)
+                    .withLandsOnBattlefield(2, "Island", 5)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hospitality = game.findPermanent("Beorn's Hospitality")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = hospitality,
+                        abilityId = animateAbilityId,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the opponent's five Islands do not feed the Bear") {
+                    game.state.projectedState.getPower(hospitality) shouldBe 7
+                }
+            }
+
+            test("the P/T keeps recomputing — playing another land grows the Bear") {
+                // The landfall counter is deliberately pointed at the Grizzly Bears, so the
+                // animated enchantment's size is a pure read of the CDA: an implementation that
+                // froze the P/T at resolution would still say 7 here.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Beorn's Hospitality")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 7)
+                    .withCardInHand(1, "Mountain")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hospitality = game.findPermanent("Beorn's Hospitality")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = hospitality,
+                        abilityId = animateAbilityId,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.state.projectedState.getPower(hospitality) shouldBe 7
+
+                val mountain = game.findCardsInHand(1, "Mountain").single()
+                game.execute(PlayLand(playerId = game.player1Id, cardId = mountain)).error shouldBe null
+
+                withClue("landfall asks who gets the +1/+1 counter") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("the counter went on the Bears, so they are 3/3") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                }
+                withClue("an eighth land makes the animated enchantment an 8/8") {
+                    game.state.projectedState.getPower(hospitality) shouldBe 8
+                    game.state.projectedState.getToughness(hospitality) shouldBe 8
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BurnBurnTreeAndFernScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BurnBurnTreeAndFernScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.BurnBurnTreeAndFern
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Chapter-by-chapter test for Burn, Burn, Tree and Fern (HOB #90) — {3}{R} Enchantment — Saga.
+ *
+ * I — This Saga deals 6 damage to target creature an opponent controls.
+ * II — Destroy target artifact an opponent controls.
+ * III, IV — Add {R}.
+ *
+ * The interesting part is the shared "III, IV" line — declared as two chapters — and the fact that
+ * both targeting chapters are opponent-scoped, so nothing on the controller's own side is at risk.
+ */
+class BurnBurnTreeAndFernScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BurnBurnTreeAndFern)
+        return driver
+    }
+
+    /** Drain the stack, auto-answering anything that pauses. */
+    fun GameTestDriver.drain() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    /** Drain, answering every target request with [targets]. */
+    fun GameTestDriver.drainTargeting(chooser: EntityId, targets: List<EntityId>) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            val decision = state.pendingDecision
+            when {
+                decision is ChooseTargetsDecision -> submitTargetSelection(chooser, targets)
+                decision != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+            guard++
+        }
+    }
+
+    /** Advance to the precombat main of the starting player's [nth] turn (a duel: turn 2n − 1). */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
+        var guard = 0
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> bothPass()
+                else -> break
+            }
+            guard++
+        }
+        if (guard >= 500) error("Failed to reach turn $targetTurn precombat main")
+    }
+
+    test("I burns an opposing creature, II destroys an opposing artifact, III and IV each add {R}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+
+        // The opponent's board: a creature for chapter I and an artifact for chapter II.
+        val giant = driver.putCreatureOnBattlefield(opponent, "Hill Giant")
+        val ornithopter = driver.putPermanentOnBattlefield(opponent, "Ornithopter")
+        // Our own creature and artifact must survive — both chapters are opponent-scoped.
+        val ourBears = driver.putCreatureOnBattlefield(controller, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(controller, Color.RED, 4)
+        val saga = driver.putCardInHand(controller, "Burn, Burn, Tree and Fern")
+        driver.castSpell(controller, saga)
+        driver.drainTargeting(controller, listOf(giant))
+
+        withClue("chapter I deals 6 damage to the 3/3, killing it") {
+            driver.findPermanent(opponent, "Hill Giant") shouldBe null
+            driver.getGraveyardCardNames(opponent).contains("Hill Giant") shouldBe true
+        }
+        withClue("our own creature is untouched") {
+            driver.findPermanent(controller, "Grizzly Bears") shouldBe ourBears
+        }
+
+        driver.advanceToMain(2) // lore 2 → chapter II
+        driver.drainTargeting(controller, listOf(ornithopter))
+
+        withClue("chapter II destroys the opponent's artifact") {
+            driver.findPermanent(opponent, "Ornithopter") shouldBe null
+            driver.getGraveyardCardNames(opponent).contains("Ornithopter") shouldBe true
+        }
+
+        driver.advanceToMain(3) // lore 3 → chapter III
+        driver.drain()
+
+        withClue("chapter III adds {R} to the controller's pool") {
+            driver.state.getEntity(controller)?.get<ManaPoolComponent>()?.red shouldBe 1
+        }
+
+        driver.advanceToMain(4) // lore 4 → chapter IV
+        driver.drain()
+
+        withClue("chapter IV adds {R} as well") {
+            driver.state.getEntity(controller)?.get<ManaPoolComponent>()?.red shouldBe 1
+        }
+        withClue("a four-chapter Saga is sacrificed after its last chapter resolves") {
+            driver.findPermanent(controller, "Burn, Burn, Tree and Fern") shouldBe null
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RollRollRollRollScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RollRollRollRollScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.RollRollRollRoll
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Chapter test for Roll-Roll-Roll-Roll (HOB #54) — {2}{U} Enchantment — Saga.
+ *
+ * I, II, III, IV — Exile up to one target creature or land you control. If you do, return it to the
+ * battlefield under its owner's control at the beginning of the next end step.
+ *
+ * Covered: chapter I blinks the chosen permanent and it is back by the next turn (so chapter II can
+ * pick it again), and the "up to one" is genuinely optional — declining exiles nothing.
+ */
+class RollRollRollRollScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RollRollRollRoll)
+        return driver
+    }
+
+    fun GameTestDriver.drainTargeting(chooser: EntityId, targets: List<EntityId>) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 60) {
+            val decision = state.pendingDecision
+            when {
+                decision is ChooseTargetsDecision -> submitTargetSelection(chooser, targets)
+                decision != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+            guard++
+        }
+    }
+
+    /** Advance to the precombat main of the starting player's [nth] turn (a duel: turn 2n − 1). */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
+        var guard = 0
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> bothPass()
+                else -> break
+            }
+            guard++
+        }
+        if (guard >= 500) error("Failed to reach turn $targetTurn precombat main")
+    }
+
+    fun GameTestDriver.castSaga(controller: EntityId) {
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        giveMana(controller, Color.BLUE, 3)
+        castSpell(controller, putCardInHand(controller, "Roll-Roll-Roll-Roll"))
+    }
+
+    test("chapter I blinks the chosen creature, which is back before chapter II") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+
+        val bears = driver.putCreatureOnBattlefield(controller, "Grizzly Bears")
+
+        driver.castSaga(controller)
+        driver.drainTargeting(controller, listOf(bears))
+
+        withClue("chapter I exiled the Bears; the returning card is a new object, so the old id is gone") {
+            driver.findPermanent(controller, "Grizzly Bears") shouldBe null
+            driver.getExileCardNames(controller).contains("Grizzly Bears") shouldBe true
+        }
+
+        driver.advanceToMain(2)
+
+        withClue("the delayed trigger returned it at the beginning of the next end step") {
+            driver.getPermanents(controller).any { driver.getCardName(it) == "Grizzly Bears" } shouldBe true
+            driver.getExileCardNames(controller).contains("Grizzly Bears") shouldBe false
+        }
+    }
+
+    test("declining the 'up to one' target exiles nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+
+        val bears = driver.putCreatureOnBattlefield(controller, "Grizzly Bears")
+
+        driver.castSaga(controller)
+
+        // Resolve the Saga spell itself, then answer chapter I's target request with nothing.
+        var guard = 0
+        var declined = false
+        while ((driver.state.stack.isNotEmpty() || driver.state.pendingDecision != null) && guard < 60) {
+            val decision = driver.state.pendingDecision
+            when {
+                decision is ChooseTargetsDecision && !declined -> {
+                    withClue("'up to one target' must allow choosing zero") {
+                        decision.targetRequirements.first().minTargets shouldBe 0
+                    }
+                    declined = true
+                    driver.submitTargetSelection(controller, emptyList())
+                }
+                decision != null -> driver.autoResolveDecision()
+                else -> driver.bothPass()
+            }
+            guard++
+        }
+
+        withClue("nothing was exiled") {
+            declined shouldBe true
+            driver.findPermanent(controller, "Grizzly Bears") shouldBe bears
+            driver.getExileCardNames(controller).isEmpty() shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SettleTheWreckageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SettleTheWreckageScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Settle the Wreckage (XLN #34, reprinted as HOB #26) — {2}{W}{W} Instant.
+ *
+ * Oracle: "Exile all attacking creatures target player controls. That player may search their
+ * library for that many basic land cards, put those cards onto the battlefield tapped, then
+ * shuffle."
+ *
+ * The three things that can silently go wrong: the wipe is a *group* scoped to the target player
+ * (not a target, and not "all attackers"), the fetch is done by the **target player** and not the
+ * caster, and its cap is "that many" — the number of creatures exiled.
+ */
+class SettleTheWreckageScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Settle the Wreckage") {
+
+            test("exiles only the target player's attackers and lets them fetch that many basics") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(2, "Settle the Wreckage")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Savannah Lions", summoningSickness = false)
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    // Four basics in the library, but only two creatures will be exiled.
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                // Savannah Lions stays home, so it must survive the wipe.
+                game.declareAttackers(
+                    mapOf("Grizzly Bears" to 2, "Hill Giant" to 2)
+                ).error shouldBe null
+
+                // The attacking player holds priority first; pass it to the defender.
+                game.passPriority()
+                game.castSpellTargetingPlayer(2, "Settle the Wreckage", 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("both attackers are exiled") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                    game.findPermanent("Hill Giant") shouldBe null
+                    game.isInExile(1, "Grizzly Bears") shouldBe true
+                    game.isInExile(1, "Hill Giant") shouldBe true
+                }
+                withClue("the non-attacking creature is untouched") {
+                    game.isOnBattlefield("Savannah Lions") shouldBe true
+                }
+
+                withClue("player 1 — the *target*, not the caster — is asked whether to search") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true)
+
+                val search = game.getPendingDecision() as SelectCardsDecision
+                withClue("'that many' caps the search at the two creatures exiled, not at the four basics available") {
+                    search.playerId shouldBe game.player1Id
+                    search.options.size shouldBe 4
+                    search.maxSelections shouldBe 2
+                    search.minSelections shouldBe 0
+                }
+
+                game.selectCards(search.options.take(2)).error shouldBe null
+                game.resolveStack()
+
+                val fetched = game.findAllPermanents("Forest")
+                withClue("both basics entered tapped under the target player's control") {
+                    fetched.size shouldBe 2
+                    fetched.all { game.state.getBattlefield(game.player1Id).contains(it) } shouldBe true
+                    fetched.all { game.state.getEntity(it)?.has<TappedComponent>() == true } shouldBe true
+                }
+            }
+
+            test("declining the search leaves the library alone") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(2, "Settle the Wreckage")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+
+                // The attacking player holds priority first; pass it to the defender.
+                game.passPriority()
+                game.castSpellTargetingPlayer(2, "Settle the Wreckage", 1).error shouldBe null
+                game.resolveStack()
+
+                game.isInExile(1, "Grizzly Bears") shouldBe true
+
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("the declined search fetches nothing") {
+                    game.findPermanent("Forest") shouldBe null
+                    game.librarySize(1) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLordOfTheEaglesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLordOfTheEaglesScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Lord of the Eagles (HOB #46) — {7}{U}{U} 8/8 Legendary Creature.
+ *
+ * Oracle: "Flash / This spell costs {X} less to cast, where X is the total power of creatures you
+ * control with flying. / Flying"
+ *
+ * These cover the new `CostReductionSource.TotalPropertyAmongPermanentsYouControl`, so the cases
+ * that matter are the ones a naive implementation gets wrong: ground creatures must not count, the
+ * opponent's fliers must not count, and a creature that only has flying from a continuous effect
+ * must count (the filter has to read projected keywords, not the printed type line).
+ */
+class TheLordOfTheEaglesScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Lord of the Eagles — costs {X} less for the total power of your fliers") {
+
+            test("no creatures → full {7}{U}{U} (7 generic)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Lord of the Eagles")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("The Lord of the Eagles"),
+                    game.player1Id,
+                )
+
+                withClue("an empty board reduces nothing") {
+                    cost.genericAmount shouldBe 7
+                }
+            }
+
+            test("two fliers reduce by their total power, ground creatures don't count") {
+                // Air Elemental 4/4 flying + Wind Drake 2/2 flying = 6, so {1}{U}{U}.
+                // Hill Giant 3/3 has no flying and must be ignored.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Lord of the Eagles")
+                    .withCardOnBattlefield(1, "Air Elemental")
+                    .withCardOnBattlefield(1, "Wind Drake")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("The Lord of the Eagles"),
+                    game.player1Id,
+                )
+
+                withClue("4 + 2 flying power reduces the generic from 7 to 1; the 3/3 ground creature is ignored") {
+                    cost.genericAmount shouldBe 1
+                }
+            }
+
+            test("the opponent's fliers do not count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Lord of the Eagles")
+                    .withCardOnBattlefield(2, "Air Elemental")
+                    .withCardOnBattlefield(2, "Serra Angel")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("The Lord of the Eagles"),
+                    game.player1Id,
+                )
+
+                withClue("the source is 'you control', so eight power of opposing fliers reduces nothing") {
+                    cost.genericAmount shouldBe 7
+                }
+            }
+
+            test("a creature that only has flying from a continuous effect counts") {
+                // Levitation gives creatures you control flying, so Grizzly Bears (2/2) and Hill
+                // Giant (3/3) become fliers worth 5 total power.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Lord of the Eagles")
+                    .withCardOnBattlefield(1, "Levitation")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("The Lord of the Eagles"),
+                    game.player1Id,
+                )
+
+                withClue("granted flying is projected state, so 2 + 3 power reduces the generic to 2") {
+                    cost.genericAmount shouldBe 2
+                }
+            }
+
+            test("the reduction never eats the colored pips") {
+                // 4 + 4 + 2 = 10 flying power against 7 generic: it bottoms out at 0 and {U}{U} survives.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "The Lord of the Eagles")
+                    .withCardOnBattlefield(1, "Air Elemental")
+                    .withCardOnBattlefield(1, "Serra Angel")
+                    .withCardOnBattlefield(1, "Wind Drake")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("The Lord of the Eagles"),
+                    game.player1Id,
+                )
+
+                withClue("ten flying power clears all 7 generic but cannot reduce below {U}{U}") {
+                    cost.genericAmount shouldBe 0
+                    cost.colorCount[Color.BLUE] shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five cards from The Hobbit (HOB), each implemented via the `add-card` flow.

| Card | Cost | What it does |
|---|---|---|
| **Settle the Wreckage** | `{2}{W}{W}` | Exile all attacking creatures target player controls; they may fetch that many basics tapped |
| **Burn, Burn, Tree and Fern** | `{3}{R}` | Saga — 6 damage to an opposing creature, destroy an opposing artifact, then add `{R}` twice |
| **Roll-Roll-Roll-Roll** | `{2}{U}` | Saga — each of four chapters blinks up to one creature or land you control until the next end step |
| **The Lord of the Eagles** | `{7}{U}{U}` | 8/8 flash flier costing `{X}` less for the total power of your fliers |
| **Beorn's Hospitality** | `{1}{G}` | Landfall +1/+1 counter; `{5}{G}{G}` permanently animates it as a Bear with P/T = your lands |

## Canonical placement

Settle the Wreckage's earliest real printing is **XLN #34**, so the `CardDefinition` lives in Ixalan and HOB #26 gets a `Printing` row. `just check-card-printing "Settle the Wreckage"` is clean.

## A bug this caught

The first cut of Settle the Wreckage reused `Patterns.Library.searchLibrary` under an `Effects.ForEachPlayer(Player.TargetPlayer, …)` rebinding — the Volatile Fault idiom. It compiled, snapshotted fine, and silently did nothing: `ForEach` over players **deliberately wipes `storedCollections`** per iteration, so `distinctEntitiesIn("attackers")` evaluated to 0 and the search prompted "Choose 0 cards".

The fix keeps everything in one pipeline scope and names the target player explicitly instead — `Player.TargetPlayer` scopes the library gather, the tapped battlefield entry and the shuffle, `Chooser.TargetPlayer` makes them pick, and the `may` is a `MayEffect` with `decisionMaker` delegated to them (only the prompt is delegated; the effect still resolves under the caster, which is why every step names its player). Documented in the card's KDoc so the next person doesn't re-walk it.

## SDK additions

Both are parametric generalizations of a shape that already existed, not new one-off types.

- **`CostReductionSource.TotalPropertyAmongPermanentsYouControl(property, filter)`** — the sum twin of `GreatestPropertyAmongPermanentsYouControl`, sharing its `(property, filter)` axes, and the filtered generalization of `TotalPowerYouControl` the way `PermanentsYouControlMatching` generalizes `CreaturesYouControl`. The filter runs through `PredicateEvaluator` against projected state, so a creature with *granted* flying counts. Negative power subtracts from the total and only the finished sum is floored at 0, per Ghalta's 2018-01-19 ruling on the same "total power" wording. `greatestPropertyAmongMatching` and the new `totalPropertyAmongMatching` now share a `numericProperty` helper.
- **`Effects.BecomeCreature(dynamicPower, dynamicToughness)`** — the pass-through that `BecomeCreatureEffect` and `card-sdk-language-reference.md` already documented but the facade didn't expose. Makes the animated permanent's P/T a CDA recomputed at Layer 7b (with the animating source's controller as `you`) rather than a value frozen at resolution.

`docs/card-sdk-language-reference.md` updated for both.

## Verification

- `just build` and `just test` — green.
- Scenario tests for all five cards, one file each:
  - `SettleTheWreckageScenarioTest` — the wipe is target-player-scoped (a non-attacker survives), the *target* is prompted, the cap is the two creatures exiled (not the four basics available), both fetched lands enter tapped, and declining fetches nothing.
  - `TheLordOfTheEaglesScenarioTest` — ground creatures don't count, opposing fliers don't count, granted flying does, and the reduction can't eat `{U}{U}`.
  - `BeornsHospitalityScenarioTest` — it becomes a Bear that is still an enchantment, only your lands feed it, and playing an eighth land grows it to 8/8 (the case a frozen-P/T animate fails).
  - `BurnBurnTreeAndFernScenarioTest` — chapter by chapter, including the shared III/IV mana and the CR 714.4 sacrifice.
  - `RollRollRollRollScenarioTest` — the blink round-trips before chapter II, and the "up to one" genuinely allows zero.
- Snapshot goldens re-blessed: **additions only**, no existing card moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)