### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/TheHobbitSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/TheHobbitSet.kt
@@ -41,6 +41,12 @@ object TheHobbitSet : MtgSet {
             name = "Treasure",
             imageUri = "https://cards.scryfall.io/art_crop/front/c/6/c6e096bb-ad9e-4a8b-8b42-26852fa32c1d.jpg?1783902770",
         ),
+        // thob #3 — the Army that every "amass Goblins" card in the set puts its counters on
+        // (Down, Down to Goblin Town, Gathering of Darkness, Rage into the Valley, Clap! Snap!).
+        TokenPrinting(
+            name = "Goblin Army",
+            imageUri = "https://cards.scryfall.io/normal/front/2/e/2e2028b1-34c0-40b6-8f65-79f79a279996.jpg?1785497644",
+        ),
     )
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.hob.cards"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/AnUnexpectedParty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/AnUnexpectedParty.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * An Unexpected Party // At the Door — The Hobbit #29
+ * {2}{W}{W}
+ * Enchantment
+ *
+ * As this enchantment enters, choose a creature type.
+ * Creatures you control of the chosen type get +2/+2.
+ *
+ * Adventure: At the Door — {X}{2}{W}, Sorcery — Adventure
+ * Create X 2/2 red Dwarf creature tokens.
+ *
+ * The type is picked as the enchantment enters — a replacement effect ([EntersWithChoice]), not a
+ * resolution-time trigger — so the lord is already live the first time state-based actions look
+ * (CR 614.12, Adaptive Automaton). The buff is a plain Layer 7c [ModifyStats] over
+ * `ChosenSubtypeCreatures`, so creatures of the chosen type that arrive later are covered too.
+ *
+ * The Adventure's X is the {X} in *its* mana cost, read at resolution as [DynamicAmount.XValue].
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the enchantment later from exile.)
+ */
+val AnUnexpectedParty = card("An Unexpected Party") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "As this enchantment enters, choose a creature type.\n" +
+        "Creatures you control of the chosen type get +2/+2."
+
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 2,
+            filter = GroupFilter.ChosenSubtypeCreatures().youControl()
+        )
+    }
+
+    adventure("At the Door") {
+        manaCost = "{X}{2}{W}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Create X 2/2 red Dwarf creature tokens. " +
+            "(Then exile this card. You may cast the enchantment later from exile.)"
+        spell {
+            effect = Effects.CreateToken(
+                count = DynamicAmount.XValue,
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.RED),
+                creatureTypes = setOf("Dwarf"),
+                imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1786258756",
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "29"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3aa29fe8-1687-486f-b4df-c04977869ab1.jpg?1783902787"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BofurReliableGuardian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BofurReliableGuardian.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Bofur, Reliable Guardian // Concerted Care — The Hobbit #6
+ * {W}
+ * Legendary Creature — Dwarf Scout
+ * 1/1
+ *
+ * Lifelink
+ *
+ * Adventure: Concerted Care — {1}{W}, Instant — Adventure
+ * Target artifact or creature you control gains hexproof and indestructible until end of turn.
+ *
+ * Both grants ride the same target, so a single [TargetPermanent] slot feeds two
+ * [Effects.GrantKeyword] applications — if the permanent leaves before resolution the spell fizzles
+ * as a whole rather than half-applying.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val BofurReliableGuardian = card("Bofur, Reliable Guardian") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Dwarf Scout"
+    power = 1
+    toughness = 1
+    oracleText = "Lifelink"
+
+    keywords(Keyword.LIFELINK)
+
+    adventure("Concerted Care") {
+        manaCost = "{1}{W}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Target artifact or creature you control gains hexproof and indestructible " +
+            "until end of turn. (Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val permanent = target(
+                "target artifact or creature you control",
+                TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrArtifact.youControl()))
+            )
+            effect = Effects.GrantKeyword(Keyword.HEXPROOF, permanent, Duration.EndOfTurn)
+                .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, permanent, Duration.EndOfTurn))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Kieran Yanner"
+        flavorText = "Bofur and Bombur were left behind to guard the ponies and such stores as they had."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b8e6435-7de4-41d5-bc7d-8e24c11897d0.jpg?1785496981"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GreatUglyLookingGoblin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GreatUglyLookingGoblin.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Great Ugly-Looking Goblin // Clap! Snap! — The Hobbit #74
+ * {5}{B}
+ * Creature — Goblin Soldier
+ * 4/4
+ *
+ * Each creature you control with a +1/+1 counter on it has menace.
+ *
+ * Adventure: Clap! Snap! — {1}{B}, Sorcery — Adventure
+ * Amass Goblins 2.
+ *
+ * The menace clause is a plain Layer 6 keyword grant over the counter-gated group (Training Regimen),
+ * so it tracks counters arriving and leaving continuously rather than being snapshotted. "Each
+ * creature you control" includes the Goblin itself once it carries a counter, so the group is *not*
+ * `excludeSelf` — and the Army minted by the Adventure qualifies the moment it gets its counters.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val GreatUglyLookingGoblin = card("Great Ugly-Looking Goblin") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Each creature you control with a +1/+1 counter on it has menace. " +
+        "(It can't be blocked except by two or more creatures.)"
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.MENACE,
+            GroupFilter(GameObjectFilter.Creature.youControl().withCounter(Counters.PLUS_ONE_PLUS_ONE)),
+        )
+    }
+
+    adventure("Clap! Snap!") {
+        manaCost = "{1}{B}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Amass Goblins 2. (Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.Amass(2, "Goblin")
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Jason Kang"
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c87f6004-e1cf-42b2-9647-322bc4939339.jpg?1785237962"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/HeadOfTheHunt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/HeadOfTheHunt.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.RedirectZoneChangeWithEffect
+
+/**
+ * Head of the Hunt — The Hobbit #75
+ * {2}{B}{B}
+ * Creature — Wolf
+ * 4/3
+ *
+ * Flash
+ * If a creature an opponent controls would die, exile it instead. When you do, create a 2/2 green
+ * Wolf creature token.
+ *
+ * The whole clause is one replacement effect with a rider ([RedirectZoneChangeWithEffect], The
+ * Darkness Crystal) rather than a redirect plus a separate trigger: "when you do" is reflexive on
+ * the replacement, so the Wolf is minted once per creature actually redirected. A standalone dies
+ * trigger would never fire — the redirect means those creatures never die at all, and neither do
+ * anyone else's dies triggers (CR 614.1c).
+ *
+ * The filter is deliberately *not* `nontoken()`: an opponent's token still "would die", so it is
+ * exiled instead (and then ceases to exist as a state-based action) and still pays off the Wolf.
+ */
+val HeadOfTheHunt = card("Head of the Hunt") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Wolf"
+    power = 4
+    toughness = 3
+    oracleText = "Flash\n" +
+        "If a creature an opponent controls would die, exile it instead. When you do, create a " +
+        "2/2 green Wolf creature token."
+
+    keywords(Keyword.FLASH)
+
+    replacementEffect(
+        RedirectZoneChangeWithEffect(
+            newDestination = Zone.EXILE,
+            additionalEffect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Wolf"),
+                imageUri = "https://cards.scryfall.io/normal/front/e/0/e07312b9-f3c1-4e36-88fc-b29cde581eb6.jpg?1785497932",
+            ),
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.opponentControls(),
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD,
+            ),
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Andrea Piparo"
+        flavorText = "The Wargs planned to come by night upon the villages nearest the mountains. " +
+            "If their plan had been carried out, there would have been none left there next day."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3ffe34d4-72f4-4562-a948-8909b9321e59.jpg?1785152416"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LaketownMariners.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LaketownMariners.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Lake-town Mariners // Gone Fishing — The Hobbit #44
+ * {4}{U}{U}
+ * Creature — Human Citizen
+ * 6/5
+ *
+ * Vigilance
+ * Ward {2}
+ *
+ * Adventure: Gone Fishing — {3}{U}, Instant — Adventure
+ * Exile two target creatures and/or lands you control, then return them to the battlefield under
+ * their owner's control.
+ *
+ * The blink is one atomic gather → exile (linked to this spell) → return-from-linked-exile pipeline
+ * (Another Round), seeded from [CardSource.ChosenTargets] rather than a player choice because the
+ * two permanents are *targets*, locked in as the spell is cast. Both leave and both re-enter as one
+ * batch, so enters-the-battlefield abilities see the whole pair — a per-target loop would blink them
+ * one at a time and get that wrong.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val LaketownMariners = card("Lake-town Mariners") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Citizen"
+    power = 6
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "Ward {2} (Whenever this creature becomes the target of a spell or ability an opponent " +
+        "controls, counter it unless that player pays {2}.)"
+
+    keywords(Keyword.VIGILANCE)
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    adventure("Gone Fishing") {
+        manaCost = "{3}{U}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Exile two target creatures and/or lands you control, then return them to the " +
+            "battlefield under their owner's control. (Then exile this card. You may cast the " +
+            "creature later from exile.)"
+        spell {
+            target(
+                "two target creatures and/or lands you control",
+                TargetPermanent(
+                    count = 2,
+                    filter = TargetFilter(GameObjectFilter.CreatureOrLand.youControl())
+                )
+            )
+            effect = Effects.Pipeline(
+                descriptionOverride = "Exile two target creatures and/or lands you control, then " +
+                    "return them to the battlefield under their owner's control"
+            ) {
+                val chosen = gather(source = CardSource.ChosenTargets)
+                exile(chosen, linkToSource = true)
+                val returning = gather(source = CardSource.FromLinkedExile())
+                move(returning, CardDestination.ToZone(Zone.BATTLEFIELD), underOwnersControl = true)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "44"
+        artist = "Wei Guan"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/4202a678-a5f4-47f9-9c18-e88ab9ad20a4.jpg?1785237929"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1,3 +1,63 @@
+// An Unexpected Party
+{
+    "name": "An Unexpected Party",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "As this enchantment enters, choose a creature type.\nCreatures you control of the chosen type get +2/+2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2,
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "chosenSubtypeKey": "chosenCreatureType"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CREATURE_TYPE"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "RARE",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3aa29fe8-1687-486f-b4df-c04977869ab1.jpg?1783902787"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "At the Door",
+            "manaCost": "{X}{2}{W}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Create X 2/2 red Dwarf creature tokens. (Then exile this card. You may cast the enchantment later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreateToken",
+                    "count": "XValue",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Dwarf"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1786258756"
+                }
+            }
+        }
+    ]
+}
+
 // Attercop
 {
     "name": "Attercop",
@@ -508,6 +568,72 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Bofur, Reliable Guardian
+{
+    "name": "Bofur, Reliable Guardian",
+    "manaCost": "{W}",
+    "typeLine": "Legendary Creature — Dwarf Scout",
+    "oracleText": "Lifelink",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "flavorText": "Bofur and Bombur were left behind to guard the ponies and such stores as they had.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b8e6435-7de4-41d5-bc7d-8e24c11897d0.jpg?1785496981"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Concerted Care",
+            "manaCost": "{1}{W}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Target artifact or creature you control gains hexproof and indestructible until end of turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HEXPROOF",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target artifact or creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target artifact or creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature|artifact ctrl:you"
+                        },
+                        "id": "target artifact or creature you control"
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -3636,6 +3762,68 @@
     ]
 }
 
+// Great Ugly-Looking Goblin
+{
+    "name": "Great Ugly-Looking Goblin",
+    "manaCost": "{5}{B}",
+    "typeLine": "Creature — Goblin Soldier",
+    "oracleText": "Each creature you control with a +1/+1 counter on it has menace. (It can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "MENACE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "+1/+1"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Kang",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c87f6004-e1cf-42b2-9647-322bc4939339.jpg?1785237962"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Clap! Snap!",
+            "manaCost": "{1}{B}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Amass Goblins 2. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Amass",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "subtype": "Goblin"
+                }
+            }
+        }
+    ]
+}
+
 // Guardian of the Halls
 {
     "name": "Guardian of the Halls",
@@ -3742,6 +3930,57 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Head of the Hunt
+{
+    "name": "Head of the Hunt",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Flash\nIf a creature an opponent controls would die, exile it instead. When you do, create a 2/2 green Wolf creature token.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "RedirectZoneChangeWithEffect",
+                "newDestination": "Exile",
+                "additionalEffect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Wolf"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/e/0/e07312b9-f3c1-4e36-88fc-b29cde581eb6.jpg?1785497932"
+                },
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Andrea Piparo",
+        "flavorText": "The Wargs planned to come by night upon the villages nearest the mountains. If their plan had been carried out, there would have been none left there next day.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3ffe34d4-72f4-4562-a948-8909b9321e59.jpg?1785152416"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -4092,6 +4331,95 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Lake-town Mariners
+{
+    "name": "Lake-town Mariners",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "Vigilance\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "UNCOMMON",
+        "artist": "Wei Guan",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/4202a678-a5f4-47f9-9c18-e88ab9ad20a4.jpg?1785237929"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Gone Fishing",
+            "manaCost": "{3}{U}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Exile two target creatures and/or lands you control, then return them to the battlefield under their owner's control. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered0",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "gathered2"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gathered2",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ],
+                    "descriptionOverride": "Exile two target creatures and/or lands you control, then return them to the battlefield under their owner's control"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "filter": {
+                            "baseFilter": "creature|land ctrl:you"
+                        },
+                        "id": "two target creatures and/or lands you control"
+                    }
+                ]
+            }
+        }
     ]
 }
 


### PR DESCRIPTION
Five cards from The Hobbit (HOB), each built from existing SDK primitives — no engine or SDK changes.

The set's `recruit` and `storied` keywords aren't implemented yet, which rules out most of HOB's remaining commons; these five were picked to avoid them (that's `add-feature` work, not `add-card`).

## Cards

| Card | Shape |
|---|---|
| **Bofur, Reliable Guardian // Concerted Care** | `{W}` 1/1 lifelink. Adventure grants hexproof + indestructible until end of turn. Both grants ride one target slot, so the spell fizzles as a whole rather than half-applying. |
| **Great Ugly-Looking Goblin // Clap! Snap!** | `{5}{B}` 4/4. Layer 6 `GrantKeyword(MENACE)` over `Creature.youControl().withCounter(PLUS_ONE_PLUS_ONE)` — deliberately *not* `excludeSelf`, since "each creature you control" includes the Goblin once it carries a counter. Adventure amasses Goblins 2. |
| **An Unexpected Party // At the Door** | `{2}{W}{W}` enchantment. `EntersWithChoice(CREATURE_TYPE)` is a replacement, not a resolution trigger, so the +2/+2 is already live the first time state-based actions look (CR 614.12). Adventure creates X 2/2 red Dwarves off `DynamicAmount.XValue`. |
| **Lake-town Mariners // Gone Fishing** | `{4}{U}{U}` 6/5 vigilance, ward `{2}`. Adventure blinks two permanents that are *targets*, so the pipeline is seeded from `CardSource.ChosenTargets` → linked exile → `FromLinkedExile` return. Both re-enter as one batch; a per-target loop would blink them one at a time and get ETB timing wrong. |
| **Head of the Hunt** | `{2}{B}{B}` 4/3 flash. `RedirectZoneChangeWithEffect` — "when you do" is reflexive on the replacement, so the Wolf is minted once per creature actually redirected. A standalone dies trigger would never fire, because the redirect means those creatures never die (CR 614.1c). Tokens are not excluded: an opponent's token still "would die". |

Also registers the `thob` Goblin Army token art on `TheHobbitSet`, which every "amass Goblins" card in the set (Down, Down to Goblin Town; Gathering of Darkness; Rage into the Valley) was already minting artless.

## Verification

- `just build` — green.
- `just rebless-cards` — the `HOB.json` golden shows **only** these five trees added (328 lines, zero deletions), so nothing shared moved.
- `just check-card-printing` — clean for all five; HOB is the earliest real printing of each.
- All eight image URIs verified HTTP 200 against `cards.scryfall.io`.
- No new SDK vocabulary, so per the add-card skill the snapshot + `CardLintTest` nets are the coverage; no scenario tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
