### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4568,11 +4568,19 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
   **a** <filter>" wording, which fires once per sacrificed permanent, use `YouSacrificeA`; for the "another"
   exclusion use an `OTHER`-binding trigger instead.
   By default the ANY-binding form watches only the source *controller's* sacrifices ("whenever **you**
-  sacrifice…"). For the "whenever **a player** sacrifices…" scope set
-  `EventPattern.PermanentsSacrificedEvent(filter, byAnyPlayer = true)` (Zodiark, Umbral God — "Whenever a
-  player sacrifices another creature, put a +1/+1 counter on Zodiark"): the detector then fires the trigger
-  once per sacrificing player in the batch, regardless of who controls the source, binding
-  `triggeringPlayerId` to that player.
+  sacrifice…"). `EventPattern.PermanentsSacrificedEvent.sacrificedBy` widens that scope and takes exactly
+  three meaningful values: `Player.You` (default), `Player.Each` for "whenever **a player** sacrifices…"
+  (Zodiark, Umbral God), and `Player.EachOpponent` for "whenever **an opponent** sacrifices…" (Vengeful
+  Tracker). For both multi-player scopes the detector fires the trigger once per watched sacrificing player
+  in the batch, regardless of who controls the source, binding `triggeringPlayerId` to that player — so a
+  payoff aimed at `Player.TriggeringPlayer` hits whoever actually sacrificed. `Player.EachOpponent` respects
+  CR 102.3 (teammates are not opponents) and never fires on the source's own controller, including when the
+  source is itself among the sacrificed permanents.
+- `OpponentSacrificesA(filter?)` / `OpponentSacrificesOneOrMore(filter?)` — the opponent-scoped siblings of
+  `YouSacrificeA` / `YouSacrificeOneOrMore`, i.e. `sacrificedBy = Player.EachOpponent` with `binding = ANY`.
+  `OpponentSacrificesA` is the per-permanent wording "whenever an opponent sacrifices **an** artifact"
+  (Vengeful Tracker — an opponent cracking two Clues gets hit twice); `OpponentSacrificesOneOrMore` is the
+  batch wording, firing once per opponent per batch.
 - `YouSacrificeAnother(filter?)` — the **per-permanent** template "whenever you sacrifice **another**
   permanent" (Mazirek, Kraul Death Priest; Savra; Zhao, Ruthless Admiral). Built with `binding = OTHER`
   and `EventPattern.PermanentsSacrificedEvent(filter, perPermanent = true)`. Distinct from

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1988,6 +1988,38 @@ object Triggers {
     )
 
     /**
+     * Whenever an opponent sacrifices **a** permanent matching the filter.
+     * Per-permanent trigger — fires once for EACH matching permanent that opponent sacrificed, even
+     * when several go at once (CR 603.2c) — and once per opponent when several opponents sacrifice
+     * in the same batch. The sacrificing player is bound as [Player.TriggeringPlayer], so "deals
+     * damage to them" / "they lose life" payoffs resolve against the right opponent.
+     *
+     * The opponent-scoped sibling of [YouSacrificeA]. Use [OpponentSacrificesOneOrMore] for the
+     * "one or more" batch wording.
+     *
+     * Example: "Whenever an opponent sacrifices an artifact"
+     * → OpponentSacrificesA(GameObjectFilter.Artifact)   (Vengeful Tracker)
+     */
+    fun OpponentSacrificesA(filter: GameObjectFilter = GameObjectFilter.Any): TriggerSpec = TriggerSpec(
+        event = PermanentsSacrificedEvent(
+            filter = filter,
+            sacrificedBy = Player.EachOpponent,
+            perPermanent = true
+        ),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
+     * Whenever an opponent sacrifices one or more permanents matching the filter.
+     * Batching trigger — fires at most once per opponent per event batch. The opponent-scoped
+     * sibling of [YouSacrificeOneOrMore]; see [OpponentSacrificesA] for the per-permanent wording.
+     */
+    fun OpponentSacrificesOneOrMore(filter: GameObjectFilter = GameObjectFilter.Any): TriggerSpec = TriggerSpec(
+        event = PermanentsSacrificedEvent(filter = filter, sacrificedBy = Player.EachOpponent),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * When you sacrifice this permanent.
      * Distinct from [PutIntoGraveyardFromBattlefield] / [Dies], which fire on any
      * battlefield-to-graveyard transition (including destruction).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -2212,30 +2212,46 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      *    sacrificed simultaneously (Mazirek, Savra, Zhao). Combine with [TriggerBinding.OTHER] for
      *    "another" (excludes the source) or [TriggerBinding.ANY] for "a" (includes the source).
      *
-     * By default the trigger watches only the controller's own sacrifices ("Whenever *you*
-     * sacrifice…"). Set [byAnyPlayer] = true for the "Whenever *a player* sacrifices…" scope
-     * (Zodiark, Umbral God) — then the detector fires the trigger once per player (batch) or once
-     * per that player's matching permanent (per-permanent), regardless of who controls the source.
+     * [sacrificedBy] scopes *whose* sacrifices are watched, independently of who controls the
+     * source. Only three values are meaningful, and the detector reads exactly these:
+     *  - [Player.You] (default): the controller's own sacrifices ("Whenever *you* sacrifice…").
+     *  - [Player.Each]: every player's ("Whenever *a player* sacrifices…", Zodiark, Umbral God).
+     *  - [Player.EachOpponent]: only the controller's opponents' ("Whenever *an opponent*
+     *    sacrifices…", Vengeful Tracker).
+     *
+     * For the two multi-player scopes the trigger fires once per watched player (batch) or once per
+     * that player's matching permanent (per-permanent). The sacrificing player is bound as the
+     * trigger's [Player.TriggeringPlayer], so payoffs can hit "them" specifically.
      *
      * Examples:
      *   → PermanentsSacrificedEvent(filter = GameObjectFilter.Food)
      *     "Whenever you sacrifice one or more Foods"
      *   → PermanentsSacrificedEvent(perPermanent = true)  // with OTHER binding
      *     "Whenever you sacrifice another permanent"
-     *   → PermanentsSacrificedEvent(filter = GameObjectFilter.Creature, byAnyPlayer = true)
+     *   → PermanentsSacrificedEvent(filter = GameObjectFilter.Creature, sacrificedBy = Player.Each)
      *     "Whenever a player sacrifices one or more creatures"
+     *   → PermanentsSacrificedEvent(filter = GameObjectFilter.Artifact, perPermanent = true,
+     *                               sacrificedBy = Player.EachOpponent)
+     *     "Whenever an opponent sacrifices an artifact"
      */
     @SerialName("PermanentsSacrificedEvent")
     @Serializable
     data class PermanentsSacrificedEvent(
         val filter: GameObjectFilter = GameObjectFilter.Any,
-        val byAnyPlayer: Boolean = false,
+        val sacrificedBy: Player = Player.You,
         val perPermanent: Boolean = false
     ) : EventPattern {
         override val description: String = buildString {
-            val who = if (byAnyPlayer) "a player sacrifices " else "you sacrifice "
+            val who = when (sacrificedBy) {
+                Player.Each -> "a player sacrifices "
+                Player.EachOpponent -> "an opponent sacrifices "
+                else -> "you sacrifice "
+            }
             append(who)
-            append(if (perPermanent) "another " else "one or more ")
+            // "another" is relative to the source permanent, so it only reads right when the
+            // sacrificing player is the source's own controller; other scopes take a plain article.
+            val article = if (sacrificedBy == Player.You) "another " else "a "
+            append(if (perPermanent) article else "one or more ")
             if (filter != GameObjectFilter.Any) {
                 append(filter.cardPredicates.joinToString(" ") { it.description })
                 if (!perPermanent) append("s")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZodiarkUmbralGod.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZodiarkUmbralGod.kt
@@ -36,7 +36,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *    round down. The non-God filter is `Creature.notSubtype(GOD)`, so a player's own Gods (and
  *    Zodiark) are never sacrificed and don't count toward the half.
  *  - The counter trigger uses the "a player sacrifices" scope
- *    ([EventPattern.PermanentsSacrificedEvent.byAnyPlayer] = true, ANY binding): it fires for any
+ *    ([EventPattern.PermanentsSacrificedEvent.sacrificedBy] = [Player.Each], ANY binding): it fires for any
  *    player's sacrifices, not just Zodiark's controller's. Following the engine's batching
  *    convention for sacrifice triggers, it fires once per sacrificing player per batch. The filter
  *    is `Creature`; "another" is satisfied in practice because Zodiark is indestructible and, as a
@@ -81,7 +81,7 @@ val ZodiarkUmbralGod = card("Zodiark, Umbral God") {
         trigger = TriggerSpec(
             event = EventPattern.PermanentsSacrificedEvent(
                 filter = GameObjectFilter.Creature,
-                byAnyPlayer = true
+                sacrificedBy = Player.Each
             ),
             binding = TriggerBinding.ANY
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ForumFamiliar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ForumFamiliar.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Forum Familiar — Murders at Karlov Manor #16
+ * {W} · Creature — Cat · 1/1
+ *
+ * Disguise {1}{W}
+ * When this creature is turned face up, return another target permanent you control to its owner's
+ * hand and put a +1/+1 counter on this creature.
+ *
+ * The payoff is reachable only through the disguise route: a *turned face up* trigger is not an
+ * enters trigger (CR 701.34), so hard-casting the Cat for {W} gets a vanilla 1/1. Cast face down for
+ * {3} it is a 2/2 with ward {2}; flipping it later for {1}{W} fires the trigger and leaves a 2/2 Cat
+ * (1/1 base plus the counter) having bounced one of your own permanents — the intended loop being to
+ * re-buy an enters trigger rather than to lose value.
+ *
+ * "Another target permanent you control" excludes the Familiar itself ([TargetFilter.excludeSelf]);
+ * with no other permanent on your battlefield the trigger has no legal target and is simply removed
+ * from the stack (CR 608.2b), so the +1/+1 counter is not put on either — the two halves share one
+ * resolution, they are not independent.
+ */
+val ForumFamiliar = card("Forum Familiar") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 1
+    toughness = 1
+    oracleText = "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, return another target permanent you control to its " +
+        "owner's hand and put a +1/+1 counter on this creature."
+    disguise = "{1}{W}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        val permanent = target(
+            "another target permanent you control",
+            TargetPermanent(filter = TargetFilter.Permanent.youControl().copy(excludeSelf = true)),
+        )
+        effect = Effects.Composite(
+            Effects.ReturnToHand(permanent),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+        )
+        description = "When this creature is turned face up, return another target permanent you " +
+            "control to its owner's hand and put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "16"
+        artist = "Ilse Gort"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b06a243d-acc8-42cd-926c-98a4cc96ab21.jpg?1783912926"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "Turning a permanent face up or face down doesn't change whether that permanent is " +
+                "tapped or untapped."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GriffnautTracker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GriffnautTracker.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Griffnaut Tracker — Murders at Karlov Manor #17
+ * {3}{W} · Creature — Human Detective · 3/2
+ *
+ * Flying
+ * When this creature enters, exile up to two target cards from a single graveyard.
+ *
+ * "From a single graveyard" is the [TargetObject.sameOwner] flag, the same modeling as Arashin
+ * Sunshield: both chosen cards must be owned by the same player, so the two targets can't be split
+ * across two opponents' graveyards. It is a *targeting* restriction, checked when targets are chosen
+ * and re-checked on resolution — not a resolution-time filter.
+ *
+ * "Up to two" makes the whole ability optional in the targeting sense (`optional = true`): it still
+ * goes on the stack with zero targets when every graveyard is empty, and it resolves doing nothing
+ * rather than being removed for lack of targets (CR 608.2b).
+ */
+val GriffnautTracker = card("Griffnaut Tracker") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Detective"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature enters, exile up to two target cards from a single graveyard."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to two target cards from a single graveyard",
+            TargetObject(
+                count = 2,
+                optional = true,
+                filter = TargetFilter.CardInGraveyard,
+                sameOwner = true,
+            )
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE))
+        )
+        description = "When this creature enters, exile up to two target cards from a single graveyard."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Svetlin Velinov"
+        flavorText = "\"The desperate will tread unexpected paths. Be prepared to follow.\"\n" +
+            "—Tam Sennic, Ezrim's second-in-command"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95f5d048-226f-49a4-a2ce-a6fa99aa9e8a.jpg?1783912926"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Knife.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Knife.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Knife — Murders at Karlov Manor #134
+ * {R} · Artifact — Clue Equipment
+ *
+ * During your turn, equipped creature gets +1/+0 and has first strike.
+ * {2}, Sacrifice this Equipment: Draw a card.
+ * Equip {2}
+ *
+ * One of the set's "murder weapon" Equipment — an Equipment that is also a Clue, so it carries the
+ * standard Clue sacrifice-to-draw *and* the Clue subtype, which the set's "sacrifice a Clue" payoffs
+ * read straight off the type line (Scryfall's ruling: "If an effect refers to a Clue, it means any
+ * Clue artifact, not just a Clue artifact token").
+ *
+ * "During your turn" gates both halves, so they are two [ConditionalStaticAbility] blocks sharing
+ * [Conditions.IsYourTurn] rather than one — a static ability is one continuous modification, and
+ * +1/+0 (layer 7c) and first strike (layer 6) apply in different layers anyway. "Your" is the
+ * Equipment controller's turn, not the equipped creature's controller's, which matters only when
+ * the creature has been stolen out from under the Equipment.
+ */
+val Knife = card("Knife") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Clue Equipment"
+    oracleText = "During your turn, equipped creature gets +1/+0 and has first strike.\n" +
+        "{2}, Sacrifice this Equipment: Draw a card.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = ModifyStats(+1, +0, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.EquippedCreature)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "134"
+        artist = "Tony Foti"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6883788-e1ee-4ddd-add2-24d6bc367717.jpg?1783912882"
+
+        ruling(
+            "2016-04-08",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token."
+        )
+        ruling(
+            "2016-04-08",
+            "You can't sacrifice a Clue to pay multiple costs."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RotFarmMortipede.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RotFarmMortipede.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rot Farm Mortipede — Murders at Karlov Manor #102
+ * {3}{B} · Creature — Insect · 3/4
+ *
+ * Whenever one or more creature cards leave your graveyard, this creature gets +1/+0 and gains
+ * menace and lifelink until end of turn.
+ *
+ * A *batching* trigger ([Triggers.CardsLeaveYourGraveyard]): it fires at most once per batch no
+ * matter how many creature cards left at once and no matter where they went — cast, exiled to pay
+ * for collect evidence, reanimated, or returned to hand. Escaping three creature cards in one event
+ * grows the Mortipede by +1/+0, not +3/+0.
+ *
+ * The three riders are one composite so they share a timestamp and expire together at cleanup
+ * (CR 514.2). Each firing stacks, so two separate batches in a turn leave a 5/4 with menace and
+ * lifelink — granting a keyword the creature already has is a harmless no-op.
+ */
+val RotFarmMortipede = card("Rot Farm Mortipede") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever one or more creature cards leave your graveyard, this creature gets " +
+        "+1/+0 and gains menace and lifelink until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard(GameObjectFilter.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.MENACE, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self),
+        )
+        description = "Whenever one or more creature cards leave your graveyard, this creature " +
+            "gets +1/+0 and gains menace and lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Loïc Canavaggia"
+        flavorText = "Every week, the necropsy lab's unclaimed bodies are transferred to the " +
+            "Golgari for \"recycling.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/023b0142-663a-47e7-a9f1-0b565a172b60.jpg?1783912891"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VengefulTracker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VengefulTracker.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vengeful Tracker — Murders at Karlov Manor #147
+ * {1}{R} · Creature — Human Detective · 2/2
+ *
+ * Whenever an opponent sacrifices an artifact, this creature deals 2 damage to them.
+ *
+ * The set is full of Clues, Treasures, and "murder weapon" Equipment that cash themselves in, so
+ * this punishes the opponent for using their own artifacts, not just for edicts you point at them.
+ *
+ * "An artifact" is the bare-article template, so it is a per-permanent trigger (CR 603.2c): an
+ * opponent cracking two Clues in response to one another gets hit twice, and an effect that
+ * sacrifices three artifacts at once still fires three times. "An opponent" scopes it to the
+ * Tracker controller's opponents ([Triggers.OpponentSacrificesA]) — your own Clue cracks never fire
+ * it — and in a multiplayer game two opponents sacrificing in the same batch each trigger it, each
+ * firing hitting the player who actually sacrificed via [Player.TriggeringPlayer].
+ */
+val VengefulTracker = card("Vengeful Tracker") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Detective"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever an opponent sacrifices an artifact, this creature deals 2 damage to them."
+
+    triggeredAbility {
+        trigger = Triggers.OpponentSacrificesA(GameObjectFilter.Artifact)
+        effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+        description = "Whenever an opponent sacrifices an artifact, this creature deals 2 damage to them."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "147"
+        artist = "Francisco Miyara"
+        flavorText = "\"I won't waste my time hunting down petty thieves while my brother's killer " +
+            "still walks free.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a247c9a0-0c65-47bc-92fd-bebe95cd35a3.jpg?1783912872"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -26851,7 +26851,7 @@
                 "trigger": {
                     "type": "PermanentsSacrificedEvent",
                     "filter": "creature",
-                    "byAnyPlayer": true
+                    "sacrificedBy": "Each"
                 },
                 "binding": "ANY",
                 "effect": {

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1718,6 +1718,85 @@
     ]
 }
 
+// Forum Familiar
+{
+    "name": "Forum Familiar",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Disguise {1}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, return another target permanent you control to its owner's hand and put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{W}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "another target permanent you control"
+                            },
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another target permanent you control"
+                },
+                "descriptionOverride": "When this creature is turned face up, return another target permanent you control to its owner's hand and put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "UNCOMMON",
+        "artist": "Ilse Gort",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b06a243d-acc8-42cd-926c-98a4cc96ab21.jpg?1783912926",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Galvanize
 {
     "name": "Galvanize",
@@ -1983,6 +2062,65 @@
     "colorIdentityOverride": []
 }
 
+// Griffnaut Tracker
+{
+    "name": "Griffnaut Tracker",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Flying\nWhen this creature enters, exile up to two target cards from a single graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Exile"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to two target cards from a single graveyard",
+                    "sameOwner": true
+                },
+                "descriptionOverride": "When this creature enters, exile up to two target cards from a single graveyard."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"The desperate will tread unexpected paths. Be prepared to follow.\"\n—Tam Sennic, Ezrim's second-in-command",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95f5d048-226f-49a4-a2ce-a6fa99aa9e8a.jpg?1783912926"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Haazda Vigilante
 {
     "name": "Haazda Vigilante",
@@ -2206,6 +2344,108 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Knife
+{
+    "name": "Knife",
+    "manaCost": "{R}",
+    "typeLine": "Artifact — Clue Equipment",
+    "oracleText": "During your turn, equipped creature gets +1/+0 and has first strike.\n{2}, Sacrifice this Equipment: Draw a card.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 0
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE"
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "UNCOMMON",
+        "artist": "Tony Foti",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6883788-e1ee-4ddd-add2-24d6bc367717.jpg?1783912882",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+            },
+            {
+                "date": "2016-04-08",
+                "text": "You can't sacrifice a Clue to pay multiple costs."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -3745,6 +3985,67 @@
     ]
 }
 
+// Rot Farm Mortipede
+{
+    "name": "Rot Farm Mortipede",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Whenever one or more creature cards leave your graveyard, this creature gets +1/+0 and gains menace and lifelink until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CardsLeftYourGraveyardEvent",
+                    "filter": "creature"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever one or more creature cards leave your graveyard, this creature gets +1/+0 and gains menace and lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Loïc Canavaggia",
+        "flavorText": "Every week, the necropsy lab's unclaimed bodies are transferred to the Golgari for \"recycling.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/023b0142-663a-47e7-a9f1-0b565a172b60.jpg?1783912891"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Rubblebelt Braggart
 {
     "name": "Rubblebelt Braggart",
@@ -4981,6 +5282,54 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Vengeful Tracker
+{
+    "name": "Vengeful Tracker",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Whenever an opponent sacrifices an artifact, this creature deals 2 damage to them.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact",
+                    "sacrificedBy": "EachOpponent",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                },
+                "descriptionOverride": "Whenever an opponent sacrifices an artifact, this creature deals 2 damage to them."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "UNCOMMON",
+        "artist": "Francisco Miyara",
+        "flavorText": "\"I won't waste my time hunting down petty thieves while my brother's killer still walks free.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a247c9a0-0c65-47bc-92fd-bebe95cd35a3.jpg?1783912872"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -2220,14 +2220,20 @@ class TriggerDetector(
                 // the self-sacrifice pass below (the source has left the battlefield by then).
                 if (ability.binding != TriggerBinding.ANY && ability.binding != TriggerBinding.OTHER) continue
 
-                // By default the trigger watches only the source controller's own sacrifices
-                // ("Whenever you sacrifice…"). When byAnyPlayer is set it watches every player's
-                // ("Whenever a player sacrifices…", Zodiark) — fire once per sacrificing player.
+                // Whose sacrifices this trigger watches. Player.You (default) is the source
+                // controller's own ("Whenever you sacrifice…"); Player.Each is every player's
+                // ("Whenever a player sacrifices…", Zodiark); Player.EachOpponent is the source
+                // controller's opponents' ("Whenever an opponent sacrifices…", Vengeful Tracker).
+                // The multi-player scopes fire once per sacrificing player.
                 val controllerId = entry.controllerId
-                val watchedPlayers = if (trigger.byAnyPlayer) {
-                    sacrificeByController.keys.toList()
-                } else {
-                    if (sacrificeByController.containsKey(controllerId)) listOf(controllerId) else emptyList()
+                val watchedPlayers = when (trigger.sacrificedBy) {
+                    Player.Each -> sacrificeByController.keys.toList()
+                    // CR 102.3 — teammates are not opponents, so go through getOpponents rather
+                    // than "everyone but me".
+                    Player.EachOpponent ->
+                        state.getOpponents(controllerId).filter { sacrificeByController.containsKey(it) }
+                    else ->
+                        if (sacrificeByController.containsKey(controllerId)) listOf(controllerId) else emptyList()
                 }
 
                 for (sacrificingPlayerId in watchedPlayers) {
@@ -2298,6 +2304,10 @@ class TriggerDetector(
                         val trigger = ability.trigger
                         if (trigger !is EventPattern.PermanentsSacrificedEvent) continue
                         if (Zone.BATTLEFIELD !in ability.activeZones) continue
+                        // This pass only ever sees a permanent sacrificed by its own controller, so
+                        // an opponent-scoped trigger ("Whenever an opponent sacrifices…") can never
+                        // be satisfied here.
+                        if (trigger.sacrificedBy == Player.EachOpponent) continue
 
                         if (trigger.perPermanent) {
                             // Per-permanent template ("a/another permanent") where the source is

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulTrackerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulTrackerScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.VengefulTracker
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vengeful Tracker (MKM) — {1}{R} Creature — Human Detective 2/2.
+ * "Whenever an opponent sacrifices an artifact, this creature deals 2 damage to them."
+ *
+ * Exercises the `PermanentsSacrificedEvent(sacrificedBy = Player.EachOpponent)` scope added for this
+ * card, on the three axes that scope can go wrong:
+ *  - **Whose** sacrifice counts — an opponent's fires it; the Tracker controller's own does not.
+ *  - **How many times** it fires — "an artifact" is the per-permanent template (CR 603.2c), so two
+ *    artifacts sacrificed in one event fire it twice.
+ *  - **Who takes the damage** — `Player.TriggeringPlayer` must resolve to the player who actually
+ *    sacrificed, not to the Tracker's controller.
+ * The artifact filter is checked too: sacrificing a creature must not fire it.
+ */
+class VengefulTrackerScenarioTest : ScenarioTestBase() {
+
+    private val scrapPile = card("Scrap Pile") {
+        manaCost = "{0}"
+        typeLine = "Artifact"
+    }
+
+    // {0} sorceries that make their *caster* sacrifice their own permanents, so the sacrificing
+    // player is whoever cast the spell.
+    private fun selfSacrifice(name: String, filter: GameObjectFilter, count: Int) =
+        card(name) {
+            manaCost = "{0}"
+            typeLine = "Sorcery"
+            spell {
+                effect = Effects.Sacrifice(filter, count, EffectTarget.PlayerRef(Player.You))
+            }
+        }
+
+    private val scrapOne = selfSacrifice("Scrap One", GameObjectFilter.Artifact, 1)
+    private val scrapTwo = selfSacrifice("Scrap Two", GameObjectFilter.Artifact, 2)
+    private val cullOne = selfSacrifice("Cull One", GameObjectFilter.Creature, 1)
+
+    private fun TestGame.resolveAll() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || hasPendingDecision()) && guard++ < 60) {
+            when (val d = getPendingDecision()) {
+                is SelectCardsDecision -> selectCards(d.options.take(d.minSelections))
+                null -> resolveStack()
+                else ->
+                    if (d::class.simpleName?.contains("Mana") == true) submitManaSourcesAutoPay()
+                    else error("Unexpected decision: ${d::class.simpleName}")
+            }
+        }
+    }
+
+    init {
+        cardRegistry.register(VengefulTracker)
+        cardRegistry.register(scrapPile)
+        cardRegistry.register(scrapOne)
+        cardRegistry.register(scrapTwo)
+        cardRegistry.register(cullOne)
+
+        context("Vengeful Tracker — 'whenever an opponent sacrifices an artifact'") {
+
+            test("an opponent's artifact sacrifice deals 2 damage to that opponent") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardOnBattlefield(1, "Vengeful Tracker", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Scrap Pile")
+                    .withCardInHand(2, "Scrap One")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Scrap One")
+                game.resolveAll()
+
+                withClue("the sacrificing opponent takes the 2 damage") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("the Tracker's controller is untouched") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("your own artifact sacrifice does not fire it") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardOnBattlefield(1, "Vengeful Tracker", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Scrap Pile")
+                    .withCardInHand(1, "Scrap One")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Scrap One")
+                game.resolveAll()
+
+                withClue("'an opponent' excludes the Tracker's own controller") {
+                    game.getLifeTotal(1) shouldBe 20
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("two artifacts sacrificed at once fire it twice (per-permanent, CR 603.2c)") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardOnBattlefield(1, "Vengeful Tracker", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Scrap Pile")
+                    .withCardOnBattlefield(2, "Scrap Pile")
+                    .withCardInHand(2, "Scrap Two")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Scrap Two")
+                game.resolveAll()
+
+                withClue("'an artifact' is per-permanent: two sacrifices, two triggers, 4 damage") {
+                    game.getLifeTotal(2) shouldBe 16
+                }
+            }
+
+            test("sacrificing a creature does not fire it — the filter is artifacts") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardOnBattlefield(1, "Vengeful Tracker", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(2, "Cull One")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Cull One")
+                game.resolveAll()
+
+                game.getLifeTotal(2) shouldBe 20
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZodiarkUmbralGodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZodiarkUmbralGodScenarioTest.kt
@@ -27,7 +27,7 @@ import io.kotest.matchers.shouldNotBe
  *    the interesting part (3 → 1, not 2), and Zodiark (a God) is excluded from the count and the
  *    sacrifice.
  *  - The reactive counter trigger: "Whenever a player sacrifices another creature, put a +1/+1
- *    counter on Zodiark." This exercises the new `PermanentsSacrificedEvent(byAnyPlayer = true)`
+ *    counter on Zodiark." This exercises the `PermanentsSacrificedEvent(sacrificedBy = Player.Each)`
  *    scope — an *opponent's* sacrifice (not just the controller's) must trigger it.
  */
 class ZodiarkUmbralGodScenarioTest : ScenarioTestBase() {


### PR DESCRIPTION
Griffnaut Tracker, Forum Familiar, Rot Farm Mortipede, Knife, and Vengeful Tracker — five MKM cards, four of them pure composition over existing primitives and one that needed a new trigger scope.

## Cards

| Card | Cost | Notes |
|---|---|---|
| **Griffnaut Tracker** | `{3}{W}` 3/2 | Flying + Arashin Sunshield's "up to two target cards from a single graveyard" ETB (`TargetObject.sameOwner`). |
| **Forum Familiar** | `{W}` 1/1 | Disguise `{1}{W}`; the turned-face-up trigger bounces *another* permanent you control (`excludeSelf`) and puts a +1/+1 counter on itself. Reachable only via the disguise route — turning face up isn't entering. |
| **Rot Farm Mortipede** | `{3}{B}` 3/4 | `Triggers.CardsLeaveYourGraveyard(Creature)` driving one composite, so +1/+0, menace and lifelink share a timestamp and expire together at cleanup. Batching: three creature cards leaving at once is +1/+0, not +3/+0. |
| **Knife** | `{R}` | Clue Equipment. "During your turn" is two `ConditionalStaticAbility` blocks over `Conditions.IsYourTurn` — +1/+0 and first strike land in different Rule 613 layers, so they can't be one static. |
| **Vengeful Tracker** | `{1}{R}` 2/2 | "Whenever an opponent sacrifices an artifact, this creature deals 2 damage to them." |

## SDK change: opponent-scoped sacrifice triggers

`PermanentsSacrificedEvent` could watch only the source controller's own sacrifices or every player's — there was no "an opponent" scope, and a controller-based `GameObjectFilter` doesn't help because the detector's filter check ignores controller predicates.

- `byAnyPlayer: Boolean` becomes `sacrificedBy: Player`, taking `You` (default) / `Each` / `EachOpponent` — the same shape other event patterns already use to scope players.
- `TriggerDetector` reads it in **both** passes. The battlefield-index pass resolves opponents through `GameState.getOpponents`, so CR 102.3 teammates are excluded rather than "everyone but me". The self-sacrifice pass (a permanent sacrificed while carrying its own trigger) skips the opponent scope outright — there the sacrificing player is always the source's own controller, so it can never be satisfied.
- The sacrificing player is bound as `TriggeringPlayer`, so the damage lands on whoever actually sacrificed.
- `Triggers.OpponentSacrificesA` / `OpponentSacrificesOneOrMore` are the facades for the per-permanent and batch wordings.
- Zodiark, Umbral God moves to `sacrificedBy = Player.Each`; its one snapshot line is the only pre-existing card that shifts.
- `docs/card-sdk-language-reference.md` updated in the same change.

## Verification

- `just build` — green (includes `:rules-engine:check` and the card snapshot tests).
- `just test` — green.
- `VengefulTrackerScenarioTest` (4 tests, all passing) covers whose sacrifice counts, per-permanent multiplicity on a simultaneous batch (two artifacts → 4 damage), who takes the damage, and the artifact filter.
- `just rebless-cards` — MKM.json gains exactly the five new cards; FIN.json moves only on Zodiark's renamed field.
- `just check-card-printing` clean for all five (all MKM-original; Knife's CLU reprint set isn't scaffolded).
- Every `imageUri` HEAD-checks 200.

No new decision types, `GameEvent`s, or keywords, so there is no server-DTO or client work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
