### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -8102,6 +8102,12 @@ sibling effect that reads `DynamicAmount.EntityProperty(EntityReference.AmassedA
 - It also resolves inside **target / affected-entity filters** via the pipeline-threaded
   predicate path (below), so comparison-based targeting like Grishnákh's "with power ≤ the
   amassed Army's power" works — `TargetFilter.…powerAtMostEntity(EntityReference.AmassedArmy)`.
+- When a sibling effect needs the Army as an **`EffectTarget`** rather than as an amount or a
+  filter comparand, read the same slot back with
+  `EffectTarget.PipelineTarget(EntityReference.AmassedArmy.STORAGE_KEY)` — Goblin Plate Mail's
+  "amass Goblins 1, then attach this Equipment to the amassed Army". The Army is not a target
+  (nothing is chosen on the stack); this just addresses what Amass already picked. `CardLinter`
+  knows `Amass` writes that slot, so the read does not trip the unwired-collection rule.
 
 #### Pipeline values inside target filters (`powerAtMostEntity`/`powerLessThanEntity` + `AmassedArmy`)
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -405,6 +405,18 @@ object CardLinter {
             type == "CreateToken" || type == "CreatePredefinedToken" ||
                 type == "CreateTokenCopyOfTarget" || type == "CreateTokenCopyOfSource" ->
                 listOf(Kind.WRITE to (Space.COLLECTION to "createdTokens"))
+            // Amass publishes the Army it chose under this well-known name (CR 701.47c), so a
+            // sibling step can address "the amassed Army" — either as
+            // DynamicAmount.EntityProperty(EntityReference.AmassedArmy, …) or, when it needs it
+            // as a target, EffectTarget.PipelineTarget(AmassedArmy.STORAGE_KEY) (Goblin Plate
+            // Mail's "then attach this Equipment to the amassed Army").
+            type == "Amass" ->
+                listOf(
+                    Kind.WRITE to (
+                        Space.COLLECTION to com.wingedsheep.sdk.scripting.values
+                            .EntityReference.AmassedArmy.STORAGE_KEY
+                        ),
+                )
             // The scry / surveil macros are opaque nodes on the card, but the engine expands each
             // into a Gather → Select → Move pipeline (LibraryPatterns.scryPipeline /
             // surveilPipeline) whose selected/remainder collections seed the *same* EffectContext.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/EaglesRescue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/EaglesRescue.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Eagle's Rescue
+ * {2}{W/U}{W/U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/+2 and has flying.
+ * {2}{W/U}{W/U}: Return this card from your graveyard to the battlefield attached to target
+ * creature you control with power 1 or less. Activate only as a sorcery.
+ *
+ * Modeling notes:
+ *  - The recursion ability is activated from the graveyard, so it needs
+ *    `activateFromZone = Zone.GRAVEYARD` (the Haunted Dead / Morbius idiom); without it the
+ *    ability is only ever enumerated on the battlefield and the card is a dead draw once it
+ *    hits the yard.
+ *  - "Power 1 or less" is measured when the target is chosen *and* re-checked on resolution
+ *    (CR 608.2b), so pumping the creature in response fizzles the ability — the filter lives
+ *    on the [TargetCreature] requirement rather than in the effect body.
+ *  - [Effects.ReturnSelfToBattlefieldAttached] defaults to the triggering entity (Dragon
+ *    Wings); here it takes the ability's chosen target instead.
+ *  - "Activate only as a sorcery" is [TimingRule.SorcerySpeed], not a separate restriction.
+ */
+val EaglesRescue = card("Eagle's Rescue") {
+    manaCost = "{2}{W/U}{W/U}"
+    colorIdentity = "WU"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+2 and has flying.\n" +
+        "{2}{W/U}{W/U}: Return this card from your graveyard to the battlefield attached to " +
+        "target creature you control with power 1 or less. Activate only as a sorcery."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(+2, +2, Filters.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, Filters.EnchantedCreature)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{W/U}{W/U}")
+        target = TargetCreature(filter = TargetFilter.CreatureYouControl.powerAtMost(1))
+        effect = Effects.ReturnSelfToBattlefieldAttached(EffectTarget.ContextTarget(0))
+        activateFromZone = Zone.GRAVEYARD
+        timing = TimingRule.SorcerySpeed
+        description = "Return this card from your graveyard to the battlefield attached to " +
+            "target creature you control with power 1 or less. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Ramza Psyru"
+        flavorText = "\"Don't pinch! You need not be frightened like a rabbit. What is finer than flying?\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12c8f2cc-ac9d-4cf6-9025-efe366b4e07f.jpg?1785236726"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GoblinPlateMail.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GoblinPlateMail.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Goblin Plate Mail
+ * {1}{B/R}
+ * Artifact — Equipment
+ *
+ * When this Equipment enters, amass Goblins 1, then attach this Equipment to the amassed Army.
+ * Equipped creature gets +1/+0 and has menace.
+ * Equip {4}
+ *
+ * Modeling notes:
+ *  - "Then attach … to the amassed Army" is not a target — it is the Army the Amass step
+ *    chose (CR 701.47c), whether or not counters actually landed on it. The engine writes
+ *    that id into `EntityReference.AmassedArmy.STORAGE_KEY` on the resolution pipeline, so
+ *    the follow-up attach reads it back as `EffectTarget.PipelineTarget(STORAGE_KEY)`. That
+ *    slot survives the multi-Army choice continuation, so attaching still lands on the right
+ *    Army when the player had to pick between several.
+ *  - A plain [Effects.Composite] is right here (not a reflexive trigger): "amass … , then
+ *    attach" is one resolution with no second trigger and nothing to respond to in between —
+ *    unlike Foray of Orcs' "When you do".
+ */
+val GoblinPlateMail = card("Goblin Plate Mail") {
+    manaCost = "{1}{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, amass Goblins 1, then attach this Equipment to " +
+        "the amassed Army. (To amass Goblins 1, put a +1/+1 counter on an Army you control. " +
+        "It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army " +
+        "creature token first.)\n" +
+        "Equipped creature gets +1/+0 and has menace.\n" +
+        "Equip {4}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Effects.Amass(1, "Goblin"),
+            Effects.AttachEquipment(
+                EffectTarget.PipelineTarget(EntityReference.AmassedArmy.STORAGE_KEY)
+            ),
+        )
+        description = "When this Equipment enters, amass Goblins 1, then attach this Equipment " +
+            "to the amassed Army."
+    }
+
+    staticAbility {
+        ability = ModifyStats(+1, +0, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.MENACE, Filters.EquippedCreature)
+    }
+
+    equipAbility("{4}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Miklós Ligeti"
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb982607-da37-4894-91a5-cf6307d4d703.jpg?1785323293"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MomentOfGlory.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MomentOfGlory.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Moment of Glory
+ * {W}
+ * Sorcery
+ *
+ * Put a +1/+1 counter on target creature you control. If this spell was cast from a
+ * graveyard, also put a +1/+1 counter on each other creature you control.
+ * Flashback {4}{W}
+ *
+ * Modeling notes:
+ *  - The bonus clause is "cast from *a* graveyard", not "cast with flashback" — any
+ *    graveyard-cast path turns it on, which is exactly [Conditions.WasCastFromGraveyard]
+ *    (`WasCastFromZoneCondition(Zone.GRAVEYARD)`), not a flashback-specific test.
+ *  - "Each **other** creature you control" is other than the *target*, so the group uses
+ *    [GroupFilter.otherThanTarget] — `ForEachExecutor` drops the spell's first chosen
+ *    target from the iteration set. Without it the target would get two counters.
+ *  - The whole spell still has a single target, so an illegal target on resolution fizzles
+ *    both halves (CR 608.2b); nothing here is a separate "each creature" mode.
+ */
+val MomentOfGlory = card("Moment of Glory") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Put a +1/+1 counter on target creature you control. If this spell was cast " +
+        "from a graveyard, also put a +1/+1 counter on each other creature you control.\n" +
+        "Flashback {4}{W} (You may cast this card from your graveyard for its flashback cost. " +
+        "Then exile it.)"
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature),
+            ConditionalEffect(
+                condition = Conditions.WasCastFromGraveyard,
+                effect = Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.youControl()).otherThanTarget(),
+                    Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                ),
+            ),
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{4}{W}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Jarel Threat"
+        flavorText = "\"I am Bard, slayer of the Dragon!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a6a6ff0-b1cd-4b06-bd31-612690094e0e.jpg?1785497012"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RhovanionRampager.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RhovanionRampager.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rhovanion Rampager
+ * {2}{B}
+ * Creature — Wolf
+ * 3/2
+ *
+ * Whenever this creature attacks, you may sacrifice another creature. If you do, put a
+ * number of +1/+1 counters on this creature equal to the sacrificed creature's power.
+ * When this creature dies, amass Goblins X, where X is this creature's power.
+ *
+ * Modeling notes:
+ *  - The attack trigger is the Gitrog, Ravenous Ride idiom: an inline [Effects.Pipeline]
+ *    gathers the other creatures you control, offers **up to one** ("you may") on the
+ *    battlefield-targeting UI, and sacrifices it. Declining leaves the collection empty, so
+ *    [DynamicAmounts.sacrificedPower] reads 0 and no counters are placed — which is exactly
+ *    what "If you do" gates. The sacrifice is a resolution-time action, not a cost.
+ *  - "The sacrificed creature's power" is last-known information (CR 608.2h): the sacrifice
+ *    records an `EntitySnapshot`, and `EntityReference.Sacrificed` is a `LIVE_THEN_LKI`
+ *    reference, so the amount reads the power the creature had as it left the battlefield —
+ *    including any counters or pumps it was carrying.
+ *  - The dies trigger's X is likewise this creature's *last-known* power, so counters it had
+ *    accumulated from its own attack trigger still count. [DynamicAmounts.sourcePower] over
+ *    `EntityReference.Source` is `LIVE_THEN_LKI` for the same reason.
+ */
+val RhovanionRampager = card("Rhovanion Rampager") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Wolf"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever this creature attacks, you may sacrifice another creature. If you do, " +
+        "put a number of +1/+1 counters on this creature equal to the sacrificed creature's " +
+        "power.\n" +
+        "When this creature dies, amass Goblins X, where X is this creature's power. (Put X " +
+        "+1/+1 counters on an Army you control. It's also a Goblin. If you don't control an " +
+        "Army, create a 0/0 black Goblin Army creature token first.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Pipeline {
+            val others = gather(
+                CardSource.BattlefieldMatching(
+                    filter = GameObjectFilter.Creature,
+                    player = Player.You,
+                    excludeSelf = true,
+                )
+            )
+            val chosen = chooseUpTo(
+                1,
+                from = others,
+                useTargetingUI = true,
+                prompt = "You may sacrifice another creature",
+                selectedLabel = "Sacrifice",
+            )
+            sacrifice(chosen)
+            run(
+                Effects.AddDynamicCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    DynamicAmounts.sacrificedPower(),
+                    EffectTarget.Self,
+                )
+            )
+        }
+        description = "Whenever this creature attacks, you may sacrifice another creature. If " +
+            "you do, put a number of +1/+1 counters on this creature equal to the sacrificed " +
+            "creature's power."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Amass(DynamicAmounts.sourcePower(), "Goblin")
+        description = "When this creature dies, amass Goblins X, where X is this creature's power."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "82"
+        artist = "Kevin Sidharta"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5ee45a5e-3650-47b3-8d31-6b1de9e27a14.jpg?1785412699"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/WoodlandWeavemaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/WoodlandWeavemaster.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Woodland Weavemaster
+ * {1}{G}
+ * Creature — Elf Druid
+ * 1/2
+ *
+ * Vigilance
+ * Whenever another Elf you control enters, this creature gets +1/+1 until end of turn.
+ * {T}: Add X mana of any one color, where X is this creature's power. Spend this mana only
+ * to cast Elf spells and activate abilities of Elf sources.
+ *
+ * Modeling notes:
+ *  - "Another Elf **you control**" is an OTHER-bound enters trigger over
+ *    `Elf.youControl()` — the OTHER binding is what keeps the Weavemaster's own ETB from
+ *    pumping itself. The filter is "Elf", not "Elf creature": a noncreature Elf permanent
+ *    would still count, and the projected type is what the filter reads.
+ *  - The mana ability's amount is [DynamicAmounts.sourcePower], read at resolution, so the
+ *    pumps this creature has already taken this turn (and any counters on it) are included.
+ *    Power 0 or less simply adds no mana.
+ *  - "Elf spells **and** abilities of Elf sources" is
+ *    [ManaRestriction.SubtypeSpellsOrAbilitiesOnly] with `creatureOnly = false` — the
+ *    Unclaimed Territory shape, where activations of Elf sources also qualify — rather than
+ *    the Cavern of Souls creature-spells-only shape.
+ */
+val WoodlandWeavemaster = card("Woodland Weavemaster") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 1
+    toughness = 2
+    oracleText = "Vigilance\n" +
+        "Whenever another Elf you control enters, this creature gets +1/+1 until end of turn.\n" +
+        "{T}: Add X mana of any one color, where X is this creature's power. Spend this mana " +
+        "only to cast Elf spells and activate abilities of Elf sources."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.ELF).youControl(),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.ModifyStats(+1, +1, EffectTarget.Self)
+        description = "Whenever another Elf you control enters, this creature gets +1/+1 until " +
+            "end of turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(
+            amount = DynamicAmounts.sourcePower(),
+            restriction = ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Elf", creatureOnly = false),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "Add X mana of any one color, where X is this creature's power. Spend this " +
+            "mana only to cast Elf spells and activate abilities of Elf sources."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "143"
+        artist = "Nia Kovalevski"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe2b4bcf-56de-44d3-83af-aeb27f82c25e.jpg?1785237990"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1685,6 +1685,74 @@
     ]
 }
 
+// Eagle's Rescue
+{
+    "name": "Eagle's Rescue",
+    "manaCost": "{2}{W/U}{W/U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.\n{2}{W/U}{W/U}: Return this card from your graveyard to the battlefield attached to target creature you control with power 1 or less. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W/U}{W/U}"
+                    }
+                },
+                "effect": {
+                    "type": "ReturnSelfToBattlefieldAttached",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=1 ctrl:you"
+                        }
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "Return this card from your graveyard to the battlefield attached to target creature you control with power 1 or less. Activate only as a sorcery."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "UNCOMMON",
+        "artist": "Ramza Psyru",
+        "flavorText": "\"Don't pinch! You need not be frightened like a rabbit. What is finer than flying?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12c8f2cc-ac9d-4cf6-9025-efe366b4e07f.jpg?1785236726"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Elven Raft-Steerer
 {
     "name": "Elven Raft-Steerer",
@@ -2528,6 +2596,93 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Goblin Plate Mail
+{
+    "name": "Goblin Plate Mail",
+    "manaCost": "{1}{B/R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, amass Goblins 1, then attach this Equipment to the amassed Army. (To amass Goblins 1, put a +1/+1 counter on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)\nEquipped creature gets +1/+0 and has menace.\nEquip {4}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Amass",
+                            "subtype": "Goblin"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "__amassed_army"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this Equipment enters, amass Goblins 1, then attach this Equipment to the amassed Army."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "MENACE"
+            }
+        ]
+    },
+    "equipCost": "{4}",
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Miklós Ligeti",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb982607-da37-4894-91a5-cf6307d4d703.jpg?1785323293"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -3930,6 +4085,83 @@
     ]
 }
 
+// Moment of Glory
+{
+    "name": "Moment of Glory",
+    "manaCost": "{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put a +1/+1 counter on target creature you control. If this spell was cast from a graveyard, also put a +1/+1 counter on each other creature you control.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{4}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "WasCastFromZone",
+                            "zone": "Graveyard"
+                        }
+                    },
+                    "then": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you",
+                                "excludeTarget": true
+                            }
+                        },
+                        "body": {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Jarel Threat",
+        "flavorText": "\"I am Bard, slayer of the Dragon!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a6a6ff0-b1cd-4b06-bd31-612690094e0e.jpg?1785497012"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Most Decrepit Old Bird
 {
     "name": "Most Decrepit Old Bird",
@@ -4882,6 +5114,103 @@
         "artist": "Antonio José Manzanedo",
         "flavorText": "The grey chief spoke in their dreadful language, and every now and then all the Wargs in the circle would answer together.",
         "imageUri": "https://cards.scryfall.io/normal/front/1/6/16765eb2-d497-4cd6-b683-20eac2f10bbf.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Rhovanion Rampager
+{
+    "name": "Rhovanion Rampager",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Whenever this creature attacks, you may sacrifice another creature. If you do, put a number of +1/+1 counters on this creature equal to the sacrificed creature's power.\nWhen this creature dies, amass Goblins X, where X is this creature's power. (Put X +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature",
+                                "player": "You",
+                                "excludeSelf": true
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected1",
+                            "prompt": "You may sacrifice another creature",
+                            "selectedLabel": "Sacrifice",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Sacrifice"
+                        },
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Sacrificed",
+                                "numericProperty": "Power"
+                            },
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may sacrifice another creature. If you do, put a number of +1/+1 counters on this creature equal to the sacrificed creature's power."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Amass",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "subtype": "Goblin"
+                },
+                "descriptionOverride": "When this creature dies, amass Goblins X, where X is this creature's power."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "rarity": "RARE",
+        "artist": "Kevin Sidharta",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5ee45a5e-3650-47b3-8d31-6b1de9e27a14.jpg?1785412699"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -7297,6 +7626,77 @@
         "artist": "Tomas Duchek",
         "flavorText": "Wargs had little trouble devouring and digesting the most putrid of carcasses.",
         "imageUri": "https://cards.scryfall.io/normal/front/6/3/63078f42-f404-4c61-86be-45d934393b0a.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Woodland Weavemaster
+{
+    "name": "Woodland Weavemaster",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "Vigilance\nWhenever another Elf you control enters, this creature gets +1/+1 until end of turn.\n{T}: Add X mana of any one color, where X is this creature's power. Spend this mana only to cast Elf spells and activate abilities of Elf sources.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "Elf ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever another Elf you control enters, this creature gets +1/+1 until end of turn."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "restriction": {
+                        "type": "SubtypeSpellsOrAbilitiesOnly",
+                        "subtype": "Elf"
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "Add X mana of any one color, where X is this creature's power. Spend this mana only to cast Elf spells and activate abilities of Elf sources."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "UNCOMMON",
+        "artist": "Nia Kovalevski",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe2b4bcf-56de-44d3-83af-aeb27f82c25e.jpg?1785237990"
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EaglesRescueScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EaglesRescueScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Eagle's Rescue (HOB #155) — {2}{W/U}{W/U} Enchantment — Aura.
+ *
+ * "Enchant creature
+ *  Enchanted creature gets +2/+2 and has flying.
+ *  {2}{W/U}{W/U}: Return this card from your graveyard to the battlefield attached to target
+ *  creature you control with power 1 or less. Activate only as a sorcery."
+ *
+ * The recursion ability is activated from the **graveyard**, which is a separate enumeration path
+ * from battlefield abilities, and its target is restricted to power 1 or less — a bigger creature
+ * must not be offerable.
+ */
+class EaglesRescueScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Eagle's Rescue") {
+
+            test("the enchanted creature gets +2/+2 and flying") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Eagle's Rescue", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+                projected.getPower(bears) shouldBe 4
+                projected.getToughness(bears) shouldBe 4
+                projected.hasKeyword(bears, Keyword.FLYING) shouldBe true
+            }
+
+            test("it returns from the graveyard attached to a small creature you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Eagle's Rescue")
+                    .withCardOnBattlefield(1, "Llanowar Elves")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rescue = game.findCardsInGraveyard(1, "Eagle's Rescue").single()
+                val mystic = game.findPermanent("Llanowar Elves")!!
+                val abilityId = cardRegistry.requireCard("Eagle's Rescue").activatedAbilities.single().id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rescue,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(mystic)),
+                    )
+                ).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val returned = game.findPermanent("Eagle's Rescue")
+                withClue("the Aura is on the battlefield attached to the 1/1") {
+                    returned shouldNotBe null
+                    game.state.getEntity(returned!!)?.get<AttachedToComponent>()?.targetId shouldBe mystic
+                    game.isInGraveyard(1, "Eagle's Rescue") shouldBe false
+                }
+                withClue("and it is buffing its new host") {
+                    game.state.projectedState.getPower(mystic) shouldBe 3
+                    game.state.projectedState.getToughness(mystic) shouldBe 3
+                    game.state.projectedState.hasKeyword(mystic, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("a creature with power 2 is not a legal target for the recursion") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Eagle's Rescue")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rescue = game.findCardsInGraveyard(1, "Eagle's Rescue").single()
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.requireCard("Eagle's Rescue").activatedAbilities.single().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = rescue,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("power 2 fails the 'power 1 or less' restriction") {
+                    result.error shouldNotBe null
+                    game.isInGraveyard(1, "Eagle's Rescue") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinPlateMailScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinPlateMailScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Goblin Plate Mail (HOB #157) — {1}{B/R} Artifact — Equipment.
+ *
+ * "When this Equipment enters, amass Goblins 1, then attach this Equipment to the amassed Army.
+ *  Equipped creature gets +1/+0 and has menace.
+ *  Equip {4}"
+ *
+ * The load-bearing part is "the amassed Army": the attach step is not a target, it reads the
+ * Army the Amass step just chose out of the resolution pipeline
+ * (`EntityReference.AmassedArmy.STORAGE_KEY`). Covered both when Amass has to create the Army
+ * from nothing and when a pre-existing Army is grown instead.
+ */
+class GoblinPlateMailScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Goblin Plate Mail") {
+
+            fun ScenarioTestBase.TestGame.armies() =
+                state.getBattlefield().filter {
+                    state.projectedState.isCreature(it) && state.projectedState.hasSubtype(it, "Army")
+                }
+
+            fun ScenarioTestBase.TestGame.castPlateMail() {
+                castSpell(1, "Goblin Plate Mail")
+                if (getPendingDecision() is SelectManaSourcesDecision) submitManaSourcesAutoPay()
+                resolveStack()
+            }
+
+            test("entering amasses a Goblin Army and attaches itself to it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Goblin Plate Mail")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castPlateMail()
+
+                val mail = game.findPermanent("Goblin Plate Mail")!!
+                val army = game.armies().single()
+                val projected = game.state.projectedState
+
+                withClue("the amassed token is a Goblin Army") {
+                    projected.hasSubtype(army, "Goblin") shouldBe true
+                }
+                withClue("0/0 base + one +1/+1 counter, then +1/+0 from the Equipment") {
+                    projected.getPower(army) shouldBe 2
+                    projected.getToughness(army) shouldBe 1
+                }
+                withClue("the Equipment attached itself to the Army it just amassed") {
+                    game.state.getEntity(mail)?.get<AttachedToComponent>()?.targetId shouldBe army
+                    projected.hasKeyword(army, Keyword.MENACE) shouldBe true
+                }
+            }
+
+            test("a second copy grows the same Army instead of making a new one, and attaches there too") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardsInHand(1, "Goblin Plate Mail", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castPlateMail()
+                val firstArmy = game.armies().single()
+
+                game.castPlateMail()
+
+                withClue("Amass grows the Army you already control — no second Army token") {
+                    game.armies() shouldBe listOf(firstArmy)
+                }
+                withClue("both Equipment ended up on that Army") {
+                    game.findAllPermanents("Goblin Plate Mail").forEach { mail ->
+                        game.state.getEntity(mail)?.get<AttachedToComponent>()?.targetId shouldBe firstArmy
+                    }
+                }
+                withClue("0/0 + two counters = 2/2, plus +1/+0 from each of the two Equipment") {
+                    game.state.projectedState.getPower(firstArmy) shouldBe 4
+                    game.state.projectedState.getToughness(firstArmy) shouldBe 2
+                }
+            }
+
+            test("the ETB attach goes to the Army, not to another creature you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Goblin Plate Mail")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castPlateMail()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val mail = game.findPermanent("Goblin Plate Mail")!!
+                withClue("the Bears are untouched — the Equipment is on the amassed Army") {
+                    game.state.getEntity(mail)?.get<AttachedToComponent>()?.targetId shouldBe game.armies().single()
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                    game.state.projectedState.hasKeyword(bears, Keyword.MENACE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomentOfGloryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomentOfGloryScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Moment of Glory (HOB #21) — {W} Sorcery.
+ *
+ * "Put a +1/+1 counter on target creature you control. If this spell was cast from a graveyard,
+ *  also put a +1/+1 counter on each other creature you control.
+ *  Flashback {4}{W}"
+ *
+ * Two things worth proving: the bonus clause is off on a hand cast and on for the flashback cast,
+ * and "each **other** creature" is other than the *target* — the target must not be counted twice.
+ */
+class MomentOfGloryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Moment of Glory") {
+
+            test("cast from hand it only grows the target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Moment of Glory")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.castSpell(1, "Moment of Glory", bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("only the target got a counter") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getPower(courser) shouldBe 3
+                }
+            }
+
+            test("cast from the graveyard with flashback it also grows each other creature you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Moment of Glory")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myBears = game.findAllPermanents("Grizzly Bears")
+                    .single { game.state.projectedState.getController(it) == game.player1Id }
+                val theirBears = game.findAllPermanents("Grizzly Bears")
+                    .single { game.state.projectedState.getController(it) == game.player2Id }
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.castSpellFromGraveyard(1, "Moment of Glory", myBears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the target got exactly one counter — 'each other' excludes it") {
+                    game.state.projectedState.getPower(myBears) shouldBe 3
+                    game.state.projectedState.getToughness(myBears) shouldBe 3
+                }
+                withClue("your other creature got the bonus counter") {
+                    game.state.projectedState.getPower(courser) shouldBe 4
+                    game.state.projectedState.getToughness(courser) shouldBe 4
+                }
+                withClue("'you control' keeps the opponent's creature out of it") {
+                    game.state.projectedState.getPower(theirBears) shouldBe 2
+                }
+                withClue("flashback exiles the card") {
+                    game.isInGraveyard(1, "Moment of Glory") shouldBe false
+                    game.isInExile(1, "Moment of Glory") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RhovanionRampagerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RhovanionRampagerScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+
+/**
+ * Rhovanion Rampager (HOB #82) — {2}{B} Creature — Wolf 3/2.
+ *
+ * "Whenever this creature attacks, you may sacrifice another creature. If you do, put a number
+ *  of +1/+1 counters on this creature equal to the sacrificed creature's power.
+ *  When this creature dies, amass Goblins X, where X is this creature's power."
+ *
+ * Both halves read power off last-known information: the sacrificed creature is already in the
+ * graveyard when the counters are placed, and the Rampager itself is gone when the dies trigger
+ * resolves. The "you may" is a resolution-time choice, so declining must place no counters.
+ */
+class RhovanionRampagerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rhovanion Rampager") {
+
+            fun ScenarioTestBase.TestGame.armyPower(): Int? =
+                state.getBattlefield()
+                    .firstOrNull { state.projectedState.isCreature(it) && state.projectedState.hasSubtype(it, "Army") }
+                    ?.let { state.projectedState.getPower(it) }
+
+            test("sacrificing another creature on attack adds counters equal to its power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rhovanion Rampager")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rampager = game.findPermanent("Rhovanion Rampager")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Rhovanion Rampager" to 2)).error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("the offer is 'another creature' — the Rampager itself is not on the list") {
+                    (decision is SelectCardsDecision) shouldBe true
+                    (decision as SelectCardsDecision).options shouldContainExactlyInAnyOrder listOf(courser)
+                }
+                game.selectCards(listOf(courser)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the 3/3 Courser was sacrificed for three +1/+1 counters") {
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe true
+                    game.state.projectedState.getPower(rampager) shouldBe 6
+                    game.state.projectedState.getToughness(rampager) shouldBe 5
+                }
+            }
+
+            test("declining the sacrifice places no counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rhovanion Rampager")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rampager = game.findPermanent("Rhovanion Rampager")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Rhovanion Rampager" to 2)).error shouldBe null
+                game.resolveStack()
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                withClue("'If you do' never fired — nothing was sacrificed and nothing grew") {
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe false
+                    game.state.projectedState.getPower(rampager) shouldBe 3
+                    game.state.projectedState.getToughness(rampager) shouldBe 2
+                }
+            }
+
+            test("dying amasses Goblins equal to its last-known power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rhovanion Rampager")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 3)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rampager = game.findPermanent("Rhovanion Rampager")!!
+                game.castSpell(2, "Lightning Bolt", rampager)
+                game.resolveStack()
+                game.checkStateBasedActions()
+                game.resolveStack()
+
+                withClue("a 3-power Wolf died, so the Army carries three +1/+1 counters") {
+                    game.isInGraveyard(1, "Rhovanion Rampager") shouldBe true
+                    game.armyPower() shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoodlandWeavemasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoodlandWeavemasterScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Woodland Weavemaster (HOB #143) — {1}{G} Creature — Elf Druid 1/2.
+ *
+ * "Vigilance
+ *  Whenever another Elf you control enters, this creature gets +1/+1 until end of turn.
+ *  {T}: Add X mana of any one color, where X is this creature's power. Spend this mana only to
+ *  cast Elf spells and activate abilities of Elf sources."
+ *
+ * The trigger is OTHER-bound (its own arrival must not pump it) and "you control"-scoped, and the
+ * mana amount is read at resolution so the pumps it has already taken are included.
+ */
+class WoodlandWeavemasterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Woodland Weavemaster") {
+
+            test("it is a 1/2 with vigilance") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Woodland Weavemaster")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val weavemaster = game.findPermanent("Woodland Weavemaster")!!
+                game.state.projectedState.getPower(weavemaster) shouldBe 1
+                game.state.projectedState.getToughness(weavemaster) shouldBe 2
+                game.state.projectedState.hasKeyword(weavemaster, Keyword.VIGILANCE) shouldBe true
+            }
+
+            test("another Elf you control entering pumps it, but its own arrival did not") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Woodland Weavemaster")
+                    .withCardInHand(1, "Llanowar Elves")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val weavemaster = game.findPermanent("Woodland Weavemaster")!!
+                withClue("no self-pump from being on the battlefield already") {
+                    game.state.projectedState.getPower(weavemaster) shouldBe 1
+                }
+
+                game.castSpell(1, "Llanowar Elves").error shouldBe null
+                game.resolveStack()
+
+                withClue("+1/+1 until end of turn from the other Elf") {
+                    game.state.projectedState.getPower(weavemaster) shouldBe 2
+                    game.state.projectedState.getToughness(weavemaster) shouldBe 3
+                }
+            }
+
+            test("a non-Elf creature entering does not pump it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Woodland Weavemaster")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val weavemaster = game.findPermanent("Woodland Weavemaster")!!
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                game.state.projectedState.getPower(weavemaster) shouldBe 1
+            }
+
+            test("the mana ability produces as much mana as its current power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Woodland Weavemaster")
+                    .withCardInHand(1, "Llanowar Elves")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Grow it to 2 power first, so the amount is demonstrably read at resolution.
+                game.castSpell(1, "Llanowar Elves").error shouldBe null
+                game.resolveStack()
+
+                val weavemaster = game.findPermanent("Woodland Weavemaster")!!
+                game.state.projectedState.getPower(weavemaster) shouldBe 2
+
+                val manaAbility = cardRegistry.requireCard("Woodland Weavemaster")
+                    .activatedAbilities.single().id
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = weavemaster,
+                        abilityId = manaAbility,
+                    )
+                ).error shouldBe null
+                // Mana abilities don't use the stack, but "any one color" pauses to ask first.
+                val colorChoice = game.getPendingDecision() as ChooseColorDecision
+                game.submitDecision(ColorChosenResponse(colorChoice.id, Color.GREEN)).error shouldBe null
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                withClue("power 2 produced two green mana, all of it Elf-restricted") {
+                    pool.restrictedMana.size shouldBe 2
+                    pool.restrictedMana.all { it.color == Color.GREEN } shouldBe true
+                    pool.restrictedMana.all {
+                        it.restriction == ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Elf")
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five HOB cards, each canonical in HOB (Scryfall shows no earlier printing for any of them).

| Card | Cost | Shape |
|---|---|---|
| Moment of Glory | `{W}` | Sorcery + Flashback `{4}{W}`; graveyard-cast bonus |
| Goblin Plate Mail | `{1}{B/R}` | Equipment; ETB amass Goblins 1 → attach to the amassed Army |
| Rhovanion Rampager | `{2}{B}` | 3/2 Wolf; attack sacrifice → counters, dies → amass X |
| Eagle's Rescue | `{2}{W/U}{W/U}` | Aura +2/+2 flying; graveyard-activated self-recursion |
| Woodland Weavemaster | `{1}{G}` | 1/2 Elf Druid; Elf-enters pump + Elf-restricted mana |

## Engine change

One, and it's a linter correctness fix rather than new vocabulary. `Amass` publishes the Army it chose (CR 701.47c) into `EffectContext.pipeline.storedCollections[EntityReference.AmassedArmy.STORAGE_KEY]`. `CardLinter` knew that slot only as a *read*, so Goblin Plate Mail's "then attach this Equipment to the amassed Army" — which addresses it as `EffectTarget.PipelineTarget(STORAGE_KEY)` — tripped the "nothing on this card writes it" rule. Declared as an implicit write next to the existing `CreateToken` / `Scry` / `Surveil` entries, and the `EffectTarget` route is now documented in `docs/card-sdk-language-reference.md`.

## Modeling notes

- **Moment of Glory** — "each **other** creature you control" is other than the *target*, so the group is `GroupFilter.otherThanTarget()`; `ForEachExecutor` drops the spell's first chosen target, otherwise the target would take two counters. The bonus clause is `Conditions.WasCastFromGraveyard` (any graveyard cast), not a flashback-specific test.
- **Goblin Plate Mail** — a plain `Composite`, not a reflexive trigger: "amass …, then attach" is one resolution with nothing to respond to in between. The pipeline slot survives the multi-Army choice continuation, so the attach still lands on the Army the player picked.
- **Rhovanion Rampager** — the attack sacrifice is a resolution-time "you may" (the Gitrog, Ravenous Ride idiom: gather → `chooseUpTo(1)` on the battlefield UI → sacrifice). Declining leaves the collection empty, so `sacrificedPower` reads 0 and no counters land — that is the "If you do" gate. Both halves read power off last-known information (CR 608.2h), since the sacrificed creature and the Rampager itself are already gone when the counters / amass resolve.
- **Eagle's Rescue** — `activateFromZone = Zone.GRAVEYARD` (Haunted Dead / Morbius idiom), sorcery timing, and the "power 1 or less" restriction lives on the target requirement so it is re-checked at resolution.
- **Woodland Weavemaster** — OTHER-bound enters trigger so its own arrival does not pump it; the mana amount is `DynamicAmounts.sourcePower()` read at resolution, and "Elf spells **and** abilities of Elf sources" is `SubtypeSpellsOrAbilitiesOnly("Elf", creatureOnly = false)` (Unclaimed Territory shape, not Cavern of Souls).

## Verification

- `just build` — green.
- Five scenario tests, one per card, 14 tests total, all passing. They cover the amassed-Army attach (fresh token and pre-existing Army), the decline path and last-known power on the Rampager, hand-cast vs flashback-cast on Moment of Glory, the graveyard activation and the illegal power-2 target on Eagle's Rescue, and the Elf-restricted mana amount.
- `just rebless-cards` — only the five new cards moved in `HOB.json`.
- `just check-card-printing` — ok for all five.
- Scryfall re-verified field by field (name, cost, type line, P/T, rarity, collector number, artist); image URIs return HTTP 200. No rulings published for the set yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)