### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/DrossScorpion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/DrossScorpion.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Dross Scorpion — Mirrodin #164
+ * {4} · Artifact Creature — Scorpion · 3/1
+ *
+ * Whenever this creature or another artifact creature dies, you may untap target artifact.
+ *
+ * "This creature or another artifact creature" is [TriggerBinding.ANY] over an artifact-creature
+ * filter — ANY already covers the source itself, so no separate self-trigger is needed. Any
+ * controller's artifact creature counts; the oracle doesn't restrict it to yours.
+ *
+ * The Scorpion's own death fires this, which is the card's whole point in an untap-for-value deck:
+ * the trigger is put on the stack from the graveyard as a leaves-the-battlefield trigger, so it
+ * still resolves after the body is gone. The target is chosen as the trigger goes on the stack; the
+ * "may" is a resolution-time decline ([MayEffect]), so declining still uses up the trigger.
+ */
+val DrossScorpion = card("Dross Scorpion") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scorpion"
+    power = 3
+    toughness = 1
+    oracleText = "Whenever this creature or another artifact creature dies, you may untap target artifact."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.ArtifactCreature,
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        val artifact = target("target artifact", TargetPermanent(filter = TargetFilter.Artifact))
+        effect = MayEffect(Effects.Untap(artifact))
+        description = "Whenever this creature or another artifact creature dies, you may untap target artifact."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Jim Nelson"
+        flavorText = "They skitter out of the mists to consume fresh kill before Mephidross has a " +
+            "chance to corrode it away."
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27c5381c-2e79-41fa-b1d7-2cf0c6dc1808.jpg?1783944523"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LeoninDenGuard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LeoninDenGuard.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Leonin Den-Guard — Mirrodin #9
+ * {1}{W} · Creature — Cat Soldier · 1/3
+ *
+ * As long as this creature is equipped, it gets +1/+1 and has vigilance.
+ *
+ * Two statics sharing one condition rather than one compound ability, because the halves land in
+ * different Rule 613 layers: [ModifyStats] applies in layer 7c and [GrantKeyword] in layer 6, and
+ * splitting them lets each sort into its own layer without a bespoke multi-layer type.
+ *
+ * The gate is [Conditions.SourceMatches] over `equipped()`, evaluated during static-ability
+ * projection — so attaching or removing Equipment flips both halves immediately, with no trigger
+ * and no timestamp of its own.
+ */
+val LeoninDenGuard = card("Leonin Den-Guard") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Soldier"
+    power = 1
+    toughness = 3
+    oracleText = "As long as this creature is equipped, it gets +1/+1 and has vigilance."
+
+    val whileEquipped = Conditions.SourceMatches(GameObjectFilter.Any.equipped())
+
+    staticAbility {
+        condition = whileEquipped
+        ability = ModifyStats(powerBonus = 1, toughnessBonus = 1, filter = GroupFilter.source())
+    }
+    staticAbility {
+        condition = whileEquipped
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter.source())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Todd Lockwood"
+        flavorText = "No one under the four suns can elude the watchful eye of the den-guard."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9f30b7a-75bb-44e6-b1a2-726df1b5b1f3.jpg?1783944561"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SomberHoverguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SomberHoverguard.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Somber Hoverguard — Mirrodin #51
+ * {5}{U} · Creature — Drone · 3/2
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Flying
+ *
+ * The blue affinity common. Unlike [Frogmite], only the {5} is shaveable — affinity reduces
+ * generic mana only, so the {U} always has to be paid however many artifacts are out, and the
+ * floor is one blue mana rather than free.
+ *
+ * Affinity is a cost reduction rather than an alternative cost: the mana value stays 6 in every
+ * zone no matter how cheaply it was cast.
+ */
+val SomberHoverguard = card("Somber Hoverguard") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Drone"
+    power = 3
+    toughness = 2
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Flying"
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Adam Rex"
+        flavorText = "The vedalken interrogate all intruders—once the hoverguards are done with them."
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83a46ac2-d96d-4d5a-94fc-a9fc83a9ea1d.jpg?1783944550"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WeldingJar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WeldingJar.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Welding Jar — Mirrodin #274
+ * {0} · Artifact
+ *
+ * Sacrifice this artifact: Regenerate target artifact.
+ *
+ * Regeneration on an *artifact*, not a creature: [RegenerateEffect] banks a destruction-replacement
+ * shield on whatever permanent it names, and the engine's destroy chokepoint consults that shield
+ * for any permanent type. The shield's "tap it, remove it from combat, heal its damage" (CR 701.15a)
+ * simply has less to do on a noncreature artifact — it still gets tapped.
+ *
+ * Targets are chosen before costs are paid (CR 601.2c before 601.2h), so Welding Jar may legally
+ * target *itself* — and then sacrifices itself to pay, leaving the shield on an object that is
+ * already gone. Legal, and useless; players choose another artifact.
+ */
+val WeldingJar = card("Welding Jar") {
+    manaCost = "{0}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Sacrifice this artifact: Regenerate target artifact."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target("target artifact", TargetPermanent(filter = TargetFilter.Artifact))
+        effect = RegenerateEffect(t)
+        description = "Sacrifice this artifact: Regenerate target artifact."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "274"
+        artist = "Mark Brill"
+        flavorText = "The wires crawl over broken metal and heat themselves to melting, filling " +
+            "cracks quickly and efficiently."
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42b7b73b-4800-4fc7-9a5c-93e00ea88498.jpg?1783944496"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WizardReplica.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WizardReplica.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wizard Replica — Mirrodin #275
+ * {3} · Artifact Creature — Wizard · 1/3
+ *
+ * Flying
+ * {U}, Sacrifice this creature: Counter target spell unless its controller pays {2}.
+ *
+ * The blue member of the Replica cycle ([ElfReplica], [GoblinReplica]): a colourless artifact body
+ * whose one-shot ability is gated behind a coloured pip plus sacrificing itself.
+ *
+ * The sacrifice is part of the *cost*, so it happens on activation — the Replica is already in the
+ * graveyard while the counter sits on the stack, and countering the ability's own target does not
+ * bring it back.
+ */
+val WizardReplica = card("Wizard Replica") {
+    manaCost = "{3}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Wizard"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{U}, Sacrifice this creature: Counter target spell unless its controller pays {2}."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.SacrificeSelf)
+        target = Targets.Spell
+        effect = Effects.CounterUnlessPays("{2}")
+        description = "{U}, Sacrifice this creature: Counter target spell unless its controller pays {2}."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "275"
+        artist = "Carl Critchlow"
+        flavorText = "It responds with unnatural precision."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5ab68b3-864e-4fe3-a5c5-faa33b45da0f.jpg?1783944496"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -586,6 +586,59 @@
     ]
 }
 
+// Dross Scorpion
+{
+    "name": "Dross Scorpion",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Scorpion",
+    "oracleText": "Whenever this creature or another artifact creature dies, you may untap target artifact.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact creature",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact"
+                        },
+                        "tap": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact"
+                    },
+                    "id": "target artifact"
+                },
+                "descriptionOverride": "Whenever this creature or another artifact creature dies, you may untap target artifact."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Jim Nelson",
+        "flavorText": "They skitter out of the mists to consume fresh kill before Mephidross has a chance to corrode it away.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27c5381c-2e79-41fa-b1d7-2cf0c6dc1808.jpg?1783944523"
+    },
+    "colorIdentityOverride": []
+}
+
 // Electrostatic Bolt
 {
     "name": "Electrostatic Bolt",
@@ -1440,6 +1493,72 @@
         "imageUri": "https://cards.scryfall.io/normal/front/7/8/780199bc-dce4-4ed0-88fb-7d288f304e69.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Leonin Den-Guard
+{
+    "name": "Leonin Den-Guard",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Soldier",
+    "oracleText": "As long as this creature is equipped, it gets +1/+1 and has vigilance.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsEquipped"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsEquipped"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Todd Lockwood",
+        "flavorText": "No one under the four suns can elude the watchful eye of the den-guard.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9f30b7a-75bb-44e6-b1a2-726df1b5b1f3.jpg?1783944561"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Leonin Elder
@@ -3467,6 +3586,37 @@
     "colorIdentityOverride": []
 }
 
+// Somber Hoverguard
+{
+    "name": "Somber Hoverguard",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Drone",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Adam Rex",
+        "flavorText": "The vedalken interrogate all intruders—once the hoverguards are done with them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83a46ac2-d96d-4d5a-94fc-a9fc83a9ea1d.jpg?1783944550"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Spikeshot Goblin
 {
     "name": "Spikeshot Goblin",
@@ -5142,6 +5292,107 @@
         "artist": "Luca Zontini",
         "flavorText": "Created by the vedalken to guard Lumengrid, the drones' empty eyes look beyond the Quicksilver Sea.",
         "imageUri": "https://cards.scryfall.io/normal/front/5/2/52ac6290-1401-41c5-90a1-99acb344719e.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Welding Jar
+{
+    "name": "Welding Jar",
+    "manaCost": "{0}",
+    "typeLine": "Artifact",
+    "oracleText": "Sacrifice this artifact: Regenerate target artifact.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        },
+                        "id": "target artifact"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice this artifact: Regenerate target artifact."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "274",
+        "artist": "Mark Brill",
+        "flavorText": "The wires crawl over broken metal and heat themselves to melting, filling cracks quickly and efficiently.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42b7b73b-4800-4fc7-9a5c-93e00ea88498.jpg?1783944496"
+    },
+    "colorIdentityOverride": []
+}
+
+// Wizard Replica
+{
+    "name": "Wizard Replica",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Wizard",
+    "oracleText": "Flying\n{U}, Sacrifice this creature: Counter target spell unless its controller pays {2}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Counter",
+                    "condition": {
+                        "type": "CounterCondition.UnlessPaysMana",
+                        "cost": "{2}"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Stack"
+                        }
+                    }
+                ],
+                "descriptionOverride": "{U}, Sacrifice this creature: Counter target spell unless its controller pays {2}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "275",
+        "artist": "Carl Critchlow",
+        "flavorText": "It responds with unnatural precision.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5ab68b3-864e-4fe3-a5c5-faa33b45da0f.jpg?1783944496"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeldingJarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeldingJarScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.WeldingJar
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Welding Jar (MRD #274) — {0} Artifact, "Sacrifice this artifact: Regenerate target artifact."
+ *
+ * Regeneration on a permanent that isn't a creature is the part worth proving: the shield has to be
+ * consulted at the destroy chokepoint for any permanent type, and the CR 701.15a replacement still
+ * taps what it saves.
+ */
+class WeldingJarScenarioTest : ScenarioTestBase() {
+
+    private val regenerateAbility = WeldingJar.activatedAbilities.single().id
+
+    init {
+        context("Welding Jar") {
+
+            test("regenerates a targeted artifact out of a destroy effect, tapping it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Welding Jar")
+                    .withCardOnBattlefield(1, "Frogmite") // 2/2 Artifact Creature
+                    .withCardInHand(1, "Deconstruct")     // {2}{G}: Destroy target artifact
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val jar = game.findPermanent("Welding Jar")!!
+                val frogmite = game.findPermanent("Frogmite")!!
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = jar,
+                        abilityId = regenerateAbility,
+                        targets = listOf(ChosenTarget.Permanent(frogmite))
+                    )
+                )
+                withClue("activation should succeed: ${activation.error}") { activation.error shouldBe null }
+                game.resolveStack()
+
+                withClue("the Jar sacrificed itself to pay") { game.findPermanent("Welding Jar") shouldBe null }
+
+                game.castSpell(1, "Deconstruct", frogmite).error shouldBe null
+                game.resolveStack()
+
+                withClue("the shield replaces the destruction — Frogmite survives, tapped") {
+                    game.findPermanent("Frogmite") shouldNotBe null
+                    game.state.getEntity(frogmite)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("without the shield the same destroy effect kills the artifact") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Frogmite")
+                    .withCardInHand(1, "Deconstruct")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val frogmite = game.findPermanent("Frogmite")!!
+                game.castSpell(1, "Deconstruct", frogmite).error shouldBe null
+                game.resolveStack()
+
+                withClue("control case — nothing shields it") { game.findPermanent("Frogmite") shouldBe null }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five Mirrodin cards, all Mirrodin-original printings so each canonical `CardDefinition` belongs in `definitions/mrd/` — verified with `just check-card-printing`.

| Card | Cost | Text |
|---|---|---|
| Somber Hoverguard | `{5}{U}` 3/2 | Affinity for artifacts · Flying |
| Welding Jar | `{0}` | Sacrifice this artifact: Regenerate target artifact |
| Wizard Replica | `{3}` 1/3 | Flying · `{U}`, Sacrifice: Counter target spell unless its controller pays `{2}` |
| Dross Scorpion | `{4}` 3/1 | Whenever this or another artifact creature dies, you may untap target artifact |
| Leonin Den-Guard | `{1}{W}` 1/3 | While equipped, gets +1/+1 and has vigilance |

## Rebased after #1730

This branch originally carried Electrostatic Bolt, Molten Rain and Tel-Jilad Chosen. #1730 landed those same three cards on main first, so on rebase I took main's versions wholesale and dropped mine — their implementations are equivalent (same `DynamicAmount.Conditional` shape for the Bolt; Molten Rain just orders the damage before the destroy). Nothing of theirs was reverted. Three fresh Mirrodin cards were added to keep this a handful.

Neurok Spy was considered as a replacement and rejected: "can't be blocked as long as defending player controls an artifact" needs a defender-aware evasion static the SDK doesn't have, and `ConditionalStaticAbility` conditions are evaluated during projection where no defender is bound. Approximating it as "an opponent controls an artifact" would be wrong in multiplayer, so it's left for an `add-feature` pass.

## Modelling notes

No new SDK vocabulary — everything composes existing primitives, so `docs/card-sdk-language-reference.md` is unchanged.

- **Welding Jar** — regeneration on a *noncreature* artifact. `RegenerateEffect` banks its shield on any permanent and the destroy chokepoint consults it regardless of type; CR 701.15a's "tap it" still applies. Targets are chosen before costs (CR 601.2c/601.2h), so it may legally target itself and then sacrifice itself — legal and useless.
- **Dross Scorpion** — "this creature or another artifact creature" is `TriggerBinding.ANY` over an artifact-creature filter; ANY already covers the source, so no separate self-trigger. Any controller's artifact creature counts, per the oracle.
- **Leonin Den-Guard** — two statics sharing one `equipped()` condition rather than one compound ability, because `ModifyStats` lands in layer 7c and `GrantKeyword` in layer 6.
- **Wizard Replica** — the blue member of the Replica cycle, matching Elf/Goblin Replica's `SacrificeSelf` shape.
- **Somber Hoverguard** — stock affinity; only the `{5}` is shaveable, so the floor is one blue mana rather than free.

## Verification

- `just build` green on the two-card state before the rebase, and again after the three replacement cards compiled — at which point the only failure was the expected `CardDefinitionSnapshotTest` MRD diff, since re-blessed. The MRD snapshot diff is 251 added lines and nothing else moved.
- `WeldingJarScenarioTest` passing: the shield saves a Frogmite from Deconstruct and taps it, plus an unshielded control case.
- All five `imageUri`s verified HTTP 200.
- The other four cards are keyword/static/trigger compositions over proven primitives, covered by the snapshot, card-lint and facade-boundary nets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
