### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Candlestick.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Candlestick.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Candlestick — Murders at Karlov Manor #43
+ * {U} · Artifact — Clue Equipment
+ *
+ * Equipped creature gets +1/+1 and has "Whenever this creature attacks, surveil 2."
+ * {2}, Sacrifice this Equipment: Draw a card.
+ * Equip {2}
+ *
+ * One of the set's "murder weapon" Equipment — an Equipment that is also a Clue, so it carries the
+ * standard Clue sacrifice-to-draw *and* the Clue subtype, which the set's "sacrifice a Clue"
+ * payoffs read straight off the type line (Scryfall's ruling: "If an effect refers to a Clue, it
+ * means any Clue artifact, not just a Clue artifact token").
+ *
+ * The attack trigger is granted to the equipped creature via [GrantTriggeredAbility] with
+ * [Triggers.Attacks] (SELF binding), so it fires on that creature's attack rather than on any
+ * attack — and it surveils for the *creature's* controller, which is what matters when the
+ * Equipment's controller and the equipped creature's controller have diverged. Unequipping
+ * before the trigger resolves doesn't fizzle it: the granted ability has already triggered and
+ * exists independently on the stack (CR 603.2).
+ */
+val Candlestick = card("Candlestick") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Clue Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, " +
+        "surveil 2.\"\n" +
+        "{2}, Sacrifice this Equipment: Draw a card.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = Patterns.Library.surveil(2)
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "43"
+        artist = "Julia Metzger"
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5aeae6fb-3834-4891-924e-3d1fb3e19e09.jpg?1783912915"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/JadedAnalyst.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/JadedAnalyst.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Jaded Analyst — Murders at Karlov Manor #62
+ * {1}{U} · Creature — Human Detective · 3/2
+ *
+ * Defender
+ * Whenever you draw your second card each turn, this creature loses defender and gains vigilance
+ * until end of turn.
+ *
+ * A 3/2 for two that has to be unlocked: the second draw each turn turns it into an attacker that
+ * doesn't even tap. Both halves are [Duration.EndOfTurn] — the printed defender comes back at
+ * cleanup, so the Analyst blocks again on the opponent's turn and needs unlocking afresh each turn.
+ *
+ * [Triggers.NthCardDrawn]`(2)` (CR 121.2) reads the per-turn draw counter rather than counting
+ * draw *events*, so a single "draw two cards" spell crosses the threshold once and fires the
+ * trigger once, and a card put into hand without the word "draw" (CR 121.5) doesn't advance it at
+ * all. The turn's first draw — including the draw step's — counts toward the two, so on your own
+ * turn one extra draw is enough.
+ *
+ * Losing defender is [Effects.RemoveKeyword], not a stat or type change: the Analyst stays a
+ * Human Detective (relevant for the set's Detective payoffs) and simply sheds the attack
+ * restriction. Vigilance is granted in the same resolution; the two are separate keyword
+ * modifications in Layer 6 and don't depend on each other.
+ */
+val JadedAnalyst = card("Jaded Analyst") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Detective"
+    power = 3
+    toughness = 2
+    oracleText = "Defender\n" +
+        "Whenever you draw your second card each turn, this creature loses defender and gains " +
+        "vigilance until end of turn."
+
+    keywords(Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        effect = Effects.Composite(
+            listOf(
+                Effects.RemoveKeyword(Keyword.DEFENDER, EffectTarget.Self, Duration.EndOfTurn),
+                Effects.GrantKeyword(Keyword.VIGILANCE, EffectTarget.Self, Duration.EndOfTurn)
+            )
+        )
+        description = "Whenever you draw your second card each turn, this creature loses defender " +
+            "and gains vigilance until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Borja Pindado"
+        flavorText = "\"Oh, good, another case with too many victims and not enough clues.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/2807dcfb-d99c-483b-835f-2606eae4bd30.jpg?1783912907"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KrovodHaunch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KrovodHaunch.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Krovod Haunch — Murders at Karlov Manor #21
+ * {W} · Artifact — Food Equipment
+ *
+ * Equipped creature gets +2/+0.
+ * {2}, {T}, Sacrifice this Equipment: You gain 3 life.
+ * When this Equipment is put into a graveyard from the battlefield, you may pay {1}{W}. If you do,
+ * create two 1/1 white Dog creature tokens.
+ * Equip {2}
+ *
+ * A Food that is also an Equipment. The Food subtype is on the type line, so "sacrifice a Food" /
+ * "tap a Food" payoffs see it without anything extra (Scryfall's ruling: "If an effect refers to a
+ * Food, it means any Food artifact, not just a Food artifact token" — you can tap Krovod Haunch to
+ * pay for Apothecary White). Note the printed sacrifice ability is *not* the Food token's ability:
+ * it costs an extra {T} and gains 3 life rather than the token's plain "{2}, {T}, Sacrifice: You
+ * gain 3 life" — same shape here, but it is printed on the card rather than conferred by the
+ * subtype, which is why it's written out.
+ *
+ * The leaves-the-battlefield trigger is [Triggers.Dies] (battlefield → graveyard, SELF binding),
+ * which is a superset of the sacrifice ability's own path: cashing the Haunch in for 3 life *also*
+ * offers the Dogs, since sacrificing puts it into the graveyard from the battlefield. The
+ * [MayPayManaEffect] models "you may pay {1}{W}. If you do" — a resolution-time optional mana
+ * payment, not an additional cost — and nothing downstream reads the source, so the Equipment
+ * already being in the graveyard when the trigger resolves is harmless.
+ *
+ * The Dog token takes its art from the MKM `tokenArt` layer (as Dog Walker's does), so no
+ * `imageUri` is baked in here.
+ */
+val KrovodHaunch = card("Krovod Haunch") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Food Equipment"
+    oracleText = "Equipped creature gets +2/+0.\n" +
+        "{2}, {T}, Sacrifice this Equipment: You gain 3 life.\n" +
+        "When this Equipment is put into a graveyard from the battlefield, you may pay {1}{W}. " +
+        "If you do, create two 1/1 white Dog creature tokens.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = ModifyStats(+2, +0, Filters.EquippedCreature)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.GainLife(3)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}{W}"),
+            effect = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Dog"),
+                count = 2
+            )
+        )
+        description = "When this Equipment is put into a graveyard from the battlefield, you may " +
+            "pay {1}{W}. If you do, create two 1/1 white Dog creature tokens."
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Craig J Spearing"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f663cd86-39e6-467b-85b7-dd27536251a6.jpg?1783912923"
+
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Food, it means any Food artifact, not just a Food artifact " +
+                "token. For example, you can tap Krovod Haunch to pay for Apothecary White's " +
+                "activated ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Rope.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Rope.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Rope — Murders at Karlov Manor #173
+ * {G} · Artifact — Clue Equipment
+ *
+ * Equipped creature gets +1/+2, has reach, and can't be blocked by more than one creature.
+ * {2}, Sacrifice this Equipment: Draw a card.
+ * Equip {3}
+ *
+ * One of the set's "murder weapon" Equipment — an Equipment that is also a Clue, so it carries the
+ * standard Clue sacrifice-to-draw *and* the Clue subtype, which the set's "sacrifice a Clue"
+ * payoffs read straight off the type line (Scryfall's ruling: "If an effect refers to a Clue, it
+ * means any Clue artifact, not just a Clue artifact token").
+ *
+ * The blocking restriction is granted as the [AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE]
+ * keyword rather than as a [com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan] static scoped
+ * to [Filters.EquippedCreature]. That matters: `BlockPhaseManager.validateMaxBlockersRequirements`
+ * reads the printed `CantBeBlockedByMoreThan` form off the *attacker's own* card definition and
+ * only when its filter scope is `Self`, so a copy of it living on the Equipment would never be
+ * consulted. The flag form goes through the layer system onto the equipped creature and is picked
+ * up by the same validator's projected-keyword branch — the identical path Glorfindel, Dauntless
+ * Rescuer uses for its durational grant — and the client already has a display name for it.
+ *
+ * Rope stacks with menace rather than overriding it: "at least two" and "at most one" are both
+ * enforced, so an equipped creature with menace simply can't be blocked at all (Scryfall ruling).
+ */
+val Rope = card("Rope") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Clue Equipment"
+    oracleText = "Equipped creature gets +1/+2, has reach, and can't be blocked by more than one " +
+        "creature.\n" +
+        "{2}, Sacrifice this Equipment: Draw a card.\n" +
+        "Equip {3}"
+
+    staticAbility {
+        ability = ModifyStats(+1, +2, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.REACH, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE.name,
+            Filters.EquippedCreature
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "173"
+        artist = "Matt Forsyth"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/6881946c-5036-4d9f-926f-932c9a592aff.jpg?1783912861"
+
+        ruling(
+            "2024-02-02",
+            "If the equipped creature also has menace, it can't be blocked at all."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Wrench.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/Wrench.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Wrench — Murders at Karlov Manor #37
+ * {W} · Artifact — Clue Equipment
+ *
+ * Equipped creature gets +1/+1 and has vigilance and "{3}, {T}: Tap target creature."
+ * {2}, Sacrifice this Equipment: Draw a card.
+ * Equip {2}
+ *
+ * One of the set's "murder weapon" Equipment — an Equipment that is also a Clue, so it carries the
+ * standard Clue sacrifice-to-draw *and* the Clue subtype, which the set's "sacrifice a Clue"
+ * payoffs read straight off the type line (Scryfall's ruling: "If an effect refers to a Clue, it
+ * means any Clue artifact, not just a Clue artifact token").
+ *
+ * The tapper is a [GrantActivatedAbility] scoped to [Filters.EquippedCreature] rather than an
+ * ability on the Equipment: the granted ability lives on the *creature*, so its {T} taps the
+ * creature (not the Wrench), it needs the creature to be untapped, and it's subject to the
+ * creature's own summoning sickness. Vigilance in the same grant is what makes the pair work —
+ * an equipped attacker stays untapped and can still tap for the ability afterwards.
+ */
+val Wrench = card("Wrench") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Clue Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has vigilance and \"{3}, {T}: Tap target " +
+        "creature.\"\n" +
+        "{2}, Sacrifice this Equipment: Draw a card.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap),
+                effect = Effects.Tap(EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(TargetCreature()),
+                descriptionOverride = "{3}, {T}: Tap target creature."
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "37"
+        artist = "Edgar Sánchez Hidalgo"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c36cc39b-8f3b-4297-b118-86fa624308b4.jpg?1783912917"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -305,6 +305,97 @@
     ]
 }
 
+// Candlestick
+{
+    "name": "Candlestick",
+    "manaCost": "{U}",
+    "typeLine": "Artifact — Clue Equipment",
+    "oracleText": "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, surveil 2.\"\n{2}, Sacrifice this Equipment: Draw a card.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "Surveil",
+                        "count": 2
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "43",
+        "rarity": "UNCOMMON",
+        "artist": "Julia Metzger",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5aeae6fb-3834-4891-924e-3d1fb3e19e09.jpg?1783912915"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Cerebral Confiscation
 {
     "name": "Cerebral Confiscation",
@@ -2478,6 +2569,58 @@
     ]
 }
 
+// Jaded Analyst
+{
+    "name": "Jaded Analyst",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Defender\nWhenever you draw your second card each turn, this creature loses defender and gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "RemoveKeyword",
+                            "keyword": "DEFENDER",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever you draw your second card each turn, this creature loses defender and gains vigilance until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Borja Pindado",
+        "flavorText": "\"Oh, good, another case with too many victims and not enough clues.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/2807dcfb-d99c-483b-835f-2606eae4bd30.jpg?1783912907"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Knife
 {
     "name": "Knife",
@@ -2630,6 +2773,129 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Krovod Haunch
+{
+    "name": "Krovod Haunch",
+    "manaCost": "{W}",
+    "typeLine": "Artifact — Food Equipment",
+    "oracleText": "Equipped creature gets +2/+0.\n{2}, {T}, Sacrifice this Equipment: You gain 3 life.\nWhen this Equipment is put into a graveyard from the battlefield, you may pay {1}{W}. If you do, create two 1/1 white Dog creature tokens.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}{W}"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Dog"
+                        ]
+                    }
+                },
+                "descriptionOverride": "When this Equipment is put into a graveyard from the battlefield, you may pay {1}{W}. If you do, create two 1/1 white Dog creature tokens."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "UNCOMMON",
+        "artist": "Craig J Spearing",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f663cd86-39e6-467b-85b7-dd27536251a6.jpg?1783912923",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Food, it means any Food artifact, not just a Food artifact token. For example, you can tap Krovod Haunch to pay for Apothecary White's activated ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -4156,6 +4422,100 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Rope
+{
+    "name": "Rope",
+    "manaCost": "{G}",
+    "typeLine": "Artifact — Clue Equipment",
+    "oracleText": "Equipped creature gets +1/+2, has reach, and can't be blocked by more than one creature.\n{2}, Sacrifice this Equipment: Draw a card.\nEquip {3}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "REACH"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "CANT_BE_BLOCKED_BY_MORE_THAN_ONE"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Forsyth",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/6881946c-5036-4d9f-926f-932c9a592aff.jpg?1783912861",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If the equipped creature also has menace, it can't be blocked at all."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -5734,5 +6094,124 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Wrench
+{
+    "name": "Wrench",
+    "manaCost": "{W}",
+    "typeLine": "Artifact — Clue Equipment",
+    "oracleText": "Equipped creature gets +1/+1 and has vigilance and \"{3}, {T}: Tap target creature.\"\n{2}, Sacrifice this Equipment: Draw a card.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{3}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "{3}, {T}: Tap target creature."
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "UNCOMMON",
+        "artist": "Edgar Sánchez Hidalgo",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c36cc39b-8f3b-4297-b118-86fa624308b4.jpg?1783912917"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JadedAnalystScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JadedAnalystScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.JadedAnalyst
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Jaded Analyst (MKM #62).
+ *
+ * "Defender. Whenever you draw your second card each turn, this creature loses defender and gains
+ *  vigilance until end of turn."
+ *
+ * The interesting half is that the payoff has to *remove a printed keyword* and have attack
+ * legality notice — a defender that merely gains vigilance is still stuck at home. These tests
+ * drive real draws through free instants (so the only variable is the draw count, per
+ * [com.wingedsheep.sdk.dsl.Triggers.NthCardDrawn] / CR 121.2), then assert both the projected
+ * keywords and that the Analyst can actually be declared as an attacker.
+ */
+class JadedAnalystScenarioTest : ScenarioTestBase() {
+
+    // A free instant so a cast costs no mana and the only thing under test is the draw count.
+    private val drawOne = card("Jaded Draw One Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Draw a card."
+        spell { effect = Effects.DrawCards(1) }
+    }
+
+    init {
+        cardRegistry.register(JadedAnalyst)
+        cardRegistry.register(drawOne)
+
+        test("the second draw of the turn strips defender and grants vigilance; the first does not") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Jaded Analyst", summoningSickness = false)
+                .withCardsInHand(1, "Jaded Draw One Test", 2)
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Island")
+                .withCardsDrawnThisTurn(1, 0)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val analyst = game.findPermanent("Jaded Analyst")!!
+
+            game.castSpell(1, "Jaded Draw One Test").error shouldBe null
+            game.resolveStack()
+
+            withClue("the first draw of the turn advances no NthCardDrawn(2)") {
+                val projected = StateProjector().project(game.state)
+                projected.hasKeyword(analyst, Keyword.DEFENDER) shouldBe true
+                projected.hasKeyword(analyst, Keyword.VIGILANCE) shouldBe false
+            }
+
+            game.castSpell(1, "Jaded Draw One Test").error shouldBe null
+            game.resolveStack()
+
+            withClue("the second draw sheds defender and grants vigilance") {
+                val projected = StateProjector().project(game.state)
+                projected.hasKeyword(analyst, Keyword.DEFENDER) shouldBe false
+                projected.hasKeyword(analyst, Keyword.VIGILANCE) shouldBe true
+            }
+        }
+
+        test("the unlocked Analyst can be declared as an attacker") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Jaded Analyst", summoningSickness = false)
+                .withCardsInHand(1, "Jaded Draw One Test", 2)
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Island")
+                .withCardInLibrary(1, "Island")
+                .withCardsDrawnThisTurn(1, 0)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Jaded Draw One Test").error shouldBe null
+            game.resolveStack()
+            game.castSpell(1, "Jaded Draw One Test").error shouldBe null
+            game.resolveStack()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            val attack = game.declareAttackers(mapOf("Jaded Analyst" to 2))
+            withClue("with defender gone the Analyst may attack: ${attack.error}") {
+                attack.error shouldBe null
+            }
+        }
+
+        test("without a second draw the Analyst still can't attack") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Jaded Analyst", summoningSickness = false)
+                .withCardsDrawnThisTurn(1, 0)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            val attack = game.declareAttackers(mapOf("Jaded Analyst" to 2))
+            withClue("defender is still on, so the attack is illegal") {
+                attack.error shouldNotBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KrovodHaunchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KrovodHaunchScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.KrovodHaunch
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Krovod Haunch (MKM #21) — {W} Artifact — Food Equipment.
+ *
+ * "Equipped creature gets +2/+0.
+ *  {2}, {T}, Sacrifice this Equipment: You gain 3 life.
+ *  When this Equipment is put into a graveyard from the battlefield, you may pay {1}{W}. If you
+ *  do, create two 1/1 white Dog creature tokens.
+ *  Equip {2}"
+ *
+ * The shape worth pinning is that the two halves *chain*: the sacrifice ability's own cost puts
+ * the Haunch into the graveyard from the battlefield, which is exactly what the second ability
+ * triggers on — so cashing it in for life also offers the Dogs. The trigger is
+ * [com.wingedsheep.sdk.dsl.Triggers.Dies] (battlefield → graveyard, SELF binding) rather than
+ * anything sacrifice-specific, and the optional {1}{W} is a resolution-time `MayPayManaEffect`
+ * (CR 603.12 style "you may pay … if you do"), not an additional cost — so declining still leaves
+ * the life gain intact, and the Haunch already sitting in the graveyard when the trigger resolves
+ * is harmless.
+ */
+class KrovodHaunchScenarioTest : FunSpec({
+
+    val equipAbilityId = KrovodHaunch.activatedAbilities.single { it.isEquipAbility }.id
+    val sacAbilityId = KrovodHaunch.activatedAbilities.single { !it.isEquipAbility }.id
+
+    fun GameTestDriver.dogCount(playerId: EntityId): Int =
+        getPermanents(playerId).count { state.getEntity(it)?.get<CardComponent>()?.name == "Dog Token" }
+
+    fun setup(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20, skipMulligans = true)
+    }
+
+    test("equipped creature gets +2/+0") {
+        val d = setup()
+        val p1 = d.activePlayer!!
+
+        val courser = d.putCreatureOnBattlefield(p1, "Centaur Courser") // 3/3
+        d.removeSummoningSickness(courser)
+        val haunch = d.putPermanentOnBattlefield(p1, "Krovod Haunch")
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveColorlessMana(p1, 2)
+        d.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = haunch,
+                abilityId = equipAbilityId,
+                targets = listOf(ChosenTarget.Permanent(courser))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.state.getEntity(haunch)?.get<AttachedToComponent>()?.targetId shouldBe courser
+
+        d.state.projectedState.getPower(courser) shouldBe 5
+        d.state.projectedState.getToughness(courser) shouldBe 3
+    }
+
+    test("sacrificing for life gains 3 and offers the Dogs; paying {1}{W} makes two of them") {
+        val d = setup()
+        val p1 = d.activePlayer!!
+
+        val haunch = d.putPermanentOnBattlefield(p1, "Krovod Haunch")
+        d.removeSummoningSickness(haunch)
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveColorlessMana(p1, 2)                        // {2} for the sacrifice ability
+        repeat(2) { d.putLandOnBattlefield(p1, "Plains") } // {1}{W} for the optional payment
+
+        d.submit(
+            ActivateAbility(playerId = p1, sourceId = haunch, abilityId = sacAbilityId)
+        ).isSuccess shouldBe true
+
+        var guard = 0
+        while (guard++ < 12) {
+            while (d.pendingDecision == null && d.state.stack.isNotEmpty()) d.bothPass()
+            when (d.pendingDecision) {
+                is YesNoDecision -> d.submitYesNo(p1, true).error shouldBe null
+                is SelectManaSourcesDecision -> d.submitManaAutoPayOrDecline(p1, true)
+                else -> break
+            }
+        }
+        while (d.pendingDecision == null && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getLifeTotal(p1) shouldBe 23
+        d.dogCount(p1) shouldBe 2
+    }
+
+    test("declining the {1}{W} makes no Dogs but still gains the life") {
+        val d = setup()
+        val p1 = d.activePlayer!!
+
+        val haunch = d.putPermanentOnBattlefield(p1, "Krovod Haunch")
+        d.removeSummoningSickness(haunch)
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveColorlessMana(p1, 2)
+        repeat(2) { d.putLandOnBattlefield(p1, "Plains") }
+
+        d.submit(
+            ActivateAbility(playerId = p1, sourceId = haunch, abilityId = sacAbilityId)
+        ).isSuccess shouldBe true
+
+        var guard = 0
+        while (guard++ < 12) {
+            while (d.pendingDecision == null && d.state.stack.isNotEmpty()) d.bothPass()
+            when (d.pendingDecision) {
+                is YesNoDecision -> {
+                    d.submitYesNo(p1, false).error shouldBe null
+                    break
+                }
+                else -> break
+            }
+        }
+        while (d.pendingDecision == null && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getLifeTotal(p1) shouldBe 23
+        d.dogCount(p1) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RopeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RopeScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.Rope
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Rope (MKM #173).
+ *
+ * "Equipped creature gets +1/+2, has reach, and can't be blocked by more than one creature."
+ *
+ * The blocking restriction is the reason this test exists. `BlockPhaseManager` reads the printed
+ * [com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan] static off the *attacker's own* card
+ * definition and only when its filter scope is `Self`, so the obvious spelling — that static
+ * scoped to `Filters.EquippedCreature` on the Equipment — would compile, snapshot cleanly, and
+ * silently never restrict anything. Rope instead grants the
+ * [com.wingedsheep.sdk.core.AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE] keyword through the
+ * layer system, which the same validator honors via its projected-keyword branch. These tests pin
+ * that down: a double block is rejected, a single block is legal, and the restriction leaves with
+ * the Equipment.
+ */
+class RopeScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(Rope)
+        cardRegistry.register(
+            CardDefinition.creature("Rope Blocker A", ManaCost.parse("{1}"), emptySet(), power = 1, toughness = 1)
+        )
+        cardRegistry.register(
+            CardDefinition.creature("Rope Blocker B", ManaCost.parse("{1}"), emptySet(), power = 1, toughness = 1)
+        )
+
+        test("equipped creature gets +1/+2 and has reach") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                .withCardAttachedTo(1, "Rope", "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val projected = StateProjector().project(game.state)
+
+            withClue("Grizzly Bears should be 3/4 with Rope attached") {
+                projected.getPower(bears) shouldBe 3
+                projected.getToughness(bears) shouldBe 4
+            }
+            withClue("Grizzly Bears should have reach from Rope") {
+                projected.hasKeyword(bears, Keyword.REACH) shouldBe true
+            }
+        }
+
+        test("the equipped attacker can't be blocked by two creatures") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardAttachedTo(1, "Rope", "Grizzly Bears")
+                .withCardOnBattlefield(2, "Rope Blocker A")
+                .withCardOnBattlefield(2, "Rope Blocker B")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            val doubleBlock = game.declareBlockers(
+                mapOf(
+                    "Rope Blocker A" to listOf("Grizzly Bears"),
+                    "Rope Blocker B" to listOf("Grizzly Bears"),
+                )
+            )
+            withClue("Rope caps the equipped creature at one blocker") {
+                doubleBlock.error shouldNotBe null
+            }
+        }
+
+        test("a single creature can still block the equipped attacker") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardAttachedTo(1, "Rope", "Grizzly Bears")
+                .withCardOnBattlefield(2, "Rope Blocker A")
+                .withCardOnBattlefield(2, "Rope Blocker B")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            val singleBlock = game.declareBlockers(mapOf("Rope Blocker A" to listOf("Grizzly Bears")))
+            withClue("One blocker is legal: ${singleBlock.error}") {
+                singleBlock.error shouldBe null
+            }
+        }
+
+        test("an unequipped creature is not restricted") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Rope")
+                .withCardOnBattlefield(2, "Rope Blocker A")
+                .withCardOnBattlefield(2, "Rope Blocker B")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            val doubleBlock = game.declareBlockers(
+                mapOf(
+                    "Rope Blocker A" to listOf("Grizzly Bears"),
+                    "Rope Blocker B" to listOf("Grizzly Bears"),
+                )
+            )
+            withClue("With Rope sitting unattached, two creatures may gang-block: ${doubleBlock.error}") {
+                doubleBlock.error shouldBe null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five more MKM cards, completing the set's "murder weapon" Clue Equipment cycle (Knife and Lead Pipe were already implemented) plus two others.

| Card | Cost | What it does |
|---|---|---|
| **Rope** | `{G}` | Equipped creature gets +1/+2, has reach, and can't be blocked by more than one creature |
| **Wrench** | `{W}` | +1/+1, vigilance, and a granted `{3}, {T}: Tap target creature` |
| **Candlestick** | `{U}` | +1/+1 and a granted "Whenever this creature attacks, surveil 2" |
| **Krovod Haunch** | `{W}` | Food Equipment: +2/+0; sac for 3 life; on hitting the graveyard, may pay `{1}{W}` for two 1/1 Dogs |
| **Jaded Analyst** | `{1}{U}` | 3/2 Defender that loses defender and gains vigilance on your second draw each turn |

All five compose existing SDK primitives — no new effects, triggers, or keywords, so the language reference needs no update.

## The one non-obvious spelling

Rope's blocking restriction does **not** use `CantBeBlockedByMoreThan` scoped to `Filters.EquippedCreature`. That would compile and snapshot cleanly while never restricting anything: `BlockPhaseManager.validateMaxBlockersRequirements` reads the printed form off the *attacker's own* card definition and only when the filter scope is `Self`, so a copy living on the Equipment is never consulted.

Rope instead grants `AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE` through the layer system. The same validator honors that via its projected-keyword branch — the path Glorfindel, Dauntless Rescuer already uses for its durational grant — and the client already has a display name for the flag. The card comment records why, so the next person doesn't "simplify" it back.

## Tests

Scenario tests for the three shapes without close precedent:

- `RopeScenarioTest` — +1/+2 and reach apply; a double block is rejected; a single block is legal; the restriction is absent while the Equipment sits unattached.
- `KrovodHaunchScenarioTest` — the sacrifice ability's own cost puts the Haunch into the graveyard, which fires its own put-into-graveyard trigger. Paying `{1}{W}` makes two Dogs; declining makes none and still gains the 3 life.
- `JadedAnalystScenarioTest` — the first draw of the turn changes nothing, the second strips printed defender and grants vigilance, and attack legality actually notices (the Analyst can be declared as an attacker only after the second draw).

Wrench and Candlestick ride patterns already covered by the `DeconstructionHammer`/`GlowcapLantern` (granted activated ability) and `PirateHat` (granted attack trigger) scenario tests, so they add no test file of their own.

## Verification

- `just build` — green (compile + all module tests + kover).
- `just rebless-cards` — MKM golden moved by 479 added lines, 0 deleted; only the five new cards.
- `just check-card-printing` — clean for all five; MKM is the earliest real printing of each, and CLU (the only reprint set, for the three Equipment) isn't scaffolded.
- `just card-status --set MKM` — 95 → 100 of 276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)