### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ElectrostaticBolt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ElectrostaticBolt.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Electrostatic Bolt — Mirrodin #89
+ * {R} · Instant
+ *
+ * Electrostatic Bolt deals 2 damage to target creature. If it's an artifact creature,
+ * Electrostatic Bolt deals 4 damage to it instead.
+ *
+ * "Instead" replaces the amount, not the event, so this is one damage event whose amount is a
+ * [DynamicAmount.Conditional] (the Bring Low shape) rather than two branching damage effects. The
+ * artifact check is resolution-time: a creature that becomes an artifact in response is dealt 4,
+ * and one that loses artifact-ness in response is dealt 2.
+ */
+val ElectrostaticBolt = card("Electrostatic Bolt") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Electrostatic Bolt deals 2 damage to target creature. If it's an artifact creature, " +
+        "Electrostatic Bolt deals 4 damage to it instead."
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.DealDamage(
+            amount = DynamicAmount.Conditional(
+                condition = Conditions.TargetMatchesFilter(GameObjectFilter.ArtifactCreature),
+                ifTrue = DynamicAmount.Fixed(4),
+                ifFalse = DynamicAmount.Fixed(2)
+            ),
+            target = EffectTarget.ContextTarget(0)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Randy Gallegos"
+        flavorText = "It's hard to avoid electric shock when the entire plane is metallic."
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c455c8d4-6f20-4dcb-8e82-c2bb70d6bc3e.jpg?1783944541"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MoltenRain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MoltenRain.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Molten Rain
+ * {1}{R}{R}
+ * Sorcery
+ * Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's controller.
+ */
+val MoltenRain = card("Molten Rain") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's controller."
+
+    spell {
+        target = Targets.Land
+        // Same ordering as Choking Sands: deal the damage while the target is still on the
+        // battlefield with its controller intact, then destroy. The conditional reads the
+        // target's current nonbasic status, which matches the past-tense oracle phrasing
+        // ("if that land was nonbasic").
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.IsLand,
+                        CardPredicate.Not(CardPredicate.IsBasicLand),
+                    )
+                )
+            ),
+            effect = Effects.DealDamage(2, EffectTarget.TargetController)
+        ) then Effects.Move(EffectTarget.ContextTarget(0), Zone.GRAVEYARD, byDestruction = true)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Hugh Jamieson"
+        flavorText = "When the molten rains fall, entire landscapes melt and flow away in rivulets of fire."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f888b4d4-31f9-4322-8225-4d7e7a9f4dd5.jpg?1783944539"
+        ruling(
+            "2021-03-19",
+            "If the target land is an illegal target by the time Molten Rain tries to resolve, the " +
+                "spell doesn't resolve. No player is dealt 2 damage. If the target is legal but not " +
+                "destroyed (most likely because it has indestructible), its controller is dealt 2 damage."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithPredator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithPredator.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slith Predator — Mirrodin #129
+ * {G}{G} · Creature — Slith · 1/1
+ *
+ * Trample
+ * Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+ *
+ * The green member of the Slith cycle. Same growth trigger as [SlithFirewalker]; trample is what
+ * keeps it growing once the board fills up, since a chump blocker no longer stops the damage from
+ * reaching the player and so no longer stops the counter.
+ */
+val SlithPredator = card("Slith Predator") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Slith"
+    power = 1
+    toughness = 1
+    oracleText = "Trample\n" +
+        "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "129"
+        artist = "Justin Sweet"
+        flavorText = "Born amid the molten metal of the Great Furnace, the slith have more than " +
+            "adapted to the perils of a metal world."
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14bae45c-eaa8-4c6d-8042-df5cf26e294f.jpg?1783944532"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TelJiladChosen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TelJiladChosen.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Tel-Jilad Chosen — Mirrodin #132
+ * {1}{G} · Creature — Elf Warrior · 2/1
+ *
+ * Protection from artifacts
+ *
+ * Green's answer to a set built entirely out of artifacts. Modelled with the card-type protection
+ * scope ([ProtectionScope.CardType]), projected as `PROTECTION_FROM_CARDTYPE_ARTIFACT`, so
+ * targeting, damage prevention, and block evasion all honour it without per-card wiring — an
+ * artifact creature can't block it, an artifact source can't damage it, and an artifact's ability
+ * can't target it.
+ */
+val TelJiladChosen = card("Tel-Jilad Chosen") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 2
+    toughness = 1
+    oracleText = "Protection from artifacts"
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.CardType("Artifact")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Matthew D. Wilson"
+        flavorText = "\"It is my honor to keep safe Tel-Jilad's secrets, not to know them.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eefea84f-d657-491d-b60d-63e6a61e9eb2.jpg?1783944532"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ViridianLongbow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ViridianLongbow.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Viridian Longbow — Mirrodin #270
+ * {1} · Artifact — Equipment
+ *
+ * Equipped creature has "{T}: This creature deals 1 damage to any target."
+ * Equip {3}
+ *
+ * The Sorcerer's Wand shape: a [GrantActivatedAbility] static handing the host a `{T}` pinger.
+ * Two consequences of the grant living on the *host* (CR 113.7) matter here and both fall out of
+ * [EffectTarget.Self] resolving to the equipped creature inside a granted ability: the `{T}` cost
+ * taps the creature (so summoning sickness gates it, and it can't both attack and shoot), and the
+ * creature — not the Longbow — is the source of the damage, which is what makes this the classic
+ * deathtouch-and-Longbow combo.
+ */
+val ViridianLongbow = card("Viridian Longbow") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has \"{T}: This creature deals 1 damage to any target.\"\n" +
+        "Equip {3}"
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.DealDamage(
+                    amount = 1,
+                    target = EffectTarget.ContextTarget(0),
+                    damageSource = EffectTarget.Self
+                ),
+                targetRequirements = listOf(AnyTarget())
+            )
+        )
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "270"
+        artist = "Jeremy Jarvis"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/be892d73-d1f4-4c36-b674-01ae21ff1484.jpg?1783944497"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -586,6 +586,59 @@
     ]
 }
 
+// Electrostatic Bolt
+{
+    "name": "Electrostatic Bolt",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Electrostatic Bolt deals 2 damage to target creature. If it's an artifact creature, Electrostatic Bolt deals 4 damage to it instead.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "filter": "artifact creature"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 4
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 2
+                }
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Randy Gallegos",
+        "flavorText": "It's hard to avoid electric shock when the entire plane is metallic.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c455c8d4-6f20-4dcb-8e82-c2bb70d6bc3e.jpg?1783944541"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Elf Replica
 {
     "name": "Elf Replica",
@@ -2030,6 +2083,83 @@
     ]
 }
 
+// Molten Rain
+{
+    "name": "Molten Rain",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's controller.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsLand",
+                                    {
+                                        "type": "Not",
+                                        "predicate": "IsBasicLand"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "TargetController"
+                    }
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Hugh Jamieson",
+        "flavorText": "When the molten rains fall, entire landscapes melt and flow away in rivulets of fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f888b4d4-31f9-4322-8225-4d7e7a9f4dd5.jpg?1783944539",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "If the target land is an illegal target by the time Molten Rain tries to resolve, the spell doesn't resolve. No player is dealt 2 damage. If the target is legal but not destroyed (most likely because it has indestructible), its controller is dealt 2 damage."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Myr Mindservant
 {
     "name": "Myr Mindservant",
@@ -3135,6 +3265,50 @@
     ]
 }
 
+// Slith Predator
+{
+    "name": "Slith Predator",
+    "manaCost": "{G}{G}",
+    "typeLine": "Creature — Slith",
+    "oracleText": "Trample\nWhenever this creature deals combat damage to a player, put a +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "UNCOMMON",
+        "artist": "Justin Sweet",
+        "flavorText": "Born amid the molten metal of the Great Furnace, the slith have more than adapted to the perils of a metal world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14bae45c-eaa8-4c6d-8042-df5cf26e294f.jpg?1783944532"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Soldier Replica
 {
     "name": "Soldier Replica",
@@ -3975,6 +4149,36 @@
     "colorIdentityOverride": []
 }
 
+// Tel-Jilad Chosen
+{
+    "name": "Tel-Jilad Chosen",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "Protection from artifacts",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.CardType",
+                "cardType": "Artifact"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Matthew D. Wilson",
+        "flavorText": "\"It is my honor to keep safe Tel-Jilad's secrets, not to know them.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eefea84f-d657-491d-b60d-63e6a61e9eb2.jpg?1783944532"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Tel-Jilad Exile
 {
     "name": "Tel-Jilad Exile",
@@ -4592,6 +4796,77 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Viridian Longbow
+{
+    "name": "Viridian Longbow",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has \"{T}: This creature deals 1 damage to any target.\"\nEquip {3}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "damageSource": "Self"
+                    },
+                    "targetRequirements": [
+                        "AnyTarget"
+                    ]
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "270",
+        "artist": "Jeremy Jarvis",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/be892d73-d1f4-4c36-b674-01ae21ff1484.jpg?1783944497"
+    },
+    "colorIdentityOverride": []
 }
 
 // Viridian Shaman

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElectrostaticBoltScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElectrostaticBoltScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Electrostatic Bolt — {R} Instant (Mirrodin #89)
+ *
+ * "Electrostatic Bolt deals 2 damage to target creature. If it's an artifact creature,
+ *  Electrostatic Bolt deals 4 damage to it instead."
+ *
+ * Both branches are pinned with 3/3–4/4 bodies so the two amounts are actually distinguishable:
+ * a 4/4 nonartifact must survive (proving 2, not 4) and a 3/3 artifact creature must die
+ * (proving 4, not 2).
+ */
+class ElectrostaticBoltScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Electrostatic Bolt") {
+
+            test("deals 2 to a nonartifact creature") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Electrostatic Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Fangren Hunter") // 4/4, nonartifact
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(1, "Mountain") }
+                repeat(3) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val hunter = game.findPermanent("Fangren Hunter")!!
+                val cast = game.castSpell(1, "Electrostatic Bolt", hunter)
+                withClue("Casting Electrostatic Bolt should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // 4 damage would kill a 4/4; surviving proves the 2-damage branch was taken.
+                withClue("Fangren Hunter (4/4) should survive 2 damage") {
+                    game.isOnBattlefield("Fangren Hunter") shouldBe true
+                }
+            }
+
+            test("deals 4 to an artifact creature instead") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Electrostatic Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Titanium Golem") // 3/3 artifact creature
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(1, "Mountain") }
+                repeat(3) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val golem = game.findPermanent("Titanium Golem")!!
+                val cast = game.castSpell(1, "Electrostatic Bolt", golem)
+                withClue("Casting Electrostatic Bolt should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                // 2 damage would leave a 3/3 alive; dying proves the 4-damage branch was taken.
+                withClue("Titanium Golem (3/3 artifact) should die to 4 damage") {
+                    game.isOnBattlefield("Titanium Golem") shouldBe false
+                    game.isInGraveyard(2, "Titanium Golem") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenRainScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenRainScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Molten Rain — {1}{R}{R} Sorcery (Mirrodin #101)
+ *
+ * "Destroy target land. If that land was nonbasic, Molten Rain deals 2 damage to the land's
+ *  controller."
+ *
+ * The land always dies; only the 2 damage is conditional. These tests pin both branches, since a
+ * conditional that silently picks the wrong side is invisible in the card snapshot.
+ */
+class MoltenRainScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Molten Rain") {
+
+            test("destroying a nonbasic land also deals 2 damage to its controller") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Molten Rain")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Great Furnace") // nonbasic artifact land
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(1, "Mountain") }
+                repeat(3) { builder = builder.withCardInLibrary(2, "Mountain") }
+                val game = builder.build()
+
+                val furnace = game.findPermanent("Great Furnace")!!
+                val cast = game.castSpell(1, "Molten Rain", furnace)
+                withClue("Casting Molten Rain should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Great Furnace should be destroyed") {
+                    game.isOnBattlefield("Great Furnace") shouldBe false
+                    game.isInGraveyard(2, "Great Furnace") shouldBe true
+                }
+                withClue("Nonbasic land: its controller takes 2") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+            }
+
+            test("destroying a basic land deals no damage") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Molten Rain")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withLandsOnBattlefield(2, "Forest", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(1, "Mountain") }
+                repeat(3) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val forest = game.findPermanent("Forest")!!
+                val cast = game.castSpell(1, "Molten Rain", forest)
+                withClue("Casting Molten Rain should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Forest should be destroyed") {
+                    game.isInGraveyard(2, "Forest") shouldBe true
+                }
+                withClue("Basic land: no damage") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TelJiladChosenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TelJiladChosenScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.TelJiladChosen
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tel-Jilad Chosen — {1}{G} Creature — Elf Warrior 2/1 (Mirrodin #132)
+ *
+ * "Protection from artifacts"
+ *
+ * Modelled as `KeywordAbility.Protection(ProtectionScope.CardType("Artifact"))`, projected as the
+ * `PROTECTION_FROM_CARDTYPE_ARTIFACT` keyword. "Artifact" is a new instantiation of the card-type
+ * protection scope, so this test proves the DEBT legs the engine actually enforces for it —
+ * **B**locking and **D**amage — rather than trusting the generic wiring.
+ */
+class TelJiladChosenScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TelJiladChosen)
+        return driver
+    }
+
+    test("the protection keyword is projected onto the permanent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val p1 = driver.activePlayer!!
+
+        val chosen = driver.putCreatureOnBattlefield(p1, "Tel-Jilad Chosen")
+
+        projector.project(driver.state)
+            .hasKeyword(chosen, "PROTECTION_FROM_CARDTYPE_ARTIFACT") shouldBe true
+        projector.getProjectedPower(driver.state, chosen) shouldBe 2
+        projector.getProjectedToughness(driver.state, chosen) shouldBe 1
+    }
+
+    test("an artifact creature can't block it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val chosen = driver.putCreatureOnBattlefield(attacker, "Tel-Jilad Chosen") // 2/1
+        val golem = driver.putCreatureOnBattlefield(defender, "Artifact Creature") // 2/2 artifact
+        driver.removeSummoningSickness(chosen)
+        driver.removeSummoningSickness(golem)
+
+        val turn = driver.state.turnNumber
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.state.turnNumber shouldBe turn // didn't sail past this turn's combat
+        driver.declareAttackers(attacker, listOf(chosen), defender).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // The artifact Golem is not a legal blocker for a creature with protection from artifacts.
+        driver.declareBlockers(defender, mapOf(golem to listOf(chosen))).isSuccess shouldBe false
+    }
+
+    test("a nonartifact creature can still block it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val chosen = driver.putCreatureOnBattlefield(attacker, "Tel-Jilad Chosen") // 2/1
+        val courser = driver.putCreatureOnBattlefield(defender, "Centaur Courser") // 3/3 nonartifact
+        driver.removeSummoningSickness(chosen)
+        driver.removeSummoningSickness(courser)
+
+        val turn = driver.state.turnNumber
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.state.turnNumber shouldBe turn
+        driver.declareAttackers(attacker, listOf(chosen), defender).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        driver.declareBlockers(defender, mapOf(courser to listOf(chosen))).isSuccess shouldBe true
+    }
+
+    test("combat damage from an artifact creature is prevented") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        // The *active* player is the one attacking with the artifact creature, so the very next
+        // declare-attackers step is theirs — no risk of sailing into a later turn.
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val golem = driver.putCreatureOnBattlefield(attacker, "Artifact Creature") // 2/2 artifact
+        val chosen = driver.putCreatureOnBattlefield(defender, "Tel-Jilad Chosen") // 2/1
+        driver.removeSummoningSickness(golem)
+        driver.removeSummoningSickness(chosen)
+
+        val turn = driver.state.turnNumber
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.state.turnNumber shouldBe turn
+        driver.declareAttackers(attacker, listOf(golem), defender).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(defender, mapOf(chosen to listOf(golem))).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.END_COMBAT)
+
+        // The Golem's 2 damage would be lethal to a 2/1, but protection prevents all of it.
+        // The Chosen's own 2 damage is unaffected and kills the 2/2 Golem.
+        driver.findPermanent(defender, "Tel-Jilad Chosen") shouldNotBe null
+        driver.findPermanent(attacker, "Artifact Creature") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ViridianLongbowScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ViridianLongbowScenarioTest.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.ViridianLongbow
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Viridian Longbow — {1} Artifact — Equipment (Mirrodin #270)
+ *
+ * "Equipped creature has "{T}: This creature deals 1 damage to any target."
+ *  Equip {3}"
+ *
+ * The whole card is a [GrantActivatedAbility] static, so what needs proving is that the granted
+ * ability behaves as if printed on the *host* (CR 113.7):
+ *  - the `{T}` cost taps the equipped creature, not the Longbow;
+ *  - the equipped creature is the source of the damage (the deathtouch combo);
+ *  - the ability goes away when the Longbow is no longer attached.
+ */
+class ViridianLongbowScenarioTest : FunSpec({
+
+    // Equip {3} is the Longbow's only printed activated ability.
+    fun equipAbilityId() = ViridianLongbow.activatedAbilities.single().id
+
+    // The granted pinger lives inside the GrantActivatedAbility static.
+    fun grantedAbilityId() =
+        ViridianLongbow.staticAbilities.filterIsInstance<GrantActivatedAbility>().single().ability.id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ViridianLongbow)
+        return driver
+    }
+
+    /** Puts the Longbow and [creatureName] on p1's battlefield and equips them. */
+    fun GameTestDriver.equipTo(p1: EntityId, creatureName: String): Pair<EntityId, EntityId> {
+        val longbow = putPermanentOnBattlefield(p1, "Viridian Longbow")
+        val creature = putCreatureOnBattlefield(p1, creatureName)
+        // The granted ability costs {T}, so the host must be able to tap (CR 302.6).
+        removeSummoningSickness(creature)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        giveColorlessMana(p1, 3)
+        submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = longbow,
+                abilityId = equipAbilityId(),
+                targets = listOf(ChosenTarget.Permanent(creature))
+            )
+        ).isSuccess shouldBe true
+        bothPass()
+
+        state.getEntity(longbow)?.get<AttachedToComponent>()?.targetId shouldBe creature
+        return longbow to creature
+    }
+
+    test("granted {T} ability pings a creature and taps the host, not the Equipment") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+
+        val (longbow, courser) = driver.equipTo(p1, "Centaur Courser") // 3/3
+        val lions = driver.putCreatureOnBattlefield(opponent, "Savannah Lions") // 1/1
+
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = courser,
+                abilityId = grantedAbilityId(),
+                targets = listOf(ChosenTarget.Permanent(lions))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // 1 damage is lethal to a 1/1, so the damage demonstrably landed.
+        driver.findPermanent(opponent, "Savannah Lions") shouldBe null
+
+        // The {T} tapped the equipped creature (Self = host), and left the Longbow untapped.
+        driver.state.getEntity(courser)?.get<TappedComponent>() shouldNotBe null
+        driver.state.getEntity(longbow)?.get<TappedComponent>() shouldBe null
+    }
+
+    test("granted {T} ability can shoot a player") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+
+        val (_, courser) = driver.equipTo(p1, "Centaur Courser")
+
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = courser,
+                abilityId = grantedAbilityId(),
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getLifeTotal(opponent) shouldBe 19
+    }
+
+    test("the equipped creature is the damage source, so its deathtouch makes 1 damage lethal") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+
+        val (_, rat) = driver.equipTo(p1, "Deathtouch Rat") // 1/1 deathtouch
+        val courser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser") // 3/3
+
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = rat,
+                abilityId = grantedAbilityId(),
+                targets = listOf(ChosenTarget.Permanent(courser))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // If the Longbow were the source the 3/3 would survive 1 damage. It doesn't:
+        // the Rat is the source, and any nonzero damage from a deathtouch source is lethal.
+        driver.findPermanent(opponent, "Centaur Courser") shouldBe null
+    }
+
+    test("unequipping removes the granted ability") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+
+        val (longbow, courser) = driver.equipTo(p1, "Centaur Courser")
+
+        // Longbow leaves the battlefield; the grant goes with it.
+        driver.moveToGraveyard(longbow)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = courser,
+                abilityId = grantedAbilityId(),
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        ).isSuccess shouldBe false
+        driver.getLifeTotal(opponent) shouldBe 20
+    }
+})


### PR DESCRIPTION
Five more Mirrodin commons/uncommons, taking MRD from 112/291 to 117/291. All five have Mirrodin as
their earliest real printing, so each canonical `CardDefinition` lands in `definitions/mrd/cards/`
(confirmed with `just check-card-printing` for all five).

No new SDK vocabulary — every card composes existing primitives.

| Card | Shape |
|---|---|
| **Molten Rain** `{1}{R}{R}` | The Choking Sands shape: `ConditionalEffect` on a nonbasic `CardPredicate` deals the 2 **first**, then `Move(byDestruction = true)`. Ordering is load-bearing — it keeps the target's controller readable and makes an indestructible land still cost its controller 2 life, which is exactly what the 2021-03-19 ruling says (recorded on the card). |
| **Slith Predator** `{G}{G}` | Trample plus the Slith growth trigger — the same `Triggers.DealsCombatDamageToPlayer` + `AddCounters(PLUS_ONE_PLUS_ONE, Self)` pair already shipped on Slith Firewalker. |
| **Tel-Jilad Chosen** `{1}{G}` | `Protection(ProtectionScope.CardType("Artifact"))`. First use of `"Artifact"` in that scope; projects as `PROTECTION_FROM_CARDTYPE_ARTIFACT` and rides the same generic wiring as Emrakul's protection from instants. |
| **Electrostatic Bolt** `{R}` | One damage event whose amount is a `DynamicAmount.Conditional` (the Bring Low shape) rather than two branching damage effects — "instead" replaces the amount, not the event. |
| **Viridian Longbow** `{1}` | `GrantActivatedAbility` handing the host a `{T}` pinger. `EffectTarget.Self` inside a granted ability resolves to the equipped creature (CR 113.7), so the `{T}` taps the creature and the creature — not the Longbow — is the damage source. |

## Tests

Four scenario tests, one file per card, covering the behaviour a snapshot can't prove:

- `MoltenRainScenarioTest` — nonbasic branch (land destroyed **and** controller to 18) and basic branch (destroyed, life untouched).
- `ElectrostaticBoltScenarioTest` — a 4/4 nonartifact survives (proving 2, not 4) and a 3/3 artifact creature dies (proving 4, not 2).
- `TelJiladChosenScenarioTest` — the keyword is projected; an artifact creature can't block it; a nonartifact creature still can; an attacking artifact creature's lethal combat damage is prevented while the Chosen's own damage still kills it.
- `ViridianLongbowScenarioTest` — the ping lands, the **host** ends up tapped and the Longbow doesn't, it can shoot a player, a deathtouch host makes its 1 damage lethal to a 3/3 (proving the source), and the ability is gone once the Longbow leaves.

Slith Predator has no test file: it's the already-shipped Slith Firewalker shape, so the snapshot and lint nets cover it.

## Verification

- `just build` — green (full `check` across mtg-sets, rules-engine, game-server).
- `just rebless-cards` — only the five new cards appear in `snapshots/cards/MRD.json`; the diff is pure insertion.
- All five `image_uris.normal` HEAD-checked as HTTP 200.
- Rulings pulled from Scryfall: only Molten Rain has one, and it's recorded.

## One thing worth flagging

The client renders protection icons from `ClientDTO.protections: List<Color>`, so **card-type** protection has no keyword glyph — Tel-Jilad Chosen shows "Protection from artifacts" in its oracle text but gets no shield icon. That's a pre-existing gap shared with Emrakul, the Promised End (protection from instants), not something this card introduces. Adding a card-type protection icon path is `add-feature` scope, so I left it alone rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
