### PR TITLE
Show which permanent a per-object decision is about (Killing Wave)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2027,6 +2027,15 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     multi-block puts one mirror trigger on the stack per damaged creature, and "decline down to the
     biggest number" is only a real line of play if the three prompts can be told apart. Pairs
     naturally with `TriggeredAbility.effectOncePerTurn`, which is what makes declining free.
+  - **Per-object prompts name their subject automatically.** The sibling problem to dynamic hints:
+    a gate nested inside a `ForEachInGroup` / `ForEachInCollection` body raises one prompt per
+    entity, and the sentences are identical. `GatedEffectExecutor` stamps every gate prompt's
+    `DecisionContext.subjectEntityId` from the loop's `pipeline.iterationTarget` — the same binding
+    `EffectTarget.Self` reads inside the body — so the client renders that permanent beside the
+    source card and rings it on the battlefield in `--color-decision-subject`. Nothing to declare on
+    the card: **Killing Wave** ("for each creature, its controller sacrifices it unless they pay X
+    life") gets it from the shape alone. Only the entity id crosses the wire, so the client's
+    already-masked card map keeps a face-down subject face-down.
   - **`decisionMaker` routes the yes/no to a non-controller** — pass any player `EffectTarget`
     (`EffectTarget.TargetController` for "that creature's controller may …", or a bound target such
     as `target("target opponent", Targets.Opponent)` for "**target opponent may …**"). Only the

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/KillingWave.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/KillingWave.kt
@@ -49,10 +49,11 @@ val KillingWave = card("Killing Wave") {
                         ifNotPaid = Effects.SacrificeTarget(EffectTarget.Self),
                         // The gate labels its own "yes" button with the computed cost ("Pay 2
                         // life") and its "no" with "Don't pay", so the prompt only has to state
-                        // the stakes. It can't name *which* creature is being asked about — the
-                        // decision's source is the spell, not the iteration entity — so a board
-                        // with several creatures shows one identical prompt per creature.
-                        descriptionOverride = "Pay life for this creature, or sacrifice it.",
+                        // the stakes. *Which* creature each of the N identical prompts covers is
+                        // carried by `DecisionContext.subjectEntityId`, which the gate executor
+                        // stamps from the enclosing per-entity iteration: the client shows that
+                        // creature beside the spell and rings it on the battlefield.
+                        descriptionOverride = "Pay life to keep this creature, or sacrifice it.",
                     ),
                 ),
             ),

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -918,7 +918,7 @@
                         "type": "SacrificeTarget",
                         "target": "Self"
                     },
-                    "descriptionOverride": "Pay life for this creature, or sacrifice it."
+                    "descriptionOverride": "Pay life to keep this creature, or sacrifice it."
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -53,6 +53,22 @@ data class DecisionContext(
     val effectHint: String? = null,
 
     /**
+     * The specific object this decision is *about*, when one effect raises the same prompt once per
+     * object. Distinct from [sourceId] (the spell/ability doing the asking) and
+     * [triggeringEntityId] (what caused the ability to trigger): Killing Wave asks
+     * "pay X life or sacrifice it" once per creature, and without this the player sees N identical
+     * prompts with no way to tell which creature each one covers.
+     *
+     * Set from the enclosing per-entity iteration (`pipeline.iterationTarget` — the same binding
+     * `EffectTarget.Self` reads inside a `ForEachInGroup` body), so any gate raised inside such a
+     * loop names its subject for free.
+     *
+     * Only the id travels: the client resolves the card through its already-masked state map, so a
+     * face-down subject can never leak its name through the prompt.
+     */
+    val subjectEntityId: EntityId? = null,
+
+    /**
      * Definition-scoped identity of the ability that raised this decision, when it was raised by a
      * triggered or activated ability of a card. Lets the client offer "always yes/no to this
      * ability" and the engine match the answer against every current and future instance of the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -228,11 +228,9 @@ class GatedEffectExecutor(
             id = decisionId,
             playerId = playerId,
             prompt = effect.description,
-            context = DecisionContext(
-                sourceId = context.sourceId,
-                sourceName = sourceName,
-                phase = DecisionPhase.RESOLUTION,
-                triggeringEntityId = context.triggeringEntityId,
+            context = decisionContext(
+                context,
+                sourceName,
                 inlineOnTrigger = (gate as? Gate.MayDecide)?.inlineOnTrigger ?: false
             ),
             yesText = payLabel ?: "Yes",
@@ -287,12 +285,7 @@ class GatedEffectExecutor(
             id = decisionId,
             playerId = playerId,
             prompt = "Pay $manaCost?",
-            context = DecisionContext(
-                sourceId = context.sourceId,
-                sourceName = sourceName,
-                phase = DecisionPhase.RESOLUTION,
-                triggeringEntityId = context.triggeringEntityId
-            ),
+            context = decisionContext(context, sourceName),
             yesText = "Pay $manaCost",
             noText = "Don't pay"
         )
@@ -380,12 +373,7 @@ class GatedEffectExecutor(
             } else {
                 "Waterbend $manaCost (tap artifacts/creatures to help)"
             },
-            context = DecisionContext(
-                sourceId = context.sourceId,
-                sourceName = sourceName,
-                phase = DecisionPhase.RESOLUTION,
-                triggeringEntityId = context.triggeringEntityId
-            ),
+            context = decisionContext(context, sourceName),
             availableSources = sourceOptions,
             requiredCost = manaCost.toString(),
             autoPaySuggestion = autoPaySuggestion,
@@ -509,12 +497,7 @@ class GatedEffectExecutor(
             id = decisionId,
             playerId = playerId,
             prompt = "Pay {X}? Choose X (0 to decline)",
-            context = DecisionContext(
-                sourceId = context.sourceId,
-                sourceName = sourceName,
-                phase = DecisionPhase.RESOLUTION,
-                triggeringEntityId = context.triggeringEntityId
-            ),
+            context = decisionContext(context, sourceName),
             minValue = 0,
             maxValue = maxAffordable
         )
@@ -543,6 +526,28 @@ class GatedEffectExecutor(
             )
         )
     }
+
+    /**
+     * The [DecisionContext] every gate prompt in this executor carries.
+     *
+     * Beyond the source/trigger plumbing, it stamps the *subject* of the prompt from the enclosing
+     * per-entity iteration ([com.wingedsheep.engine.handlers.PipelineState.iterationTarget], the
+     * binding `EffectTarget.Self` already reads inside a `ForEachInGroup` body). A gate that runs
+     * once per creature — Killing Wave's "sacrifice it unless you pay X life" — otherwise raises N
+     * character-identical prompts, and the player has no way to tell which creature each covers.
+     */
+    private fun decisionContext(
+        context: EffectContext,
+        sourceName: String?,
+        inlineOnTrigger: Boolean = false
+    ): DecisionContext = DecisionContext(
+        sourceId = context.sourceId,
+        sourceName = sourceName,
+        phase = DecisionPhase.RESOLUTION,
+        triggeringEntityId = context.triggeringEntityId,
+        inlineOnTrigger = inlineOnTrigger,
+        subjectEntityId = context.pipeline.iterationTarget
+    )
 
     /**
      * Fill a [DynamicHint]'s `{n}` from the resolving context, so a "that much damage" prompt says

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KillingWaveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KillingWaveScenarioTest.kt
@@ -61,6 +61,32 @@ class KillingWaveScenarioTest : FunSpec({
         driver.getGraveyardCardNames(opponent) shouldBe listOf("Grizzly Bears")
     }
 
+    test("each prompt names the creature it covers") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+        val caster = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+        val giant = driver.putCreatureOnBattlefield(caster, "Hill Giant")
+
+        val wave = driver.putCardInHand(caster, "Killing Wave")
+        driver.giveMana(caster, Color.BLACK, 3)
+        driver.castXSpell(caster, wave, xValue = 2).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Two creatures, two character-identical prompts: the only thing telling them apart is the
+        // subject the gate stamps from the per-creature iteration. Order follows the loop, so
+        // assert on the set rather than a specific sequence.
+        val first = driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>().context.subjectEntityId
+        driver.submitYesNo(caster, true).error shouldBe null
+        val second = driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>().context.subjectEntityId
+        driver.submitYesNo(caster, true).error shouldBe null
+
+        setOf(first, second) shouldBe setOf(bears, giant)
+        driver.getLifeTotal(caster) shouldBe 16
+    }
+
     test("a player who cannot pay X life is never offered the choice and just sacrifices") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)

--- a/web-client/src/components/decisions/DecisionContextCards.tsx
+++ b/web-client/src/components/decisions/DecisionContextCards.tsx
@@ -1,0 +1,104 @@
+import type { ClientCard, ClientGameState, DecisionContext, EntityId } from '@/types'
+import { getCardImageUrl } from '@/utils/cardImages.ts'
+import styles from './DecisionUI.module.css'
+
+/**
+ * The cards a decision prompt can illustrate itself with, resolved against the (already masked)
+ * client state — the server sends only ids, so a face-down permanent stays face-down here.
+ *
+ * Three distinct roles, deliberately not collapsed into one:
+ *  - `source` — the spell or ability doing the asking (Killing Wave).
+ *  - `subject` — the object *this* instance of the prompt is about, when one effect asks the same
+ *    question once per object. Without it a board of five creatures produces five
+ *    character-identical prompts and the player is guessing which one they're answering for.
+ *  - `triggering` — what caused the ability to trigger (the blocked creature, the aura's host).
+ */
+export interface DecisionCards {
+  readonly source?: { card: ClientCard; imageUrl: string } | undefined
+  readonly subject?: { card: ClientCard; imageUrl: string } | undefined
+  readonly triggering?: { card: ClientCard; imageUrl: string } | undefined
+}
+
+function resolve(
+  entityId: EntityId | undefined,
+  gameState: ClientGameState | null,
+): { card: ClientCard; imageUrl: string } | undefined {
+  if (!entityId) return undefined
+  const card = gameState?.cards[entityId]
+  if (!card) return undefined
+  const imageUrl = getCardImageUrl(card.name, card.imageUri)
+  return imageUrl ? { card, imageUrl } : undefined
+}
+
+export function resolveDecisionCards(
+  context: DecisionContext,
+  gameState: ClientGameState | null,
+): DecisionCards {
+  const source = resolve(context.sourceId, gameState)
+  const subject = resolve(context.subjectEntityId, gameState)
+  const triggering = resolve(context.triggeringEntityId, gameState)
+  return {
+    source,
+    subject,
+    // The subject and the triggering entity are the same card often enough (a per-entity loop over
+    // the very thing that triggered) that showing it twice would just be noise.
+    triggering: triggering && triggering.card.id !== source?.card.id && triggering.card.id !== subject?.card.id
+      ? triggering
+      : undefined,
+  }
+}
+
+export function hasDecisionContextCards(cards: DecisionCards): boolean {
+  return cards.source != null || cards.subject != null || cards.triggering != null
+}
+
+/**
+ * The card strip above a decision prompt. The subject is rendered largest and ringed in
+ * `--color-decision-subject` — the same orange `GameCard` puts around it on the battlefield, so
+ * minimizing the modal to look at the board keeps the connection.
+ */
+export function DecisionContextCards({ cards }: { cards: DecisionCards }) {
+  if (!hasDecisionContextCards(cards)) return null
+
+  // A lone source card needs no caption — the prompt right below it already says what it does.
+  // Once a second role is on screen, every card gets labelled so the roles can't be confused.
+  const labelled = [cards.source, cards.subject, cards.triggering].filter(Boolean).length > 1
+
+  return (
+    <div className={styles.contextCards}>
+      {cards.source && (
+        <div className={styles.contextCard}>
+          {labelled && <p className={styles.contextCardLabel}>Source</p>}
+          <img
+            src={cards.source.imageUrl}
+            alt={cards.source.card.name}
+            className={styles.contextCardImage}
+          />
+        </div>
+      )}
+
+      {cards.triggering && (
+        <div className={styles.contextCard}>
+          <p className={styles.contextCardLabel}>Triggered by</p>
+          <img
+            src={cards.triggering.imageUrl}
+            alt={cards.triggering.card.name}
+            className={styles.contextCardImageSecondary}
+          />
+        </div>
+      )}
+
+      {cards.subject && (
+        <div className={styles.contextCard}>
+          <p className={styles.contextCardLabelSubject}>Deciding for</p>
+          <img
+            src={cards.subject.imageUrl}
+            alt={cards.subject.card.name}
+            className={styles.contextCardImageSubject}
+          />
+          <p className={styles.contextCardName}>{cards.subject.card.name}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/decisions/DecisionUI.module.css
+++ b/web-client/src/components/decisions/DecisionUI.module.css
@@ -127,6 +127,95 @@
 }
 
 /* =========================================================================
+ * Decision Context Cards (the source of a prompt, and the object it is about)
+ *
+ * A prompt raised once per object — Killing Wave's "sacrifice it unless you pay X life", asked
+ * for each of your creatures in turn — is indistinguishable from its siblings unless the subject
+ * is shown. The subject is the card the player is actually judging, so it is rendered larger than
+ * the source and ringed in the same orange the battlefield highlight uses.
+ * ========================================================================= */
+.contextCards {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-6);
+  margin-bottom: var(--space-2);
+}
+
+.contextCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.contextCardLabel {
+  color: var(--text-tertiary);
+  margin: 0;
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.contextCardName {
+  color: var(--text-primary);
+  margin: 0;
+  max-width: 190px;
+  font-size: var(--font-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+.contextCardImage {
+  width: 150px;
+  height: auto;
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+}
+
+/* Secondary context (what triggered the ability) — present but visibly subordinate. */
+.contextCardImageSecondary {
+  composes: contextCardImage;
+  width: 110px;
+  opacity: 0.85;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.contextCardImageSubject {
+  composes: contextCardImage;
+  width: 176px;
+  outline: 3px solid var(--color-decision-subject);
+  outline-offset: 2px;
+  box-shadow:
+    0 0 16px var(--color-decision-subject-glow),
+    0 0 32px var(--color-decision-subject-shadow);
+}
+
+.contextCardLabelSubject {
+  composes: contextCardLabel;
+  color: var(--color-decision-subject);
+  font-weight: var(--font-weight-bold);
+}
+
+@media (max-width: 639px) {
+  .contextCards {
+    gap: var(--space-3);
+  }
+
+  .contextCardImage {
+    width: 96px;
+  }
+
+  .contextCardImageSecondary {
+    width: 76px;
+  }
+
+  .contextCardImageSubject {
+    width: 112px;
+  }
+}
+
+/* =========================================================================
  * Typography
  * ========================================================================= */
 .title {

--- a/web-client/src/components/decisions/DecisionUI.tsx
+++ b/web-client/src/components/decisions/DecisionUI.tsx
@@ -58,6 +58,13 @@ export function DecisionUI() {
 
   if (!pendingDecision) return null
 
+  // A prompt raised once per object names its subject on the minimized button too, so a player
+  // who stepped out to read the board knows which creature they are coming back to answer for.
+  const subjectName = pendingDecision.context.subjectEntityId
+    ? gameState?.cards[pendingDecision.context.subjectEntityId]?.name
+    : undefined
+  const returnLabel = subjectName ? `Return to decision — ${subjectName}` : 'Return to decision'
+
   // Handle SelectManaSourcesDecision (mana source selection for Lightning Rift etc.)
   if (pendingDecision.type === 'SelectManaSourcesDecision') {
     return <ManaSourceSelectionUI decision={pendingDecision} />
@@ -98,7 +105,7 @@ export function DecisionUI() {
           className={styles.floatingReturnButton}
           onClick={() => setDecisionMinimized(false)}
         >
-          Return to decision
+          {returnLabel}
         </button>
       )
     }
@@ -121,7 +128,7 @@ export function DecisionUI() {
           className={styles.floatingReturnButton}
           onClick={() => setDecisionMinimized(false)}
         >
-          Return to decision
+          {returnLabel}
         </button>
       )
     }
@@ -144,7 +151,7 @@ export function DecisionUI() {
           className={styles.floatingReturnButton}
           onClick={() => setDecisionMinimized(false)}
         >
-          Return to decision
+          {returnLabel}
         </button>
       )
     }

--- a/web-client/src/components/decisions/YesNoDecisionUI.tsx
+++ b/web-client/src/components/decisions/YesNoDecisionUI.tsx
@@ -1,12 +1,16 @@
 import { useGameStore } from '@/store/gameStore.ts'
 import type { YesNoDecision, ClientGameState } from '@/types'
-import { getCardImageUrl } from '@/utils/cardImages.ts'
 import { AbilityText } from '../ui/ManaSymbols'
+import { DecisionContextCards, hasDecisionContextCards, resolveDecisionCards } from './DecisionContextCards'
 import styles from './DecisionUI.module.css'
 
 /**
  * Yes/No decision - make a binary choice.
- * Shows source card (the ability owner) and optionally the triggering entity for context.
+ *
+ * Shows the source card (the ability owner), the triggering entity when there is one, and — for a
+ * prompt raised once per object (Killing Wave asks "pay X life or sacrifice it" for each of your
+ * creatures in turn) — the subject this instance is about.
+ *
  * Supports an optional hint (e.g., keyword reminder text) and a View Battlefield button.
  */
 export function YesNoDecisionUI({
@@ -28,61 +32,12 @@ export function YesNoDecisionUI({
     submitYesNoDecision(false)
   }
 
-  // Look up source and triggering entity cards for display
-  const sourceCard = decision.context.sourceId ? gameState?.cards[decision.context.sourceId] : undefined
-  const triggeringCard = decision.context.triggeringEntityId ? gameState?.cards[decision.context.triggeringEntityId] : undefined
-  const sourceImageUrl = sourceCard ? getCardImageUrl(sourceCard.name, sourceCard.imageUri) : undefined
-  const triggeringImageUrl = triggeringCard ? getCardImageUrl(triggeringCard.name, triggeringCard.imageUri) : undefined
-
-  // Show card images when we have a source card with an image
-  const showCardContext = sourceImageUrl != null
+  const cards = resolveDecisionCards(decision.context, gameState)
+  const showCardContext = hasDecisionContextCards(cards)
 
   return (
     <>
-      {showCardContext && (
-        <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 24,
-          marginBottom: 8,
-        }}>
-          {/* Source card (the ability owner) — shown prominently */}
-          <div style={{ textAlign: 'center' }}>
-            <img
-              src={sourceImageUrl}
-              alt={sourceCard?.name ?? ''}
-              style={{
-                width: 160,
-                borderRadius: 8,
-                boxShadow: '0 4px 16px rgba(0, 0, 0, 0.6)',
-              }}
-            />
-          </div>
-
-          {/* Triggering entity — shown smaller as secondary context */}
-          {triggeringImageUrl && triggeringCard && sourceCard && triggeringCard.id !== sourceCard.id && (
-            <div style={{ textAlign: 'center' }}>
-              <p style={{
-                color: 'var(--text-tertiary)',
-                fontSize: 'var(--font-xs)',
-                margin: '0 0 4px 0',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px',
-              }}>Triggered by</p>
-              <img
-                src={triggeringImageUrl}
-                alt={triggeringCard.name}
-                style={{
-                  width: 120,
-                  borderRadius: 8,
-                  boxShadow: '0 4px 16px rgba(0, 0, 0, 0.4)',
-                  opacity: 0.85,
-                }}
-              />
-            </div>
-          )}
-        </div>
-      )}
+      <DecisionContextCards cards={cards} />
 
       <h2 className={styles.title}>
         <AbilityText text={decision.prompt} size={20} />

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -447,6 +447,11 @@ function GameCardImpl({
     && pendingDecision.context.inlineOnTrigger
     && pendingDecision.context.triggeringEntityId === card.id
 
+  // The permanent the pending prompt is currently *about* — Killing Wave asks "pay X life or
+  // sacrifice it" once per creature, and the prompts are otherwise identical. Ringing the subject
+  // keeps "which creature is this?" answerable after minimizing the modal to view the battlefield.
+  const isDecisionSubject = pendingDecision?.context.subjectEntityId === card.id
+
   // Combat mode checks
   const isInAttackerMode = combatState?.mode === 'declareAttackers'
   const isInBlockerMode = combatState?.mode === 'declareBlockers'
@@ -1109,6 +1114,11 @@ function GameCardImpl({
     // Orange/gold glow for the trigger creature (matches distribute target style)
     borderStyle = '3px solid #ff6b35'
     boxShadow = '0 0 16px rgba(255, 107, 53, 0.7), 0 0 32px rgba(255, 107, 53, 0.4)'
+  } else if (isDecisionSubject) {
+    // Same orange as the decision modal's ring around this card — one visual language for
+    // "this is the object the current prompt is about".
+    borderStyle = '3px solid var(--color-decision-subject)'
+    boxShadow = '0 0 16px var(--color-decision-subject-glow), 0 0 32px var(--color-decision-subject-shadow)'
   } else if (isDistributeTarget && distributeAllocated > 0) {
     // Orange for distribute targets with damage allocated
     borderStyle = '3px solid #ff6b35'

--- a/web-client/src/store/selectors.ts
+++ b/web-client/src/store/selectors.ts
@@ -733,13 +733,20 @@ const EMPTY_ID_SET: ReadonlySet<EntityId> = Object.freeze(new Set<EntityId>())
  * Eligible-but-unchosen targets are deliberately NOT included: identical tokens are
  * interchangeable, so the player can click the collapsed stack's representative to
  * pick one. Only a *committed* target needs its specific arrow to resolve.
+ *
+ * The pending decision's *subject* is included for the same reason: Killing Wave asks
+ * "pay X life or sacrifice it" once per creature, and a subject collapsed into a token
+ * stack would highlight the whole pile instead of the one creature being decided.
  */
 export function useSplitOutTargetIds(): ReadonlySet<EntityId> {
   const stackCards = useStackCards()
   const targetingState = useGameStore(selectTargetingState)
+  const decisionSubjectId = useGameStore((s) => s.pendingDecision?.context.subjectEntityId)
   return useMemo(() => {
     const selected = targetingState?.selectedTargets
-    if (stackCards.length === 0 && (!selected || selected.length === 0)) return EMPTY_ID_SET
+    if (stackCards.length === 0 && (!selected || selected.length === 0) && !decisionSubjectId) {
+      return EMPTY_ID_SET
+    }
     const ids = new Set<EntityId>()
     for (const card of stackCards) {
       for (const t of card.targets) {
@@ -748,8 +755,9 @@ export function useSplitOutTargetIds(): ReadonlySet<EntityId> {
       if (card.triggeringEntityId) ids.add(card.triggeringEntityId)
     }
     if (selected) for (const id of selected) ids.add(id)
+    if (decisionSubjectId) ids.add(decisionSubjectId)
     return ids
-  }, [stackCards, targetingState])
+  }, [stackCards, targetingState, decisionSubjectId])
 }
 
 /**

--- a/web-client/src/styles/variables.css
+++ b/web-client/src/styles/variables.css
@@ -117,6 +117,14 @@
   --color-target-glow-bright: rgba(51, 204, 255, 0.95);
   --color-target-glow-outer: rgba(0, 187, 255, 0.7);
 
+  /* Decision subject - the permanent a per-object prompt is currently about (Killing Wave's
+   * "sacrifice it unless you pay X life", asked once per creature). Same orange the inline
+   * trigger/distribute highlights use, so "this is the card in question" reads as one language
+   * on the battlefield and in the decision modal. */
+  --color-decision-subject: #ff6b35;
+  --color-decision-subject-glow: rgba(255, 107, 53, 0.7);
+  --color-decision-subject-shadow: rgba(255, 107, 53, 0.4);
+
   /* Targeting / Selection - selected (green) */
   --color-selected: #44dd44;
   --color-selected-bg: #0a2a1a;

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -301,6 +301,12 @@ export interface DecisionContext {
   readonly inlineOnTrigger?: boolean
   /** Resolved effect description (e.g., "-6/-6 until end of turn") */
   readonly effectHint?: string
+  /**
+   * The permanent this prompt is *about*, when one effect asks the same question once per object
+   * (Killing Wave: "pay X life or sacrifice it", once per creature). Resolve it through
+   * `gameState.cards` — the server sends only the id, so masking still applies.
+   */
+  readonly subjectEntityId?: EntityId
 }
 
 /**


### PR DESCRIPTION
## The problem

Killing Wave — *"For each creature, its controller sacrifices it unless they pay X life."* — raises
one yes/no per creature. Every prompt rendered the same sentence over the same card art, so a player
with three creatures answered three indistinguishable questions with no way to tell which creature
each one covered. The card definition even documented the limitation ("It can't name *which* creature
is being asked about").

## The fix — at the class, not the card

`DecisionContext` gains **`subjectEntityId`**: the object *this* instance of a repeated prompt is
about. It is deliberately a third role, distinct from `sourceId` (the spell doing the asking) and
`triggeringEntityId` (what put the ability on the stack).

`GatedEffectExecutor` stamps it on every gate prompt from the enclosing per-entity iteration —
`pipeline.iterationTarget`, the same binding `EffectTarget.Self` already reads inside a
`ForEachInGroup` body. So **any** gate nested in a per-entity loop names its subject with nothing
declared on the card; Killing Wave gets it from its shape alone. This is the sibling of the existing
`DynamicHint` affordance, which solves the same "N identical prompts" problem for numbers.

Only the entity id crosses the wire. The client resolves it through its already-masked card map, so a
face-down subject can't leak its name through a prompt.

## Client — one visual language, three places

All three share a new `--color-decision-subject` orange (the same hue the inline trigger / distribute
highlights already use):

1. **The decision modal** renders the subject beside the source — larger, ringed, captioned
   "Deciding for" with its name. New `DecisionContextCards` component owns the source / subject /
   trigger strip and starts labelling the roles once more than one card is on screen.
2. **`GameCard` rings the same permanent on the battlefield**, so "View Battlefield" answers the
   question directly. The subject is also split out of any collapsed token stack (`useSplitOutTargetIds`),
   so with five identical Saprolings the ring lands on the one creature being decided, not the pile.
3. **The minimized button** reads `Return to decision — Grizzly Bears`.

Killing Wave's prompt copy is now *"Pay life to keep this creature, or sacrifice it."* (AVR golden
re-blessed).

## Screenshots

Decision modal — Killing Wave on the left as the source, the creature in question on the right,
ringed and named. Note the same creature already glowing on the battlefield behind the overlay:

![Killing Wave decision modal](https://raw.githubusercontent.com/wingedsheep/argentum-engine/killing-wave-subject-screenshots/modal.png)

After "View Battlefield" — Grizzly Bears is ringed among the caster's three creatures, and the return
button names it:

![Battlefield highlight](https://raw.githubusercontent.com/wingedsheep/argentum-engine/killing-wave-subject-screenshots/battlefield.png)

*(Images live on the throwaway branch `killing-wave-subject-screenshots`, not in this diff — delete it
after merge.)*

## Verification

- `just test-class KillingWaveScenarioTest` — 3/3 pass, including a new
  *"each prompt names the creature it covers"* asserting the two prompts carry the two distinct
  creatures as their subjects.
- `:mtg-sets:test --tests "*CardDefinitionSnapshotTest"` — green (AVR golden updated for the reworded
  prompt; nothing else moved).
- `npm run typecheck` in `web-client` — clean.
- Screenshots above are the real app, driven end-to-end through `/api/dev/scenarios`.

## Docs

`docs/card-sdk-language-reference.md` gains a "Per-object prompts name their subject automatically"
entry next to *Dynamic hints*, since it's the same class of problem and equally invisible from the
card's source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
