### PR TITLE
Fix Intangible Virtue buffing nontoken creatures

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/IntangibleVirtue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/IntangibleVirtue.kt
@@ -28,11 +28,11 @@ val IntangibleVirtue = card("Intangible Virtue") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+            filter = GroupFilter(GameObjectFilter.Creature.token().youControl())
         )
     }
     staticAbility {
-        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter(GameObjectFilter.Creature.youControl()))
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter(GameObjectFilter.Creature.token().youControl()))
     }
     metadata {
         rarity = Rarity.UNCOMMON

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -2785,14 +2785,14 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature ctrl:you"
+                    "baseFilter": "creature token ctrl:you"
                 }
             },
             {
                 "type": "GrantKeyword",
                 "keyword": "VIGILANCE",
                 "filter": {
-                    "baseFilter": "creature ctrl:you"
+                    "baseFilter": "creature token ctrl:you"
                 }
             }
         ]

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -3232,8 +3232,8 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     // OneOrMoreOpponentPermanentsEnter for opponents), so the rendered filter must NOT re-encode the
     // controller clause. Only the exact "token" subject renders today — the bare GameObjectFilter.Token
     // (Spiritcall Enthusiast's "tokens you control", Kambal's "tokens your opponents control"). Any other
-    // subject filter declines -> SCAFFOLD rather than widening (gameObjectFilterDsl has no positive
-    // IsToken rendering, so it would silently drop the token restriction).
+    // subject filter declines -> SCAFFOLD rather than widening (gameObjectFilterDsl composes `.token()`
+    // onto a *cardtype* base, so a bare `IsToken` subject has no base to hang it on there).
     if (jsonContains(trig, "_Trigger", "WhenAnyNumberOfPermanentsEnterTheBattlefield")) {
         val subject = (trig["args"] as? JsonArray)?.firstOrNull() ?: trig["args"]
         val opponentControlled = jsonContains(subject, "_Players", "Opponent")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/TargetRecovery.kt
@@ -93,6 +93,15 @@ internal object FilterPredicates {
     fun nontoken(node: JsonElement?): Link? = if (node.hasTag("IsNonToken")) Link("nontoken") else null
 
     /**
+     * `.token()` for a positive `IsToken` clause ("creature tokens you control"), else null. The
+     * mirror of [nontoken] — without it an `And(IsCardtype Creature, IsToken, ControlledByAPlayer)`
+     * subject rendered as a bare `Creature.youControl()`, silently WIDENING the anthem to every
+     * creature you control (Intangible Virtue). [hasTag] matches the discriminator value exactly, so
+     * this never fires on the `IsNonToken` sibling.
+     */
+    fun token(node: JsonElement?): Link? = if (node.hasTag("IsToken")) Link("token") else null
+
+    /**
      * `.powerOrToughnessAtLeast(N)` for the `Or[PowerIs >= N, ToughnessIs >= N]` shape ("power or
      * toughness 4 or greater"), else null. When this fires, the caller must NOT also append the
      * standalone [powerAtLeast] — the `PowerIs` clause it would match lives inside this Or, and emitting
@@ -367,8 +376,8 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
         // widen the target. Decline so the card scaffolds rather than emit a too-broad filter.
         val statePredicates = listOf(
             "IsAttacking", "IsBlocking", "IsTapped", "IsUntapped", "PowerIs", "ToughnessIs", "ManaValueIs",
-            "IsColor", "IsNonColor", "HasAbility", "DoesntHaveAbility", "IsNonToken", "HasACounterOfType",
-            "WasDealtDamageThisTurn",
+            "IsColor", "IsNonColor", "HasAbility", "DoesntHaveAbility", "IsNonToken", "IsToken",
+            "HasACounterOfType", "WasDealtDamageThisTurn",
         )
         if (statePredicates.any { it in blob }) return null
         return Call("TargetFilter", listOf(arg(Infix("or", subs.map { Lit("GameObjectFilter.Creature").dot("withSubtype", arg(subtypeArg(it))) }))))
@@ -392,6 +401,9 @@ internal fun EmitCtx.creatureFilterExpr(filterNode: JsonElement?): Dsl? {
     FilterPredicates.tapped(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.attacking(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.nontoken(filterNode)?.let { node = node.dot(it) }
+    // "target token you control" (IsToken) — the positive mirror of nontoken; dropping it would widen
+    // the target to any creature.
+    FilterPredicates.token(filterNode)?.let { node = node.dot(it) }
     // "power or toughness N or greater" takes the whole Or; suppress the standalone power bounds it
     // would otherwise also match (the PowerIs clause inside the Or) — see [powerOrToughnessAtLeast].
     val powerOrToughness = FilterPredicates.powerOrToughnessAtLeast(filterNode)
@@ -1207,6 +1219,9 @@ internal fun EmitCtx.gameObjectFilterExpr(filterNode: JsonElement?): Dsl? {
     // GameObjectFilter.Creature.blocking(), the same helper TargetFilter.BlockingCreature uses).
     FilterPredicates.blocking(filterNode)?.let { node = node.dot(it) }
     FilterPredicates.nontoken(filterNode)?.let { node = node.dot(it) }
+    // "creature TOKENS you control get +1/+1" (IsToken) — Intangible Virtue. Dropping this widened the
+    // anthem to every creature you control, so it's a real predicate here, not decoration.
+    FilterPredicates.token(filterNode)?.let { node = node.dot(it) }
     // "a face-down permanent you control" (IsFaceDown) — Cryptid Inspector's "whenever a face-down
     // permanent you control enters". Backed by GameObjectFilter.faceDown(); dropping it would widen
     // the trigger to every permanent entering, so it's a real predicate here.

--- a/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/inr.emitted.golden.txt
@@ -5392,11 +5392,11 @@ val IntangibleVirtue = card("Intangible Virtue") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+            filter = GroupFilter(GameObjectFilter.Creature.token().youControl())
         )
     }
     staticAbility {
-        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter(GameObjectFilter.Creature.youControl()))
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter(GameObjectFilter.Creature.token().youControl()))
     }
     metadata {
         rarity = Rarity.UNCOMMON

--- a/mtgish-tooling/src/test/resources/fixtures/isd.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/isd.emitted.golden.txt
@@ -4276,11 +4276,11 @@ val IntangibleVirtue = card("Intangible Virtue") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+            filter = GroupFilter(GameObjectFilter.Creature.token().youControl())
         )
     }
     staticAbility {
-        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter(GameObjectFilter.Creature.youControl()))
+        ability = GrantKeyword(Keyword.VIGILANCE, GroupFilter(GameObjectFilter.Creature.token().youControl()))
     }
     metadata {
         rarity = Rarity.UNCOMMON

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntangibleVirtueScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntangibleVirtueScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/** Scenario tests for Intangible Virtue. */
+class IntangibleVirtueScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Intangible Virtue — the anthem hits creature tokens only") {
+            test("Spirit tokens get +1/+1 and vigilance while a nontoken creature gets neither") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Intangible Virtue")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Midnight Haunting")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val haunting = game.findCardsInHand(1, "Midnight Haunting").first()
+                game.execute(CastSpell(game.player1Id, haunting, emptyList(), faceIndex = 0))
+                    .isSuccess shouldBe true
+                game.resolveStack()
+
+                val spirit = game.findPermanent("Spirit Token")!!
+                withClue("a 1/1 creature token becomes 2/2") {
+                    game.state.projectedState.getPower(spirit) shouldBe 2
+                    game.state.projectedState.getToughness(spirit) shouldBe 2
+                }
+                withClue("…and has vigilance") {
+                    game.state.projectedState.hasKeyword(spirit, Keyword.VIGILANCE) shouldBe true
+                }
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("a nontoken creature you control keeps its printed P/T") {
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+                withClue("a nontoken creature you control does not gain vigilance") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+
+            test("a creature token an opponent controls is unaffected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Intangible Virtue")
+                    .withCardInHand(2, "Midnight Haunting")
+                    .withLandsOnBattlefield(2, "Plains", 3)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val haunting = game.findCardsInHand(2, "Midnight Haunting").first()
+                game.execute(CastSpell(game.player2Id, haunting, emptyList(), faceIndex = 0))
+                    .isSuccess shouldBe true
+                game.resolveStack()
+
+                val spirit = game.findPermanent("Spirit Token")!!
+                withClue("the anthem is scoped to tokens *you* control") {
+                    game.state.projectedState.getPower(spirit) shouldBe 1
+                    game.state.projectedState.getToughness(spirit) shouldBe 1
+                    game.state.projectedState.hasKeyword(spirit, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Intangible Virtue read *"Creature tokens you control get +1/+1 and have vigilance"* but was implemented as:

```kotlin
filter = GroupFilter(GameObjectFilter.Creature.youControl())
```

— so it pumped **every** creature its controller had, not just tokens.

## Root cause is the emitter, not the card

The card is a mtgish-tooling render, and the oracle IR *does* carry the restriction:

```
And[ IsCardtype "Creature", IsToken, ControlledByAPlayer(You) ]
```

`FilterPredicates` had a `.nontoken()` helper for `IsNonToken` but **no positive mirror for `IsToken`**, so the clause was silently dropped and the anthem was widened. Per `mtgish-tooling/AGENTS.md` ("fix the emitter, not the generated card"), the fix goes in both places.

## Changes

- **`TargetRecovery.kt`** — add `FilterPredicates.token()` and wire it into `gameObjectFilterExpr` (group/anthem surface) and `creatureFilterExpr` (TargetFilter surface). `hasTag` matches the discriminator value exactly, so it never fires on the `IsNonToken` sibling.
- **`TargetRecovery.kt`** — add `IsToken` to the multi-creature-subtype `statePredicates` decline list, so the restriction can't be dropped on that path either.
- **`IntangibleVirtue.kt`** — `GameObjectFilter.Creature.token().youControl()` on both statics, matching what the fixed emitter now renders.
- **`CardStructure.kt`** — refresh a now-stale comment that asserted the filter renderer had no positive `IsToken` rendering.
- Re-blessed `snapshots/cards/ISD.json` and the INR/ISD emitter goldens. **Only Intangible Virtue moved** in each — the diff is 2 lines per file.

## Test

New `IntangibleVirtueScenarioTest` (rules-engine):

1. With the Virtue out, `Midnight Haunting`'s Spirit tokens become **2/2 with vigilance**, while a nontoken `Grizzly Bears` stays **2/2 without vigilance** — this is the assertion that fails on the old filter.
2. A Spirit token an **opponent** controls is untouched (1/1, no vigilance), pinning the `youControl` half.

## Verification

- `just test` — BUILD SUCCESSFUL, 0 failures
- `EmitterGoldenTest` — 11/11 sets pass after re-bless (`--rerun-tasks`)
- `CardDefinitionSnapshotTest` — all sets pass
- `just check-card-printing "Intangible Virtue"` — canonical still in ISD, CMR/NCC/INR reprint rows intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)