### PR TITLE
Add six Mirrodin cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2820,6 +2820,7 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `Targets.Enchantment` — any enchantment.
 - `Targets.Land` — any land.
 - `Targets.ArtifactOrLand` — any artifact or land (Territory Forge).
+- `Targets.ArtifactEnchantmentOrLand` — any artifact, enchantment, or land (Creeping Mold). One target slot over a three-way union, not three modes.
 - `Targets.BasicLand` — any basic land.
 - `Targets.Spell` — any spell on the stack.
 - `Targets.SpellYouControl` — any spell on the stack you control, unrestricted by type (Slick Imitator's "Copy target spell you control"; a copied permanent spell resolves into a token).
@@ -3055,8 +3056,11 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   `IsCreature` + `.notColor(...)`. FQL keys: `nonland` / `noncreature` / `nonartifact`.
 - **Combined-type filters** — `GameObjectFilter.InstantOrSorcery` / `CreatureOrPlaneswalker` /
   `CreatureOrEnchantment` / `ArtifactOrEnchantment` / `CreatureOrArtifact` / `CreatureOrVehicle` /
-  `ArtifactOrLand` / `ArtifactCreatureOrEnchantment` each wrap a `CardPredicate.Or` of the named
+  `ArtifactOrLand` / `ArtifactEnchantmentOrLand` / `ArtifactCreatureOrEnchantment` each wrap a
+  `CardPredicate.Or` of the named
   types (`CreatureOrVehicle` matches a creature or any object with the Vehicle subtype).
+  `ArtifactEnchantmentOrLand` (the flexible-Naturalize union) has the matching target constants
+  `TargetFilter.ArtifactEnchantmentOrLand` / `Targets.ArtifactEnchantmentOrLand` — Creeping Mold.
   `ArtifactCreatureOrEnchantment` (the three-type O-Ring restriction) has matching target constants
   `TargetFilter.ArtifactCreatureOrEnchantment` and
   `TargetFilter.ArtifactCreatureOrEnchantmentOpponentControls` — the latter for "exile target

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
@@ -180,6 +180,12 @@ object Targets {
     val ArtifactOrLand: TargetRequirement = TargetPermanent(filter = TargetFilter.ArtifactOrLand)
 
     /**
+     * Target artifact, enchantment, or land (Creeping Mold).
+     */
+    val ArtifactEnchantmentOrLand: TargetRequirement =
+        TargetPermanent(filter = TargetFilter.ArtifactEnchantmentOrLand)
+
+    /**
      * Target land.
      */
     val Land: TargetRequirement = TargetPermanent(filter = TargetFilter.Land)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -215,6 +215,23 @@ data class GameObjectFilter(
                 CardPredicate.Or(listOf(CardPredicate.IsArtifact, CardPredicate.IsLand))
             )
         )
+
+        /**
+         * Artifact, enchantment, or land — the "flexible Naturalize" target family
+         * (Creeping Mold, Fade from History). Sits alongside [ArtifactOrEnchantment]
+         * and [ArtifactOrLand] as the third member of the same union family.
+         */
+        val ArtifactEnchantmentOrLand = GameObjectFilter(
+            cardPredicates = listOf(
+                CardPredicate.Or(
+                    listOf(
+                        CardPredicate.IsArtifact,
+                        CardPredicate.IsEnchantment,
+                        CardPredicate.IsLand,
+                    )
+                )
+            )
+        )
         val ArtifactCreature = GameObjectFilter(
             cardPredicates = listOf(CardPredicate.IsArtifact, CardPredicate.IsCreature)
         )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -186,6 +186,10 @@ data class TargetFilter(
         /** Target artifact or land */
         val ArtifactOrLand = TargetFilter(GameObjectFilter.Companion.ArtifactOrLand)
 
+        /** Target artifact, enchantment, or land (Creeping Mold) */
+        val ArtifactEnchantmentOrLand =
+            TargetFilter(GameObjectFilter.Companion.ArtifactEnchantmentOrLand)
+
         /** Target land */
         val Land = TargetFilter(GameObjectFilter.Companion.Land)
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/CreepingMoldReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/CreepingMoldReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Creeping Mold reprint in 10E. Canonical CardDefinition lives in Visions (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.vis.cards.CreepingMold`.
+ */
+val CreepingMold10eReprint = Printing(
+    oracleId = "59180e94-ccdf-4d9f-9a4a-fe55497d0d63",
+    name = "Creeping Mold",
+    setCode = "10E",
+    collectorNumber = "258",
+    scryfallId = "c68d2204-e771-427a-a840-98f6150f648c",
+    artist = "Gary Ruddell",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c68d2204-e771-427a-a840-98f6150f648c.jpg?1783943004",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/RuleOfLawReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/RuleOfLawReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rule of Law reprint in 10E. Canonical CardDefinition lives in Mirrodin (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.RuleOfLaw`.
+ */
+val RuleOfLaw10eReprint = Printing(
+    oracleId = "53e88e64-6f82-4154-a66e-6aeb0154b368",
+    name = "Rule of Law",
+    setCode = "10E",
+    collectorNumber = "37",
+    scryfallId = "1529ebe9-c809-4c84-9096-1fa05388b660",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/1529ebe9-c809-4c84-9096-1fa05388b660.jpg?1783943073",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/CreepingMoldReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/CreepingMoldReprint.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.`8ed`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Creeping Mold reprint in 8ED. Canonical CardDefinition lives in Visions (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.vis.cards.CreepingMold`.
+ */
+val CreepingMold8edReprint = Printing(
+    oracleId = "59180e94-ccdf-4d9f-9a4a-fe55497d0d63",
+    name = "Creeping Mold",
+    setCode = "8ED",
+    collectorNumber = "240",
+    scryfallId = "19a053c7-650b-4b4a-b54d-082a194e3cc2",
+    artist = "Gary Ruddell",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/19a053c7-650b-4b4a-b54d-082a194e3cc2.jpg?1783944685",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.UNCOMMON,
+)
+
+val CreepingMold8edReprintB = Printing(
+    oracleId = "59180e94-ccdf-4d9f-9a4a-fe55497d0d63",
+    name = "Creeping Mold",
+    setCode = "8ED",
+    collectorNumber = "240★",
+    scryfallId = "d7c5b5b7-e223-41c0-86e0-ed636ab77ae9",
+    artist = "Gary Ruddell",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d7c5b5b7-e223-41c0-86e0-ed636ab77ae9.jpg?1783944689",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/BottleGnomesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/BottleGnomesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bottle Gnomes reprint in C14. Canonical CardDefinition lives in Tempest (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.tmp.cards.BottleGnomes`.
+ */
+val BottleGnomesReprint = Printing(
+    oracleId = "54b5e429-7a44-480d-bea4-4f8eeb7449b5",
+    name = "Bottle Gnomes",
+    setCode = "C14",
+    collectorNumber = "231",
+    scryfallId = "2a1eda8a-bb1e-42a5-938a-1d4e8b84624e",
+    artist = "Ben Thompson",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a1eda8a-bb1e-42a5-938a-1d4e8b84624e.jpg?1783938824",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/CathodionReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/CathodionReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cathodion reprint in C14. Canonical CardDefinition lives in Urza's Saga (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.usg.cards.Cathodion`.
+ */
+val CathodionReprint = Printing(
+    oracleId = "fcd4f816-2de1-4b30-82fb-cb87f45747ea",
+    name = "Cathodion",
+    setCode = "C14",
+    collectorNumber = "234",
+    scryfallId = "0621478c-7e68-40af-aabd-fa4df29f3a20",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/0621478c-7e68-40af-aabd-fa4df29f3a20.jpg?1783938824",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ArrestReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ArrestReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arrest reprint in J22. Canonical CardDefinition lives in Mercadian Masques (its earliest
+ * real printing), `com.wingedsheep.mtg.sets.definitions.mmq.cards.Arrest`.
+ */
+val ArrestReprint = Printing(
+    oracleId = "81728b98-8cf9-4734-a318-69184bb4d15c",
+    name = "Arrest",
+    setCode = "J22",
+    collectorNumber = "52",
+    scryfallId = "2f6b9897-a473-4c47-994a-a6d7e9e81ef2",
+    artist = "Canata Katana",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2f6b9897-a473-4c47-994a-a6d7e9e81ef2.jpg?1783919175",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/CreepingMoldReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/CreepingMoldReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Creeping Mold reprint in KLD. Canonical CardDefinition lives in Visions (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.vis.cards.CreepingMold`.
+ */
+val CreepingMoldReprint = Printing(
+    oracleId = "59180e94-ccdf-4d9f-9a4a-fe55497d0d63",
+    name = "Creeping Mold",
+    setCode = "KLD",
+    collectorNumber = "150",
+    scryfallId = "277b549c-8691-42b2-9867-802b158a506c",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/277b549c-8691-42b2-9867-802b158a506c.jpg?1783937182",
+    releaseDate = "2016-09-30",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/RuleOfLawReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/RuleOfLawReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rule of Law reprint in M20. Canonical CardDefinition lives in Mirrodin (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.RuleOfLaw`.
+ */
+val RuleOfLawReprint = Printing(
+    oracleId = "53e88e64-6f82-4154-a66e-6aeb0154b368",
+    name = "Rule of Law",
+    setCode = "M20",
+    collectorNumber = "35",
+    scryfallId = "a1f4e79b-b103-4380-afa0-61a2b1773c9e",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1f4e79b-b103-4380-afa0-61a2b1773c9e.jpg?1783933020",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Arrest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/Arrest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttack
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Arrest
+ * {2}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature can't attack or block, and its activated abilities can't be activated.
+ *
+ * Mercadian Masques is the earliest real-expansion printing, so the canonical definition lives
+ * here; Mirrodin, Scars of Mirrodin and later sets contribute only `Printing` rows.
+ *
+ * Same three-static shape as Petrify (LCI): Pacifism's combat lock scoped to the attached
+ * permanent, plus the Cursed Totem-style activation lock narrowed to just this Aura's host via
+ * [PreventActivatedAbilities] with `attachedToBySource()`. The lock covers mana abilities too —
+ * Arrest has no "unless they're mana abilities" clause (CR 605.1a abilities are still activated
+ * abilities), so `nonManaAbilitiesOnly` stays false.
+ */
+val Arrest = card("Arrest") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature can't attack or block, and its activated abilities can't be activated."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = CantAttack(filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = CantBlock(filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = PreventActivatedAbilities(
+            filter = GameObjectFilter.Permanent.attachedToBySource(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "4"
+        artist = "Dan Frazier"
+        flavorText = "Orim had no memory of the previous night—the first thing she could " +
+            "remember was waking up with the dead guard's blood on her hands."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b083fd8-6422-4cd3-a27d-41b6d88598c2.jpg?1783945985"
+        ruling(
+            "2016-06-08",
+            "Activated abilities contain a colon. They're generally written " +
+                "\"[Cost]: [Effect].\" Some keywords are activated abilities and will have " +
+                "colons in their reminder text."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ArrestReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ArrestReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arrest reprint in Mirrodin. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Mercadian Masques' `cards/` package
+ * (earliest real-expansion printing); this file contributes only presentation data.
+ */
+val ArrestReprint = Printing(
+    oracleId = "81728b98-8cf9-4734-a318-69184bb4d15c",
+    name = "Arrest",
+    setCode = "MRD",
+    collectorNumber = "2",
+    scryfallId = "a5ca260d-4ed8-4a99-b00a-0be15ba0df9f",
+    artist = "Tim Hildebrandt",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5ca260d-4ed8-4a99-b00a-0be15ba0df9f.jpg?1783944564",
+    releaseDate = "2003-10-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BottleGnomesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BottleGnomesReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bottle Gnomes reprint in Mirrodin. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Tempest's `cards/` package (earliest
+ * real-expansion printing); this file contributes only presentation data.
+ */
+val BottleGnomesReprint = Printing(
+    oracleId = "54b5e429-7a44-480d-bea4-4f8eeb7449b5",
+    name = "Bottle Gnomes",
+    setCode = "MRD",
+    collectorNumber = "148",
+    scryfallId = "018dcb37-221a-4552-9e72-2b9492883eae",
+    artist = "Ben Thompson",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/018dcb37-221a-4552-9e72-2b9492883eae.jpg?1783944527",
+    releaseDate = "2003-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CathodionReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CathodionReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cathodion reprint in Mirrodin. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Urza's Saga's `cards/` package (earliest
+ * real-expansion printing); this file contributes only presentation data.
+ */
+val CathodionReprint = Printing(
+    oracleId = "fcd4f816-2de1-4b30-82fb-cb87f45747ea",
+    name = "Cathodion",
+    setCode = "MRD",
+    collectorNumber = "149",
+    scryfallId = "e223e822-a7a0-48d1-9bb7-88ee3d939c6f",
+    artist = "Eric Peterson",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e223e822-a7a0-48d1-9bb7-88ee3d939c6f.jpg?1783944528",
+    releaseDate = "2003-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CreepingMoldReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CreepingMoldReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Creeping Mold reprint in Mirrodin. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Visions' `cards/` package (earliest
+ * real-expansion printing); this file contributes only presentation data.
+ */
+val CreepingMoldReprint = Printing(
+    oracleId = "59180e94-ccdf-4d9f-9a4a-fe55497d0d63",
+    name = "Creeping Mold",
+    setCode = "MRD",
+    collectorNumber = "117",
+    scryfallId = "d6b50bda-f19f-4991-977b-de794f11103d",
+    artist = "Dany Orizio",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d6b50bda-f19f-4991-977b-de794f11103d.jpg?1783944535",
+    releaseDate = "2003-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/DiscipleOfTheVault.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/DiscipleOfTheVault.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Disciple of the Vault
+ * {B}
+ * Creature — Human Cleric
+ * 1/1
+ * Whenever an artifact is put into a graveyard from the battlefield, you may have target
+ * opponent lose 1 life.
+ *
+ * Any artifact, any controller — hence `TriggerBinding.ANY` with a bare
+ * [GameObjectFilter.Artifact] rather than a `youControl()` scope or a SELF binding. Artifact
+ * *creatures* and artifact tokens count: both are artifacts put into a graveyard from the
+ * battlefield.
+ *
+ * The "you may" is an explicit [MayEffect] rather than `optional = true` on the ability. With a
+ * *player* target the bare `optional` flag is silently lost: `TriggerProcessor` auto-selects the
+ * sole legal opponent and puts the trigger straight on the stack, skipping the target-selection
+ * decision that would otherwise carry the decline. A `MayEffect` owns its own consent gate, so
+ * the trigger routes through the may-then-target path and always asks.
+ */
+val DiscipleOfTheVault = card("Disciple of the Vault") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "Whenever an artifact is put into a graveyard from the battlefield, you may " +
+        "have target opponent lose 1 life."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Artifact,
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = MayEffect(
+            Effects.LoseLife(1, opponent),
+            descriptionOverride = "You may have target opponent lose 1 life"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Matt Thompson"
+        flavorText = "He stands in the shadow of his lord, Geth, drinking in the dark " +
+            "energies of the Vault."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/644359dc-3c4c-4291-876d-7390dc466877.jpg?1783944548"
+        ruling(
+            "2020-08-07",
+            "If an artifact is put into a graveyard at the same time as Disciple of the Vault, " +
+                "its ability triggers for that artifact."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RuleOfLaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RuleOfLaw.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.RestrictSpellsCastPerTurn
+
+/**
+ * Rule of Law
+ * {2}{W}
+ * Enchantment
+ * Each player can't cast more than one spell each turn.
+ *
+ * The global (`eachPlayer = true`) form of [RestrictSpellsCastPerTurn] — the same primitive
+ * High Noon uses. The engine compares each player's spells-cast-this-turn tally against the
+ * cap during cast-legality checks, so spells cast earlier in the turn count even if Rule of
+ * Law entered afterwards, and a countered spell still counts (both Scryfall rulings below).
+ */
+val RuleOfLaw = card("Rule of Law") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Each player can't cast more than one spell each turn."
+
+    staticAbility {
+        ability = RestrictSpellsCastPerTurn(maxPerTurn = 1, eachPlayer = true)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "19"
+        artist = "Scott M. Fischer"
+        flavorText = "Appointed by the kha himself, members of the tribunal ensure all " +
+            "disputes are settled with the utmost fairness."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/246a68e9-fd19-4a1e-8c7b-fcd3f7306dfb.jpg?1783944559"
+        ruling(
+            "2019-07-12",
+            "Rule of Law looks at the entire turn to see if a player has cast a spell, even " +
+                "if Rule of Law wasn't on the battlefield when that spell was cast. Notably, " +
+                "you can't cast Rule of Law and then cast another spell during the same turn."
+        )
+        ruling(
+            "2019-07-12",
+            "If you cast a spell that was countered, you can't cast another spell during the same turn."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ArrestReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/ArrestReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arrest reprint in RTR. Canonical CardDefinition lives in Mercadian Masques (its earliest
+ * real printing), `com.wingedsheep.mtg.sets.definitions.mmq.cards.Arrest`.
+ */
+val ArrestReprint = Printing(
+    oracleId = "81728b98-8cf9-4734-a318-69184bb4d15c",
+    name = "Arrest",
+    setCode = "RTR",
+    collectorNumber = "3",
+    scryfallId = "498f74a2-7e5e-4082-97e7-b938d703f869",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/498f74a2-7e5e-4082-97e7-b938d703f869.jpg?1783940379",
+    releaseDate = "2012-10-05",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ArrestReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ArrestReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arrest reprint in SOM. Canonical CardDefinition lives in Mercadian Masques (its earliest
+ * real printing), `com.wingedsheep.mtg.sets.definitions.mmq.cards.Arrest`.
+ */
+val ArrestReprint = Printing(
+    oracleId = "81728b98-8cf9-4734-a318-69184bb4d15c",
+    name = "Arrest",
+    setCode = "SOM",
+    collectorNumber = "2",
+    scryfallId = "f52d6cf9-1d92-4d3b-8631-0db19a073b44",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f52d6cf9-1d92-4d3b-8631-0db19a073b44.jpg?1783941747",
+    releaseDate = "2010-10-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/CreepingMold.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/CreepingMold.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.vis.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Creeping Mold
+ * {2}{G}{G}
+ * Sorcery
+ * Destroy target artifact, enchantment, or land.
+ *
+ * Visions is the earliest real-expansion printing, so the canonical definition lives here;
+ * later printings (Mirrodin, Sixth Edition, …) contribute only `Printing` rows.
+ *
+ * The three-way union is [Targets.ArtifactEnchantmentOrLand] — a single target slot, not
+ * three modes, so a permanent that is (say) both an artifact and a land is one legal choice.
+ */
+val CreepingMold = card("Creeping Mold") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target artifact, enchantment, or land."
+
+    spell {
+        val t = target("target", Targets.ArtifactEnchantmentOrLand)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "103"
+        artist = "David Seeley"
+        flavorText = "\"Mold could catch you.\"\n—Suq'Ata insult"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36e7691f-c771-4451-ac54-3532ca10d48f.jpg?1783946984"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
@@ -1,3 +1,62 @@
+// Arrest
+{
+    "name": "Arrest",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttack",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "CantBlock",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "PreventActivatedAbilities",
+                "filter": {
+                    "cardPredicates": [
+                        "IsPermanent"
+                    ],
+                    "statePredicates": [
+                        "IsAttachedToBySource"
+                    ]
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "UNCOMMON",
+        "artist": "Dan Frazier",
+        "flavorText": "Orim had no memory of the previous night—the first thing she could remember was waking up with the dead guard's blood on her hands.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b083fd8-6422-4cd3-a27d-41b6d88598c2.jpg?1783945985",
+        "rulings": [
+            {
+                "date": "2016-06-08",
+                "text": "Activated abilities contain a colon. They're generally written \"[Cost]: [Effect].\" Some keywords are activated abilities and will have colons in their reminder text."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ballista Squad
 {
     "name": "Ballista Squad",

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -643,6 +643,67 @@
     ]
 }
 
+// Disciple of the Vault
+{
+    "name": "Disciple of the Vault",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Whenever an artifact is put into a graveyard from the battlefield, you may have target opponent lose 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target opponent"
+                        }
+                    },
+                    "descriptionOverride": "You may have target opponent lose 1 life"
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Matt Thompson",
+        "flavorText": "He stands in the shadow of his lord, Geth, drinking in the dark energies of the Vault.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/644359dc-3c4c-4291-876d-7390dc466877.jpg?1783944548",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "If an artifact is put into a graveyard at the same time as Disciple of the Vault, its ability triggers for that artifact."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dross Prowler
 {
     "name": "Dross Prowler",
@@ -3361,6 +3422,42 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Rule of Law
+{
+    "name": "Rule of Law",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Each player can't cast more than one spell each turn.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "RestrictSpellsCastPerTurn",
+                "eachPlayer": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "RARE",
+        "artist": "Scott M. Fischer",
+        "flavorText": "Appointed by the kha himself, members of the tribunal ensure all disputes are settled with the utmost fairness.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/246a68e9-fd19-4a1e-8c7b-fcd3f7306dfb.jpg?1783944559",
+        "rulings": [
+            {
+                "date": "2019-07-12",
+                "text": "Rule of Law looks at the entire turn to see if a player has cast a spell, even if Rule of Law wasn't on the battlefield when that spell was cast. Notably, you can't cast Rule of Law and then cast another spell during the same turn."
+            },
+            {
+                "date": "2019-07-12",
+                "text": "If you cast a spell that was countered, you can't cast another spell during the same turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/VIS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VIS.json
@@ -63,6 +63,44 @@
     ]
 }
 
+// Creeping Mold
+{
+    "name": "Creeping Mold",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target artifact, enchantment, or land.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment|land"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "rarity": "UNCOMMON",
+        "artist": "David Seeley",
+        "flavorText": "\"Mold could catch you.\"\n—Suq'Ata insult",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36e7691f-c771-4451-ac54-3532ca10d48f.jpg?1783946984"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Elven Cache
 {
     "name": "Elven Cache",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArrestScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArrestScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Arrest (MMQ #4, reprinted in MRD) — {2}{W} Enchantment — Aura.
+ *
+ *   Enchant creature
+ *   Enchanted creature can't attack or block, and its activated abilities can't be activated.
+ *
+ * Same three-static shape as Petrify, but restricted to creature hosts. The activation lock
+ * is deliberately not `nonManaAbilitiesOnly`, so mana abilities are locked too.
+ */
+class ArrestScenarioTest : ScenarioTestBase() {
+
+    private val elvesManaAbilityId =
+        cardRegistry.getCard("Llanowar Elves")!!.script.activatedAbilities.first().id
+
+    init {
+        context("Arrest") {
+
+            test("enchanted creature can't attack or block") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Arrest", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Arrest should be on the battlefield") {
+                    game.isOnBattlefield("Arrest") shouldBe true
+                }
+                withClue("Enchanted creature can't attack") {
+                    game.state.projectedState.cantAttack(bears) shouldBe true
+                }
+                withClue("Enchanted creature can't block") {
+                    game.state.projectedState.cantBlock(bears) shouldBe true
+                }
+            }
+
+            test("enchanted creature's activated abilities can't be activated") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(2, "Llanowar Elves", summoningSickness = false)
+                    .withCardAttachedTo(1, "Arrest", "Llanowar Elves")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elves = game.findPermanent("Llanowar Elves")!!
+                val elvesActivation = game.getLegalActions(2).find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == elves && a.abilityId == elvesManaAbilityId
+                }
+                withClue("Arrest should lock the enchanted creature's mana ability") {
+                    elvesActivation shouldBe null
+                }
+            }
+
+            test("the lock is scoped to the host: another creature is unaffected") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Llanowar Elves", summoningSickness = false)
+                    .withCardAttachedTo(1, "Arrest", "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elves = game.findPermanent("Llanowar Elves")!!
+                withClue("The unenchanted creature can still attack") {
+                    game.state.projectedState.cantAttack(elves) shouldBe false
+                }
+                val elvesActivation = game.getLegalActions(2).find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == elves && a.abilityId == elvesManaAbilityId
+                }
+                withClue("The unenchanted creature's mana ability is still available") {
+                    (elvesActivation != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CreepingMoldScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CreepingMoldScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Creeping Mold (VIS #103, reprinted in MRD) — {2}{G}{G} Sorcery.
+ *
+ *   Destroy target artifact, enchantment, or land.
+ *
+ * Exercises the new `Targets.ArtifactEnchantmentOrLand` union: one target slot that accepts
+ * any of the three types, and rejects everything else (a plain creature).
+ */
+class CreepingMoldScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Creeping Mold") {
+
+            test("destroys a target artifact") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Creeping Mold")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardOnBattlefield(2, "Bottle Gnomes")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gnomes = game.findPermanent("Bottle Gnomes")!!
+                game.castSpell(1, "Creeping Mold", gnomes).isSuccess shouldBe true
+                game.resolveStack()
+
+                withClue("The targeted artifact should be destroyed") {
+                    game.isOnBattlefield("Bottle Gnomes") shouldBe false
+                    game.isInGraveyard(2, "Bottle Gnomes") shouldBe true
+                }
+            }
+
+            test("destroys a target enchantment") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Creeping Mold")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardOnBattlefield(2, "Rule of Law")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ruleOfLaw = game.findPermanent("Rule of Law")!!
+                game.castSpell(1, "Creeping Mold", ruleOfLaw).isSuccess shouldBe true
+                game.resolveStack()
+
+                withClue("The targeted enchantment should be destroyed") {
+                    game.isOnBattlefield("Rule of Law") shouldBe false
+                    game.isInGraveyard(2, "Rule of Law") shouldBe true
+                }
+            }
+
+            test("destroys a target land") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Creeping Mold")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val island = game.findPermanent("Island")!!
+                game.castSpell(1, "Creeping Mold", island).isSuccess shouldBe true
+                game.resolveStack()
+
+                withClue("The targeted land should be destroyed") {
+                    game.isInGraveyard(2, "Island") shouldBe true
+                }
+            }
+
+            test("a plain creature is not a legal target") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardInHand(1, "Creeping Mold")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("A nonartifact creature must not be targetable") {
+                    game.castSpell(1, "Creeping Mold", bears).isSuccess shouldBe false
+                }
+                withClue("The creature should still be on the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscipleOfTheVaultScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscipleOfTheVaultScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Disciple of the Vault (MRD #62) — {B} Creature — Human Cleric 1/1.
+ *
+ *   Whenever an artifact is put into a graveyard from the battlefield, you may have target
+ *   opponent lose 1 life.
+ *
+ * The trigger is scoped to *any* artifact regardless of controller (`TriggerBinding.ANY` over a
+ * bare `GameObjectFilter.Artifact`), and the "you may" is a resolution-time yes/no on top of a
+ * target chosen when the ability goes on the stack.
+ */
+class DiscipleOfTheVaultScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Disciple of the Vault") {
+
+            test("an opponent's artifact dying drains the targeted opponent for 1") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Disciple of the Vault")
+                    .withCardInHand(1, "Shatter")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Bottle Gnomes")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startingLife = game.getLifeTotal(2)
+                val gnomes = game.findPermanent("Bottle Gnomes")!!
+
+                game.castSpell(1, "Shatter", gnomes).isSuccess shouldBe true
+                game.resolveStack()
+
+                withClue("The artifact should be in the graveyard") {
+                    game.isInGraveyard(2, "Bottle Gnomes") shouldBe true
+                }
+
+                // The trigger is optional — accept it, then let it resolve.
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("The targeted opponent should have lost 1 life") {
+                    game.getLifeTotal(2) shouldBe (startingLife - 1)
+                }
+            }
+
+            test("declining the 'you may' costs the opponent nothing") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Disciple of the Vault")
+                    .withCardInHand(1, "Shatter")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Bottle Gnomes")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startingLife = game.getLifeTotal(2)
+                val gnomes = game.findPermanent("Bottle Gnomes")!!
+
+                game.castSpell(1, "Shatter", gnomes).isSuccess shouldBe true
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) game.answerYesNo(false)
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Declining should leave the opponent's life untouched") {
+                    game.getLifeTotal(2) shouldBe startingLife
+                }
+            }
+
+            test("your own artifact dying also triggers it (any controller)") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Disciple of the Vault")
+                    .withCardInHand(1, "Shatter")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Bottle Gnomes")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startingLife = game.getLifeTotal(2)
+                val gnomes = game.findPermanent("Bottle Gnomes")!!
+
+                game.castSpell(1, "Shatter", gnomes).isSuccess shouldBe true
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("An artifact you control dying triggers the Disciple too") {
+                    game.getLifeTotal(2) shouldBe (startingLife - 1)
+                }
+            }
+
+            test("a nonartifact creature dying does not trigger it") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Disciple of the Vault")
+                    .withCardInHand(1, "Terror")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val startingLife = game.getLifeTotal(2)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Terror", bears).isSuccess shouldBe true
+                game.resolveStack()
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("The creature should be dead") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("A nonartifact creature dying must not drain") {
+                    game.getLifeTotal(2) shouldBe startingLife
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuleOfLawScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuleOfLawScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rule of Law (MRD #19) — {2}{W} Enchantment.
+ *
+ *   Each player can't cast more than one spell each turn.
+ *
+ * The global (`eachPlayer = true`) form of `RestrictSpellsCastPerTurn`, so the cap binds the
+ * opponent as well as the controller. The engine reads the per-player spells-cast-this-turn
+ * tally at cast-legality time, so a spell cast earlier in the turn counts.
+ */
+class RuleOfLawScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rule of Law") {
+
+            test("the controller can't cast a second spell in the same turn") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Rule of Law")
+                    .withCardsInHand(1, "Shock", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val firstShock = game.findCardsInHand(1, "Shock").first()
+                game.castSpellTargetingPlayer(1, "Shock", 2).isSuccess shouldBe true
+                game.resolveStack()
+
+                val secondShock = game.findCardsInHand(1, "Shock").first()
+                withClue("A different card should be left in hand") {
+                    (secondShock == firstShock) shouldBe false
+                }
+
+                val castActions = game.getLegalActions(1).filter {
+                    val a = it.action
+                    a is CastSpell && a.cardId == secondShock
+                }
+                withClue("Rule of Law must block the second spell this turn") {
+                    castActions.isEmpty() shouldBe true
+                }
+            }
+
+            test("the opponent, who doesn't control it, is capped too") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Rule of Law")
+                    .withCardsInHand(2, "Shock", 2)
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(2, "Shock", 1).isSuccess shouldBe true
+                game.resolveStack()
+
+                val secondShock = game.findCardsInHand(2, "Shock").first()
+                val castActions = game.getLegalActions(2).filter {
+                    val a = it.action
+                    a is CastSpell && a.cardId == secondShock
+                }
+                withClue("The restriction is global, so the opponent is capped as well") {
+                    castActions.isEmpty() shouldBe true
+                }
+            }
+
+            test("control: without Rule of Law a second spell is castable") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardsInHand(1, "Shock", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Shock", 2).isSuccess shouldBe true
+                game.resolveStack()
+
+                val secondShock = game.findCardsInHand(1, "Shock").first()
+                val castActions = game.getLegalActions(1).filter {
+                    val a = it.action
+                    a is CastSpell && a.cardId == secondShock
+                }
+                withClue("Without the enchantment the second spell is legal") {
+                    castActions.isNotEmpty() shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Six cards from Mirrodin's missing list — four new canonical `CardDefinition`s plus MRD `Printing` rows, and two that only needed a printing row because their canonicals already exist.

## Cards

Canonical placement follows the earliest real expansion, so two scripts land outside MRD:

| Card | Canonical | Shape |
|---|---|---|
| **Creeping Mold** | Visions (1997) | `{2}{G}{G}` sorcery — destroy target artifact, enchantment, or land |
| **Arrest** | Mercadian Masques (1999) | Aura — the Petrify shape: `CantAttack` + `CantBlock` + `PreventActivatedAbilities` scoped to the host |
| **Rule of Law** | Mirrodin | `RestrictSpellsCastPerTurn(1, eachPlayer = true)` — the global variant High Noon already uses |
| **Disciple of the Vault** | Mirrodin | ANY-binding artifact-dies trigger over a bare `Artifact` filter, wrapped in `MayEffect` |
| **Bottle Gnomes** | Tempest (already implemented) | MRD `Printing` row only |
| **Cathodion** | Urza's Saga (already implemented) | MRD `Printing` row only |

## SDK

Adds `GameObjectFilter` / `TargetFilter` / `Targets.ArtifactEnchantmentOrLand` — the third member of the existing `ArtifactOrEnchantment` / `ArtifactOrLand` union family, so Creeping Mold's three-way target is one target slot rather than three modes. `docs/card-sdk-language-reference.md` updated in the same change.

## Engine gap found (not fixed here)

Disciple of the Vault models its "you may" as an explicit `MayEffect` rather than `optional = true` on the triggered ability. With a **player** target the bare flag is silently lost: `TriggerProcessor` (`TriggerProcessor.kt:685-693`) auto-selects the sole legal opponent and puts the trigger straight on the stack, skipping the target-selection decision whose `minTargets = 0` is what carries the decline — so the trigger resolves as mandatory. A `MayEffect` owns its own consent gate and routes through the may-then-target path at `TriggerProcessor.kt:342` instead, which always asks.

This is a fail-open bug for any "you may have target player/opponent do X" trigger in a two-player game, but fixing it is engine work with cross-card blast radius, so it's flagged rather than changed here.

## Printing hygiene

`just check-card-printing` flagged missing `Printing(...)` rows for these oracle identities in other scaffolded sets (8ED, 10E, KLD, SOM, RTR, J22, M20, C14). Those are filled in; all six cards now pass the gate.

## Verification

- `just build` — green
- Scenario tests, one file per card:
  - `CreepingMoldScenarioTest` — destroys an artifact / enchantment / land; a plain creature is rejected as a target
  - `ArrestScenarioTest` — combat lock, activation lock (mana abilities included), lock scoped to the host only
  - `RuleOfLawScenarioTest` — controller capped, opponent capped (global), control without the enchantment
  - `DiscipleOfTheVaultScenarioTest` — drain on accept, no drain on decline, own artifact triggers it, nonartifact creature does not
- `CardDefinitionSnapshotTest` re-blessed; only MMQ/MRD/VIS moved, additions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)