### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CerebralConfiscation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CerebralConfiscation.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Cerebral Confiscation — Murders at Karlov Manor #81
+ * {2}{B} · Sorcery
+ *
+ * Choose one —
+ * • Target opponent discards two cards.
+ * • Target opponent reveals their hand. You choose a nonland card from it. That player discards
+ *   that card.
+ *
+ * Each mode targets independently, so the mode is chosen as the spell is cast and only that
+ * mode's target is picked (CR 601.2b). Mode 1 is the opponent's own choice of two cards; mode 2
+ * is the Pilfer / Ego Drain idiom — reveal, gather the revealed hand, then *you* pick one
+ * nonland card. Both move with [MoveType.Discard] so discard triggers (madness, "whenever you
+ * discard") see it.
+ */
+val CerebralConfiscation = card("Cerebral Confiscation") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Target opponent discards two cards.\n" +
+        "• Target opponent reveals their hand. You choose a nonland card from it. That player discards that card."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Target opponent discards two cards") {
+                val opponent = target("target opponent", TargetOpponent())
+                effect = Effects.Discard(2, opponent)
+            }
+            mode("Target opponent reveals their hand — you choose a nonland card to discard") {
+                val opponent = target("target opponent", TargetOpponent())
+                effect = Effects.Pipeline {
+                    run(RevealHandEffect(opponent))
+                    val hand = gather(CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)), name = "opponentHand")
+                    val chosen = chooseExactly(
+                        1, from = hand,
+                        filter = GameObjectFilter.Nonland,
+                        prompt = "Choose a nonland card to discard",
+                        alwaysPrompt = true,
+                        showAllCards = true,
+                        name = "toDiscard"
+                    )
+                    move(
+                        chosen,
+                        CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                        moveType = MoveType.Discard
+                    )
+                }
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Lius Lasahido"
+        flavorText = "\"Never rely on secondhand description. Always review the memory yourself.\"\n—Lazav"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c3c3d15-b775-44a2-91ea-4abcc3cf2dba.jpg?1783912903"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GearbaneOrangutan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GearbaneOrangutan.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Gearbane Orangutan — Murders at Karlov Manor #129
+ * {2}{R} · Creature — Ape · 2/2
+ *
+ * Reach
+ * When this creature enters, choose one —
+ * • Destroy up to one target artifact.
+ * • Sacrifice an artifact. If you do, put two +1/+1 counters on this creature.
+ *
+ * The mode is chosen as the trigger goes on the stack (CR 601.2b via 603.3d), and both modes are
+ * always legal choices: mode 1 is "up to one" so zero targets is legal, mode 2 takes no target.
+ * That matters for a board with no artifacts at all — you may still pick either mode and simply
+ * accomplish nothing.
+ *
+ * Mode 2's sacrifice is **mandatory, not a "may"**, so it is [Effects.IfYouDo] rather than a
+ * `MayEffect`: with no artifact to sacrifice nothing is sacrificed and the counters don't happen.
+ * [SuccessCriterion.PermanentsSacrificed] is the criterion that reads that correctly — `Auto`
+ * can't infer a sacrifice (which graveyard it lands in isn't known until the chooser picks) and
+ * `Always` would fail open and hand out counters for free. Gearbane Orangutan is itself a
+ * creature, not an artifact, so it can never be the artifact it sacrifices.
+ */
+val GearbaneOrangutan = card("Gearbane Orangutan") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ape"
+    power = 2
+    toughness = 2
+    oracleText = "Reach\n" +
+        "When this creature enters, choose one —\n" +
+        "• Destroy up to one target artifact.\n" +
+        "• Sacrifice an artifact. If you do, put two +1/+1 counters on this creature."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.Destroy(EffectTarget.ContextTarget(0)),
+                TargetPermanent(optional = true, filter = TargetFilter.Artifact),
+                "Destroy up to one target artifact"
+            ),
+            Mode.noTarget(
+                Effects.IfYouDo(
+                    action = Effects.Sacrifice(
+                        GameObjectFilter.Artifact,
+                        count = 1,
+                        target = EffectTarget.Controller
+                    ),
+                    ifYouDo = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+                    successCriterion = SuccessCriterion.PermanentsSacrificed
+                ),
+                "Sacrifice an artifact — if you do, put two +1/+1 counters on this creature"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Svetlin Velinov"
+        flavorText = "\"In her defense, thopters are very fun to smash.\"\n—Udol of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/6900a344-a155-4ee1-a3ac-d6c28e024270.jpg?1783912881"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OnTheJob.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OnTheJob.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * On the Job — Murders at Karlov Manor #30
+ * {2}{W}{W} · Instant
+ *
+ * Creatures you control get +2/+1 until end of turn. Investigate.
+ *
+ * Untargeted, unlike [AuspiciousArrival] — the Clue is never at risk of the spell being
+ * countered on resolution for want of a legal target. The pump snapshots the battlefield as
+ * the spell resolves (CR 611.2c): creatures that enter afterwards get nothing.
+ */
+val OnTheJob = card("On the Job") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +2/+1 until end of turn. Investigate. " +
+        "(Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Group.modifyStatsForAll(2, 1, Filters.Group.creaturesYouControl),
+            Effects.Investigate()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Jason A. Engle"
+        flavorText = "For all their differences, Kaya, Kellan, and Agrus Kos agreed on one thing: " +
+            "none of them would rest until Teysa's murderer was brought to justice."
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48b92629-4196-4943-91fd-8c8d5f3fcaef.jpg?1783912920"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ReasonableDoubt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ReasonableDoubt.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Reasonable Doubt — Murders at Karlov Manor #69
+ * {1}{U} · Instant
+ *
+ * Counter target spell unless its controller pays {2}.
+ * Suspect up to one target creature.
+ *
+ * Two independent targets, and the spell target must come **first**: `CounterEffectExecutor`
+ * reads the countered spell off the head of the target list. The creature is `optional = true`
+ * and therefore last, matching the cast-time slot ordering rule.
+ *
+ * The two sentences are independent — if the targeted spell has left the stack by resolution
+ * but the creature is still legal, the spell still resolves and suspects it (CR 608.2b), which
+ * is exactly what `Effects.Composite` does here: a failed sub-effect is skipped, not fatal.
+ * The reverse also holds — declining the creature (or it dying in response) never stops the
+ * counter. There is no "cast it just to suspect" mode: the spell target is mandatory, so a
+ * legal spell on the stack is required to cast this at all.
+ */
+val ReasonableDoubt = card("Reasonable Doubt") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell unless its controller pays {2}.\n" +
+        "Suspect up to one target creature. (A suspected creature has menace and can't block.)"
+
+    spell {
+        target("target spell", Targets.Spell)
+        val creature = target("up to one target creature", TargetCreature(count = 1, optional = true))
+        effect = Effects.Composite(
+            Effects.CounterUnlessDynamicPays(DynamicAmount.Fixed(2)),
+            Effects.Suspect(creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Betty Jiang"
+        flavorText = "\"Merle had the motive, but Blovinac was the one caught with the murder " +
+            "weapon. And who was the seven-foot-tall hooded figure? This case is a mess!\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/270570a3-8637-4e4e-92d9-e985474cd5d2.jpg?1783912905"
+        ruling("2024-02-02", "You can't cast Reasonable Doubt just to suspect a creature. There has to be a spell on the stack that's a legal target for Reasonable Doubt.")
+        ruling("2024-02-02", "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected.")
+        ruling("2024-02-02", "If a creature is already suspected, suspecting it again won't have any effect.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TheChaseIsOn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TheChaseIsOn.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * The Chase Is On — Murders at Karlov Manor #116
+ * {2}{R} · Instant
+ *
+ * Target creature gets +3/+0 and gains first strike until end of turn. Investigate.
+ *
+ * Same shape as [AuspiciousArrival] / [ToxinAnalysis]: the Clue rides on the whole spell
+ * resolving, so an illegal target by resolution counters the spell (CR 608.2b) and no Clue
+ * is created.
+ */
+val TheChaseIsOn = card("The Chase Is On") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+0 and gains first strike until end of turn. Investigate. " +
+        "(Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 0, creature),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature),
+            Effects.Investigate()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Diego Gisbert"
+        flavorText = "Etrata evaded the Boros arresters and Azorius lawmages, but not even a " +
+            "master assassin could give Kaya the slip."
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d54d596-f7aa-4b05-ab13-19b246698c04.jpg?1783912886"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -305,6 +305,145 @@
     ]
 }
 
+// Cerebral Confiscation
+{
+    "name": "Cerebral Confiscation",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Target opponent discards two cards.\n• Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 2 cards to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponent",
+                            "id": "target opponent"
+                        }
+                    ],
+                    "description": "Target opponent discards two cards"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "RevealHand",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target opponent"
+                                }
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "opponentHand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "opponentHand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "filter": "nonland",
+                                "storeSelected": "toDiscard",
+                                "prompt": "Choose a nonland card to discard",
+                                "showAllCards": true,
+                                "alwaysPrompt": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toDiscard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetOpponent",
+                            "id": "target opponent"
+                        }
+                    ],
+                    "description": "Target opponent reveals their hand — you choose a nonland card to discard"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "Lius Lasahido",
+        "flavorText": "\"Never rely on secondhand description. Always review the memory yourself.\"\n—Lazav",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c3c3d15-b775-44a2-91ea-4abcc3cf2dba.jpg?1783912903"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cold Case Cracker
 {
     "name": "Cold Case Cracker",
@@ -1623,6 +1762,88 @@
         "artist": "Matt Forsyth",
         "flavorText": "\"Why doesn't Kylox put an off switch on these things?!\"",
         "imageUri": "https://cards.scryfall.io/normal/front/6/4/64ed3bfa-3294-45dd-825e-3afc2580f0d4.jpg?1783912882"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Gearbane Orangutan
+{
+    "name": "Gearbane Orangutan",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Ape",
+    "oracleText": "Reach\nWhen this creature enters, choose one —\n• Destroy up to one target artifact.\n• Sacrifice an artifact. If you do, put two +1/+1 counters on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "optional": true,
+                                    "filter": {
+                                        "baseFilter": "artifact"
+                                    }
+                                }
+                            ],
+                            "description": "Destroy up to one target artifact"
+                        },
+                        {
+                            "effect": {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.DoAction",
+                                    "action": {
+                                        "type": "ForceSacrifice",
+                                        "filter": "artifact",
+                                        "target": "Controller"
+                                    },
+                                    "successCriterion": "SuccessCriterion.PermanentsSacrificed"
+                                },
+                                "then": {
+                                    "type": "AddCounters",
+                                    "counterType": "+1/+1",
+                                    "count": 2,
+                                    "target": "Self"
+                                }
+                            },
+                            "description": "Sacrifice an artifact — if you do, put two +1/+1 counters on this creature"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"In her defense, thopters are very fun to smash.\"\n—Udol of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/6900a344-a155-4ee1-a3ac-d6c28e024270.jpg?1783912881"
     },
     "colorIdentityOverride": [
         "RED"
@@ -2992,6 +3213,55 @@
     ]
 }
 
+// On the Job
+{
+    "name": "On the Job",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +2/+1 until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Jason A. Engle",
+        "flavorText": "For all their differences, Kaya, Kellan, and Agrus Kos agreed on one thing: none of them would rest until Teysa's murderer was brought to justice.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48b92629-4196-4943-91fd-8c8d5f3fcaef.jpg?1783912920"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Person of Interest
 {
     "name": "Person of Interest",
@@ -3230,6 +3500,102 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Reasonable Doubt
+{
+    "name": "Reasonable Doubt",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell unless its controller pays {2}.\nSuspect up to one target creature. (A suspected creature has menace and can't block.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Counter",
+                    "condition": {
+                        "type": "CounterCondition.UnlessPaysDynamic",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SetSuspected",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature"
+                            },
+                            "duration": "Permanent"
+                        }
+                    ],
+                    "descriptionOverride": "target becomes suspected"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                },
+                "id": "target spell"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "up to one target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Betty Jiang",
+        "flavorText": "\"Merle had the motive, but Blovinac was the one caught with the murder weapon. And who was the seven-foot-tall hooded figure? This case is a mess!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/270570a3-8637-4e4e-92d9-e985474cd5d2.jpg?1783912905",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You can't cast Reasonable Doubt just to suspect a creature. There has to be a spell on the stack that's a legal target for Reasonable Doubt."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature is already suspected, suspecting it again won't have any effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -4079,6 +4445,66 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// The Chase Is On
+{
+    "name": "The Chase Is On",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+0 and gains first strike until end of turn. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Diego Gisbert",
+        "flavorText": "Etrata evaded the Boros arresters and Azorius lawmages, but not even a master assassin could give Kaya the slip.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d54d596-f7aa-4b05-ab13-19b246698c04.jpg?1783912886"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CerebralConfiscationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CerebralConfiscationScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CerebralConfiscation
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cerebral Confiscation (MKM #81) — {2}{B} Sorcery.
+ *
+ * "Choose one —
+ *  • Target opponent discards two cards.
+ *  • Target opponent reveals their hand. You choose a nonland card from it. That player discards
+ *    that card."
+ *
+ * Both modes target the same opponent but hand the *choice* to different players: mode 0 is the
+ * opponent's own discard, mode 1 is yours. The cards always land in the opponent's graveyard —
+ * the pair of things easiest to wire backwards, and what these tests pin.
+ */
+class CerebralConfiscationScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CerebralConfiscation))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun castMode(driver: GameTestDriver, you: EntityId, opponent: EntityId, mode: Int) {
+        val card = driver.putCardInHand(you, "Cerebral Confiscation")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 2)
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = card,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                chosenModes = listOf(mode),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(opponent))),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+    }
+
+    test("mode 0: the opponent discards two cards of their own choosing") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        driver.putCardInHand(opponent, "Grizzly Bears")
+        driver.putCardInHand(opponent, "Hill Giant")
+        val gyBefore = driver.getGraveyard(opponent).size
+        val myGyBefore = driver.getGraveyard(you).size
+
+        castMode(driver, you, opponent, mode = 0)
+
+        val decision = driver.state.pendingDecision as? SelectCardsDecision
+            ?: error("expected a SelectCardsDecision for the discard; got ${driver.state.pendingDecision}")
+        withClue("the discarding player chooses — not the caster") {
+            decision.playerId shouldBe opponent
+        }
+        driver.submitCardSelection(opponent, decision.options.take(2))
+
+        withClue("two cards moved to the opponent's graveyard") {
+            (driver.getGraveyard(opponent).size - gyBefore) shouldBe 2
+        }
+        withClue("the caster discards nothing — only the spell itself hits their graveyard") {
+            (driver.getGraveyard(you).size - myGyBefore) shouldBe 1
+            driver.getGraveyardCardNames(you).contains("Cerebral Confiscation") shouldBe true
+        }
+    }
+
+    test("mode 1: you pick a nonland card from the revealed hand and they discard it") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val nonland = driver.putCardInHand(opponent, "Grizzly Bears")
+        val land = driver.putCardInHand(opponent, "Plains")
+        val gyBefore = driver.getGraveyard(opponent).size
+
+        castMode(driver, you, opponent, mode = 1)
+
+        val decision = driver.state.pendingDecision as? SelectCardsDecision
+            ?: error("expected a SelectCardsDecision for the chosen card; got ${driver.state.pendingDecision}")
+        withClue("the caster chooses, and only nonland cards are on offer") {
+            decision.playerId shouldBe you
+            decision.options.contains(nonland) shouldBe true
+            decision.options.contains(land) shouldBe false
+        }
+        driver.submitCardSelection(you, listOf(nonland))
+
+        withClue("the chosen card lands in the opponent's graveyard") {
+            driver.getGraveyard(opponent).contains(nonland) shouldBe true
+            (driver.getGraveyard(opponent).size - gyBefore) shouldBe 1
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GearbaneOrangutanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GearbaneOrangutanScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gearbane Orangutan (MKM #129) — {2}{R} Creature — Ape, 2/2, Reach.
+ *
+ * "When this creature enters, choose one —
+ *  • Destroy up to one target artifact.
+ *  • Sacrifice an artifact. If you do, put two +1/+1 counters on this creature."
+ *
+ * The interesting half is mode 1: the sacrifice is mandatory, not a "may", and the counters are
+ * gated on it actually happening (`SuccessCriterion.PermanentsSacrificed`). With no artifact to
+ * sacrifice the mode must be a legal choice that simply accomplishes nothing — `Always` would
+ * hand out two free counters there, which is what these tests pin down.
+ */
+class GearbaneOrangutanScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Gearbane Orangutan") {
+
+            fun castAndReachModeChoice(game: TestGame): ChooseOptionDecision {
+                val cast = game.castSpell(1, "Gearbane Orangutan")
+                withClue("Gearbane Orangutan should cast: ${cast.error}") { cast.error shouldBe null }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                return game.getPendingDecision() as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision for the ETB; got ${game.getPendingDecision()}")
+            }
+
+            test("mode 0 destroys the targeted artifact") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Gearbane Orangutan")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Millstone")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val millstone = game.findPermanent("Millstone")!!
+
+                val mode = castAndReachModeChoice(game)
+                game.submitDecision(OptionChosenResponse(mode.id, optionIndex = 0))
+
+                val targets = game.getPendingDecision() as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the destroy mode; got ${game.getPendingDecision()}")
+                game.submitDecision(TargetsResponse(targets.id, mapOf(0 to listOf(millstone))))
+                game.resolveStack()
+
+                withClue("the opponent's artifact is destroyed") {
+                    game.isOnBattlefield("Millstone") shouldBe false
+                }
+                withClue("no counters — that's the other mode") {
+                    val ape = game.findPermanent("Gearbane Orangutan")!!
+                    game.state.projectedState.getPower(ape) shouldBe 2
+                    game.state.projectedState.getToughness(ape) shouldBe 2
+                }
+            }
+
+            test("mode 1 sacrifices your artifact and grows the Ape to 4/4") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Gearbane Orangutan")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(1, "Millstone")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mode = castAndReachModeChoice(game)
+                game.submitDecision(OptionChosenResponse(mode.id, optionIndex = 1))
+                game.resolveStack()
+
+                withClue("the only legal artifact is sacrificed") {
+                    game.isOnBattlefield("Millstone") shouldBe false
+                    game.isInGraveyard(1, "Millstone") shouldBe true
+                }
+                withClue("two +1/+1 counters on a 2/2") {
+                    val ape = game.findPermanent("Gearbane Orangutan")!!
+                    game.state.projectedState.getPower(ape) shouldBe 4
+                    game.state.projectedState.getToughness(ape) shouldBe 4
+                }
+            }
+
+            test("mode 1 with no artifact sacrifices nothing and gives no counters") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Gearbane Orangutan")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mode = castAndReachModeChoice(game)
+                game.submitDecision(OptionChosenResponse(mode.id, optionIndex = 1))
+                game.resolveStack()
+
+                withClue("nothing was sacrificed, so the payoff must not fire") {
+                    val ape = game.findPermanent("Gearbane Orangutan")!!
+                    game.state.projectedState.getPower(ape) shouldBe 2
+                    game.state.projectedState.getToughness(ape) shouldBe 2
+                }
+            }
+
+            test("mode 0 targets nothing when there is no artifact — the Ape still enters") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Gearbane Orangutan")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mode = castAndReachModeChoice(game)
+                game.submitDecision(OptionChosenResponse(mode.id, optionIndex = 0))
+                if (game.getPendingDecision() is ChooseTargetsDecision) game.skipTargets()
+                game.resolveStack()
+
+                withClue("\"up to one\" tolerates zero targets") {
+                    game.isOnBattlefield("Gearbane Orangutan") shouldBe true
+                    val ape = game.findPermanent("Gearbane Orangutan")!!
+                    game.state.projectedState.getPower(ape) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReasonableDoubtScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReasonableDoubtScenarioTest.kt
@@ -1,0 +1,190 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.ReasonableDoubt
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Reasonable Doubt (MKM #69) — {1}{U} Instant.
+ *
+ * "Counter target spell unless its controller pays {2}. Suspect up to one target creature."
+ *
+ * Two independent targets on one spell, so the risky part is *ordering*: the counter reads the
+ * spell off the head of the target list, while the optional creature must occupy the last slot.
+ * These cover both halves firing together, the optional target being declined, and the two
+ * sentences being genuinely independent (paying {2} still leaves the creature suspected).
+ */
+class ReasonableDoubtScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ReasonableDoubt))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("counters the spell and suspects the creature") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        val doubt = driver.putCardInHand(me, "Reasonable Doubt")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = doubt,
+                targets = listOf(ChosenTarget.Spell(boltOnStack), ChosenTarget.Permanent(bear)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        // Enough floating mana that declining is a real choice rather than an auto-counter.
+        driver.giveColorlessMana(opponent, 2)
+
+        driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(opponent, false)
+
+        withClue("declining {2} counters the spell") {
+            driver.getGraveyardCardNames(opponent) shouldContain "Lightning Bolt"
+        }
+        withClue("the second sentence resolves too — the creature is suspected") {
+            StateProjector().project(driver.state).isSuspected(bear) shouldBe true
+        }
+    }
+
+    test("paying {2} saves the spell but the creature is still suspected") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        val doubt = driver.putCardInHand(me, "Reasonable Doubt")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = doubt,
+                targets = listOf(ChosenTarget.Spell(boltOnStack), ChosenTarget.Permanent(bear)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        driver.giveColorlessMana(opponent, 2)
+
+        driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(opponent, true)
+
+        withClue("the two sentences are independent — paying doesn't spare the creature") {
+            StateProjector().project(driver.state).isSuspected(bear) shouldBe true
+        }
+        // Lightning Bolt was not countered — it resolves and deals 3.
+        driver.bothPass()
+        driver.assertLifeTotal(me, 17)
+    }
+
+    test("the creature target is optional — the counter still works alone") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        val doubt = driver.putCardInHand(me, "Reasonable Doubt")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = doubt,
+                targets = listOf(ChosenTarget.Spell(boltOnStack)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        driver.bothPass()
+        if (driver.pendingDecision is YesNoDecision) driver.submitYesNo(opponent, false)
+
+        withClue("no creature chosen — the counter half is unaffected") {
+            driver.getGraveyardCardNames(opponent) shouldContain "Lightning Bolt"
+        }
+        withClue("nothing was suspected") {
+            StateProjector().project(driver.state).isSuspected(bear) shouldBe false
+        }
+    }
+
+    test("an unpayable {2} counters without prompting") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(me)
+        driver.castSpell(opponent, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opponent)
+
+        val doubt = driver.putCardInHand(me, "Reasonable Doubt")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 1)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = doubt,
+                targets = listOf(ChosenTarget.Spell(boltOnStack)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        driver.bothPass()
+
+        withClue("the opponent is tapped out, so there is nothing to decide") {
+            driver.getGraveyardCardNames(opponent) shouldContain "Lightning Bolt"
+            driver.getGraveyardCardNames(me) shouldNotContain "Lightning Bolt"
+        }
+    }
+})


### PR DESCRIPTION
Implements five MKM cards, each canonical in MKM (no reprint rows needed) and each built entirely from existing SDK primitives — no new effect, trigger, condition, or keyword types.

| Card | Cost | Shape |
|---|---|---|
| On the Job | {2}{W}{W} Instant | Creatures you control get +2/+1 UEOT. Investigate. |
| The Chase Is On | {2}{R} Instant | Target creature gets +3/+0 and first strike UEOT. Investigate. |
| Reasonable Doubt | {1}{U} Instant | Counter target spell unless its controller pays {2}. Suspect up to one target creature. |
| Cerebral Confiscation | {2}{B} Sorcery | Choose one — opponent discards two; or reveal hand, you choose a nonland, they discard it. |
| Gearbane Orangutan | {2}{R} 2/2 Ape | Reach. ETB choose one — destroy up to one target artifact; or sacrifice an artifact, and if you do, two +1/+1 counters. |

## Notes on the three non-obvious ones

**Reasonable Doubt** carries two independent targets. The spell target must be **first** — `CounterEffectExecutor` resolves the countered spell off the head of the target list — and the `optional = true` creature must be **last**, per the fixed-width positional cast-time slots. The two sentences are genuinely independent: `Effects.Composite` skips a failed sub-effect rather than aborting, so paying the {2} still leaves the creature suspected, and a spell target that has left the stack doesn't stop the suspect.

**Cerebral Confiscation** uses per-mode targets. Mode 0 lowers to a discard whose chooser is the *target player*; mode 1 is the Pilfer / Ego Drain pipeline where the chooser is the *controller* and the filter is `Nonland`. Both move with `MoveType.Discard` so madness and "whenever you discard" triggers see them.

**Gearbane Orangutan** mode 1's sacrifice is mandatory, not a "may", so it is `Effects.IfYouDo` with `SuccessCriterion.PermanentsSacrificed`. `Auto` cannot infer a sacrifice (which graveyard it lands in isn't known until the chooser decides) and `Always` would fail open and grant two counters to a player with no artifact. Both modes are always legal choices — mode 0 is "up to one", mode 1 takes no target — which matters on an artifact-free board.

## Verification

- `just build` — green (full gate, all modules).
- `just check-card-printing` — clean for all five; MKM is the earliest real printing in every case.
- `just rebless-cards` — only the five new cards move in `snapshots/cards/MKM.json`.
- Scenario tests (10 tests, all passing) for the three shapes that are easy to wire backwards:
  - `ReasonableDoubtScenarioTest` — counter + suspect together, paying {2} still suspects, declined optional target, unpayable cost auto-counters.
  - `CerebralConfiscationScenarioTest` — who chooses in each mode, and whose graveyard the cards land in.
  - `GearbaneOrangutanScenarioTest` — both modes, plus mode 1 with no artifact (no counters) and mode 0 with no artifact (zero targets is legal).
- On the Job and The Chase Is On follow Auspicious Arrival / Toxin Analysis exactly and are covered by the snapshot and lint nets, matching how those cards are covered today.

No new SDK vocabulary, so `docs/card-sdk-language-reference.md` is unchanged. No client changes — every decision routes to an existing component (mode-selection overlay, battlefield targeting, card selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)