### PR TITLE
Fix planeswalkers with two same-cost loyalty abilities showing one text twice

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1512,11 +1512,14 @@ class ClientStateTransformer(
         if (!cardDef.typeLine.cardTypes.contains(CardType.PLANESWALKER)) return null
         val abilities = cardDef.script.activatedAbilities.filter { it.isPlaneswalkerAbility }
         if (abilities.isEmpty()) return null
+        // Consumed in order, so two abilities sharing a loyalty cost (Garruk Relentless's two
+        // 0-cost abilities) each take their own oracle line instead of both echoing the first.
         val oracleDescriptions = parseOracleLoyaltyLines(cardDef.oracleText)
+            .mapValues { (_, lines) -> ArrayDeque(lines) }
         return abilities.mapNotNull { ability ->
             val loyalty = (ability.cost as? com.wingedsheep.sdk.scripting.AbilityCost.Loyalty)?.change
                 ?: return@mapNotNull null
-            val description = oracleDescriptions[loyalty]
+            val description = oracleDescriptions[loyalty]?.removeFirstOrNull()
                 ?: ability.descriptionOverride
                 ?: effectDisplayText(ability.effect, "this planeswalker")
             ClientPlaneswalkerAbility(
@@ -1528,23 +1531,25 @@ class ClientStateTransformer(
     }
 
     /**
-     * Parse a planeswalker's oracle text into a map of loyalty change → ability text.
-     * Example line: "−2: Ajani deals 4 damage to target tapped creature."
+     * Parse a planeswalker's oracle text into a map of loyalty change → ability texts, in the order
+     * the lines appear. Example line: "−2: Ajani deals 4 damage to target tapped creature."
      * Handles the Unicode minus (U+2212), the ASCII hyphen, and a leading "+".
-     * If a planeswalker has two abilities with the same loyalty cost (rare — Vivien, Monsters'
-     * Advocate), only the first is kept here; the fallback to `effect.description` covers the rest.
+     *
+     * A loyalty cost maps to a *list* because it isn't unique: Garruk Relentless has two 0-cost
+     * abilities, Vivien, Monsters' Advocate two −2s. Keying one text per cost gave every ability
+     * sharing that cost the first line's text, so the card showed the same ability twice.
      */
-    private fun parseOracleLoyaltyLines(oracleText: String): Map<Int, String> {
+    private fun parseOracleLoyaltyLines(oracleText: String): Map<Int, List<String>> {
         if (oracleText.isBlank()) return emptyMap()
         val pattern = Regex("""^\s*([+−\-]?)(\d+):\s*(.+?)\s*$""")
-        val result = mutableMapOf<Int, String>()
+        val result = mutableMapOf<Int, MutableList<String>>()
         for (raw in oracleText.lines()) {
             val match = pattern.matchEntire(raw) ?: continue
             val sign = match.groupValues[1]
             val magnitude = match.groupValues[2].toIntOrNull() ?: continue
             val loyalty = if (sign == "−" || sign == "-") -magnitude else magnitude
             val text = match.groupValues[3].trimEnd('.', ' ')
-            result.putIfAbsent(loyalty, text)
+            result.getOrPut(loyalty) { mutableListOf() }.add(text)
         }
         return result
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/PlaneswalkerAbilityTextVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/PlaneswalkerAbilityTextVisibilityTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * [ClientStateTransformer] hands the client one [ClientPlaneswalkerAbility] per loyalty ability so
+ * the card's full ability menu can be rendered (including the ones that aren't currently legal).
+ * The text comes from the matching oracle-text line.
+ *
+ * A loyalty *cost* is not a unique key: Garruk Relentless has two 0-cost abilities, Jaya Ballard two
+ * +1s, and so do Sorin, Imperious Bloodlord, Jace Reawakened, Arlinn Kord, and Chandra, Dressed to
+ * Kill. Keying one oracle line per cost made every ability sharing a cost report the *first* line's
+ * text, so those cards showed the same ability twice.
+ */
+class PlaneswalkerAbilityTextVisibilityTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun abilities(d: GameTestDriver, permanent: EntityId, viewer: EntityId) =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+            .transform(d.state, viewingPlayerId = viewer)
+            .cards[permanent]
+            .shouldNotBeNull()
+            .planeswalkerAbilities
+            .shouldNotBeNull()
+
+    test("Garruk Relentless's two 0-cost abilities each get their own oracle line") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val garruk = d.putPermanentOnBattlefield(player, "Garruk Relentless")
+
+        val pwAbilities = abilities(d, garruk, player)
+
+        pwAbilities.map { it.loyaltyChange } shouldBe listOf(0, 0)
+        pwAbilities.map { it.description } shouldBe listOf(
+            "Garruk deals 3 damage to target creature. That creature deals damage equal to its power to him",
+            "Create a 2/2 green Wolf creature token",
+        )
+        pwAbilities.map { it.abilityId }.toSet().size shouldBe 2
+    }
+
+    test("Jaya Ballard's two +1 abilities are not collapsed onto the first one's text") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val jaya = d.putPermanentOnBattlefield(player, "Jaya Ballard")
+
+        val pwAbilities = abilities(d, jaya, player)
+
+        pwAbilities.map { it.loyaltyChange } shouldBe listOf(1, 1, -8)
+        pwAbilities[0].description shouldBe
+            "Add {R}{R}{R}. Spend this mana only to cast instant or sorcery spells"
+        pwAbilities[1].description shouldBe "Discard up to three cards, then draw that many cards"
+    }
+
+    test("a planeswalker with distinct loyalty costs still maps each ability to its own line") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val liliana = d.putPermanentOnBattlefield(player, "Liliana of the Veil")
+
+        val pwAbilities = abilities(d, liliana, player)
+
+        pwAbilities.map { it.loyaltyChange } shouldBe listOf(1, -2, -6)
+        pwAbilities.map { it.description } shouldBe listOf(
+            "Each player discards a card",
+            "Target player sacrifices a creature",
+            "Separate all permanents target player controls into two piles. That player sacrifices " +
+                "all permanents in the pile of their choice",
+        )
+    }
+})


### PR DESCRIPTION
## The bug

Garruk Relentless renders both of his abilities with the same text — the damage ability's line shows up twice, and the Wolf token ability is nowhere to be seen.

`ClientStateTransformer.buildPlaneswalkerAbilities` parsed the oracle text into a `Map<Int, String>` keyed by loyalty change (built with `putIfAbsent`) and looked each ability's display text up by its cost. A loyalty cost is **not** a unique key, so every ability sharing one got the *first* matching line's text. The old comment claimed "the fallback to `effect.description` covers the rest" — it never did, because the map hit always won.

Six implemented cards are affected: Garruk Relentless (two 0s), Jaya Ballard, Sorin, Imperious Bloodlord, Jace Reawakened, Arlinn Kord, and Chandra, Dressed to Kill (two +1s apiece).

## The fix

Parse to `Map<Int, List<String>>` preserving oracle order, and have each ability consume the next unused line for its cost. Cards with distinct costs are unaffected; the `descriptionOverride` / rendered-effect fallbacks still apply when the oracle text has fewer lines than the card has abilities.

## Tests

New `PlaneswalkerAbilityTextVisibilityTest` (rules-engine `view` package):

- Garruk Relentless's two 0-cost abilities each get their own oracle line, with distinct ability IDs
- Jaya Ballard's two +1s aren't collapsed onto the first one's text
- regression: Liliana of the Veil (+1 / −2 / −6) still maps each ability to its own line

Verified the first two fail against the pre-fix code and pass after. `just test-rules` is green.