### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BeornReluctantHost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BeornReluctantHost.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PlayAdditionalLandsEffect
+
+/**
+ * Beorn, Reluctant Host // Till and Tend
+ * {4}{G}
+ * Legendary Creature — Human Bear Shapeshifter
+ * 5/5
+ *
+ * Trample
+ *
+ * Adventure: Till and Tend — {1}{G}, Sorcery — Adventure
+ * You may play an additional land this turn.
+ *
+ * The Adventure half is Explore's land-drop grant without the draw, so it reuses
+ * [PlayAdditionalLandsEffect] rather than modelling a second way to say the same thing. The grant lasts
+ * only for the turn the Adventure resolves, which matters here: the creature half is cast from exile on
+ * a later turn and gets no land drop of its own.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster cast
+ * it as the creature spell while it remains in exile.)
+ */
+val BeornReluctantHost = card("Beorn, Reluctant Host") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Bear Shapeshifter"
+    power = 5
+    toughness = 5
+    oracleText = "Trample"
+
+    keywords(Keyword.TRAMPLE)
+
+    adventure("Till and Tend") {
+        manaCost = "{1}{G}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "You may play an additional land this turn. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = PlayAdditionalLandsEffect(count = 1)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Javier Charro"
+        flavorText = "He never invited people into his house if he could help it. Now he had got " +
+            "fifteen strangers sitting in his porch!"
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/804589b7-3ef9-473d-97cc-c61a2d41f70d.jpg?1785323267"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BeornTheFierce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BeornTheFierce.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Beorn the Fierce — The Hobbit #119
+ * {3}{G}{G} · Legendary Creature — Bear Shapeshifter Warrior · Mythic
+ * 6/6
+ *
+ * Trample
+ * Other Bears you control get +2/+2.
+ * At the beginning of combat on your turn, put a trample counter on up to one target creature you
+ * control. It becomes a Bear in addition to its other types. Then if you control three or more
+ * Bears, draw two cards.
+ *
+ * Modeling notes:
+ *  - The anthem is the Elvish Champion shape with `.youControl()` added; `excludeSelf` carries the
+ *    "Other". Beorn is himself a Bear, so he still counts toward the draw check below.
+ *  - "Up to one target" is `TargetCreature(optional = true)` (→ `minCount = 0`), and the payload runs
+ *    through [ForEachTargetEffect] so choosing zero targets skips the counter and the type change
+ *    without fizzling the trigger — the draw clause still gets its chance.
+ *  - The Bear subtype is [Duration.Permanent], not end-of-turn: the text has no duration, so the
+ *    creature stays a Bear (CR 205.1b). It is [Effects.AddSubtype] rather than any "becomes"
+ *    primitive that *sets* subtypes — "in addition to its other types" is purely additive.
+ *  - The draw check is a plain [ConditionalEffect] evaluated after the type change, and the count is
+ *    a projected battlefield read, so the creature that just became a Bear is already counted.
+ */
+val BeornTheFierce = card("Beorn the Fierce") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Bear Shapeshifter Warrior"
+    power = 6
+    toughness = 6
+    oracleText = "Trample\n" +
+        "Other Bears you control get +2/+2.\n" +
+        "At the beginning of combat on your turn, put a trample counter on up to one target " +
+        "creature you control. It becomes a Bear in addition to its other types. Then if you " +
+        "control three or more Bears, draw two cards."
+
+    keywords(Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 2,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.BEAR).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.Creature.youControl())
+        )
+        effect = Effects.Composite(
+            ForEachTargetEffect(
+                listOf(
+                    Effects.AddCounters(Counters.TRAMPLE, 1, EffectTarget.ContextTarget(0)),
+                    Effects.AddSubtype(
+                        Subtype.BEAR.value,
+                        EffectTarget.ContextTarget(0),
+                        Duration.Permanent
+                    )
+                )
+            ),
+            ConditionalEffect(
+                condition = Conditions.YouControlAtLeast(
+                    3,
+                    GameObjectFilter.Creature.withSubtype(Subtype.BEAR)
+                ),
+                effect = Effects.DrawCards(2)
+            )
+        )
+        description = "At the beginning of combat on your turn, put a trample counter on up to one " +
+            "target creature you control. It becomes a Bear in addition to its other types. Then " +
+            "if you control three or more Bears, draw two cards."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "119"
+        artist = "Nia Kovalevski"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/367d5f8b-77ee-47f7-bc71-972d62c280a9.jpg?1784632151"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DainsCompany.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DainsCompany.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dáin's Company — The Hobbit #152
+ * {R}{W} · Creature — Dwarf Warrior · Rare
+ * 2/2
+ *
+ * This creature has lifelink as long as you control another Dwarf.
+ * When this creature enters, look at the top four cards of your library. You may reveal a Dwarf or
+ * Equipment card from among them and put it into your hand. Put the rest on the bottom of your library
+ * in a random order.
+ *
+ * Modeling notes:
+ *  - The lifelink clause is the Bolg's Company / Barrow Naughty shape: a `ConditionalStaticAbility`
+ *    gated on `YouControl(..., excludeSelf = true)`, so it goes dark the instant the other Dwarf
+ *    leaves rather than latching on once.
+ *  - The dig is the Boughside Wanderers idiom — gather four, `ChooseUpTo` one ("you may reveal" means
+ *    declining stays legal even with hits present), move the pick to hand `revealed = true`, and bottom
+ *    the remainder with [CardOrder.Random].
+ *  - "A Dwarf or Equipment card" is one `HasAnyOfSubtypes` rather than an `Or` of two predicates: both
+ *    halves are subtypes, and the card doesn't care which type line carries them (a Dwarf Equipment
+ *    would qualify once, not twice).
+ */
+val DainsCompany = card("Dáin's Company") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Creature — Dwarf Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "This creature has lifelink as long as you control another Dwarf.\n" +
+        "When this creature enters, look at the top four cards of your library. You may reveal a " +
+        "Dwarf or Equipment card from among them and put it into your hand. Put the rest on the " +
+        "bottom of your library in a random order."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.LIFELINK, GroupFilter.source()),
+            condition = Conditions.YouControl(
+                GameObjectFilter.Creature.withSubtype(Subtype.DWARF),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            GatherCardsEffect(CardSource.TopOfLibrary(DynamicAmount.Fixed(4)), storeAs = "looked"),
+            SelectFromCollectionEffect(
+                from = "looked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.HasAnyOfSubtypes(listOf(Subtype.DWARF, Subtype.EQUIPMENT))
+                    )
+                ),
+                storeSelected = "kept",
+                storeRemainder = "rest",
+                selectedLabel = "Put in hand",
+                remainderLabel = "Put on bottom"
+            ),
+            MoveCollectionEffect(from = "kept", destination = CardDestination.ToZone(Zone.HAND), revealed = true),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "152"
+        artist = "Erikas Perl"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36db4405-8589-481f-b627-f26087488337.jpg?1785236717"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DesolationOfSmaug.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DesolationOfSmaug.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Desolation of Smaug — The Hobbit #93
+ * {2}{R}{R} · Sorcery · Rare
+ *
+ * Desolation of Smaug deals 3 damage to each non-Dragon creature.
+ * Add four mana in any combination of colors. Spend this mana only to cast Dragon spells.
+ *
+ * Modeling notes:
+ *  - The sweep is the Slagstorm / Breath of Darigaaz idiom: `ForEachInGroup` over a
+ *    projection-read battlefield group with a per-creature [DealDamageEffect]. `notSubtype(Dragon)`
+ *    rather than a hand-rolled predicate, so a creature that has *become* a Dragon (Beorn the
+ *    Fierce's Bear-making cousin, a Shapeshifter) is correctly spared.
+ *  - The mana rider is not a mana ability — it's part of a sorcery's resolution, so the four mana
+ *    land in the controller's pool mid-resolution and empty at end of step like any other mana
+ *    (CR 500.4). In practice that means casting the Dragon in the same main phase, right after this
+ *    resolves.
+ *  - "In any combination of colors" is [Effects.AddManaInAnyCombination], not `AddAnyColorMana`:
+ *    each of the four pips is colored independently, so {R}{R}{G}{U} is a legal split.
+ *  - The spend restriction is [ManaRestriction.SubtypeSpellsOnly] on "Dragon" — spells only, which
+ *    matches the text ("to cast Dragon spells"); it can't pay for a Dragon's activated ability.
+ */
+val DesolationOfSmaug = card("Desolation of Smaug") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Desolation of Smaug deals 3 damage to each non-Dragon creature.\n" +
+        "Add four mana in any combination of colors. Spend this mana only to cast Dragon spells."
+
+    spell {
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.Creature.notSubtype(Subtype.DRAGON)),
+                DealDamageEffect(3, EffectTarget.Self)
+            ),
+            Effects.AddManaInAnyCombination(
+                amount = 4,
+                restriction = ManaRestriction.SubtypeSpellsOnly(setOf("Dragon"))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "93"
+        artist = "Irvin Rodriguez"
+        flavorText = "At the twanging of the bows and the shrilling of the trumpets, the Dragon's " +
+            "wrath blazed to its height, till he was blind and mad with it."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/2462358b-52c8-49b2-8d97-d65a9188f8f7.jpg?1784376974"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/OrcristGoblinCleaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/OrcristGoblinCleaver.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ChooseCreatureTypeEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Orcrist, Goblin-cleaver — The Hobbit #177
+ * {3} · Legendary Artifact — Equipment · Mythic
+ *
+ * Equipped creature gets +2/+2 and has trample.
+ * Whenever equipped creature deals combat damage to a player, choose a creature type. Create a
+ * Treasure token for each creature you control of that type.
+ * Equip {3}
+ *
+ * Modeling notes:
+ *  - The trigger is bound to the *attached* creature ([TriggerBinding.ATTACHED]), the Goldvein Pick
+ *    shape, so it follows the Equipment as it moves rather than watching Orcrist itself.
+ *  - "Choose a creature type" happens on resolution, not on equip, so it is a
+ *    [ChooseCreatureTypeEffect] pipeline step; the count then reads the pick back through
+ *    `withSubtypeFromVariable("chosenCreatureType")`. Counting *after* the choice matters — the
+ *    board is re-read at that moment, and combat damage has already killed whatever died.
+ *  - The count is a battlefield read, so it goes through [DynamicAmount.Count] (projection-aware):
+ *    a Rabbit that a lord has turned into a Goblin counts as a Goblin.
+ *  - Nothing forces a type with hits on it — naming a type you control none of is legal and simply
+ *    makes zero Treasures.
+ */
+val OrcristGoblinCleaver = card("Orcrist, Goblin-cleaver") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+2 and has trample.\n" +
+        "Whenever equipped creature deals combat damage to a player, choose a creature type. " +
+        "Create a Treasure token for each creature you control of that type.\n" +
+        "Equip {3}"
+
+    staticAbility {
+        ability = ModifyStats(+2, +2, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            DamageType.Combat,
+            RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED
+        )
+        effect = Effects.Composite(
+            ChooseCreatureTypeEffect,
+            Effects.CreateTreasure(
+                count = DynamicAmount.Count(
+                    Player.You,
+                    Zone.BATTLEFIELD,
+                    GameObjectFilter.Creature.withSubtypeFromVariable("chosenCreatureType")
+                )
+            )
+        )
+        description = "Whenever equipped creature deals combat damage to a player, choose a " +
+            "creature type. Create a Treasure token for each creature you control of that type."
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "177"
+        artist = "Erikas Perl"
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f54f1c1d-6a22-43e9-a842-0a1ae25b323c.jpg?1784798240"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -185,6 +185,116 @@
     ]
 }
 
+// Beorn the Fierce
+{
+    "name": "Beorn the Fierce",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Legendary Creature — Bear Shapeshifter Warrior",
+    "oracleText": "Trample\nOther Bears you control get +2/+2.\nAt the beginning of combat on your turn, put a trample counter on up to one target creature you control. It becomes a Bear in addition to its other types. Then if you control three or more Bears, draw two cards.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": "IterationSpace.Targets",
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "AddCounters",
+                                        "counterType": "trample",
+                                        "count": 1,
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "AddSubtype",
+                                        "subtype": "Bear",
+                                        "duration": "Permanent"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "creature Bear"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "up to one target creature you control"
+                },
+                "descriptionOverride": "At the beginning of combat on your turn, put a trample counter on up to one target creature you control. It becomes a Bear in addition to its other types. Then if you control three or more Bears, draw two cards."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "creature Bear ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "MYTHIC",
+        "artist": "Nia Kovalevski",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/367d5f8b-77ee-47f7-bc71-972d62c280a9.jpg?1784632151"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Beorn's Hospitality
 {
     "name": "Beorn's Hospitality",
@@ -267,6 +377,45 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Beorn, Reluctant Host
+{
+    "name": "Beorn, Reluctant Host",
+    "manaCost": "{4}{G}",
+    "typeLine": "Legendary Creature — Human Bear Shapeshifter",
+    "oracleText": "Trample",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Javier Charro",
+        "flavorText": "He never invited people into his house if he could help it. Now he had got fifteen strangers sitting in his porch!",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/804589b7-3ef9-473d-97cc-c61a2d41f70d.jpg?1785323267"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Till and Tend",
+            "manaCost": "{1}{G}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "You may play an additional land this turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "PlayAdditionalLands",
+                    "count": 1
+                }
+            }
+        }
     ]
 }
 
@@ -1119,6 +1268,76 @@
     ]
 }
 
+// Desolation of Smaug
+{
+    "name": "Desolation of Smaug",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Desolation of Smaug deals 3 damage to each non-Dragon creature.\nAdd four mana in any combination of colors. Spend this mana only to cast Dragon spells.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotSubtype",
+                                        "subtype": "Dragon"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "AddDynamicMana",
+                    "amountSource": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "allowedColors": [
+                        "WHITE",
+                        "BLUE",
+                        "BLACK",
+                        "RED",
+                        "GREEN"
+                    ],
+                    "restriction": {
+                        "type": "SubtypeSpellsOnly",
+                        "subtypes": [
+                            "Dragon"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "rarity": "RARE",
+        "artist": "Irvin Rodriguez",
+        "flavorText": "At the twanging of the bows and the shrilling of the trumpets, the Dragon's wrath blazed to its height, till he was blind and mad with it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/2462358b-52c8-49b2-8d97-d65a9188f8f7.jpg?1784376974"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Dori, Bearer of Friends
 {
     "name": "Dori, Bearer of Friends",
@@ -1663,6 +1882,120 @@
         "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2341cf3-4d2c-4a4f-9aea-8834104a8910.jpg?1785496931"
     },
     "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Dáin's Company
+{
+    "name": "Dáin's Company",
+    "manaCost": "{R}{W}",
+    "typeLine": "Creature — Dwarf Warrior",
+    "oracleText": "This creature has lifelink as long as you control another Dwarf.\nWhen this creature enters, look at the top four cards of your library. You may reveal a Dwarf or Equipment card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "HasAnyOfSubtypes",
+                                        "subtypes": [
+                                            "Dwarf",
+                                            "Equipment"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put on bottom"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Dwarf",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "RARE",
+        "artist": "Erikas Perl",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36db4405-8589-481f-b627-f26087488337.jpg?1785236717"
+    },
+    "colorIdentityOverride": [
+        "RED",
         "WHITE"
     ]
 }
@@ -4923,6 +5256,101 @@
         "artist": "Francisco Miyara",
         "flavorText": "\"We may not understand him, but that old bird understands us, I am sure.\"\n—Balin",
         "imageUri": "https://cards.scryfall.io/normal/front/3/a/3ad02b56-13ec-46ef-92bd-ae078b8bb517.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Orcrist, Goblin-cleaver
+{
+    "name": "Orcrist, Goblin-cleaver",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+2 and has trample.\nWhenever equipped creature deals combat damage to a player, choose a creature type. Create a Treasure token for each creature you control of that type.\nEquip {3}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "ChooseCreatureType",
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure",
+                            "dynamicCount": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Battlefield",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "HasSubtypeFromVariable",
+                                            "variableName": "chosenCreatureType"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever equipped creature deals combat damage to a player, choose a creature type. Create a Treasure token for each creature you control of that type."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "177",
+        "rarity": "MYTHIC",
+        "artist": "Erikas Perl",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f54f1c1d-6a22-43e9-a842-0a1ae25b323c.jpg?1784798240"
     },
     "colorIdentityOverride": []
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeornReluctantHostScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeornReluctantHostScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Beorn, Reluctant Host // Till and Tend (HOB #118) — {4}{G} 5/5 Trample // {1}{G} Sorcery — Adventure
+ *
+ * Till and Tend: You may play an additional land this turn.
+ *
+ * Proves the Adventure half actually grants the extra land drop and then exiles on resolution, so
+ * the creature stays castable from exile later (CR 715).
+ */
+class BeornReluctantHostScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Beorn, Reluctant Host") {
+
+            test("Till and Tend grants a second land drop and exiles the card") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Beorn, Reluctant Host")
+                    .withCardsInHand(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Beorn, Reluctant Host"
+                }
+
+                // faceIndex = 0 is the Adventure half.
+                val cast = game.execute(
+                    CastSpell(playerId = game.player1Id, cardId = cardId, faceIndex = 0)
+                )
+                withClue("Casting Till and Tend should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The Adventure exiles on resolution, ready to be cast as Beorn later") {
+                    game.isInExile(1, "Beorn, Reluctant Host") shouldBe true
+                }
+
+                val handForests = game.findCardsInHand(1, "Forest")
+                withClue("The normal land drop") {
+                    game.execute(PlayLand(game.player1Id, handForests[0])).error shouldBe null
+                }
+                withClue("And the additional one Till and Tend granted") {
+                    game.execute(PlayLand(game.player1Id, handForests[1])).error shouldBe null
+                }
+                withClue("Two Forests started in play, two more were played") {
+                    game.findAllPermanents("Forest").size shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeornTheFierceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeornTheFierceScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Beorn the Fierce (HOB #119) — {3}{G}{G} Legendary Creature — Bear Shapeshifter Warrior 6/6
+ *
+ * Trample
+ * Other Bears you control get +2/+2.
+ * At the beginning of combat on your turn, put a trample counter on up to one target creature you
+ * control. It becomes a Bear in addition to its other types. Then if you control three or more
+ * Bears, draw two cards.
+ *
+ * Three things here can silently go wrong, so each gets a test: the subtype must be *added* (not
+ * set) and must outlive the turn; the newly-made Bear must count toward the draw check, and pick up
+ * the anthem; and declining the optional target must not eat the draw clause.
+ */
+class BeornTheFierceScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    /** Pass until the begin-combat trigger asks for its "up to one target creature you control". */
+    private fun advanceToTargetPrompt(game: TestGame) {
+        var guard = 0
+        while (guard++ < 30 && !game.hasPendingDecision()) {
+            game.passPriority()
+        }
+        withClue("Beorn's begin-combat trigger should have prompted for a target") {
+            game.hasPendingDecision() shouldBe true
+        }
+    }
+
+    init {
+        context("Beorn the Fierce") {
+
+            test("the anthem pumps other Bears you control but not Beorn himself") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Beorn the Fierce")
+                    .withCardOnBattlefield(1, "Ordinary Bear")
+                    .withCardOnBattlefield(2, "Large Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val projected = projector.project(game.state)
+                val beorn = game.findPermanent("Beorn the Fierce")!!
+                val myBear = game.findPermanent("Ordinary Bear")!!
+                val theirBear = game.findPermanent("Large Bear")!!
+
+                withClue("Beorn stays 6/6 — 'Other'") {
+                    projected.getPower(beorn) shouldBe 6
+                    projected.getToughness(beorn) shouldBe 6
+                }
+                withClue("Ordinary Bear 4/5 -> 6/7") {
+                    projected.getPower(myBear) shouldBe 6
+                    projected.getToughness(myBear) shouldBe 7
+                }
+                withClue("The opponent's Bear is untouched — 'you control'") {
+                    projected.getPower(theirBear) shouldBe 5
+                    projected.getToughness(theirBear) shouldBe 5
+                }
+            }
+
+            test("the trigger adds a trample counter and the Bear type, and draws on three Bears") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Beorn the Fierce")
+                    .withCardOnBattlefield(1, "Ordinary Bear")
+                    .withCardOnBattlefield(1, "Goblin-town Flunkies")
+                    .withCardInLibrary(1, "Little Bear")
+                    .withCardInLibrary(1, "Large Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val flunkies = game.findPermanent("Goblin-town Flunkies")!!
+                val handBefore = game.handSize(1)
+
+                advanceToTargetPrompt(game)
+                game.selectTargets(listOf(flunkies))
+                game.resolveStack()
+
+                val projected = projector.project(game.state)
+
+                withClue("A trample counter landed, and it grants trample through the layers") {
+                    game.state.getEntity(flunkies)?.get<CountersComponent>()
+                        ?.getCount(CounterType.TRAMPLE) shouldBe 1
+                    projected.hasKeyword(flunkies, Keyword.TRAMPLE) shouldBe true
+                }
+                withClue("Bear is added, not substituted — Goblin and Soldier survive") {
+                    projected.hasSubtype(flunkies, "Bear") shouldBe true
+                    projected.hasSubtype(flunkies, "Goblin") shouldBe true
+                    projected.hasSubtype(flunkies, "Soldier") shouldBe true
+                }
+                withClue("The new Bear picks up the anthem: base 1/1 -> 3/3") {
+                    projected.getPower(flunkies) shouldBe 3
+                    projected.getToughness(flunkies) shouldBe 3
+                }
+                withClue("Beorn + Ordinary Bear + the new Bear = three, so draw two") {
+                    game.handSize(1) shouldBe handBefore + 2
+                }
+            }
+
+            test("declining the optional target still runs the draw check") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Beorn the Fierce")
+                    .withCardOnBattlefield(1, "Ordinary Bear")
+                    .withCardInLibrary(1, "Little Bear")
+                    .withCardInLibrary(1, "Large Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                advanceToTargetPrompt(game)
+                game.skipTargets()
+                game.resolveStack()
+
+                withClue("Only two Bears, so no draw — but the trigger resolved without fizzling") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("Beorn is still around; the trigger didn't blow up on zero targets") {
+                    game.isOnBattlefield("Beorn the Fierce") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DainsCompanyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DainsCompanyScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dáin's Company (HOB #152) — {R}{W} Creature — Dwarf Warrior 2/2
+ *
+ * This creature has lifelink as long as you control another Dwarf.
+ * When this creature enters, look at the top four cards of your library. You may reveal a Dwarf or
+ * Equipment card from among them and put it into your hand. Put the rest on the bottom of your
+ * library in a random order.
+ *
+ * Two claims worth proving: the lifelink clause is live/dark on *another* Dwarf rather than latching
+ * on once, and the dig's "Dwarf or Equipment" filter really admits both halves (a single
+ * `HasAnyOfSubtypes`, not one subtype with the other silently dropped).
+ */
+class DainsCompanyScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Dáin's Company") {
+
+            test("lifelink is dark alone and live once another Dwarf joins") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Dáin's Company")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dain = game.findPermanent("Dáin's Company")!!
+                withClue("Alone, it is not another Dwarf to itself") {
+                    projector.project(game.state).hasKeyword(dain, Keyword.LIFELINK) shouldBe false
+                }
+
+                val withFriend = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Dáin's Company")
+                    .withCardOnBattlefield(1, "Dwarven Mauler")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dain2 = withFriend.findPermanent("Dáin's Company")!!
+                withClue("A second Dwarf turns the clause on") {
+                    projector.project(withFriend.state).hasKeyword(dain2, Keyword.LIFELINK) shouldBe true
+                }
+            }
+
+            test("the dig offers both Dwarf and Equipment cards, and skips the rest") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dáin's Company")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    // Top four, in library order: an Equipment, a Dwarf, and two of neither.
+                    .withCardInLibrary(1, "Ordinary Bear")
+                    .withCardInLibrary(1, "Large Bear")
+                    .withCardInLibrary(1, "Dwarven Mauler")
+                    .withCardInLibrary(1, "Dwarven Shortsword")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Dáin's Company").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("The ETB dig should pause to pick a card") {
+                    (decision is SelectCardsDecision) shouldBe true
+                }
+                val selectable = (decision as SelectCardsDecision).options.map { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name
+                }.toSet()
+
+                withClue("Both the Dwarf and the Equipment are legal picks: $selectable") {
+                    selectable.contains("Dwarven Mauler") shouldBe true
+                    selectable.contains("Dwarven Shortsword") shouldBe true
+                }
+                withClue("The two Bears are neither Dwarf nor Equipment: $selectable") {
+                    selectable.contains("Ordinary Bear") shouldBe false
+                    selectable.contains("Large Bear") shouldBe false
+                }
+            }
+
+            test("declining the reveal is legal even with a hit present") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dáin's Company")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInLibrary(1, "Ordinary Bear")
+                    .withCardInLibrary(1, "Large Bear")
+                    .withCardInLibrary(1, "Little Bear")
+                    .withCardInLibrary(1, "Dwarven Mauler")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Dáin's Company").error shouldBe null
+                game.resolveStack()
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("Declining leaves the hand empty — 'you may reveal'") {
+                    game.isInHand(1, "Dwarven Mauler") shouldBe false
+                }
+                withClue("All four looked-at cards went to the bottom of the library") {
+                    game.librarySize(1) shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesolationOfSmaugScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesolationOfSmaugScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Desolation of Smaug (HOB #93) — {2}{R}{R} Sorcery
+ *
+ * Desolation of Smaug deals 3 damage to each non-Dragon creature.
+ * Add four mana in any combination of colors. Spend this mana only to cast Dragon spells.
+ *
+ * The exclusion is the part that fails silently — a sweep whose filter forgets the "non-Dragon"
+ * clause still looks correct on a board with no Dragons. The mana half is checked for arriving at
+ * all (four pips, independently colored) rather than for its restriction, which
+ * `ManaRestriction.SubtypeSpellsOnly` already owns.
+ */
+class DesolationOfSmaugScenarioTest : ScenarioTestBase() {
+
+    /**
+     * Resolve the spell and answer the four "colour this pip" prompts with [colors]. Stops as soon
+     * as the prompts are done — passing priority any further would end the step and empty the pool
+     * (CR 500.4), which is exactly what the mana test needs to read before.
+     */
+    private fun resolveAndColorMana(game: TestGame, colors: List<Color>) {
+        game.resolveStack()
+        var i = 0
+        var guard = 0
+        while (game.hasPendingDecision() && guard++ < 12) {
+            game.submitDecision(
+                ColorChosenResponse(game.getPendingDecision()!!.id, colors.getOrElse(i++) { Color.RED })
+            )
+        }
+    }
+
+    init {
+        context("Desolation of Smaug") {
+
+            test("the sweep spares Dragons and kills everything else that can't take 3") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Desolation of Smaug")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardOnBattlefield(1, "Smaug, the Great Calamity")
+                    .withCardOnBattlefield(2, "Goblin-town Flunkies")
+                    .withCardOnBattlefield(2, "Ordinary Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Desolation of Smaug").error shouldBe null
+                resolveAndColorMana(game, List(4) { Color.RED })
+                game.checkStateBasedActions()
+
+                withClue("Smaug is a Dragon — untouched by its own desolation") {
+                    game.isOnBattlefield("Smaug, the Great Calamity") shouldBe true
+                }
+                withClue("A 1/1 non-Dragon takes 3 and dies") {
+                    game.isInGraveyard(2, "Goblin-town Flunkies") shouldBe true
+                }
+                withClue("A 4/5 non-Dragon takes 3 and survives — damage, not destruction") {
+                    game.isOnBattlefield("Ordinary Bear") shouldBe true
+                }
+            }
+
+            test("it adds four Dragons-only mana, each pip colored independently") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Desolation of Smaug")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Desolation of Smaug").error shouldBe null
+                resolveAndColorMana(game, listOf(Color.RED, Color.RED, Color.BLUE, Color.GREEN))
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                val restricted = pool?.restrictedMana.orEmpty()
+
+                withClue("Restricted mana never lands in the plain colour counters") {
+                    pool?.red shouldBe 0
+                }
+                withClue("Four mana in any combination — two red, one blue, one green: $restricted") {
+                    restricted.count { it.color == Color.RED } shouldBe 2
+                    restricted.count { it.color == Color.BLUE } shouldBe 1
+                    restricted.count { it.color == Color.GREEN } shouldBe 1
+                }
+                withClue("Every pip carries the Dragon-spells-only restriction") {
+                    restricted.all {
+                        it.restriction == ManaRestriction.SubtypeSpellsOnly(setOf("Dragon"))
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrcristGoblinCleaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrcristGoblinCleaverScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.AssignDamageDecision
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.CombatResolutionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Orcrist, Goblin-cleaver (HOB #177) — {3} Legendary Artifact — Equipment
+ *
+ * Equipped creature gets +2/+2 and has trample.
+ * Whenever equipped creature deals combat damage to a player, choose a creature type. Create a
+ * Treasure token for each creature you control of that type.
+ * Equip {3}
+ *
+ * The composition under test is the second ability: a resolution-time creature-type choice feeding a
+ * *dynamic* token count. The risk it covers is the count reading the wrong thing — a fixed 1, the
+ * whole board, or a type chosen before the board was re-read.
+ */
+class OrcristGoblinCleaverScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    /** Push through combat until the Equipment's creature-type choice surfaces. */
+    private fun advanceToTypeChoice(game: TestGame): ChooseOptionDecision {
+        var blockersDeclared = false
+        var guard = 0
+        while (guard++ < 60) {
+            val pending = game.getPendingDecision()
+            if (pending is ChooseOptionDecision) return pending
+            when {
+                pending is CombatResolutionDecision -> game.submitDefaultCombatDamage()
+                pending is AssignDamageDecision -> game.submitDefaultDamageAssignment()
+                pending != null -> error("unexpected pending decision: $pending")
+                game.state.step == Step.DECLARE_BLOCKERS && !blockersDeclared -> {
+                    blockersDeclared = true
+                    game.declareNoBlockers()
+                }
+                else -> game.passPriority()
+            }
+        }
+        error("no creature-type choice surfaced; last was ${game.getPendingDecision()}")
+    }
+
+    private fun treasureCount(game: TestGame): Int {
+        val projected = projector.project(game.state)
+        return game.state.getBattlefield(game.player1Id).count { projected.hasSubtype(it, "Treasure") }
+    }
+
+    init {
+        context("Orcrist, Goblin-cleaver") {
+
+            test("the static half grants +2/+2 and trample to the equipped creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ordinary Bear")
+                    .withCardAttachedTo(1, "Orcrist, Goblin-cleaver", "Ordinary Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Ordinary Bear")!!
+                val projected = projector.project(game.state)
+
+                withClue("Ordinary Bear is a 4/5, so equipping makes it 6/7") {
+                    projected.getPower(bear) shouldBe 6
+                    projected.getToughness(bear) shouldBe 7
+                }
+                projected.hasKeyword(bear, Keyword.TRAMPLE) shouldBe true
+            }
+
+            test("combat damage mints one Treasure per creature you control of the chosen type") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ordinary Bear")
+                    .withCardOnBattlefield(1, "Large Bear")
+                    .withCardOnBattlefield(1, "Goblin-town Flunkies")
+                    .withCardAttachedTo(1, "Orcrist, Goblin-cleaver", "Ordinary Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Ordinary Bear" to 2)).error shouldBe null
+
+                val decision = advanceToTypeChoice(game)
+                val bearIndex = decision.options.indexOf("Bear")
+                withClue("Bear must be offered as a creature type") { (bearIndex >= 0) shouldBe true }
+                game.submitDecision(OptionChosenResponse(decision.id, bearIndex))
+                game.resolveStack()
+
+                withClue("Two Bears on the battlefield -> two Treasures, not one and not three") {
+                    treasureCount(game) shouldBe 2
+                }
+            }
+
+            test("naming a type you control none of makes no Treasures") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ordinary Bear")
+                    .withCardAttachedTo(1, "Orcrist, Goblin-cleaver", "Ordinary Bear")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Ordinary Bear" to 2)).error shouldBe null
+
+                val decision = advanceToTypeChoice(game)
+                val dragonIndex = decision.options.indexOf("Dragon")
+                game.submitDecision(OptionChosenResponse(decision.id, dragonIndex))
+                game.resolveStack()
+
+                withClue("No Dragons controlled -> zero Treasures, and no crash on an empty count") {
+                    treasureCount(game) shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements five HOB cards, all composed from existing SDK primitives — no new effects, triggers, or keywords.

| Card | # | Shape |
|---|---|---|
| Beorn, Reluctant Host // Till and Tend | 118 | Adventure + additional land drop |
| Dáin's Company | 152 | Conditional lifelink + ETB dig |
| Orcrist, Goblin-cleaver | 177 | Equipment, chosen-type Treasures |
| Desolation of Smaug | 93 | Non-Dragon sweep + restricted mana |
| Beorn the Fierce | 119 | Bear anthem, trample counter + type grant |

## Modelling notes

- **Orcrist** — "choose a creature type. Create a Treasure token for each creature you control of that type" is a resolution-time `ChooseCreatureTypeEffect` feeding a `DynamicAmount.Count` over `withSubtypeFromVariable("chosenCreatureType")`. Counting *after* the choice matters: the board is re-read at that moment, and the count is projection-aware, so a creature a lord has turned into the named type is included. The trigger is `TriggerBinding.ATTACHED` (Goldvein Pick shape) so it follows the Equipment.
- **Beorn the Fierce** — the Bear subtype is `Duration.Permanent`, not end-of-turn: the text carries no duration (CR 205.1b). `Effects.AddSubtype` is additive, so the target keeps its printed types. "Up to one target" runs through `ForEachTargetEffect`, so declining skips the counter and the type change without eating the draw clause.
- **Desolation of Smaug** — the sweep filters on `notSubtype(Dragon)` so a creature that has *become* a Dragon is spared. The four mana are `AddManaInAnyCombination` (each pip colored independently) under `ManaRestriction.SubtypeSpellsOnly("Dragon")`; they land in the pool mid-resolution, so the Dragon has to be cast in that same main phase.
- **Dáin's Company** — "a Dwarf or Equipment card" is one `HasAnyOfSubtypes`, not an `Or` of two predicates. Lifelink is a `ConditionalStaticAbility` on `YouControl(Dwarf, excludeSelf = true)`, so it goes dark the moment the other Dwarf leaves.
- **Beorn, Reluctant Host** — Till and Tend reuses `PlayAdditionalLandsEffect` (Explore's grant, minus the draw) rather than a second way to say the same thing.

## Not implemented

Three HOB set mechanics are still missing engine support and were deliberately avoided here — they're `add-feature` work, not card work:

- **recruit** ("Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier token")
- **storied** / enduring story
- **hone counters**

## Verification

`just build` green (full gate, 8m19s). Card snapshot re-blessed — diff is pure additions, only these five cards moved. `just check-card-printing` clean for all five: HOB is each card's earliest real printing, so each is canonical here.

Each card has its own scenario test (`{CardName}ScenarioTest.kt`), covering the happy path plus the edge most likely to fail silently:

- Orcrist: naming a type you control none of → zero Treasures, no crash on the empty count
- Beorn the Fierce: declining the optional target still runs the draw check; Bear is *added* (Goblin and Soldier survive) and the new Bear counts toward its own three-Bear check
- Desolation: the Dragon survives its own desolation; a 4/5 non-Dragon takes 3 and lives
- Dáin's Company: both the Dwarf and the Equipment are offered, the Bears aren't; declining is legal with a hit present
- Beorn, Reluctant Host: both land drops are actually playable, and the card exiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)