### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DesertWereWorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DesertWereWorm.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Desert Were-Worm — The Hobbit #92
+ * {4}{R}{R} · Creature — Dragon Wurm · Rare
+ * 0/5
+ *
+ * This creature gets +2/+0 for each Mountain you control.
+ * Whenever you attack with creatures with total power 12 or greater for the first time each turn,
+ * untap all attacking creatures. After this phase, there is an additional combat phase.
+ *
+ * Modeling notes:
+ *  - The Mountain pump is a static [GrantDynamicStatsEffect] on the source, so it feeds the total
+ *    power the attack trigger measures — a Were-Worm swinging alongside six Mountains is already
+ *    12 power by itself.
+ *  - "For the first time each turn" is `oncePerTurn` on the ability paired with an
+ *    intervening-if [Compare] on the attackers' total power (CR 603.4). Because the condition is
+ *    checked before the ability triggers, an under-12 attack in an earlier combat doesn't spend
+ *    the turn's single use — the trigger still fires on a later combat that does reach 12.
+ *  - "Untap all attacking creatures" is every attacker on the battlefield, not just yours, so the
+ *    group filter is unscoped by controller.
+ *  - "After this phase, there is an additional combat phase" is [Effects.AddCombatPhase] alone —
+ *    combat only, with no trailing main phase (CR 500.8).
+ */
+val DesertWereWorm = card("Desert Were-Worm") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon Wurm"
+    power = 0
+    toughness = 5
+    oracleText = "This creature gets +2/+0 for each Mountain you control.\n" +
+        "Whenever you attack with creatures with total power 12 or greater for the first time " +
+        "each turn, untap all attacking creatures. After this phase, there is an additional " +
+        "combat phase."
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.Multiply(
+                DynamicAmounts.battlefield(
+                    Player.You,
+                    GameObjectFilter.Land.withSubtype(Subtype.MOUNTAIN)
+                ).count(),
+                2
+            ),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        triggerCondition = Compare(
+            left = DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Creature.attacking(),
+                aggregation = Aggregation.SUM,
+                property = CardNumericProperty.POWER
+            ),
+            operator = ComparisonOperator.GTE,
+            right = DynamicAmount.Fixed(12)
+        )
+        oncePerTurn = true
+        effect = Effects.Composite(
+            listOf(
+                Effects.ForEachInGroup(
+                    filter = GroupFilter(baseFilter = GameObjectFilter.Creature.attacking()),
+                    effect = TapUntapEffect(EffectTarget.Self, tap = false)
+                ),
+                Effects.AddCombatPhase
+            )
+        )
+        description = "Whenever you attack with creatures with total power 12 or greater for the " +
+            "first time each turn, untap all attacking creatures. After this phase, there is an " +
+            "additional combat phase."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "92"
+        artist = "Aldo Domínguez"
+        flavorText = "Fight wild Were-worms in the Last Desert\n" +
+            "—Expression meaning \"an impossible task\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc12c22a-11ff-4fb0-bc42-dd8490b8efb7.jpg?1784733924"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MastersCouncillors.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/MastersCouncillors.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Master's Councillors — The Hobbit #47
+ * {1}{U} · Creature — Human Advisor · Uncommon
+ * 1/3
+ *
+ * Vigilance
+ * This creature gets +2/+0 for each graveyard with seven or more cards in it.
+ * Whenever you draw your second card each turn, target player mills three cards.
+ *
+ * Modeling notes:
+ *  - "Each graveyard" is every player's graveyard, the controller's included, so the scope of
+ *    [DynamicAmount.CountPlayersWith] is [Player.Each]. That primitive rebinds `Player.You` inside
+ *    its condition to each candidate player in turn, which makes
+ *    [Conditions.CardsInGraveyardAtLeast] the per-graveyard test. The count doubles into a power
+ *    bonus via [DynamicAmount.Multiply]; toughness is untouched.
+ *  - The pump is a static ability rather than a printed `*` power, so it stacks with counters and
+ *    other effects in the normal layer order and recomputes as graveyards grow and shrink.
+ *  - [Triggers.NthCardDrawn] fires exactly once per turn, on the draw that crosses the second
+ *    card — including a single draw-two that crosses it in one event.
+ */
+val MastersCouncillors = card("Master's Councillors") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Advisor"
+    power = 1
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "This creature gets +2/+0 for each graveyard with seven or more cards in it.\n" +
+        "Whenever you draw your second card each turn, target player mills three cards. " +
+        "(They put the top three cards of their library into their graveyard.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.Multiply(
+                DynamicAmount.CountPlayersWith(
+                    scope = Player.Each,
+                    condition = Conditions.CardsInGraveyardAtLeast(7)
+                ),
+                2
+            ),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        val milled = target("player", TargetPlayer())
+        effect = Patterns.Library.mill(count = 3, target = milled)
+        description = "Whenever you draw your second card each turn, target player mills three cards."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "47"
+        artist = "Narendra Bintara Adi"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/addcefdd-e012-4adf-9052-e60376a8d2d3.jpg?1784798124"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/PartInFriendship.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/PartInFriendship.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Part in Friendship — The Hobbit #134
+ * {4}{G} · Enchantment · Rare
+ *
+ * Whenever a nontoken creature you control dies, reveal cards from the top of your library until
+ * you reveal a creature card. If its mana value is less than or equal to the number of lands you
+ * control, put it onto the battlefield. Otherwise, put it into your hand. Put the rest on the
+ * bottom of your library in a random order. This ability triggers only once each turn.
+ *
+ * Modeling notes:
+ *  - The reveal is the Spinner of Souls pipeline with a branch grafted in: gather until the first
+ *    creature card, split the revealed pile into that single match and everything under it, then
+ *    branch the match on mana value while the remainder always goes to the bottom in a random
+ *    order. Splitting first is what keeps the match from being swept to the bottom along with the
+ *    rest — [GatherUntilMatchEffect]'s revealed pile includes the card it stopped on.
+ *  - The branch is a [Compare] against the *live* land count, read at resolution, so lands that
+ *    entered or left since the trigger went on the stack are counted correctly.
+ *  - An empty library (no creature revealed) leaves the match collection empty: both branches
+ *    move nothing and every revealed card goes to the bottom, which is the printed behaviour.
+ *  - "This ability triggers only once each turn" is `oncePerTurn`: the first nontoken creature to
+ *    die spends the turn's use whether or not a creature card was found.
+ */
+val PartInFriendship = card("Part in Friendship") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a nontoken creature you control dies, reveal cards from the top of " +
+        "your library until you reveal a creature card. If its mana value is less than or equal " +
+        "to the number of lands you control, put it onto the battlefield. Otherwise, put it into " +
+        "your hand. Put the rest on the bottom of your library in a random order. This ability " +
+        "triggers only once each turn."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        oncePerTurn = true
+        effect = Effects.Composite(
+            listOf(
+                GatherUntilMatchEffect(
+                    filter = GameObjectFilter.Creature,
+                    storeMatch = "ignored",
+                    storeRevealed = "revealed"
+                ),
+                RevealCollectionEffect(from = "revealed"),
+                FilterCollectionEffect(
+                    from = "revealed",
+                    filter = CollectionFilter.MatchesFilter(GameObjectFilter.Creature),
+                    storeMatching = "found",
+                    storeNonMatching = "rest"
+                ),
+                ConditionalEffect(
+                    condition = Compare(
+                        left = DynamicAmount.StoredCardManaValue("found"),
+                        operator = ComparisonOperator.LTE,
+                        right = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Land).count()
+                    ),
+                    effect = MoveCollectionEffect(
+                        from = "found",
+                        destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                    ),
+                    elseEffect = MoveCollectionEffect(
+                        from = "found",
+                        destination = CardDestination.ToZone(Zone.HAND),
+                        revealed = true
+                    )
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+        description = "Whenever a nontoken creature you control dies, reveal cards from the top " +
+            "of your library until you reveal a creature card. If its mana value is less than or " +
+            "equal to the number of lands you control, put it onto the battlefield. Otherwise, " +
+            "put it into your hand. Put the rest on the bottom of your library in a random order."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "134"
+        artist = "Jarel Threat"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4ff1eac-6d97-40ab-9b7c-c2fdca0917d9.jpg?1784632164"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheMasterOfLakeTown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheMasterOfLakeTown.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Master of Lake-town — The Hobbit #77
+ * {1}{B}{B} · Legendary Creature — Human Advisor · Rare
+ * 3/2
+ *
+ * Deathtouch
+ * Whenever a player loses life, that player mills that many cards. (Damage causes loss of life.)
+ * When The Master of Lake-town dies, draw a card for each graveyard with seven or more cards in it.
+ *
+ * Modeling notes:
+ *  - The mill trigger is [Triggers.AnyPlayerLosesLife], so it fires for *every* player including
+ *    its own controller, once per life-loss event. The amount rides on the triggering
+ *    [com.wingedsheep.engine.core.LifeChangedEvent] via
+ *    [ContextPropertyKey.TRIGGER_LIFE_LOST], and [Player.TriggeringPlayer] sends the mill at the
+ *    player who lost the life — not at the controller.
+ *  - "Each graveyard with seven or more cards in it" counts *every* player's graveyard, yours
+ *    included, so the scope is [Player.Each] rather than [Player.EachOpponent].
+ *    [DynamicAmount.CountPlayersWith] rebinds `Player.You` inside the condition to each candidate
+ *    player in turn, which makes [Conditions.CardsInGraveyardAtLeast] the per-graveyard test.
+ *  - The dies trigger resolves after The Master of Lake-town has already reached the graveyard, so
+ *    it counts itself toward its controller's seven.
+ */
+val TheMasterOfLakeTown = card("The Master of Lake-town") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 3
+    toughness = 2
+    oracleText = "Deathtouch\n" +
+        "Whenever a player loses life, that player mills that many cards. " +
+        "(Damage causes loss of life.)\n" +
+        "When The Master of Lake-town dies, draw a card for each graveyard with seven or more " +
+        "cards in it."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.AnyPlayerLosesLife
+        effect = Patterns.Library.mill(
+            count = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_LIFE_LOST),
+            target = EffectTarget.PlayerRef(Player.TriggeringPlayer)
+        )
+        description = "Whenever a player loses life, that player mills that many cards."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.DrawCards(
+            DynamicAmount.CountPlayersWith(
+                scope = Player.Each,
+                condition = Conditions.CardsInGraveyardAtLeast(7)
+            )
+        )
+        description = "When The Master of Lake-town dies, draw a card for each graveyard with " +
+            "seven or more cards in it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "77"
+        artist = "Marius Bota"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/3788ada6-34a9-41af-a31c-2d090550e503.jpg?1784632114"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/UncoverTheMoonLetters.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/UncoverTheMoonLetters.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Uncover the Moon-Letters — The Hobbit #57
+ * {3}{U} · Enchantment · Rare
+ *
+ * Whenever you cast a noncreature spell, you may draw X cards, where X is the amount of mana
+ * spent to cast that spell. If you do, discard two cards.
+ *
+ * Modeling notes:
+ *  - X is [ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL] — the mana actually spent on the
+ *    *triggering* spell, not its mana value. Cost reductions lower it; an X spell or a kicked
+ *    spell raises it, and mana spent from Treasures or rituals counts all the same.
+ *  - "You may … If you do" is one [MayEffect] over both halves: accepting draws and then discards,
+ *    declining does neither. The discard is not a separate optional step — it rides on the same
+ *    decision, so a player can't take the cards and skip the cost.
+ *  - The enchantment is itself a noncreature spell, but it isn't on the battlefield while it's on
+ *    the stack, so casting it doesn't trigger its own ability.
+ */
+val UncoverTheMoonLetters = card("Uncover the Moon-Letters") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast a noncreature spell, you may draw X cards, where X is the " +
+        "amount of mana spent to cast that spell. If you do, discard two cards."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = MayEffect(
+            Effects.Composite(
+                Effects.DrawCards(
+                    DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL)
+                ),
+                Patterns.Hand.discardCards(2)
+            ),
+            descriptionOverride = "Draw X cards, where X is the amount of mana spent to cast that " +
+                "spell, then discard two cards?"
+        )
+        description = "Whenever you cast a noncreature spell, you may draw X cards, where X is " +
+            "the amount of mana spent to cast that spell. If you do, discard two cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "57"
+        artist = "Leon Tukker"
+        flavorText = "Elrond took the map and gazed long at it, and he shook his head, until he " +
+            "saw what the moon revealed."
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/79edf5f6-f6b6-4271-bd2a-14a980f30616.jpg?1785496445"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1343,6 +1343,96 @@
     ]
 }
 
+// Desert Were-Worm
+{
+    "name": "Desert Were-Worm",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Dragon Wurm",
+    "oracleText": "This creature gets +2/+0 for each Mountain you control.\nWhenever you attack with creatures with total power 12 or greater for the first time each turn, untap all attacking creatures. After this phase, there is an additional combat phase.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature attacking"
+                                }
+                            },
+                            "body": {
+                                "type": "TapUntap",
+                                "target": "Self",
+                                "tap": false
+                            }
+                        },
+                        "AddCombatPhase"
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature attacking",
+                        "aggregation": "SUM",
+                        "property": "POWER"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 12
+                    }
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever you attack with creatures with total power 12 or greater for the first time each turn, untap all attacking creatures. After this phase, there is an additional combat phase."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land Mountain"
+                    },
+                    "multiplier": 2
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "RARE",
+        "artist": "Aldo Domínguez",
+        "flavorText": "Fight wild Were-worms in the Last Desert\n—Expression meaning \"an impossible task\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc12c22a-11ff-4fb0-bc42-dd8490b8efb7.jpg?1784733924"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Desolation Prowler
 {
     "name": "Desolation Prowler",
@@ -4738,6 +4828,114 @@
     ]
 }
 
+// Master's Councillors
+{
+    "name": "Master's Councillors",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Advisor",
+    "oracleText": "Vigilance\nThis creature gets +2/+0 for each graveyard with seven or more cards in it.\nWhenever you draw your second card each turn, target player mills three cards. (They put the top three cards of their library into their graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "player"
+                },
+                "descriptionOverride": "Whenever you draw your second card each turn, target player mills three cards."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "CountPlayersWith",
+                        "scope": "Each",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Graveyard"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 7
+                            }
+                        }
+                    },
+                    "multiplier": 2
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "rarity": "UNCOMMON",
+        "artist": "Narendra Bintara Adi",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/addcefdd-e012-4adf-9052-e60376a8d2d3.jpg?1784798124"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Mirkwood
 {
     "name": "Mirkwood",
@@ -5697,6 +5895,110 @@
         "artist": "Andrea Piparo",
         "flavorText": "\"I should say there were little bears, large bears, ordinary bears, and gigantic big bears, all dancing outside from dark to nearly dawn.\"\n—Gandalf",
         "imageUri": "https://cards.scryfall.io/normal/front/0/f/0feb9817-56e1-465a-851c-b2fe202aa8ae.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Part in Friendship
+{
+    "name": "Part in Friendship",
+    "manaCost": "{4}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a nontoken creature you control dies, reveal cards from the top of your library until you reveal a creature card. If its mana value is less than or equal to the number of lands you control, put it onto the battlefield. Otherwise, put it into your hand. Put the rest on the bottom of your library in a random order. This ability triggers only once each turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherUntilMatch",
+                            "filter": "creature",
+                            "storeMatch": "ignored",
+                            "storeRevealed": "revealed"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "revealed"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "revealed",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "creature"
+                            },
+                            "storeMatching": "found",
+                            "storeNonMatching": "rest"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "StoredCardManaValue",
+                                        "collectionName": "found"
+                                    },
+                                    "operator": "LTE",
+                                    "right": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "land"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            },
+                            "otherwise": {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "Whenever a nontoken creature you control dies, reveal cards from the top of your library until you reveal a creature card. If its mana value is less than or equal to the number of lands you control, put it onto the battlefield. Otherwise, put it into your hand. Put the rest on the bottom of your library in a random order."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "134",
+        "rarity": "RARE",
+        "artist": "Jarel Threat",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4ff1eac-6d97-40ab-9b7c-c2fdca0917d9.jpg?1784632164"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -7289,6 +7591,99 @@
     ]
 }
 
+// The Master of Lake-town
+{
+    "name": "The Master of Lake-town",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "Deathtouch\nWhenever a player loses life, that player mills that many cards. (Damage causes loss of life.)\nWhen The Master of Lake-town dies, draw a card for each graveyard with seven or more cards in it.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "LifeLossEvent",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_LIFE_LOST"
+                                },
+                                "player": "TriggeringPlayer",
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "TriggeringPlayer"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a player loses life, that player mills that many cards."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "CountPlayersWith",
+                        "scope": "Each",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Graveyard"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 7
+                            }
+                        }
+                    }
+                },
+                "descriptionOverride": "When The Master of Lake-town dies, draw a card for each graveyard with seven or more cards in it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "RARE",
+        "artist": "Marius Bota",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/3788ada6-34a9-41af-a31c-2d090550e503.jpg?1784632114"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // The Misty Mountains Cold
 {
     "name": "The Misty Mountains Cold",
@@ -8262,6 +8657,93 @@
         "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b4b1c59-bcec-4779-9e27-0e6f9feb4e11.jpg?1785639568"
     },
     "colorIdentityOverride": []
+}
+
+// Uncover the Moon-Letters
+{
+    "name": "Uncover the Moon-Letters",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast a noncreature spell, you may draw X cards, where X is the amount of mana spent to cast that spell. If you do, discard two cards.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "ContextProperty",
+                                    "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 2
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 2 cards to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "Draw X cards, where X is the amount of mana spent to cast that spell, then discard two cards?"
+                },
+                "descriptionOverride": "Whenever you cast a noncreature spell, you may draw X cards, where X is the amount of mana spent to cast that spell. If you do, discard two cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "RARE",
+        "artist": "Leon Tukker",
+        "flavorText": "Elrond took the map and gazed long at it, and he shook his head, until he saw what the moon revealed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/79edf5f6-f6b6-4271-bd2a-14a980f30616.jpg?1785496445"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Uneasy Partings

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesertWereWormScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DesertWereWormScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.AdditionalPhasesComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.DesertWereWorm
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Desert Were-Worm {4}{R}{R} — Creature — Dragon Wurm 0/5
+ *   This creature gets +2/+0 for each Mountain you control.
+ *   Whenever you attack with creatures with total power 12 or greater for the first time each
+ *   turn, untap all attacking creatures. After this phase, there is an additional combat phase.
+ *
+ * The gate is an intervening-"if" over the attackers' total power, and CR 603.4 says a trigger
+ * whose condition is false never triggers — so an under-12 swing must leave the `oncePerTurn` cap
+ * unspent. These tests pin both sides of that gate, and that the Mountain pump is what feeds the
+ * total power in the first place.
+ */
+class DesertWereWormScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DesertWereWorm))
+        return driver
+    }
+
+    /**
+     * Puts the Were-Worm and [mountains] Mountains onto the battlefield, then attacks alone.
+     * Returns the Were-Worm's entity id.
+     */
+    fun attackAlone(driver: GameTestDriver, mountains: Int): Pair<GameTestDriver, EntityId> {
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        repeat(mountains) { driver.putPermanentOnBattlefield(you, "Mountain") }
+        val worm = driver.putCreatureOnBattlefield(you, "Desert Were-Worm")
+        driver.removeSummoningSickness(worm)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(worm), defendingPlayer = opponent).error shouldBe null
+        driver.bothPass() // resolve the attack trigger, if it fired at all
+        return driver to worm
+    }
+
+    test("six Mountains make it a 12/5, and attacking untaps it and queues an extra combat phase") {
+        val (driver, worm) = attackAlone(createDriver(), mountains = 6)
+        val you = driver.activePlayer!!
+
+        driver.state.projectedState.getPower(worm) shouldBe 12
+        driver.state.projectedState.getToughness(worm) shouldBe 5
+        // Declaring it as an attacker tapped it; the trigger untapped it again.
+        driver.isTapped(worm) shouldBe false
+        driver.state.getEntity(you)?.has<AdditionalPhasesComponent>() shouldBe true
+    }
+
+    test("five Mountains leave it at 10 power, below the gate — no untap, no extra combat") {
+        val (driver, worm) = attackAlone(createDriver(), mountains = 5)
+        val you = driver.activePlayer!!
+
+        driver.state.projectedState.getPower(worm) shouldBe 10
+        driver.isTapped(worm) shouldBe true
+        driver.state.getEntity(you)?.has<AdditionalPhasesComponent>() shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MastersCouncillorsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MastersCouncillorsScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.MastersCouncillors
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Master's Councillors {1}{U} — Creature — Human Advisor 1/3
+ *   Vigilance
+ *   This creature gets +2/+0 for each graveyard with seven or more cards in it.
+ *   Whenever you draw your second card each turn, target player mills three cards.
+ *
+ * The pump is a [com.wingedsheep.sdk.scripting.values.DynamicAmount.CountPlayersWith] read from
+ * inside a continuous effect — the count has to be recomputed through the layer projection as
+ * graveyards fill, and it has to include the controller's own graveyard, not just opponents'.
+ */
+class MastersCouncillorsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MastersCouncillors))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("with no full graveyard it is a printed 1/3") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val councillors = driver.putCreatureOnBattlefield(you, "Master's Councillors")
+
+        driver.state.projectedState.getPower(councillors) shouldBe 1
+        driver.state.projectedState.getToughness(councillors) shouldBe 3
+    }
+
+    test("your own graveyard counts: seven cards makes it a 3/3") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val councillors = driver.putCreatureOnBattlefield(you, "Master's Councillors")
+
+        repeat(6) { driver.putCardInGraveyard(you, "Island") }
+        driver.state.projectedState.getPower(councillors) shouldBe 1 // six is not enough
+
+        driver.putCardInGraveyard(you, "Island")
+        driver.state.projectedState.getPower(councillors) shouldBe 3
+        driver.state.projectedState.getToughness(councillors) shouldBe 3
+    }
+
+    test("both graveyards over seven makes it a 5/3") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val councillors = driver.putCreatureOnBattlefield(you, "Master's Councillors")
+
+        repeat(7) { driver.putCardInGraveyard(you, "Island") }
+        repeat(9) { driver.putCardInGraveyard(opponent, "Island") }
+
+        driver.state.projectedState.getPower(councillors) shouldBe 5
+        driver.state.projectedState.getToughness(councillors) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PartInFriendshipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PartInFriendshipScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.PartInFriendship
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Part in Friendship {4}{G} — Enchantment
+ *   Whenever a nontoken creature you control dies, reveal cards from the top of your library
+ *   until you reveal a creature card. If its mana value is less than or equal to the number of
+ *   lands you control, put it onto the battlefield. Otherwise, put it into your hand. Put the
+ *   rest on the bottom of your library in a random order. This ability triggers only once each
+ *   turn.
+ *
+ * The branch is the interesting part: the same revealed creature goes to the battlefield or to
+ * hand purely on the mana-value-vs-lands comparison, and the cards revealed underneath it must
+ * end up on the bottom of the library either way rather than following it.
+ */
+class PartInFriendshipScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(PartInFriendship))
+        return driver
+    }
+
+    /**
+     * Board: the enchantment out, [lands] Forests on the battlefield, a doomed Savannah Lions to
+     * kill, and a library topped by two Forests over [creature]. Bolts the Lions and lets the
+     * trigger resolve.
+     */
+    fun setUpAndKill(driver: GameTestDriver, lands: Int, creature: String) {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(you, "Part in Friendship")
+        repeat(lands) { driver.putPermanentOnBattlefield(you, "Forest") }
+
+        val doomed = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+
+        // Library from the top: Forest, Forest, then the creature the reveal will stop on.
+        driver.putCardOnTopOfLibrary(you, creature)
+        driver.putCardOnTopOfLibrary(you, "Forest")
+        driver.putCardOnTopOfLibrary(you, "Forest")
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(doomed)).isSuccess shouldBe true
+        driver.bothPass() // Lightning Bolt kills the Lions
+        driver.bothPass() // Part in Friendship's trigger
+    }
+
+    test("a creature whose mana value fits the land count hits the battlefield") {
+        val driver = createDriver()
+        // Centaur Courser is {2}{G} — mana value 3, and we control four lands.
+        setUpAndKill(driver, lands = 4, creature = "Centaur Courser")
+        val you = driver.activePlayer!!
+
+        driver.getPermanents(you).count { driver.getCardName(it) == "Centaur Courser" } shouldBe 1
+        driver.getHand(you).count { driver.getCardName(it) == "Centaur Courser" } shouldBe 0
+        // The two Forests revealed above it went to the bottom, not along with it.
+        driver.getPermanents(you).count { driver.getCardName(it) == "Forest" } shouldBe 4
+    }
+
+    test("a creature too expensive for the land count goes to hand instead") {
+        val driver = createDriver()
+        // Force of Nature is {2}{G}{G}{G} — mana value 5, against only two lands.
+        setUpAndKill(driver, lands = 2, creature = "Force of Nature")
+        val you = driver.activePlayer!!
+
+        driver.getPermanents(you).count { driver.getCardName(it) == "Force of Nature" } shouldBe 0
+        driver.getHand(you).count { driver.getCardName(it) == "Force of Nature" } shouldBe 1
+    }
+
+    test("the ability triggers only once each turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(you, "Part in Friendship")
+        repeat(4) { driver.putPermanentOnBattlefield(you, "Forest") }
+
+        val first = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        val second = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+
+        driver.putCardOnTopOfLibrary(you, "Centaur Courser")
+        driver.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        val firstBolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, firstBolt, listOf(first)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        val secondBolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, secondBolt, listOf(second)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        // Only the first death found a Courser; the second death didn't trigger at all.
+        driver.getPermanents(you).count { driver.getCardName(it) == "Centaur Courser" } shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMasterOfLakeTownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMasterOfLakeTownScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.TheMasterOfLakeTown
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Master of Lake-town {1}{B}{B} — Legendary Creature — Human Advisor 3/2
+ *   Deathtouch
+ *   Whenever a player loses life, that player mills that many cards.
+ *   When The Master of Lake-town dies, draw a card for each graveyard with seven or more cards.
+ *
+ * [com.wingedsheep.sdk.dsl.Triggers.AnyPlayerLosesLife] has no other card using it, so the first
+ * two tests pin down that it fires for *any* player and mills the player who lost the life rather
+ * than the controller. The last two pin the "each graveyard" count, which reads every player's
+ * graveyard including the controller's own.
+ */
+class TheMasterOfLakeTownScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheMasterOfLakeTown))
+        return driver
+    }
+
+    test("an opponent losing 3 life mills that opponent 3 cards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "The Master of Lake-town")
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(opponent)).isSuccess shouldBe true
+        driver.bothPass() // Lightning Bolt: opponent 20 -> 17
+        driver.bothPass() // the mill trigger
+
+        driver.assertLifeTotal(opponent, 17)
+        driver.getGraveyard(opponent).size shouldBe 3
+    }
+
+    test("the controller losing life mills the controller, not the opponent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "The Master of Lake-town")
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(you)).isSuccess shouldBe true
+        driver.bothPass() // Lightning Bolt: you 20 -> 17
+        driver.bothPass() // the mill trigger
+
+        driver.assertLifeTotal(you, 17)
+        // Lightning Bolt itself is the 4th card in your graveyard; the mill added 3 more.
+        driver.getGraveyard(you).size shouldBe 4
+        driver.getGraveyard(opponent).size shouldBe 0
+    }
+
+    test("dying draws one card for each graveyard holding seven or more cards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        repeat(7) { driver.putCardInGraveyard(you, "Swamp") }
+        repeat(7) { driver.putCardInGraveyard(opponent, "Swamp") }
+
+        driver.putCreatureOnBattlefield(you, "The Master of Lake-town")
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        val handBefore = driver.getHandSize(you)
+        driver.castSpell(you, bolt, listOf(driver.findPermanent(you, "The Master of Lake-town")!!))
+            .isSuccess shouldBe true
+        driver.bothPass() // 3 damage kills the 3/2
+        driver.bothPass() // the dies trigger
+
+        // Both graveyards are over seven, so the trigger draws two. The Bolt left hand to pay for it.
+        driver.getHandSize(you) shouldBe handBefore - 1 + 2
+    }
+
+    test("dying draws nothing when no graveyard has seven cards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "The Master of Lake-town")
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        val handBefore = driver.getHandSize(you)
+        driver.castSpell(you, bolt, listOf(driver.findPermanent(you, "The Master of Lake-town")!!))
+            .isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        // Your graveyard holds only the Bolt and the Master — two cards, so no draws.
+        driver.getHandSize(you) shouldBe handBefore - 1
+    }
+})


### PR DESCRIPTION
Five more The Hobbit cards, all HOB-exclusive and all composed from existing SDK vocabulary — no engine or SDK changes, and no update needed to the card SDK language reference.

| Card | Cost | Type |
|---|---|---|
| The Master of Lake-town | `{1}{B}{B}` | Legendary Creature — Human Advisor 3/2 |
| Master's Councillors | `{1}{U}` | Creature — Human Advisor 1/3 |
| Desert Were-Worm | `{4}{R}{R}` | Creature — Dragon Wurm 0/5 |
| Part in Friendship | `{4}{G}` | Enchantment |
| Uncover the Moon-Letters | `{3}{U}` | Enchantment |

## Modelling notes

**The Master of Lake-town** is the first card to use `Triggers.AnyPlayerLosesLife`. The amount rides the triggering `LifeChangedEvent` via `TRIGGER_LIFE_LOST`, and the mill is aimed with `Player.TriggeringPlayer` so it hits whoever lost the life rather than the controller.

**"Each graveyard with seven or more cards in it"** — shared by the Master and Master's Councillors — is `CountPlayersWith(Player.Each, CardsInGraveyardAtLeast(7))`. `Each`, not `EachOpponent`: your own graveyard counts. `CountPlayersWith` rebinds `Player.You` inside the condition to each candidate player in turn, which is exactly what makes `CardsInGraveyardAtLeast` the per-graveyard test.

**Desert Were-Worm** — the Mountain pump is what feeds the total power its own attack trigger measures, so six Mountains make it a 12/5 that turns itself on. "For the first time each turn" is `oncePerTurn` over an intervening-"if" `Compare` on the attackers' total power: CR 603.4 says a trigger whose condition is false never triggers, so an under-12 swing doesn't spend the turn's single use and a later combat can still fire it. The rider is `AddCombatPhase` alone — combat only, no trailing main phase (CR 500.8).

**Part in Friendship** — Spinner of Souls' reveal pipeline with a branch grafted in. The revealed pile is split into the single match and the cards under it *before* the mana-value branch, because `GatherUntilMatchEffect`'s pile includes the card it stopped on; without the split the match would follow the rest to the bottom of the library.

**Uncover the Moon-Letters** — X is `MANA_SPENT_ON_TRIGGERING_SPELL`, so cost reductions lower it and mana from Treasures or rituals counts. The draw and the discard sit under one `MayEffect`, so a player can't take the cards and skip the two discards.

## Deliberately skipped

The set's `recruit`, `Storied`, and hone-counter cards. None of those mechanics exists in the engine, and each is `add-feature` work rather than `add-card` — the same call earlier HOB batches made.

## Tests

Four scenario tests, 12 cases, one file per card. They cover the paths with no prior card precedent — `AnyPlayerLosesLife` had no other user, and `CountPlayersWith` inside a continuous effect is a new projection read:

- **The Master of Lake-town** (4): an opponent's life loss mills that opponent; the controller's own life loss mills the controller and not the opponent; dying draws one per qualifying graveyard; dying draws nothing when neither graveyard is full.
- **Master's Councillors** (3): printed 1/3 with empty graveyards, 3/3 on the seventh card in your *own* graveyard (six is not enough), 5/3 with both graveyards over seven.
- **Desert Were-Worm** (2): both sides of the power gate — six Mountains untap it and queue the extra phase, five Mountains do neither.
- **Part in Friendship** (3): the battlefield branch, the hand branch, and the once-each-turn cap.

## Verification

- `just build` green.
- `just check-card-printing` clean for all five — HOB is the earliest printing for each, so all canonical with no `Printing` rows.
- HOB golden re-blessed: 482 insertions, **zero** deletions; no other set's golden moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
