### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GlintWeaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GlintWeaver.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Glint Weaver — Murders at Karlov Manor #162
+ * {5}{G}{G} · Creature — Spider · 3/3
+ *
+ * Reach
+ * When this creature enters, distribute three +1/+1 counters among one, two, or three target
+ * creatures, then you gain life equal to the greatest toughness among creatures you control.
+ *
+ * Two details the wording is precise about and the script follows literally:
+ *
+ * - The counters go on "target creatures", **not** "target creatures you control" — an unusual
+ *   freedom for a distribute effect, so the target filter is unrestricted. (Handing an opponent
+ *   counters is almost never right, but it's legal, and it matters when your own board is empty:
+ *   the trigger still needs at least one legal target.)
+ * - "then" orders the two halves within one resolution, so the life gain sees the counters already
+ *   placed. Weaver's own body is a 3/3, but after distributing all three counters onto it the
+ *   greatest toughness among your creatures is 6, not 3.
+ *
+ * `minCount = 1` encodes "one, two, or three": the distribute helper does the per-target split, and
+ * every chosen target must receive at least one counter (CR 601.2d). If all targets become illegal
+ * the trigger fizzles and no life is gained; if some remain, the counters redistribute among the
+ * legal ones and the life gain still happens.
+ */
+val GlintWeaver = card("Glint Weaver") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider"
+    oracleText = "Reach\n" +
+        "When this creature enters, distribute three +1/+1 counters among one, two, or three " +
+        "target creatures, then you gain life equal to the greatest toughness among creatures you control."
+    power = 3
+    toughness = 3
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetCreature(count = 3, minCount = 1)
+        effect = Effects.Composite(
+            Effects.DistributeCountersAmongTargets(totalCounters = 3),
+            Effects.GainLife(
+                DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).maxToughness()
+            )
+        )
+        description = "When this creature enters, distribute three +1/+1 counters among one, two, " +
+            "or three target creatures, then you gain life equal to the greatest toughness among " +
+            "creatures you control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "162"
+        artist = "Tuan Duong Chu"
+        flavorText = "The spider just loved how the gems twinkled, and the high-class prey they attracted."
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8eff4d0-67ad-4900-b33d-605659b59161.jpg?1783912866"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HomicideInvestigator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HomicideInvestigator.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Homicide Investigator — Murders at Karlov Manor #86
+ * {1}{B} · Creature — Human Detective · 2/2
+ *
+ * Whenever one or more nontoken creatures you control die, investigate.
+ * This ability triggers only once each turn.
+ *
+ * Three separate restrictions, each modelled by its own knob rather than approximated:
+ *
+ * - **"one or more … die"** is a *batched* death trigger, not a per-creature one. A board wipe that
+ *   kills four of your creatures fires this once (CR 603.3b). Using the per-creature
+ *   [Triggers.YourCreatureDies] would fire four times and over-produce Clues even before the
+ *   once-per-turn cap kicked in.
+ * - **"nontoken"** filters the batch, not the trigger's aftermath: a batch containing only tokens
+ *   never fires at all, while a mixed batch fires once. `GameObjectFilter.Creature.nontoken()`
+ *   applies the predicate at batch-membership time, which is exactly that.
+ * - **"only once each turn"** is the first-class `oncePerTurn` cap. The cap is spent by the first
+ *   *trigger*, not by the first resolution, so a second batch of deaths later in the same turn
+ *   simply doesn't trigger — it isn't a "may" the player can decline to save.
+ *
+ * Homicide Investigator's own death counts: it's a nontoken creature you control, and the batch is
+ * evaluated from last-known information, so trading it off in combat still draws you the Clue.
+ */
+val HomicideInvestigator = card("Homicide Investigator") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Detective"
+    oracleText = "Whenever one or more nontoken creatures you control die, investigate. This " +
+        "ability triggers only once each turn. (Create a Clue token. It's an artifact with " +
+        "\"{2}, Sacrifice this token: Draw a card.\")"
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.OneOrMoreCreaturesYouControlDie(GameObjectFilter.Creature.nontoken())
+        oncePerTurn = true
+        effect = Effects.Investigate()
+        description = "Whenever one or more nontoken creatures you control die, investigate. " +
+            "This ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "86"
+        artist = "Jodie Muir"
+        flavorText = "In her line of work, the dead are often better sources than the living."
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21d6accd-167a-4b21-a488-44d54cdfa608.jpg?1783912896"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RiftburstHellion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RiftburstHellion.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Riftburst Hellion — Murders at Karlov Manor #228
+ * {5}{R}{G} · Creature — Hellion · 6/7
+ *
+ * Reach
+ * Disguise {4}{R/G}{R/G}
+ *
+ * The whole card is the mana curve. Seven mana for a 6/7 reach body is unplayable on rate, so the
+ * disguise line is the real cost: {3} for a 2/2 with ward {2} on turn three, then {4}{R/G}{R/G} to
+ * flip it whenever the board wants a 6/7. Total mana spent is higher than hard-casting, split across
+ * two turns — the archetypal limited "curve smoother" that disguise exists to enable.
+ *
+ * Nothing triggers on the flip, so there is no incentive to hold the reveal: turning it face up
+ * mid-combat (CR 702.168c — a special action, no stack, no responses) is purely a combat trick that
+ * turns a chump 2/2 block into a 6/7 wall.
+ */
+val RiftburstHellion = card("Riftburst Hellion") {
+    manaCost = "{5}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Hellion"
+    oracleText = "Reach\n" +
+        "Disguise {4}{R/G}{R/G} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)"
+    power = 6
+    toughness = 7
+    keywords(Keyword.REACH)
+    disguise = "{4}{R/G}{R/G}"
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "228"
+        artist = "Brent Hollowell"
+        flavorText = "Like any Ravnican denizen, it decided to visit Plaza West for lunch."
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9fae9044-a859-434d-8dc6-4f9d455ca5e1.jpg?1783912840"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RuneBrandJuggler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RuneBrandJuggler.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Rune-Brand Juggler — Murders at Karlov Manor #229
+ * {B}{R} · Creature — Human Shaman · 2/2
+ *
+ * When this creature enters, suspect up to one other target creature you control.
+ * {3}{B}{R}, Sacrifice a suspected creature: Target creature gets -5/-5 until end of turn.
+ *
+ * The two halves are a self-contained engine: the enters trigger manufactures the fuel that the
+ * activated ability burns. Suspecting your *own* creature is a genuine cost (CR 701.60a hands it
+ * menace *and* "this creature can't block" for as long as it stays suspected), paid up front for
+ * removal later.
+ *
+ * Wording details the script follows literally rather than approximating:
+ *
+ * - **"up to one other target creature you control"** — optional (a Juggler cast into an empty
+ *   board still resolves and simply suspects nothing) and `.other()` (it can't suspect itself,
+ *   unlike Person of Interest).
+ * - **"Sacrifice a suspected creature"** is a cost, not an effect, so it's paid on activation and
+ *   can't be responded to; the filter is `Creature.suspected()`, which reads the live suspected
+ *   status rather than "a creature this card suspected". Anyone's suspecting effect — or an
+ *   opponent's Convenient Target on your own creature — feeds it, and a creature that has since
+ *   been un-suspected no longer qualifies.
+ * - **"Target creature"** is unrestricted: -5/-5 can be pointed at your own board, and the
+ *   sacrificed suspected creature may itself be the target (it's already gone by resolution, so
+ *   the ability fizzles — legal, just pointless).
+ *
+ * Nothing links the sacrifice to the trigger, so the ability is repeatable across turns as long as
+ * you keep producing suspected bodies.
+ */
+val RuneBrandJuggler = card("Rune-Brand Juggler") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Human Shaman"
+    oracleText = "When this creature enters, suspect up to one other target creature you control. " +
+        "(A suspected creature has menace and can't block.)\n" +
+        "{3}{B}{R}, Sacrifice a suspected creature: Target creature gets -5/-5 until end of turn."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val victim = target(
+            "up to one other target creature you control",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.youControl()).other(),
+                optional = true
+            )
+        )
+        effect = Effects.Suspect(victim)
+        description = "When this creature enters, suspect up to one other target creature you control."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}{B}{R}"),
+            Costs.Sacrifice(GameObjectFilter.Creature.suspected())
+        )
+        val victim = target("target creature", TargetCreature())
+        effect = Effects.ModifyStats(-5, -5, victim)
+        description = "Target creature gets -5/-5 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "229"
+        artist = "Mila Pesic"
+        flavorText = "Notice: Guests of Hellbender may be exposed to occasional bursts of flame."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/5288cf17-9d79-4d35-85f1-bf4d0a73494b.jpg?1783912839"
+
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until it " +
+                "leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VengefulCreeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VengefulCreeper.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Vengeful Creeper — Murders at Karlov Manor #182
+ * {4}{G} · Creature — Plant Elemental · 5/5
+ *
+ * Disguise {5}{G}
+ * When this creature is turned face up, destroy target artifact or enchantment an opponent controls.
+ *
+ * The Naturalize is locked behind the flip, not the cast: hard-casting for {4}{G} gets a vanilla 5/5
+ * and no removal at all, because turning face up is not entering the battlefield (CR 702.168d) and
+ * this isn't an enters trigger anyway. The disguise line is the mode that matters — {3} for a 2/2
+ * with ward {2}, then {5}{G} at instant speed to blow up an artifact or enchantment as a surprise.
+ *
+ * Turning face up is a special action (CR 702.168c): it uses no stack and can't be responded to, so
+ * the opponent's only window to save the permanent is after the *trigger* goes on the stack, with the
+ * 5/5 already face up. If the target becomes illegal before the trigger resolves it fizzles; the
+ * creature stays face up regardless.
+ */
+val VengefulCreeper = card("Vengeful Creeper") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Elemental"
+    oracleText = "Disguise {5}{G} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, destroy target artifact or enchantment an opponent controls."
+    power = 5
+    toughness = 5
+    disguise = "{5}{G}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        target = TargetObject(filter = TargetFilter.ArtifactOrEnchantment.opponentControls())
+        effect = Effects.Destroy(EffectTarget.ContextTarget(0))
+        description = "When this creature is turned face up, destroy target artifact or enchantment an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Maria Poliakova"
+        flavorText = "Seeking intact evidence in the Rubblebelt is a fool's errand."
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a914416-effd-4eda-b609-2773c53a08ec.jpg?1783912858"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -2079,6 +2079,73 @@
     ]
 }
 
+// Glint Weaver
+{
+    "name": "Glint Weaver",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Spider",
+    "oracleText": "Reach\nWhen this creature enters, distribute three +1/+1 counters among one, two, or three target creatures, then you gain life equal to the greatest toughness among creatures you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DistributeCountersAmongTargets",
+                            "totalCounters": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "creature",
+                                "aggregation": "MAX",
+                                "property": "TOUGHNESS"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 3,
+                    "minCount": 1,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, distribute three +1/+1 counters among one, two, or three target creatures, then you gain life equal to the greatest toughness among creatures you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "UNCOMMON",
+        "artist": "Tuan Duong Chu",
+        "flavorText": "The spider just loved how the gems twinkled, and the high-class prey they attracted.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8eff4d0-67ad-4900-b33d-605659b59161.jpg?1783912866"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Gravestone Strider
 {
     "name": "Gravestone Strider",
@@ -2486,6 +2553,46 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Homicide Investigator
+{
+    "name": "Homicide Investigator",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CreaturesYouControlDiedEvent",
+                    "filter": "creature nontoken"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever one or more nontoken creatures you control die, investigate. This ability triggers only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "RARE",
+        "artist": "Jodie Muir",
+        "flavorText": "In her line of work, the dead are often better sources than the living.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21d6accd-167a-4b21-a488-44d54cdfa608.jpg?1783912896"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -4425,6 +4532,43 @@
     ]
 }
 
+// Riftburst Hellion
+{
+    "name": "Riftburst Hellion",
+    "manaCost": "{5}{R}{G}",
+    "typeLine": "Creature — Hellion",
+    "oracleText": "Reach\nDisguise {4}{R/G}{R/G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 7
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{R/G}{R/G}"
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "228",
+        "artist": "Brent Hollowell",
+        "flavorText": "Like any Ravnican denizen, it decided to visit Plaza West for lunch.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fae9044-a859-434d-8dc6-4f9d455ca5e1.jpg?1783912840"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Rope
 {
     "name": "Rope",
@@ -4732,6 +4876,142 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Rune-Brand Juggler
+{
+    "name": "Rune-Brand Juggler",
+    "manaCost": "{B}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "When this creature enters, suspect up to one other target creature you control. (A suspected creature has menace and can't block.)\n{3}{B}{R}, Sacrifice a suspected creature: Target creature gets -5/-5 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SetSuspected",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one other target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one other target creature you control"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one other target creature you control"
+                            },
+                            "duration": "Permanent"
+                        }
+                    ],
+                    "descriptionOverride": "target becomes suspected"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "up to one other target creature you control"
+                },
+                "descriptionOverride": "When this creature enters, suspect up to one other target creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature"
+                                    ],
+                                    "statePredicates": [
+                                        "IsSuspected"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -5
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "Target creature gets -5/-5 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "229",
+        "rarity": "UNCOMMON",
+        "artist": "Mila Pesic",
+        "flavorText": "Notice: Guests of Hellbender may be exposed to occasional bursts of flame.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/5288cf17-9d79-4d35-85f1-bf4d0a73494b.jpg?1783912839",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -5816,6 +6096,69 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Vengeful Creeper
+{
+    "name": "Vengeful Creeper",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Plant Elemental",
+    "oracleText": "Disguise {5}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, destroy target artifact or enchantment an opponent controls.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{G}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact|enchantment ctrl:opponent"
+                    }
+                },
+                "descriptionOverride": "When this creature is turned face up, destroy target artifact or enchantment an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Maria Poliakova",
+        "flavorText": "Seeking intact evidence in the Rubblebelt is a fool's errand.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a914416-effd-4eda-b609-2773c53a08ec.jpg?1783912858",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlintWeaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlintWeaverScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.DistributeDecision
+import com.wingedsheep.engine.core.DistributionResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Glint Weaver (MKM #162).
+ *
+ * "Reach
+ *  When this creature enters, distribute three +1/+1 counters among one, two, or three target
+ *  creatures, then you gain life equal to the greatest toughness among creatures you control."
+ *
+ * The interesting claim is the **"then"**: the two halves share one resolution, and the distribute
+ * half pauses for player input. A `Composite(distribute, gainLife)` is only correct if the life
+ * gain survives that pause *and* reads the board after the counters land — the failure mode being a
+ * silently-dropped second effect, or a life total computed from pre-counter toughness.
+ *
+ * Covers:
+ *  - Counters land on the chosen targets and the life gain reads post-counter toughness.
+ *  - Targeting is unrestricted ("target creatures", not "creatures you control"), but the life gain
+ *    still only sums over creatures *you* control — pumping an opponent's creature gains nothing.
+ */
+class GlintWeaverScenarioTest : FunSpec({
+
+    // Distinct toughnesses so the life total names exactly which creature was measured.
+    val toughOne = CardDefinition.creature(
+        name = "Test Thick Yak",
+        manaCost = ManaCost.parse("{2}{G}"),
+        subtypes = setOf(Subtype("Yak")),
+        power = 1,
+        toughness = 4,
+        oracleText = ""
+    )
+    val frailOne = CardDefinition.creature(
+        name = "Test Frail Yak",
+        manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Yak")),
+        power = 1,
+        toughness = 1,
+        oracleText = ""
+    )
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(toughOne, frailOne))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Cast Glint Weaver, answer its targeting and (if offered) distribution decisions. */
+    fun castAndDistribute(
+        d: GameTestDriver,
+        caster: EntityId,
+        split: Map<EntityId, Int>
+    ) {
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveMana(caster, Color.GREEN, 7)
+
+        val card = d.putCardInHand(caster, "Glint Weaver")
+        val cast = d.castSpell(caster, card)
+        withClue("casting Glint Weaver: ${cast.error}") { cast.error shouldBe null }
+
+        // Weaver resolves and enters; its ETB trigger then asks for one-to-three targets.
+        d.bothPass()
+        withClue("expected the ETB trigger's target selection") {
+            d.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        }
+        d.submitTargetSelection(caster, split.keys.toList()).error shouldBe null
+
+        // Resolve the trigger. The engine may split evenly on its own or ask; answer either way.
+        d.bothPass()
+        (d.pendingDecision as? DistributeDecision)?.let { decision ->
+            d.submitDecision(caster, DistributionResponse(decision.id, split))
+            d.bothPass()
+        }
+    }
+
+    test("counters land, then life gained equals the greatest toughness after the counters") {
+        val d = setup()
+        val p1 = d.activePlayer!!
+
+        // A 1/4 and a 1/1. Loading all three counters onto the 1/1 makes it a 4/4 — tying the
+        // untouched 1/4 — while loading them onto the 1/4 makes it a 4/7. Splitting 2/1 here
+        // yields a 3/6 and a 2/2, so the greatest toughness must read 6, not the pre-counter 4.
+        val thick = d.putCreatureOnBattlefield(p1, "Test Thick Yak")
+        val frail = d.putCreatureOnBattlefield(p1, "Test Frail Yak")
+        val lifeBefore = d.getLifeTotal(p1)
+
+        castAndDistribute(d, p1, mapOf(thick to 2, frail to 1))
+
+        withClue("three counters split 2/1 across the two targets") {
+            plusOneCounters(d, thick) shouldBe 2
+            plusOneCounters(d, frail) shouldBe 1
+        }
+        withClue("life gain reads post-counter toughness (4 + 2 = 6), not the printed 4") {
+            d.getLifeTotal(p1) shouldBe lifeBefore + 6
+        }
+    }
+
+    test("an opponent's creature is a legal target, but only your creatures feed the life gain") {
+        val d = setup()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+
+        // Your board is Glint Weaver alone (a 3/3). The opponent has the big body, and it takes
+        // all three counters — so it becomes a 4/7 while your best toughness is still Weaver's 3.
+        val theirs = d.putCreatureOnBattlefield(p2, "Test Thick Yak")
+        val lifeBefore = d.getLifeTotal(p1)
+
+        castAndDistribute(d, p1, mapOf(theirs to 3))
+
+        withClue("all three counters went to the opponent's creature") {
+            plusOneCounters(d, theirs) shouldBe 3
+        }
+        withClue("greatest toughness among creatures YOU control is Glint Weaver's 3") {
+            d.getLifeTotal(p1) shouldBe lifeBefore + 3
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuneBrandJugglerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuneBrandJugglerScenarioTest.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.RuneBrandJuggler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Rune-Brand Juggler (MKM #229).
+ *
+ * "When this creature enters, suspect up to one other target creature you control.
+ *  {3}{B}{R}, Sacrifice a suspected creature: Target creature gets -5/-5 until end of turn."
+ *
+ * The claim under test is that "Sacrifice a **suspected** creature" is a real cost restriction and
+ * not a fail-open filter — the historically expensive bug shape in this engine's cost enumerators.
+ * A cost that quietly accepts any creature would turn a two-mana uncommon into unconditional
+ * repeatable removal.
+ *
+ * Covers:
+ *  - The ETB suspects the chosen other creature, and that creature then pays the sacrifice cost.
+ *  - An un-suspected creature is rejected as payment (the fail-open case).
+ *  - The Juggler can't suspect itself ("other"), so its own body never becomes the fuel.
+ */
+class RuneBrandJugglerScenarioTest : FunSpec({
+
+    val abilityId = RuneBrandJuggler.activatedAbilities.single().id
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        return driver
+    }
+
+    /**
+     * Put a Juggler onto the battlefield by casting it, answering the ETB's optional target with
+     * [suspectTarget] (or declining when null). Returns the Juggler's entity id.
+     */
+    fun castJuggler(d: GameTestDriver, caster: EntityId, suspectTarget: EntityId?): EntityId {
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveMana(caster, Color.BLACK, 1)
+        d.giveMana(caster, Color.RED, 1)
+
+        val card = d.putCardInHand(caster, "Rune-Brand Juggler")
+        val cast = d.castSpell(caster, card)
+        withClue("casting Rune-Brand Juggler: ${cast.error}") { cast.error shouldBe null }
+
+        // Juggler resolves and enters; the ETB trigger then asks for its up-to-one target.
+        d.bothPass()
+        if (suspectTarget != null) {
+            withClue("expected the ETB trigger's target selection") {
+                d.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+            }
+            d.submitTargetSelection(caster, listOf(suspectTarget)).error shouldBe null
+        }
+        d.bothPass()
+
+        return d.findPermanent(caster, "Rune-Brand Juggler")!!
+    }
+
+    test("the suspected creature can pay the sacrifice cost and the target gets -5/-5") {
+        val d = createDriver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+
+        val fodder = d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val victim = d.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        castJuggler(d, p1, suspectTarget = fodder)
+
+        withClue("the ETB suspected the chosen other creature") {
+            projector.project(d.state).isSuspected(fodder) shouldBe true
+        }
+
+        d.giveMana(p1, Color.BLACK, 1)
+        d.giveMana(p1, Color.RED, 1)
+        d.giveMana(p1, Color.GREEN, 3)
+
+        val juggler = d.findPermanent(p1, "Rune-Brand Juggler")!!
+        val result = d.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = juggler,
+                abilityId = abilityId,
+                targets = listOf(entityIdToChosenTarget(d.state, victim)),
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+            )
+        )
+        withClue("activating with a suspected creature as payment") { result.isSuccess shouldBe true }
+
+        // The cost is paid on activation, so the fodder is already gone before resolution.
+        d.findPermanent(p1, "Grizzly Bears") shouldBe null
+
+        d.bothPass()
+
+        // A 2/2 given -5/-5 is a -3/-3 and dies to state-based actions.
+        withClue("the -5/-5 killed the targeted 2/2") {
+            d.findPermanent(p2, "Grizzly Bears") shouldBe null
+            d.state.getGraveyard(p2) shouldContain victim
+        }
+    }
+
+    test("an un-suspected creature is rejected as payment — the cost filter is not fail-open") {
+        val d = createDriver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+
+        val innocent = d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val victim = d.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        // Decline the ETB target, so nothing on the board is suspected.
+        castJuggler(d, p1, suspectTarget = null)
+        projector.project(d.state).isSuspected(innocent) shouldBe false
+
+        d.giveMana(p1, Color.BLACK, 1)
+        d.giveMana(p1, Color.RED, 1)
+        d.giveMana(p1, Color.GREEN, 3)
+
+        val juggler = d.findPermanent(p1, "Rune-Brand Juggler")!!
+        val result = d.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = juggler,
+                abilityId = abilityId,
+                targets = listOf(entityIdToChosenTarget(d.state, victim)),
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(innocent))
+            )
+        )
+        withClue("a creature that isn't suspected must not satisfy the cost") {
+            result.isSuccess shouldBe false
+        }
+
+        // Nothing was sacrificed and the would-be victim is untouched.
+        d.findPermanent(p1, "Grizzly Bears") shouldBe innocent
+        projector.project(d.state).getToughness(victim) shouldBe 2
+    }
+
+    test("the Juggler cannot suspect itself — the ETB target must be another creature") {
+        val d = createDriver()
+        val p1 = d.activePlayer!!
+
+        // No other creature on the board, so the up-to-one target has no legal choice at all.
+        val juggler = castJuggler(d, p1, suspectTarget = null)
+
+        withClue("'other target creature you control' excludes the Juggler itself") {
+            projector.project(d.state).isSuspected(juggler) shouldBe false
+        }
+    }
+})


### PR DESCRIPTION
Implements five MKM cards, each via `/add-card`. All five are canonical MKM printings (verified with `just check-card-printing`), and all compose existing SDK primitives — no new effect, trigger, keyword, or dynamic-amount vocabulary.

| Card | Cost | Shape |
|---|---|---|
| Riftburst Hellion | `{5}{R}{G}` 6/7 | Reach + Disguise `{4}{R/G}{R/G}` |
| Vengeful Creeper | `{4}{G}` 5/5 | Disguise `{5}{G}`; turned-face-up → destroy target artifact or enchantment an opponent controls |
| Glint Weaver | `{5}{G}{G}` 3/3 | Reach; ETB distribute three +1/+1 counters among 1–3 targets, then gain life = greatest toughness among creatures you control |
| Homicide Investigator | `{1}{B}` 2/2 | Batched nontoken-death trigger → investigate, capped once each turn |
| Rune-Brand Juggler | `{B}{R}` 2/2 | ETB suspect up to one other target creature you control; `{3}{B}{R}`, Sacrifice a suspected creature: target creature gets -5/-5 |

MKM goes 100/276 → 105/276.

## Rules details worth a look

**Glint Weaver** — "distribute … **then** you gain life" is one resolution, and the distribute half pauses for player input. Modelled as a single `Composite`, which is only correct if the life gain survives the pause *and* reads the board after the counters land. Also note the targets are plain "target creatures", not "creatures you control" — so an opponent's creature is a legal recipient, but the life gain still only measures your own board.

**Rune-Brand Juggler** — "Sacrifice a **suspected** creature" is a cost, not an effect: paid on activation, filtered by `Creature.suspected()` reading live suspected status (so anyone's suspecting effect feeds it, and an un-suspected creature doesn't). The ETB target is `.other()` and optional, so the Juggler can't suspect itself and a cast into an empty board still resolves.

**Homicide Investigator** — uses the *batched* death trigger (`OneOrMoreCreaturesYouControlDie`) rather than the per-creature one, so a board wipe fires it once instead of once per creature, with the printed `oncePerTurn` cap on top. `nontoken()` filters batch membership, so an all-token batch never triggers at all.

## Tests

Two scenario tests, one per card, pinning the shapes above:

- `GlintWeaverScenarioTest` — counters land and the life gain reads post-counter toughness (6, not the printed 4); targeting an opponent's creature gains you nothing beyond your own best toughness.
- `RuneBrandJugglerScenarioTest` — the suspected creature pays the cost and the -5/-5 kills a 2/2; an **un-suspected** creature is rejected (the fail-open case this engine has been bitten by before); the Juggler never suspects itself.

The other three ride the snapshot and linter nets — they add no behavior those don't already cover.

## Dropped from the original pick

**Macabre Reconstruction** was the fifth card I initially selected and I dropped it rather than approximate. Its "costs `{2}` less to cast if a creature card was put into your graveyard **from anywhere** this turn" has no faithful primitive: the only tracker is `PutIntoGraveyardThisTurnComponent`, a per-card marker that is stripped when the card leaves the graveyard. A creature milled and then exiled or reanimated still satisfies the printed condition but would be missed by any graveyard scan. Doing it right needs a per-player turn tracker plus a new `CostReductionSource` variant — `add-feature` scope, not a card PR. Rune-Brand Juggler took its slot.

## Verification

- `just build` — green (includes `CardDefinitionSnapshotTest`, `FacadeBoundaryTest`, `CardLinterTest`)
- `just rebless-cards` — MKM golden diff is additions only; no existing card moved
- `just check-card-printing` — all five report canonical placement in their earliest real printing
- `just test-class GlintWeaverScenarioTest` / `RuneBrandJugglerScenarioTest` — 5 tests, all pass
- All five `imageUri` values verified HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)