### PR TITLE
Don't ask a signed-in player for a name

### DIFF
--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -28,6 +28,7 @@ import { trackPageView } from './utils/analytics'
 import { randomBackground } from './utils/background'
 import { useNavigate } from 'react-router-dom'
 import { useGameStore } from './store/gameStore'
+import { useConnectName } from './store/useConnectName'
 import { useRematch } from '@/components/lobby/useRematch'
 import { useViewingPlayer, useBattlefieldCards } from './store/selectors'
 import type { ClientAttacker, EntityId } from './types'
@@ -51,6 +52,7 @@ export default function App() {
   const connect = useGameStore((state) => state.connect)
   const spectateGame = useGameStore((state) => state.spectateGame)
   const sessionReplaced = useGameStore((state) => state.sessionReplaced)
+  const { name: connectName } = useConnectName()
   const hasConnectedRef = useRef(false)
 
   // Dev deep-link: /?spectate=<gameSessionId> connects and auto-spectates that game,
@@ -84,13 +86,14 @@ export default function App() {
       connect(`Spectator-${Math.floor(Math.random() * 9000 + 1000)}`, { spectator: true })
       return
     }
-    // Otherwise only auto-connect for a returning user with a stored name; new users see name entry.
-    const storedName = localStorage.getItem('argentum-player-name')
-    if (storedName) {
+    // Otherwise only auto-connect for someone who already has a name — a stored one, or the display
+    // name of a signed-in account. Genuinely new users see name entry. `connectName` starts null
+    // while the account check is in flight, so this re-runs once it resolves.
+    if (connectName) {
       hasConnectedRef.current = true
-      connect(storedName)
+      connect(connectName)
     }
-  }, [connectionStatus, connect, spectateParam, sessionReplaced])
+  }, [connectionStatus, connect, connectName, spectateParam, sessionReplaced])
 
   // Once connected, honor a /?spectate=<gameId> deep-link (fire once).
   useEffect(() => {

--- a/web-client/src/components/lobby/JoinLobbyPage.tsx
+++ b/web-client/src/components/lobby/JoinLobbyPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useGameStore } from '@/store/gameStore.ts'
+import { useConnectName } from '@/store/useConnectName'
 
 /**
  * Entry point for the `/join/:lobbyId` deep link — the target of a lobby's QR code / share link.
@@ -10,8 +11,9 @@ import { useGameStore } from '@/store/gameStore.ts'
  * sealed/draft and tournament lobbies alike.
  *
  * Two cases, mirroring {@link TournamentEntryPage}:
- * 1. Not connected: show a name entry, connect, then auto-join once connected.
- * 2. Already connected (returning user with a stored name): auto-join immediately.
+ * 1. No name yet: show a name entry, connect, then auto-join once connected.
+ * 2. A name already known (stored, or a signed-in account's display name): connect and auto-join
+ *    without asking.
  *
  * Once any lobby state arrives, navigate to "/" where the normal lobby UI takes over.
  */
@@ -28,21 +30,22 @@ export function JoinLobbyPage() {
   const lastError = useGameStore((state) => state.lastError)
   const sessionReplaced = useGameStore((state) => state.sessionReplaced)
 
+  const { name: connectName, resolving: nameResolving } = useConnectName()
   const [playerName, setPlayerName] = useState(() => localStorage.getItem('argentum-player-name') || '')
   const [joining, setJoining] = useState(false)
   const hasJoinedRef = useRef(false)
   const hasConnectedRef = useRef(false)
 
-  // Auto-connect a returning user (stored name). Never while another tab/device owns the session —
-  // reconnecting would steal it back (mirrors App.tsx / TournamentEntryPage).
+  // Auto-connect anyone who already has a name — stored, or a signed-in account's display name.
+  // Never while another tab/device owns the session — reconnecting would steal it back (mirrors
+  // App.tsx / TournamentEntryPage).
   useEffect(() => {
     if (sessionReplaced) return
-    const storedName = localStorage.getItem('argentum-player-name')
-    if (storedName && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
+    if (connectName && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
       hasConnectedRef.current = true
-      connect(storedName)
+      connect(connectName)
     }
-  }, [connectionStatus, connect, sessionReplaced])
+  }, [connectionStatus, connect, connectName, sessionReplaced])
 
   // Auto-join once connected (fires for both the returning user and the fresh name-entry path).
   useEffect(() => {
@@ -72,6 +75,9 @@ export function JoinLobbyPage() {
     ? lastError?.message
     : null
 
+  // Only a visitor with no name at all is asked for one; everyone else is mid-connect above.
+  const showNameEntry = !errorMessage && connectionStatus === 'disconnected' && !connectName && !nameResolving
+
   return (
     <div style={pageStyles.container}>
       <div style={pageStyles.card}>
@@ -79,7 +85,7 @@ export function JoinLobbyPage() {
 
         {errorMessage && <p style={pageStyles.error}>{errorMessage}</p>}
 
-        {!errorMessage && connectionStatus === 'disconnected' && (
+        {showNameEntry && (
           <div style={pageStyles.form}>
             <label style={pageStyles.label}>Enter your name to join the lobby</label>
             <input
@@ -102,11 +108,11 @@ export function JoinLobbyPage() {
           </div>
         )}
 
-        {(connectionStatus === 'connecting' || joining) && !errorMessage && (
+        {!showNameEntry && !errorMessage && (
           <div style={pageStyles.loading}>
             <div style={pageStyles.spinner} />
             <p style={pageStyles.loadingText}>
-              {connectionStatus === 'connecting' ? 'Connecting...' : 'Joining lobby...'}
+              {joining ? 'Joining lobby...' : 'Connecting...'}
             </p>
             <style>{`@keyframes join-spin { to { transform: rotate(360deg); } }`}</style>
           </div>

--- a/web-client/src/components/tournament/TournamentEntryPage.tsx
+++ b/web-client/src/components/tournament/TournamentEntryPage.tsx
@@ -1,13 +1,15 @@
 import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useGameStore } from '@/store/gameStore.ts'
+import { useConnectName } from '@/store/useConnectName'
 
 /**
  * Entry point for the /tournament/:lobbyId route.
  *
  * Handles two cases:
- * 1. Player not yet connected: show name entry, connect, then auto-join lobby
- * 2. Player already connected: auto-join lobby immediately
+ * 1. No name yet: show name entry, connect, then auto-join lobby
+ * 2. A name already known (stored, or a signed-in account's display name): connect and auto-join
+ *    without asking
  *
  * Once lobby state is received, navigates to "/" where the normal lobby/tournament UI takes over.
  */
@@ -24,6 +26,7 @@ export function TournamentEntryPage() {
   const setPendingTournamentId = useGameStore((state) => state.setPendingTournamentId)
   const sessionReplaced = useGameStore((state) => state.sessionReplaced)
 
+  const { name: connectName, resolving: nameResolving } = useConnectName()
   const [playerName, setPlayerName] = useState(() => localStorage.getItem('argentum-player-name') || '')
   const [joining, setJoining] = useState(false)
   const [tournamentInfo, setTournamentInfo] = useState<{ exists: boolean; state: string; playerCount: number; format: string } | null>(null)
@@ -43,16 +46,15 @@ export function TournamentEntryPage() {
       .catch(() => setFetchError('Tournament not found or no longer active.'))
   }, [lobbyId])
 
-  // Auto-connect if we have a stored name (returning user). Never while another
-  // tab/device owns the session — reconnecting would steal it back.
+  // Auto-connect anyone who already has a name — stored, or a signed-in account's display name.
+  // Never while another tab/device owns the session — reconnecting would steal it back.
   useEffect(() => {
     if (sessionReplaced) return
-    const storedName = localStorage.getItem('argentum-player-name')
-    if (storedName && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
+    if (connectName && connectionStatus === 'disconnected' && !hasConnectedRef.current) {
       hasConnectedRef.current = true
-      connect(storedName)
+      connect(connectName)
     }
-  }, [connectionStatus, connect, sessionReplaced])
+  }, [connectionStatus, connect, connectName, sessionReplaced])
 
   // Auto-join lobby once connected
   useEffect(() => {
@@ -81,6 +83,9 @@ export function TournamentEntryPage() {
   // Show error if lobby not found via REST or WebSocket error
   const errorMessage = fetchError || (lastError?.message?.toLowerCase().includes('lobby') || lastError?.message?.toLowerCase().includes('not found') ? lastError.message : null)
 
+  // Only a visitor with no name at all is asked for one; everyone else is mid-connect above.
+  const showNameEntry = !errorMessage && connectionStatus === 'disconnected' && !connectName && !nameResolving
+
   return (
     <div style={pageStyles.container}>
       <div style={pageStyles.card}>
@@ -107,7 +112,7 @@ export function TournamentEntryPage() {
           <p style={pageStyles.error}>{errorMessage}</p>
         )}
 
-        {!errorMessage && connectionStatus === 'disconnected' && (
+        {showNameEntry && (
           <div style={pageStyles.form}>
             <label style={pageStyles.label}>Enter your name to join</label>
             <input
@@ -133,11 +138,11 @@ export function TournamentEntryPage() {
           </div>
         )}
 
-        {(connectionStatus === 'connecting' || joining) && !errorMessage && (
+        {!showNameEntry && !errorMessage && (
           <div style={pageStyles.loading}>
             <div style={pageStyles.spinner} />
             <p style={pageStyles.loadingText}>
-              {connectionStatus === 'connecting' ? 'Connecting...' : 'Joining tournament...'}
+              {joining ? 'Joining tournament...' : 'Connecting...'}
             </p>
             <style>{`@keyframes tournament-spin { to { transform: rotate(360deg); } }`}</style>
           </div>

--- a/web-client/src/components/ui/HomeScreen.tsx
+++ b/web-client/src/components/ui/HomeScreen.tsx
@@ -22,6 +22,7 @@ import { ReplayViewer, type GameSummary } from '../admin/ReplayViewer'
 import type { ReplayData } from '@/replay/reconstructSnapshots.ts'
 import { labelForFormat } from '@/utils/deckLegality'
 import { useAuthStore } from '@/store/authStore'
+import { useConnectName } from '@/store/useConnectName'
 import { AuthWidget } from '@/components/auth/AuthWidget'
 import { LoginModal } from '@/components/auth/LoginModal'
 import { DeckMigrationPrompt } from '@/components/auth/DeckMigrationPrompt'
@@ -113,7 +114,9 @@ export function HomeScreen({
   const [joinSessionId, setJoinSessionId] = useState('')
   const [playerName, setPlayerName] = useState(() => localStorage.getItem('argentum-player-name') || '')
 
-  const [nameConfirmed, setNameConfirmed] = useState(() => !!localStorage.getItem('argentum-player-name'))
+  // The name we already have (stored, or the signed-in account's) versus one typed here just now.
+  const { name: connectName, resolving: nameResolving } = useConnectName()
+  const [nameConfirmed, setNameConfirmed] = useState(false)
   const [loginOpen, setLoginOpen] = useState(false)
   const [showReplays, setShowReplays] = useState(false)
   const [publicLobbies, setPublicLobbies] = useState<PublicLobbyEntry[]>([])
@@ -130,13 +133,10 @@ export function HomeScreen({
   const onlinePlayers = useGameStore((state) => state.onlinePlayers)
   const spectateGame = useGameStore((state) => state.spectateGame)
   const setPendingSpectateGameId = useGameStore((state) => state.setPendingSpectateGameId)
+  // Server config + session are bootstrapped by `useConnectName` above, so the AuthWidget knows
+  // whether to show at all.
   const authStatus = useAuthStore((state) => state.status)
   const accountsEnabled = useAuthStore((state) => state.accountsEnabled)
-  const authInit = useAuthStore((state) => state.init)
-  // Bootstrap server config + session on landing so the AuthWidget knows whether to show at all.
-  useEffect(() => {
-    if (authStatus === 'idle') void authInit()
-  }, [authStatus, authInit])
 
   const confirmName = () => {
     if (playerName.trim()) {
@@ -285,11 +285,12 @@ export function HomeScreen({
       spectateGame(gameSessionId)
       return
     }
-    if (!playerName.trim()) return
-    localStorage.setItem('argentum-player-name', playerName.trim())
+    const name = connectName ?? playerName.trim()
+    if (!name) return
+    localStorage.setItem('argentum-player-name', name)
     setPendingSpectateGameId(gameSessionId)
     setNameConfirmed(true)
-    connect(playerName.trim())
+    connect(name)
   }
 
   return (
@@ -322,7 +323,10 @@ export function HomeScreen({
             <p className={styles.errorMessage}>Error: {error}</p>
           )}
 
-          {!nameConfirmed && (
+          {/* Only a visitor with no name at all is asked for one. A signed-in account already has a
+              display name, and the server would overwrite anything typed here with it. Held back
+              while the account check is in flight so the prompt can't flash and vanish. */}
+          {!nameConfirmed && !connectName && !nameResolving && (
             <div className={styles.inputGroup}>
               <label className={styles.inputLabel}>{joinSessionId ? 'Enter your name to join' : 'Enter your name'}</label>
               <input
@@ -484,11 +488,13 @@ export function HomeScreen({
                   if (status === 'connected') {
                     // QuickGameLobbyHandler routes by lobby kind — works for both.
                     joinQuickGameLobby(entry.lobbyId)
-                  } else if (playerName.trim()) {
-                    localStorage.setItem('argentum-player-name', playerName.trim())
+                  } else {
+                    const name = connectName ?? playerName.trim()
+                    if (!name) return
+                    localStorage.setItem('argentum-player-name', name)
                     setPendingJoinCode(entry.lobbyId)
                     setNameConfirmed(true)
-                    connect(playerName.trim())
+                    connect(name)
                   }
                 }}
               />
@@ -497,7 +503,7 @@ export function HomeScreen({
               <LiveGameList
                 games={liveGames}
                 onSpectate={handleSpectate}
-                disabled={!playerName.trim() && status !== 'connected'}
+                disabled={!connectName && !playerName.trim() && status !== 'connected'}
               />
             )}
           </div>

--- a/web-client/src/store/authStore.ts
+++ b/web-client/src/store/authStore.ts
@@ -49,7 +49,9 @@ export const useAuthStore = create<AuthState>((set) => ({
       set({ user: null, status: 'anonymous', accountsEnabled: false })
       return
     }
-    const user = await fetchMe()
+    // A network failure must still settle the status: the entry screens hold their name entry back
+    // until auth resolves, and a stuck 'loading' would leave a guest with no way in.
+    const user = await fetchMe().catch(() => null)
     set(
       user
         ? { user, status: 'authenticated', accountsEnabled: true }

--- a/web-client/src/store/useConnectName.ts
+++ b/web-client/src/store/useConnectName.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolves the name this browser can connect to the game server with — the one gate every entry
+ * screen (home, `/join/:id`, `/tournament/:id`) puts in front of a player.
+ */
+import { useEffect } from 'react'
+import { useAuthStore } from '@/store/authStore'
+
+/** localStorage key holding the guest / last-used player name. */
+export const PLAYER_NAME_KEY = 'argentum-player-name'
+
+export interface ConnectName {
+  /** The name to connect with, or null when this browser has no name yet. */
+  readonly name: string | null
+  /** True until the account check has come back — see the note on prompting below. */
+  readonly resolving: boolean
+}
+
+/**
+ * Two sources, account first: a signed-in account's display name is what the server puts on your
+ * seat (`connectionSlice.connect` sends it over the stored one), so it *is* a name even on a
+ * browser that has never stored one. Screens used to look only at localStorage, which asked a
+ * logged-in player on a fresh device to type a name that the very next connect overwrote with
+ * their profile name.
+ *
+ * `resolving` covers the window before `/api/config` + `/api/auth/me` answer. Connecting on a
+ * stored name during it is harmless — the socket re-reads the account name when it opens — but
+ * *prompting* for one is not: the prompt would flash and then vanish under a signed-in user. Any
+ * screen that renders a name entry should hold it back until `resolving` clears.
+ *
+ * Also kicks the one-time auth bootstrap, so the deep-link entry pages resolve an account without
+ * depending on the home screen having mounted first.
+ */
+export function useConnectName(): ConnectName {
+  const status = useAuthStore((s) => s.status)
+  const init = useAuthStore((s) => s.init)
+  const accountName = useAuthStore((s) => s.user?.displayName.trim() || null)
+
+  useEffect(() => {
+    if (status === 'idle') void init()
+  }, [status, init])
+
+  // Read on every render rather than into state: `connect()` writes this key, and the callers all
+  // re-render on the connection status that follows.
+  const storedName = localStorage.getItem(PLAYER_NAME_KEY)?.trim() || null
+
+  return {
+    name: accountName ?? storedName,
+    resolving: status === 'idle' || status === 'loading',
+  }
+}


### PR DESCRIPTION
## The bug

When you are logged in, the home screen still asked you to **enter your name** if there was no name in `localStorage` — a fresh browser, a cleared cache, an incognito tab. The name typed there was then immediately overwritten by the account's display name, because `connectionSlice.connect` already prefers the profile name when it opens the socket. So the prompt asked for something it was about to throw away, and until you answered it the whole Play tier stayed hidden.

The cause: every screen that gates on "do we have a name?" read only `localStorage`, never the signed-in account.

## The fix

One shared hook, `web-client/src/store/useConnectName.ts`, resolves the name to connect with:

- `name` — the account's `displayName` when signed in, else the stored name, else `null`.
- `resolving` — true until `/api/config` + `/api/auth/me` answer. Connecting on a stored name during that window is harmless (the socket re-reads the account name when it opens), but *prompting* is not, so a screen holds its name entry until this clears rather than flashing it and pulling it away. The hook also kicks the auth bootstrap, so the deep-link pages resolve an account without depending on the home screen having mounted.

Applied at all four places that gated on a name:

- `App.tsx` — auto-connects on the resolved name; the effect re-runs when the account check resolves.
- `HomeScreen.tsx` — name entry renders only for a visitor with no name at all. The spectate and public-lobby-join handlers fall back to the account name too, instead of refusing to act while disconnected.
- `JoinLobbyPage.tsx` / `TournamentEntryPage.tsx` — the `/join/:id` and `/tournament/:id` deep links had the identical bug; they now show the spinner instead of a name form while the account check is in flight.

`authStore.init()` also had to be hardened: `fetchMe()` rejecting on a network error left `status: 'loading'` forever, and with the new gate a stuck `loading` would leave a guest with no way in. It now settles to `anonymous`.

## Verification

`npm run typecheck` clean, 516 web-client unit tests pass, plus a Playwright run against the dev client with the account endpoints stubbed:

| state | name prompt |
|---|---|
| logged in, empty `localStorage` | **not shown** — auto-connects as the account name |
| guest, empty `localStorage` | shown |
| guest, stored name | not shown |

**Logged in with empty `localStorage`** — "Signed in as Vincent", no name prompt, straight to a connect attempt:

![logged in](https://raw.githubusercontent.com/wingedsheep/argentum-engine/fix-name-prompt-screenshots/logged-in.png)

**Guest with empty `localStorage`** — the prompt still appears, unchanged:

![guest](https://raw.githubusercontent.com/wingedsheep/argentum-engine/fix-name-prompt-screenshots/guest.png)

The `WebSocket connection error` in the first shot is the local game server, not the change: `just server` failed to boot here with `OutOfMemoryError: GC overhead limit exceeded` during the Kotlin compile, because several agents' Gradle daemons were competing for the box. No Kotlin is touched by this PR. The error is itself the evidence that auto-connect fired with the account name instead of stalling on a prompt. What that leaves unverified is only the connected home screen against a live server; the name string passed to `connect()` is the sole difference from the already-working stored-name path.

Screenshots live on the throwaway branch `fix-name-prompt-screenshots`, not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
