### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SlithAscendant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/SlithAscendant.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slith Ascendant reprint in CMR.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * MRD's `cards/` package (the card's earliest real printing). This file contributes only
+ * the CMR-specific presentation row — set, collector number, art — picked up automatically
+ * by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ *
+ * Note the rarity drop: uncommon in Mirrodin, common in Commander Legends.
+ */
+val SlithAscendantReprint = Printing(
+    oracleId = "72f5095f-b4ba-45ba-82e5-9a22bddd544b",
+    name = "Slith Ascendant",
+    setCode = "CMR",
+    collectorNumber = "49",
+    artist = "Justin Sweet",
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b90157f8-ba3c-479e-80d8-8f9e042c540c.jpg?1783928871",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ChimneyImp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ChimneyImp.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Chimney Imp — Mirrodin #59
+ * {4}{B} · Creature — Imp · 1/2
+ *
+ * Flying
+ * When this creature dies, target opponent puts a card from their hand on top of their library.
+ *
+ * The dies trigger is the Gather → Select → Move pipeline over the *opponent's* hand:
+ * `Player.ContextPlayer(0)` is the declared target, and [Chooser.TargetPlayer] hands the
+ * decision to that opponent rather than to the Imp's controller — the printed text says
+ * "*target opponent* puts a card", so they pick, and there is no reveal step. That distinction
+ * is the whole difference between this and a
+ * [Duress][com.wingedsheep.mtg.sets.definitions.usg.cards.Duress]-style effect built on the
+ * same three primitives with `Chooser.Controller`.
+ *
+ * [ZonePlacement.Top] on a `Zone.LIBRARY` destination scoped to the same
+ * `Player.ContextPlayer(0)` is "on top of *their* library". The net effect is a Time Ebb on a
+ * card in hand: they lose no cards, but their next draw is already spent.
+ *
+ * Edge cases the pipeline handles by construction: an empty hand gathers nothing, so the
+ * selection is skipped and the trigger resolves as a no-op (the ability still targeted legally
+ * — an opponent is a legal target regardless of hand size); and the Imp is already in the
+ * graveyard when this resolves, so nothing here reads its battlefield state.
+ */
+val ChimneyImp = card("Chimney Imp") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Imp"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature dies, target opponent puts a card from their hand on top of their library."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        target = TargetOpponent()
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "impHand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "impHand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.TargetPlayer,
+                    storeSelected = "impTucked",
+                    prompt = "Choose a card to put on top of your library"
+                ),
+                MoveCollectionEffect(
+                    from = "impTucked",
+                    destination = CardDestination.ToZone(
+                        Zone.LIBRARY,
+                        Player.ContextPlayer(0),
+                        ZonePlacement.Top
+                    )
+                )
+            )
+        )
+        description = "When this creature dies, target opponent puts a card from their hand " +
+            "on top of their library."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Christopher Moeller"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a426922-5e96-48f3-b696-f5dc99258943.jpg?1783944549"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/FlayedNim.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/FlayedNim.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Flayed Nim — Mirrodin #65
+ * {3}{B} · Creature — Skeleton · 2/2
+ *
+ * Whenever this creature deals combat damage to a creature, that creature's controller loses
+ * that much life.
+ * {2}{B}: Regenerate this creature.
+ *
+ * The damage rider reads both halves of its own trigger payload rather than the Nim's power:
+ * `TRIGGER_DAMAGE_AMOUNT` is the damage actually dealt in that combat-damage event, and
+ * [EffectTarget.ControllerOfTriggeringEntity] is the controller of the *damaged* creature —
+ * `DamageDealtEvent` sets the triggering entity to the recipient, so "that creature's
+ * controller" resolves without a target being declared.
+ *
+ * Reading the event rather than the source's power is what makes the edge cases fall out
+ * right: a Nim pumped after blockers are declared drains for what it actually dealt, damage
+ * reduced by a protection/prevention shield drains for the reduced amount (prevented to zero
+ * deals no damage, so the trigger never fires at all), and only *combat* damage counts — the
+ * shape [Tephraderm][com.wingedsheep.mtg.sets.definitions.ons.cards.Tephraderm] uses on the
+ * incoming side.
+ *
+ * Regeneration is the survival half: a shield taps the Nim and removes it from combat instead
+ * of letting it die (CR 701.15), so the same body can trade repeatedly. Note the drain trigger
+ * has already fired by then — combat damage is dealt before the lethal-damage state-based
+ * action, so a Nim that regenerates after a trade still drained.
+ */
+val FlayedNim = card("Flayed Nim") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature deals combat damage to a creature, that creature's " +
+        "controller loses that much life.\n" +
+        "{2}{B}: Regenerate this creature."
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToCreature
+        effect = Effects.LoseLife(
+            amount = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            target = EffectTarget.ControllerOfTriggeringEntity
+        )
+        description = "Whenever this creature deals combat damage to a creature, that " +
+            "creature's controller loses that much life."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "{2}{B}: Regenerate this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Trevor Hairsine"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd2381b3-ebf8-4c65-8e89-e089c2e57145.jpg?1783944548"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithAscendant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithAscendant.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slith Ascendant — Mirrodin #23
+ * {1}{W}{W} · Creature — Slith · 1/1
+ *
+ * Flying
+ * Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+ *
+ * The white member of the Slith cycle (see [SlithBloodletter], [SlithFirewalker],
+ * [SlithPredator]) — same growth trigger, with evasion instead of a mana rider. Flying is
+ * what makes the compounding reliable: the +1/+1 counter only lands on a *connected* attack
+ * ([Triggers.DealsCombatDamageToPlayer] is combat damage to a player, so a blocked Slith or a
+ * ping from an activated ability grows nothing), and a 1/1 flier connects far more often than
+ * a ground body of the same size.
+ */
+val SlithAscendant = card("Slith Ascendant") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Slith"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "23"
+        artist = "Justin Sweet"
+        flavorText = "Instinctively drawn to the light of its \"mother-sun,\" each slith follows " +
+            "that sun's path around Mirrodin."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/0286b42a-295b-467c-a1d8-0b31774b7ac5.jpg?1783944559"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TelJiladStylus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TelJiladStylus.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Tel-Jilad Stylus — Mirrodin #260
+ * {1} · Artifact
+ *
+ * {T}: Put target permanent you own on the bottom of your library.
+ *
+ * "Permanent you **own**", not "you control" — [GameObjectFilter.ownedByYou] is the whole
+ * point of the card in its era: it answers a permanent an opponent has stolen (Dominate,
+ * Vedalken Shackles, Grab the Reins) by tucking it back into *your* library, and it dodges
+ * regeneration and dies-triggers because tucking isn't destruction. Filtering on control
+ * instead would invert exactly the case the Stylus exists for.
+ *
+ * `Zone.LIBRARY` + [ZonePlacement.Bottom] moves the permanent to its **owner's** library
+ * bottom, which is "your library" here by construction — the target is one you own. No
+ * controller override is needed: ownership, not the current controller, decides the
+ * destination zone (CR 400.3).
+ */
+val TelJiladStylus = card("Tel-Jilad Stylus") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Put target permanent you own on the bottom of your library."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val permanent = target(
+            "permanent",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.ownedByYou()))
+        )
+        effect = Effects.Move(
+            target = permanent,
+            destination = Zone.LIBRARY,
+            placement = ZonePlacement.Bottom
+        )
+        description = "{T}: Put target permanent you own on the bottom of your library."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "260"
+        artist = "Darrell Riche"
+        flavorText = "Etched on Tel-Jilad's trunk is an entire history of Mirrodin—except for an " +
+            "expanse near the ground scrubbed smooth by an unknown hand."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/522570eb-e654-4f8a-828c-3e456a0ad8e6.jpg?1783944500"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WurmskinForger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WurmskinForger.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Wurmskin Forger — Mirrodin #140
+ * {5}{G}{G} · Creature — Elf Warrior · 2/2
+ *
+ * When this creature enters, distribute three +1/+1 counters among one, two, or three target
+ * creatures.
+ *
+ * The distribute shape: `TargetCreature(count = 3, minCount = 1)` is exactly "one, two, or
+ * three target creatures" — the caster declares between one and three of them as the trigger
+ * goes on the stack, and [Effects.DistributeCountersAmongTargets] splits the fixed pool of
+ * three counters across whatever survived to resolution (CR 601.2d: the division is announced
+ * with the targets, each declared target must get at least one counter).
+ *
+ * Unlike the "you control" members of this family
+ * ([Jade Seedstones][com.wingedsheep.mtg.sets.definitions.lci.cards.JadeSeedstones],
+ * Armament Corps), the printed text has **no controller restriction** — the default
+ * `TargetFilter.Creature` is correct, so an opponent's creature is a legal recipient. The
+ * Forger itself is on the battlefield when its own enters-trigger resolves, so it can be one
+ * of the three.
+ */
+val WurmskinForger = card("Wurmskin Forger") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, distribute three +1/+1 counters among one, two, " +
+        "or three target creatures."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetCreature(count = 3, minCount = 1)
+        effect = Effects.DistributeCountersAmongTargets(totalCounters = 3)
+        description = "When this creature enters, distribute three +1/+1 counters among one, " +
+            "two, or three target creatures."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Justin Sweet"
+        flavorText = "It takes three weeks for a patrol of hunters to down a slagwurm. It takes " +
+            "just as long to make a single cut in its hide."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f14f303e-371b-47dd-bbb8-7f3e44ef9af0.jpg?1783944529"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -401,6 +401,87 @@
     "colorIdentityOverride": []
 }
 
+// Chimney Imp
+{
+    "name": "Chimney Imp",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Imp",
+    "oracleText": "Flying\nWhen this creature dies, target opponent puts a card from their hand on top of their library.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "impHand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "impHand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "impTucked",
+                            "prompt": "Choose a card to put on top of your library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impTucked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "placement": "Top"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": "TargetOpponent",
+                "descriptionOverride": "When this creature dies, target opponent puts a card from their hand on top of their library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Christopher Moeller",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a426922-5e96-48f3-b696-f5dc99258943.jpg?1783944549"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cloudpost
 {
     "name": "Cloudpost",
@@ -926,6 +1007,65 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Flayed Nim
+{
+    "name": "Flayed Nim",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Skeleton",
+    "oracleText": "Whenever this creature deals combat damage to a creature, that creature's controller loses that much life.\n{2}{B}: Regenerate this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyCreature"
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "target": "ControllerOfTriggeringEntity"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a creature, that creature's controller loses that much life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "{2}{B}: Regenerate this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Trevor Hairsine",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd2381b3-ebf8-4c65-8e89-e089c2e57145.jpg?1783944548"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -3489,6 +3629,50 @@
     "colorIdentityOverride": []
 }
 
+// Slith Ascendant
+{
+    "name": "Slith Ascendant",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Slith",
+    "oracleText": "Flying\nWhenever this creature deals combat damage to a player, put a +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "UNCOMMON",
+        "artist": "Justin Sweet",
+        "flavorText": "Instinctively drawn to the light of its \"mother-sun,\" each slith follows that sun's path around Mirrodin.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/0286b42a-295b-467c-a1d8-0b31774b7ac5.jpg?1783944559"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Slith Bloodletter
 {
     "name": "Slith Bloodletter",
@@ -4608,6 +4792,49 @@
     ]
 }
 
+// Tel-Jilad Stylus
+{
+    "name": "Tel-Jilad Stylus",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Put target permanent you own on the bottom of your library.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "permanent"
+                    },
+                    "destination": "Library",
+                    "placement": "Bottom"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent own:you"
+                        },
+                        "id": "permanent"
+                    }
+                ],
+                "descriptionOverride": "{T}: Put target permanent you own on the bottom of your library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "rarity": "UNCOMMON",
+        "artist": "Darrell Riche",
+        "flavorText": "Etched on Tel-Jilad's trunk is an entire history of Mirrodin—except for an expanse near the ground scrubbed smooth by an unknown hand.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/522570eb-e654-4f8a-828c-3e456a0ad8e6.jpg?1783944500"
+    },
+    "colorIdentityOverride": []
+}
+
 // Tempest of Light
 {
     "name": "Tempest of Light",
@@ -5636,5 +5863,53 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Wurmskin Forger
+{
+    "name": "Wurmskin Forger",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "oracleText": "When this creature enters, distribute three +1/+1 counters among one, two, or three target creatures.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DistributeCountersAmongTargets",
+                    "totalCounters": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 3,
+                    "minCount": 1,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, distribute three +1/+1 counters among one, two, or three target creatures."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Justin Sweet",
+        "flavorText": "It takes three weeks for a patrol of hunters to down a slagwurm. It takes just as long to make a single cut in its hide.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f14f303e-371b-47dd-bbb8-7f3e44ef9af0.jpg?1783944529"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChimneyImpScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChimneyImpScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Chimney Imp — Mirrodin #59, {4}{B} Creature — Imp 1/2
+ *
+ * Flying
+ * When this creature dies, target opponent puts a card from their hand on top of their library.
+ *
+ * The claim under test is *who decides*. The card is the Gather → Select → Move pipeline over
+ * the targeted opponent's hand with `Chooser.TargetPlayer`, so the selection decision must be
+ * addressed to **that opponent**, not to the Imp's controller — the same three primitives with
+ * `Chooser.Controller` would build a Duress-style effect instead, and nothing else in the
+ * engine pairs `Chooser.TargetPlayer` with a *dies* trigger's declared target.
+ *
+ * Also pinned: the chosen card lands on top of *their* library (so it is the very next card
+ * they draw), and an empty hand resolves as a clean no-op rather than a stuck decision.
+ */
+class ChimneyImpScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    /** Bolt [target] dead and resolve everything it puts on the stack up to the next decision. */
+    fun killWithBolt(driver: GameTestDriver, caster: EntityId, target: EntityId) {
+        driver.giveMana(caster, Color.RED, 1)
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(target)))
+        // Resolve the Bolt, then the dies trigger it causes, stopping at the first decision.
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) {
+            driver.bothPass()
+        }
+    }
+
+    test("the targeted opponent chooses, and their card goes on top of their own library") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+
+        val impController = driver.activePlayer!!
+        val opponent = driver.getOpponent(impController)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val imp = driver.putCreatureOnBattlefield(impController, "Chimney Imp")
+        // A distinctive card in the opponent's hand so the tuck is identifiable among lands.
+        val tuckMe = driver.putCardInHand(opponent, "Centaur Courser")
+        val handBefore = driver.getHandSize(opponent)
+        val libraryBefore = driver.state.getLibrary(opponent).size
+
+        killWithBolt(driver, impController, imp)
+
+        // The dies trigger targets the sole opponent (forced) and pauses for *their* selection.
+        val decision = driver.pendingDecision
+        decision shouldNotBe null
+        (decision as SelectCardsDecision).playerId shouldBe opponent
+
+        driver.submitCardSelection(opponent, listOf(tuckMe))
+
+        // One card left the hand for the library, and it is on top.
+        driver.getHandSize(opponent) shouldBe handBefore - 1
+        driver.state.getLibrary(opponent).size shouldBe libraryBefore + 1
+        driver.state.getLibrary(opponent).first() shouldBe tuckMe
+    }
+
+    test("an empty hand resolves the trigger as a no-op") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+
+        val impController = driver.activePlayer!!
+        val opponent = driver.getOpponent(impController)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val imp = driver.putCreatureOnBattlefield(impController, "Chimney Imp")
+        // Empty the opponent's opening hand — an opponent is still a legal target, there is
+        // just nothing to put back.
+        driver.getHand(opponent).toList().forEach { driver.moveToGraveyard(it) }
+        driver.getHandSize(opponent) shouldBe 0
+        val libraryBefore = driver.state.getLibrary(opponent).size
+
+        killWithBolt(driver, impController, imp)
+
+        // No selection is presented and nothing moves.
+        (driver.pendingDecision as? SelectCardsDecision) shouldBe null
+        driver.state.getLibrary(opponent).size shouldBe libraryBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlayedNimScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlayedNimScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Flayed Nim — Mirrodin #65, {3}{B} Creature — Skeleton 2/2
+ *
+ * Whenever this creature deals combat damage to a creature, that creature's controller loses
+ * that much life.
+ * {2}{B}: Regenerate this creature.
+ *
+ * The drain rider is the part worth proving. It is wired as
+ * `LoseLife(ContextProperty(TRIGGER_DAMAGE_AMOUNT), ControllerOfTriggeringEntity)` on an
+ * **outgoing** `DealsCombatDamageToCreature` trigger — a direction no other card exercises
+ * (Tephraderm uses the same two primitives on the *incoming* side), so all three claims are
+ * checked here:
+ *
+ *  - the life loss lands on the *damaged creature's* controller, not on the Nim's controller;
+ *  - the amount is the damage **actually dealt**, not the Nim's printed power (a pumped Nim
+ *    drains for more);
+ *  - "that creature's controller" still resolves when the damaged creature died to the same
+ *    combat damage, since the trigger reads last-known information.
+ *
+ * Blocked combat is used throughout so the defender takes no combat damage of their own —
+ * every point of life they lose is the drain.
+ */
+class FlayedNimScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    /** Attack with [attacker] into a single [blocker], stopping once combat damage is dealt. */
+    fun attackIntoBlocker(
+        driver: GameTestDriver,
+        attacker: EntityId,
+        blocker: EntityId,
+        attackingPlayer: EntityId,
+        defendingPlayer: EntityId
+    ) {
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attackingPlayer, listOf(attacker), defendingPlayer)
+        driver.bothPass()
+        driver.declareBlockers(defendingPlayer, mapOf(blocker to listOf(attacker)))
+        driver.bothPass()
+        // No first strikers, so the first-strike step is skipped entirely (CR 510.4).
+        driver.currentStep shouldBe Step.COMBAT_DAMAGE
+        // Resolve the drain trigger.
+        driver.bothPass()
+    }
+
+    test("the damaged creature's controller loses life equal to the damage dealt") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val nim = driver.putCreatureOnBattlefield(attacker, "Flayed Nim")
+        driver.removeSummoningSickness(nim)
+        // 3/3 — survives the Nim's 2 damage, so the drain is the only life change.
+        val blocker = driver.putCreatureOnBattlefield(defender, "Centaur Courser")
+        driver.removeSummoningSickness(blocker)
+
+        attackIntoBlocker(driver, nim, blocker, attacker, defender)
+
+        // Blocked, so no combat damage reached the defender — the 2 lost life is the drain.
+        driver.assertLifeTotal(defender, 18)
+        // The drain hits the *blocker's* controller, not the Nim's.
+        driver.assertLifeTotal(attacker, 20)
+    }
+
+    test("drains for the damage actually dealt, not the Nim's printed power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val nim = driver.putCreatureOnBattlefield(attacker, "Flayed Nim")
+        driver.removeSummoningSickness(nim)
+        // 5/5 — survives a pumped Nim's 5 damage.
+        val blocker = driver.putCreatureOnBattlefield(defender, "Force of Nature")
+        driver.removeSummoningSickness(blocker)
+
+        // Giant Growth the Nim to 5/5 before damage.
+        val growth = driver.putCardInHand(attacker, "Giant Growth")
+        driver.giveMana(attacker, Color.GREEN, 1)
+        driver.castSpellWithTargets(attacker, growth, listOf(ChosenTarget.Permanent(nim)))
+        driver.bothPass()
+
+        attackIntoBlocker(driver, nim, blocker, attacker, defender)
+
+        // 5 damage dealt -> 5 life lost. A hardcoded printed power would have drained 2.
+        driver.assertLifeTotal(defender, 15)
+        driver.assertLifeTotal(attacker, 20)
+    }
+
+    test("still drains when the damaged creature dies to that same combat damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val nim = driver.putCreatureOnBattlefield(attacker, "Flayed Nim")
+        driver.removeSummoningSickness(nim)
+        // 1/1 — dies to the Nim's 2 damage, so "that creature's controller" must resolve from
+        // last-known information by the time the trigger resolves.
+        val blocker = driver.putCreatureOnBattlefield(defender, "Savannah Lions")
+        driver.removeSummoningSickness(blocker)
+
+        attackIntoBlocker(driver, nim, blocker, attacker, defender)
+
+        driver.assertLifeTotal(defender, 18)
+        driver.assertLifeTotal(attacker, 20)
+    }
+
+    test("does not drain when the Nim deals combat damage to a player") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val nim = driver.putCreatureOnBattlefield(attacker, "Flayed Nim")
+        driver.removeSummoningSickness(nim)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(nim), defender)
+        driver.bothPass()
+        driver.declareNoBlockers(defender)
+        driver.bothPass()
+
+        // 2 combat damage only — the trigger is scoped to damage dealt to a *creature*, so a
+        // double-dip would show as 16.
+        driver.assertLifeTotal(defender, 18)
+    }
+})


### PR DESCRIPTION
Five Mirrodin cards, all Mirrodin-original printings, all composed from existing SDK vocabulary — no engine or SDK changes, so `docs/card-sdk-language-reference.md` is untouched.

| Card | Cost | P/T | Text |
|---|---|---|---|
| Slith Ascendant | `{1}{W}{W}` | 1/1 | Flying; whenever it deals combat damage to a player, put a +1/+1 counter on it |
| Flayed Nim | `{3}{B}` | 2/2 | Whenever it deals combat damage to a creature, that creature's controller loses that much life; `{2}{B}`: regenerate |
| Chimney Imp | `{4}{B}` | 1/2 | Flying; when it dies, target opponent puts a card from their hand on top of their library |
| Wurmskin Forger | `{5}{G}{G}` | 2/2 | ETB: distribute three +1/+1 counters among one, two, or three target creatures |
| Tel-Jilad Stylus | `{1}` | — | `{T}`: put target permanent you own on the bottom of your library |

## Notes on the two non-obvious ones

**Flayed Nim** reads its own trigger payload rather than the Nim's power: `ContextProperty(TRIGGER_DAMAGE_AMOUNT)` for the amount, `ControllerOfTriggeringEntity` for the recipient — `DamageDealtEvent` sets the triggering entity to the damage *recipient*, so "that creature's controller" resolves without declaring a target. Tephraderm establishes that pairing on the *incoming* damage side; nothing used it on the outgoing side, so `FlayedNimScenarioTest` pins all three claims:

- the life loss lands on the damaged creature's controller, not the Nim's;
- the amount is damage **actually dealt** — a Giant Growth'd Nim drains 5, not its printed 2;
- "that creature's controller" still resolves when the blocker died to that same combat damage (last-known information).

**Chimney Imp** is the Gather → Select → Move pipeline over the *targeted opponent's* hand with `Chooser.TargetPlayer`, so **they** choose the card. The same three primitives with `Chooser.Controller` would build a Duress instead, and nothing else in the engine pairs `Chooser.TargetPlayer` with a dies trigger's declared target — so `ChimneyImpScenarioTest` asserts the decision is addressed to the opponent, that the card lands on top of *their own* library, and that an empty hand resolves as a clean no-op rather than a stuck decision. Their hand does not leak to the Imp's controller: `GameSession` only ships a pending decision to the player it belongs to.

**Tel-Jilad Stylus** filters on ownership, not control (`Permanent.ownedByYou()`). That is the point of the card in its era — it answers a permanent an opponent has stolen by tucking it back into your library, and dodges regeneration and dies-triggers because tucking isn't destruction. Filtering on control would invert exactly the case it exists for. Confirmed battlefield target enumeration scans the whole battlefield and evaluates `OwnedByYou` per entity, so a permanent you own under an opponent's control is a legal target.

**Wurmskin Forger**'s printed text has no controller restriction, unlike the rest of the distribute family (Jade Seedstones, Armament Corps), so the default `TargetFilter.Creature` is correct and an opponent's creature is a legal recipient.

## Card selection

My first pass picked Bottle Gnomes, Cathodion, and Arrest as well — all three turned out to be *reprints* in Mirrodin (earliest real printings: Tempest, Urza's Saga, Mercadian Masques). Rather than move canonical definitions across sets in a card-adding PR, I swapped them for Mirrodin originals. Slith Ascendant is reprinted in Commander Legends, which is scaffolded here, so it gets a CMR `Printing` row (rarity drops uncommon → common); `CMR.json` is unchanged because the golden covers `CardDefinition`s, not `Printing` rows.

## Verification

- `just build` — **BUILD SUCCESSFUL** (full compile + all module tests)
- `just test-class FlayedNimScenarioTest` — 4/4 passed
- `just test-class ChimneyImpScenarioTest` — 2/2 passed
- `just check-card-printing` — clean for all five
- `just rebless-cards` — only `MRD.json` moved, additions only, exactly these five cards
- All five re-verified field-by-field against Scryfall (mana cost, type line, P/T, rarity, collector number, image URI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
