### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/AltarsLight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/AltarsLight.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Altar's Light — Mirrodin #1
+ * {2}{W}{W} · Instant
+ *
+ * Exile target artifact or enchantment.
+ *
+ * Mirrodin's premium Disenchant: exile rather than destroy, so regeneration, indestructible, and
+ * dies-triggers all miss it — at the cost of two extra mana over the usual {1}{W} rate.
+ */
+val AltarsLight = card("Altar's Light") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Exile target artifact or enchantment."
+
+    spell {
+        val t = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "1"
+        artist = "Daren Bader"
+        flavorText = "\"The altar does nothing; the device is crushed under the weight of its own " +
+            "impurity.\"\n—Ushanti, leonin seer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd037f62-7cef-4737-b575-942c5959f1ea.jpg?1783944565"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Frogmite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Frogmite.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Frogmite — Mirrodin #172
+ * {4} · Artifact Creature — Frog · 2/2
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ *
+ * The stock [KeywordAbility.Affinity] cost reduction over [CardType.ARTIFACT]. Frogmite's cost is
+ * entirely generic, so four artifacts make it free — affinity only shaves generic mana, and here
+ * there is nothing else to shave.
+ *
+ * Affinity is a cost reduction, not an alternative cost: Frogmite's mana value stays 4 in every
+ * zone no matter how cheaply it was cast, and the count is taken as the total cost is locked in
+ * while casting.
+ */
+val Frogmite = card("Frogmite") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Frog"
+    power = 2
+    toughness = 2
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)"
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "172"
+        artist = "Terese Nielsen"
+        flavorText = "At first, vedalken observers thought blinkmoths naturally avoided certain " +
+            "places. Then they realized those places were frogmite feeding grounds."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff504dcb-2eb8-4b3c-a8b9-29697739b649.jpg?1783944522"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NimLasher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NimLasher.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Nim Lasher — Mirrodin #71
+ * {2}{B} · Creature — Zombie · 1/1
+ *
+ * This creature gets +1/+0 for each artifact you control.
+ *
+ * A continuously recomputed [GrantDynamicStatsEffect] on the Nim itself ([GroupFilter.source]):
+ * power tracks the controller's artifact count in real time, so an artifact entering or leaving
+ * moves the Nim's power immediately rather than snapshotting on entry. Toughness is untouched
+ * ([DynamicAmount.Fixed] 0).
+ *
+ * Nim Lasher is *not* itself an artifact, so it never counts itself — with no artifacts out it
+ * attacks as a plain 1/1.
+ */
+val NimLasher = card("Nim Lasher") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 1
+    oracleText = "This creature gets +1/+0 for each artifact you control."
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).count(),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Adam Rex"
+        flavorText = "The rotting metal feeds the necrogen mists, and in turn the mists feed the nim."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b66c698-02bd-48ef-a866-5251bdc02c16.jpg?1783944546"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NimShrieker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NimShrieker.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Nim Shrieker — Mirrodin #73
+ * {3}{B} · Creature — Zombie · 0/1
+ *
+ * Flying
+ * This creature gets +1/+0 for each artifact you control.
+ *
+ * The flying member of the Nim cycle, sharing [NimLasher]'s artifact-count power boost — a
+ * continuously recomputed [GrantDynamicStatsEffect] on the source itself, toughness untouched.
+ *
+ * Printed base power is 0, so with no artifacts on the battlefield the Shrieker deals no combat
+ * damage at all; it needs at least one artifact before the evasion is worth anything. It is not
+ * itself an artifact and never counts toward its own boost.
+ */
+val NimShrieker = card("Nim Shrieker") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 0
+    toughness = 1
+    oracleText = "Flying\n" +
+        "This creature gets +1/+0 for each artifact you control."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).count(),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Adam Rex"
+        flavorText = "As imps they were an annoyance. As nim they are a pestilence."
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c3a2c39b-b302-4cc3-b507-e4fe00614036.jpg?1783944545"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithFirewalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithFirewalker.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slith Firewalker — Mirrodin #107
+ * {R}{R} · Creature — Slith · 1/1
+ *
+ * Haste
+ * Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+ *
+ * The head of the Slith cycle's red member. Haste plus the growth trigger is the whole point:
+ * it can attack the turn it lands and start compounding immediately.
+ *
+ * The trigger is [Triggers.DealsCombatDamageToPlayer] — *combat* damage only, so a burn-style
+ * ping or a damage-redirection effect never grows it — and the counter goes on the Slith itself
+ * ([EffectTarget.Self]), not on a chosen creature.
+ */
+val SlithFirewalker = card("Slith Firewalker") {
+    manaCost = "{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Slith"
+    power = 1
+    toughness = 1
+    oracleText = "Haste\n" +
+        "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "107"
+        artist = "Justin Sweet"
+        flavorText = "The slith incubate in the Great Furnace's heat, emerging on Mirrodin's " +
+            "surface only when the four suns have aligned overhead."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73ff7383-71da-46ae-849f-349c40815a29.jpg?1783944537"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -93,6 +93,43 @@
     "colorIdentityOverride": []
 }
 
+// Altar's Light
+{
+    "name": "Altar's Light",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Exile target artifact or enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target artifact or enchantment"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target artifact or enchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "UNCOMMON",
+        "artist": "Daren Bader",
+        "flavorText": "\"The altar does nothing; the device is crushed under the weight of its own impurity.\"\n—Ushanti, leonin seer",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd037f62-7cef-4737-b575-942c5959f1ea.jpg?1783944565"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ancient Den
 {
     "name": "Ancient Den",
@@ -784,6 +821,34 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Frogmite
+{
+    "name": "Frogmite",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Frog",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "172",
+        "artist": "Terese Nielsen",
+        "flavorText": "At first, vedalken observers thought blinkmoths naturally avoided certain places. Then they realized those places were frogmite feeding grounds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff504dcb-2eb8-4b3c-a8b9-29697739b649.jpg?1783944522"
+    },
+    "colorIdentityOverride": []
 }
 
 // Galvanic Key
@@ -2285,6 +2350,47 @@
     "colorIdentityOverride": []
 }
 
+// Nim Lasher
+{
+    "name": "Nim Lasher",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "This creature gets +1/+0 for each artifact you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "artifact"
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Adam Rex",
+        "flavorText": "The rotting metal feeds the necrogen mists, and in turn the mists feed the nim.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b66c698-02bd-48ef-a866-5251bdc02c16.jpg?1783944546"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Nim Replica
 {
     "name": "Nim Replica",
@@ -2344,6 +2450,50 @@
         "artist": "Carl Critchlow",
         "flavorText": "It kills with unfeeling malice.",
         "imageUri": "https://cards.scryfall.io/normal/front/d/1/d11a56e7-30a4-44da-a58b-336f4c0c4882.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Nim Shrieker
+{
+    "name": "Nim Shrieker",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Flying\nThis creature gets +1/+0 for each artifact you control.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "artifact"
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Adam Rex",
+        "flavorText": "As imps they were an annoyance. As nim they are a pestilence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c3a2c39b-b302-4cc3-b507-e4fe00614036.jpg?1783944545"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -2939,6 +3089,50 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/8/684a6e3f-909a-4ca0-a6aa-7354b9476df2.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Slith Firewalker
+{
+    "name": "Slith Firewalker",
+    "manaCost": "{R}{R}",
+    "typeLine": "Creature — Slith",
+    "oracleText": "Haste\nWhenever this creature deals combat damage to a player, put a +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "rarity": "UNCOMMON",
+        "artist": "Justin Sweet",
+        "flavorText": "The slith incubate in the Great Furnace's heat, emerging on Mirrodin's surface only when the four suns have aligned overhead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73ff7383-71da-46ae-849f-349c40815a29.jpg?1783944537"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Soldier Replica


### PR DESCRIPTION
Implements five Mirrodin (MRD) cards. All are canonical MRD printings (verified earliest real
expansion via Scryfall `prints_search_uri`), and all are built entirely from existing SDK
primitives — no new effects, triggers, keywords, or client work.

| Card | Cost | Modeling |
|---|---|---|
| Slith Firewalker | `{R}{R}` 1/1 | `Keyword.HASTE` + `Triggers.DealsCombatDamageToPlayer` → `Effects.AddCounters(PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)` |
| Nim Lasher | `{2}{B}` 1/1 | `GrantDynamicStatsEffect(GroupFilter.source(), powerBonus = artifacts you control, toughnessBonus = 0)` |
| Nim Shrieker | `{3}{B}` 0/1 | `Keyword.FLYING` + the same artifact-count power boost |
| Frogmite | `{4}` 2/2 | `KeywordAbility.Affinity(CardType.ARTIFACT)` |
| Altar's Light | `{2}{W}{W}` | `spell { }` with `Targets.ArtifactOrEnchantment` → `Effects.Exile` |

### Notes

- The Nim pair use a **continuously recomputed** `GrantDynamicStatsEffect`, not a snapshot — an
  artifact entering or leaving moves their power immediately. Neither is itself an artifact, so
  neither counts toward its own boost.
- Slith Firewalker's trigger is **combat** damage only, and the counter lands on the Slith itself
  (`EffectTarget.Self`), not on a chosen creature.
- Frogmite's cost is all generic, so four artifacts make it free; affinity is a cost reduction, so
  its mana value stays 4 in every zone.
- Altar's Light exiles rather than destroys — regeneration, indestructible, and dies-triggers all
  miss it.
- No rulings on Scryfall for any of the five.

### Verification

- `just build` — green.
- `just check-card-printing` — clean for all five (`canonical is in the card's earliest real printing`).
- `CardDefinitionSnapshotTest` re-blessed via `just rebless-cards`; the `MRD.json` golden diff is
  194 insertions and zero deletions — only these five cards moved.
- No scenario tests: per the `add-card` skill, tests are added only when a card introduces new SDK
  vocabulary. Every primitive here is already exercised by existing cards (Stromkirk Noble for the
  combat-damage counter, Molten Man for dynamic stats, Gearseeker Serpent for affinity, Disenchant
  for the artifact-or-enchantment target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)