### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MoriokScavenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MoriokScavenger.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Moriok Scavenger — Mirrodin #68
+ * {3}{B} · Creature — Human Rogue · 2/3
+ *
+ * When this creature enters, you may return target artifact creature card from your graveyard
+ * to your hand.
+ *
+ * A [Gravedigger][com.wingedsheep.mtg.sets.definitions.por.cards.Gravedigger] narrowed to
+ * Mirrodin's own currency: the graveyard card must be an *artifact creature*, not just any
+ * creature, so a plain Myr-less board gets nothing back.
+ *
+ * The "you may" is `optional = true` on the trigger — the controller declines before the
+ * return, matching CR 603.1 (the choice is made on resolution, after the target is locked in
+ * at trigger time). The target itself is mandatory: the ability still needs a legal artifact
+ * creature card in the graveyard to go on the stack at all.
+ */
+val MoriokScavenger = card("Moriok Scavenger") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, you may return target artifact creature card " +
+        "from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val card = target(
+            "card",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.ArtifactCreature.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Move(target = card, destination = Zone.HAND)
+        description = "When this creature enters, you may return target artifact creature card " +
+            "from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Puddnhead"
+        flavorText = "Many go to Mephidross in search of lost riches. Most end up as part of the cache."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f27426b-3679-44e4-9249-f57b92baa3f3.jpg?1783944546"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NimShambler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NimShambler.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Nim Shambler — Mirrodin #72
+ * {2}{B}{B} · Creature — Zombie · 2/1
+ *
+ * This creature gets +1/+0 for each artifact you control.
+ * Sacrifice a creature: Regenerate this creature.
+ *
+ * The nim's power is a [GrantDynamicStatsEffect] scoped to the source itself
+ * ([GroupFilter.source]) — a Layer 7c bonus that recomputes continuously rather than a snapshot,
+ * so it grows and shrinks as artifacts enter and leave. Toughness is untouched: the Shambler
+ * stays a 1-toughness liability no matter how wide the artifact board gets.
+ *
+ * The regeneration cost is a bare sacrifice with no mana attached, so the Shambler can eat the
+ * rest of the board — including itself, which is a legal (if pointless) choice: sacrificing the
+ * Shambler to its own ability pays the cost, and the regeneration shield then has nothing to
+ * protect.
+ */
+val NimShambler = card("Nim Shambler") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 1
+    oracleText = "This creature gets +1/+0 for each artifact you control.\n" +
+        "Sacrifice a creature: Regenerate this creature."
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.Count(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Artifact
+            ),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Creature)
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "Sacrifice a creature: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "72"
+        artist = "Adam Rex"
+        flavorText = "Called \"the Dross\" by its inhabitants, Mephidross is home to the nim, " +
+            "Mirrodin's mindless, ravenous undead."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e59c09a0-a374-46c1-978f-ec7478dc7ab7.jpg?1783944546"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/OgreLeadfoot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/OgreLeadfoot.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ogre Leadfoot — Mirrodin #102
+ * {4}{R} · Creature — Ogre · 3/3
+ *
+ * Whenever this creature becomes blocked by an artifact creature, destroy that creature.
+ *
+ * Modelled with the *filtered* SELF-binding [Triggers.becomesBlocked] shape (the same one
+ * flanking is built on): the filter constrains the **blocker**, and the detector fires the
+ * ability once per matching blocker with `triggeringEntityId` set to that blocker. So a gang
+ * block by three artifact creatures destroys all three, one trigger each, and
+ * [EffectTarget.TriggeringEntity] resolves to the right one every time.
+ *
+ * The unfiltered [Triggers.BecomesBlocked] would be wrong here — it fires exactly once no matter
+ * how many creatures block — and [Triggers.BlocksOrBecomesBlockedBy] would over-trigger, since
+ * the printed text covers only the blocked direction, not the Leadfoot blocking something.
+ *
+ * "Destroy that creature" is a plain [Effects.Destroy] with no regeneration clause, so an
+ * artifact creature with a regeneration shield survives.
+ */
+val OgreLeadfoot = card("Ogre Leadfoot") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever this creature becomes blocked by an artifact creature, destroy that creature."
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(filter = GameObjectFilter.ArtifactCreature)
+        effect = Effects.Destroy(EffectTarget.TriggeringEntity)
+        description = "Whenever this creature becomes blocked by an artifact creature, destroy that creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Heather Hudson"
+        flavorText = "When the goblins need more scrap for the Great Furnace, they simply let " +
+            "the ogres loose and follow in their wake."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3c77744-3a86-46cf-9e0f-5a217a1c08b9.jpg?1783944539"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithBloodletter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithBloodletter.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slith Bloodletter — Mirrodin #77
+ * {B}{B} · Creature — Slith · 1/1
+ *
+ * Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+ * {1}{B}: Regenerate this creature.
+ *
+ * The black member of the Slith cycle (see [SlithFirewalker], [SlithPredator]). Same growth
+ * trigger as the rest — [Triggers.DealsCombatDamageToPlayer], so *combat* damage only, and the
+ * counter lands on the Slith itself ([EffectTarget.Self]) rather than a chosen creature.
+ *
+ * Black's rider is regeneration, which is what makes the compounding stick: the Bloodletter can
+ * trade in combat and keep its accumulated counters, since a regeneration shield removes it from
+ * combat and taps it without ever moving it to the graveyard (CR 701.15). Counters live on the
+ * permanent, so they survive untouched.
+ */
+val SlithBloodletter = card("Slith Bloodletter") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Slith"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.\n" +
+        "{1}{B}: Regenerate this creature."
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "{1}{B}: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "77"
+        artist = "Justin Sweet"
+        flavorText = "Goblins fear the slith, believing they are children banished from the womb " +
+            "of the Steel Mother, deep within Kuldotha."
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/22a04ccb-cb57-4548-81db-e1b77b09f5da.jpg?1783944545"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TelJiladArchers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TelJiladArchers.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Tel-Jilad Archers — Mirrodin #131
+ * {4}{G} · Creature — Elf Archer · 2/4
+ *
+ * Protection from artifacts; reach
+ *
+ * The Tangle's anti-air battery, and the big brother of [TelJiladChosen]. Both halves are printed
+ * keywords: reach via [Keyword.REACH], and protection from artifacts via the card-type protection
+ * scope ([ProtectionScope.CardType]), projected as `PROTECTION_FROM_CARDTYPE_ARTIFACT`. Targeting,
+ * damage prevention, and block evasion all read that projected keyword, so an artifact creature
+ * can't block it, an artifact source can't damage it, and an artifact's ability can't target it —
+ * no per-card wiring needed.
+ *
+ * Note the two keywords pull in opposite directions in combat: reach lets it block fliers, while
+ * protection from artifacts means an artifact flier it blocks deals it no damage at all.
+ */
+val TelJiladArchers = card("Tel-Jilad Archers") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Archer"
+    power = 2
+    toughness = 4
+    oracleText = "Protection from artifacts; reach (This creature can block creatures with flying.)"
+
+    keywords(Keyword.REACH)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.CardType("Artifact")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Marcelo Vignali"
+        flavorText = "They are extensions of the Tangle, stretching its vines into the furthest " +
+            "reaches of the sky."
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a1fde33-e86a-4146-9c90-4616a5fc0868.jpg?1783944531"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -2279,6 +2279,56 @@
     ]
 }
 
+// Moriok Scavenger
+{
+    "name": "Moriok Scavenger",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "When this creature enters, you may return target artifact creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "card"
+                    },
+                    "destination": "Hand"
+                },
+                "optional": true,
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "card"
+                },
+                "descriptionOverride": "When this creature enters, you may return target artifact creature card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Puddnhead",
+        "flavorText": "Many go to Mephidross in search of lost riches. Most end up as part of the cache.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f27426b-3679-44e4-9249-f57b92baa3f3.jpg?1783944546"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Myr Mindservant
 {
     "name": "Myr Mindservant",
@@ -2705,6 +2755,66 @@
     ]
 }
 
+// Nim Shambler
+{
+    "name": "Nim Shambler",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "This creature gets +1/+0 for each artifact you control.\nSacrifice a creature: Regenerate this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "Sacrifice a creature: Regenerate this creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact"
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Rex",
+        "flavorText": "Called \"the Dross\" by its inhabitants, Mephidross is home to the nim, Mirrodin's mindless, ravenous undead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e59c09a0-a374-46c1-978f-ec7478dc7ab7.jpg?1783944546"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Nim Shrieker
 {
     "name": "Nim Shrieker",
@@ -2746,6 +2856,45 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Ogre Leadfoot
+{
+    "name": "Ogre Leadfoot",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Ogre",
+    "oracleText": "Whenever this creature becomes blocked by an artifact creature, destroy that creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesBlockedEvent",
+                    "filter": "artifact creature"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "TriggeringEntity",
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "descriptionOverride": "Whenever this creature becomes blocked by an artifact creature, destroy that creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Heather Hudson",
+        "flavorText": "When the goblins need more scrap for the Great Furnace, they simply let the ogres loose and follow in their wake.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3c77744-3a86-46cf-9e0f-5a217a1c08b9.jpg?1783944539"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -3338,6 +3487,64 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/8/684a6e3f-909a-4ca0-a6aa-7354b9476df2.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Slith Bloodletter
+{
+    "name": "Slith Bloodletter",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Slith",
+    "oracleText": "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.\n{1}{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{1}{B}: Regenerate this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "UNCOMMON",
+        "artist": "Justin Sweet",
+        "flavorText": "Goblins fear the slith, believing they are children banished from the womb of the Steel Mother, deep within Kuldotha.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/22a04ccb-cb57-4548-81db-e1b77b09f5da.jpg?1783944545"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
 }
 
 // Slith Firewalker
@@ -4297,6 +4504,39 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/6/361a524c-17aa-43a0-8aea-1d26a9a1044c.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Tel-Jilad Archers
+{
+    "name": "Tel-Jilad Archers",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Elf Archer",
+    "oracleText": "Protection from artifacts; reach (This creature can block creatures with flying.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.CardType",
+                "cardType": "Artifact"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Marcelo Vignali",
+        "flavorText": "They are extensions of the Tangle, stretching its vines into the furthest reaches of the sky.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a1fde33-e86a-4146-9c90-4616a5fc0868.jpg?1783944531"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Tel-Jilad Chosen


### PR DESCRIPTION
Five more Mirrodin commons/uncommons, all Mirrodin-original printings (canonical `CardDefinition` lives here — verified with `just check-card-printing` for each). Every card composes existing SDK vocabulary; no engine or SDK changes.

| Card | Cost | P/T | Text |
|---|---|---|---|
| Tel-Jilad Archers | `{4}{G}` | 2/4 | Protection from artifacts; reach |
| Moriok Scavenger | `{3}{B}` | 2/3 | ETB: you may return target artifact creature card from your graveyard to your hand |
| Slith Bloodletter | `{B}{B}` | 1/1 | Combat damage to a player → +1/+1 counter; `{1}{B}`: Regenerate |
| Nim Shambler | `{2}{B}{B}` | 2/1 | +1/+0 for each artifact you control; Sacrifice a creature: Regenerate |
| Ogre Leadfoot | `{4}{R}` | 3/3 | Becomes blocked by an artifact creature → destroy that creature |

### Modelling notes

**Ogre Leadfoot** uses the *filtered* SELF-binding `becomesBlocked` shape — the same detector path flanking is built on. The filter constrains the **blocker**, and the detector fires once per matching blocker with `triggeringEntityId` set to that blocker, so a gang block by three artifact creatures destroys all three and `EffectTarget.TriggeringEntity` resolves correctly each time. The two nearby alternatives are both wrong here: unfiltered `BecomesBlocked` fires exactly once no matter how many creatures block, and `BlocksOrBecomesBlockedBy` would over-trigger on the blocking direction the printed text doesn't cover.

**Nim Shambler**'s power is a `GrantDynamicStatsEffect` scoped to `GroupFilter.source()` — a layer 7c bonus that recomputes continuously rather than snapshotting, so it tracks artifacts entering and leaving. Toughness is pinned at `Fixed(0)`, keeping it a 1-toughness liability however wide the artifact board gets.

**Moriok Scavenger**'s "you may" is `optional = true` on the trigger: the target is locked in when the ability goes on the stack, and the decline happens on resolution (CR 603.3d) — the same shape as the already-shipped Oversold Cemetery.

**Tel-Jilad Archers** carries protection via `ProtectionScope.CardType("Artifact")`, matching its sibling Tel-Jilad Chosen; targeting, damage prevention, and block evasion all read the projected `PROTECTION_FROM_CARDTYPE_ARTIFACT` keyword.

### Verification

- `just build` — green (only the expected `CardDefinitionSnapshotTest` diff, re-blessed with `just rebless-cards`; **only these five cards** moved in `MRD.json`).
- All eight mechanical fields plus oracle text re-fetched from Scryfall and diffed field-by-field against each `.kt` — exact match on all five.
- All five `image_uris.normal` verified HTTP 200.
- `just check-card-printing` clean for each.

No scenario tests: every card is built purely from existing primitives, so the snapshot and lint nets cover them (same convention as the two preceding Mirrodin batches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)