### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GleamingGeardrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GleamingGeardrake.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gleaming Geardrake — Murders at Karlov Manor #205
+ * {U}{R} · Artifact Creature — Drake · 1/1
+ *
+ * Flying
+ * When this creature enters, investigate.
+ * Whenever you sacrifice an artifact, put a +1/+1 counter on this creature.
+ *
+ * The two abilities are a closed loop by design: the enters trigger hands you the Clue, and
+ * cracking that Clue is a sacrifice the second ability sees. Nothing about that needs wiring — a
+ * Clue's own "{2}, Sacrifice this token: Draw a card" routes through the same sacrifice hook as any
+ * other, so [Triggers.YouSacrificeA] over `GameObjectFilter.Artifact` picks it up.
+ *
+ * `YouSacrificeA` (per-permanent, bare article) rather than `YouSacrificeOneOrMore` (batched): the
+ * text says "an artifact", so sacrificing three artifacts to one cost puts three counters on the
+ * Drake, not one (CR 603.2c). And `YouSacrificeA` rather than `YouSacrificeAnother` — the Geardrake
+ * is itself an artifact and the oracle text has no "another", so it counts itself. That last case
+ * is not idle: the trigger still goes on the stack when the Drake is the artifact sacrificed, and
+ * then resolves with nothing to put a counter on.
+ */
+val GleamingGeardrake = card("Gleaming Geardrake") {
+    manaCost = "{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Artifact Creature — Drake"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature enters, investigate. (Create a Clue token. It's an artifact with " +
+        "\"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "Whenever you sacrifice an artifact, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Investigate()
+        description = "When this creature enters, investigate."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Artifact)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever you sacrifice an artifact, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "205"
+        artist = "Filipe Pagliuso"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/cabb5875-42ff-4e3a-a32e-aab392fccff8.jpg?1783912848"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OffenderAtLarge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OffenderAtLarge.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Offender at Large — Murders at Karlov Manor #138
+ * {4}{R} · Creature — Giant Rogue · 5/4
+ *
+ * Disguise {4}{R}
+ * When this creature enters or is turned face up, up to one target creature gets +2/+0 until end
+ * of turn.
+ *
+ * One ability with two trigger conditions, so it is a single `Triggers.or` of the two SELF-bound
+ * event patterns rather than two abilities — it must fire exactly once on either route, never
+ * twice. The routes are disjoint (CR 702.168d: turning face up is not entering the battlefield), so
+ * a hard-cast Offender gets the pump on entry and a disguised one gets it when it flips, and
+ * neither gets it twice.
+ *
+ * "**Up to one** target creature" is `optional = true`, not a mandatory target: the ability still
+ * triggers and still resolves with no target chosen, which is the only sane behaviour when the
+ * Offender flips face up at instant speed on an empty board. Modelling it as a required target
+ * would remove the ability from the stack in exactly the case the "up to" wording exists to cover.
+ *
+ * The target is any creature, not "creature you control" — flipping it up mid-combat to hand +2/+0
+ * to an opposing blocker is a legal, if unusual, line.
+ */
+val OffenderAtLarge = card("Offender at Large") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Rogue"
+    power = 5
+    toughness = 4
+    oracleText = "Disguise {4}{R} (You may cast this card face down for {3} as a 2/2 creature " +
+        "with ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature enters or is turned face up, up to one target creature gets +2/+0 " +
+        "until end of turn."
+
+    disguise = "{4}{R}"
+
+    triggeredAbility {
+        trigger = Triggers.or(Triggers.EntersBattlefield, Triggers.TurnedFaceUp)
+        val creature = target("up to one target creature", TargetCreature(optional = true))
+        effect = Effects.ModifyStats(2, 0, creature)
+        description = "When this creature enters or is turned face up, up to one target creature " +
+            "gets +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Mike Bierek"
+        flavorText = "\"In a city this big, anyone can blend in.\"\n—Imel of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f096ff4a-85f4-46f1-9478-e8921f21309d.jpg?1783912876"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RecklessDetective.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/RecklessDetective.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Reckless Detective — Murders at Karlov Manor #141
+ * {1}{R} · Creature — Devil Detective · 0/3
+ *
+ * Whenever this creature attacks, you may sacrifice an artifact or discard a card. If you do, draw
+ * a card and this creature gets +2/+0 until end of turn.
+ *
+ * "**If** you do" — not "when you do" — so the payoff happens inside the same resolution, with no
+ * second trip through the stack and nothing for an opponent to respond to in between. That rules
+ * out `ReflexiveTriggerEffect` and leaves the K'un-Lun Warrior shape: a [MayEffect] over a
+ * [ChooseActionEffect] whose two branches each pay their own cost and then run the payoff, so the
+ * draw and the pump can only ever follow a cost that was actually paid.
+ *
+ * The [FeasibilityCheck]s do the "if you do" bookkeeping the branch structure can't: a controller
+ * with no artifact never sees the sacrifice option, and one with an empty hand never sees the
+ * discard option. With neither available the whole "may" is skipped rather than offered and then
+ * silently no-opping into a free card.
+ *
+ * The pump is [EffectTarget.Self] and untargeted — the Detective doesn't target itself, so it still
+ * gets +2/+0 even while an opponent's shroud effect or protection would block a targeted buff. A
+ * 0/3 body that attacks for 2 only when it feeds itself is the whole design; the attack trigger
+ * resolves before blockers are declared, so the +2/+0 is live for the block decision.
+ */
+val RecklessDetective = card("Reckless Detective") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil Detective"
+    power = 0
+    toughness = 3
+    oracleText = "Whenever this creature attacks, you may sacrifice an artifact or discard a " +
+        "card. If you do, draw a card and this creature gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val payoff: Effect = Effects.DrawCards(1) then
+            Effects.ModifyStats(2, 0, EffectTarget.Self)
+        effect = MayEffect(
+            effect = ChooseActionEffect(
+                choices = listOf(
+                    EffectChoice(
+                        label = "Sacrifice an artifact",
+                        effect = SacrificeEffect(filter = GameObjectFilter.Artifact) then payoff,
+                        feasibilityCheck = FeasibilityCheck.ControlsPermanentMatching(
+                            filter = GameObjectFilter.Artifact
+                        ),
+                    ),
+                    EffectChoice(
+                        label = "Discard a card",
+                        effect = Patterns.Hand.discardCards(1) then payoff,
+                        feasibilityCheck = FeasibilityCheck.HasCardsInZone(zone = Zone.HAND),
+                    ),
+                )
+            ),
+            descriptionOverride = "You may sacrifice an artifact or discard a card. If you do, " +
+                "draw a card and this creature gets +2/+0 until end of turn.",
+        )
+        description = "Whenever this creature attacks, you may sacrifice an artifact or discard " +
+            "a card. If you do, draw a card and this creature gets +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "141"
+        artist = "Tuan Duong Chu"
+        flavorText = "He's gonna crack this thing wide open."
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18da1a1d-e6ba-47e5-a545-0bacd427b782.jpg?1783912874"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SanguineSavior.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SanguineSavior.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sanguine Savior — Murders at Karlov Manor #230
+ * {1}{W}{B} · Creature — Vampire Cleric · 2/1
+ *
+ * Flying, lifelink
+ * Disguise {W/B}{W/B}
+ * When this creature is turned face up, another target creature you control gains lifelink until
+ * end of turn.
+ *
+ * Unlike its Disguise neighbours that read "enters **or** is turned face up", this trigger is
+ * face-up only ([Triggers.TurnedFaceUp], SELF). Hard-casting the Savior for {1}{W}{B} gets you a
+ * flying lifelinker and nothing else; the lifelink hand-out is the reward for going the long way
+ * round, and CR 702.168d — turning face up is not entering the battlefield — is what keeps the two
+ * routes apart with no extra wiring.
+ *
+ * "**Another** target creature you control" is [Targets.OtherCreatureYouControl], which excludes
+ * the Savior itself. That exclusion has teeth here: the Savior already has printed lifelink, so
+ * without it the ability could be pointed at a creature that gains nothing, and — worse — a lone
+ * Savior with no other creature would still be offered a legal target. With the exclusion it simply
+ * has no legal target in that spot, and the ability is removed from the stack.
+ */
+val SanguineSavior = card("Sanguine Savior") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Vampire Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "Flying, lifelink\n" +
+        "Disguise {W/B}{W/B} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, another target creature you control gains " +
+        "lifelink until end of turn."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+    disguise = "{W/B}{W/B}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        val other = target("another target creature you control", Targets.OtherCreatureYouControl)
+        effect = Effects.GrantKeyword(Keyword.LIFELINK, other)
+        description = "When this creature is turned face up, another target creature you control " +
+            "gains lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "230"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cba5503-ba99-43d8-8062-66d905e0d86b.jpg?1783912837"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UndercityEliminator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UndercityEliminator.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Undercity Eliminator — Murders at Karlov Manor #108
+ * {3}{B}{B} · Creature — Gorgon Assassin · 3/3
+ *
+ * When this creature enters, you may sacrifice an artifact or creature. When you do, exile target
+ * creature an opponent controls.
+ *
+ * "**When** you do" is the giveaway: this is a genuine CR 603.12 reflexive trigger, not an "if you
+ * do" continuation, and Scryfall's ruling spells the consequence out — no target is chosen when the
+ * enters trigger goes on the stack. The target is picked only once the sacrifice has happened, as
+ * the reflexive ability goes on the stack, and opponents get priority to respond to *that*. So a
+ * board with no legal opposing creature at ETB time is not a reason to skip the sacrifice, and an
+ * opponent who kills their own creature in response to the reflexive can still fizzle the exile
+ * after the artifact is already gone. [ReflexiveTriggerEffect]'s `reflexiveTargetRequirements`
+ * models exactly that split.
+ *
+ * The action is a plain [SacrificeEffect] over `CreatureOrArtifact` rather than a cost rail: it is
+ * an *effect* of a resolving ability, so nothing is paid on announcement. `optional = true` carries
+ * the "you may", and the executor's feasibility check declines to prompt at all when the controller
+ * has no artifact and no creature — which can genuinely happen, since the Eliminator itself is a
+ * legal choice (the text says "an artifact or creature", not "another") and something may have
+ * removed it before the trigger resolves.
+ */
+val UndercityEliminator = card("Undercity Eliminator") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Gorgon Assassin"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, you may sacrifice an artifact or creature. When you " +
+        "do, exile target creature an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = SacrificeEffect(filter = GameObjectFilter.CreatureOrArtifact),
+            optional = true,
+            reflexiveEffect = Effects.Exile(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(Targets.CreatureOpponentControls),
+        )
+        description = "When this creature enters, you may sacrifice an artifact or creature. " +
+            "When you do, exile target creature an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "108"
+        artist = "Quintin Gleim"
+        flavorText = "With their guild shunned for opening the doors to Phyrexia, some among the " +
+            "Golgari embraced their status as pariahs and took out their bitterness on all who " +
+            "crossed their paths."
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a67a4c5e-215b-4f03-87f7-c1af4f9f0a63.jpg?1783912889"
+        ruling(
+            "2024-02-02",
+            "You don't choose a target at the time Undercity Eliminator's ability triggers. " +
+                "Rather, a second \"reflexive\" ability triggers when you sacrifice an artifact or " +
+                "creature this way. You choose a target for that ability as it goes on the stack. " +
+                "Each player may respond to this triggered ability as normal.",
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -2079,6 +2079,63 @@
     ]
 }
 
+// Gleaming Geardrake
+{
+    "name": "Gleaming Geardrake",
+    "manaCost": "{U}{R}",
+    "typeLine": "Artifact Creature — Drake",
+    "oracleText": "Flying\nWhen this creature enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\nWhenever you sacrifice an artifact, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "descriptionOverride": "When this creature enters, investigate."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you sacrifice an artifact, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "UNCOMMON",
+        "artist": "Filipe Pagliuso",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/cabb5875-42ff-4e3a-a32e-aab392fccff8.jpg?1783912848"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Glint Weaver
 {
     "name": "Glint Weaver",
@@ -4000,6 +4057,80 @@
     ]
 }
 
+// Offender at Large
+{
+    "name": "Offender at Large",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Giant Rogue",
+    "oracleText": "Disguise {4}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature enters or is turned face up, up to one target creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{R}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AnyOfEvents",
+                    "events": [
+                        {
+                            "type": "ZoneChangeEvent",
+                            "to": "Battlefield"
+                        },
+                        "TurnFaceUpEvent"
+                    ]
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to one target creature"
+                },
+                "descriptionOverride": "When this creature enters or is turned face up, up to one target creature gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Mike Bierek",
+        "flavorText": "\"In a city this big, anyone can blend in.\"\n—Imel of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f096ff4a-85f4-46f1-9478-e8921f21309d.jpg?1783912876"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // On the Job
 {
     "name": "On the Job",
@@ -4383,6 +4514,153 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Reckless Detective
+{
+    "name": "Reckless Detective",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Devil Detective",
+    "oracleText": "Whenever this creature attacks, you may sacrifice an artifact or discard a card. If you do, draw a card and this creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ChooseAction",
+                        "choices": [
+                            {
+                                "label": "Sacrifice an artifact",
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "Sacrifice",
+                                            "filter": "artifact"
+                                        },
+                                        {
+                                            "type": "Composite",
+                                            "effects": [
+                                                {
+                                                    "type": "DrawCards",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    }
+                                                },
+                                                {
+                                                    "type": "ModifyStats",
+                                                    "powerModifier": {
+                                                        "type": "Fixed",
+                                                        "amount": 2
+                                                    },
+                                                    "toughnessModifier": {
+                                                        "type": "Fixed",
+                                                        "amount": 0
+                                                    },
+                                                    "target": "Self"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "feasibilityCheck": {
+                                    "type": "ControlsPermanentMatching",
+                                    "filter": "artifact"
+                                }
+                            },
+                            {
+                                "label": "Discard a card",
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded",
+                                            "prompt": "Choose 1 card to discard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        },
+                                        {
+                                            "type": "Composite",
+                                            "effects": [
+                                                {
+                                                    "type": "DrawCards",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    }
+                                                },
+                                                {
+                                                    "type": "ModifyStats",
+                                                    "powerModifier": {
+                                                        "type": "Fixed",
+                                                        "amount": 2
+                                                    },
+                                                    "toughnessModifier": {
+                                                        "type": "Fixed",
+                                                        "amount": 0
+                                                    },
+                                                    "target": "Self"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "feasibilityCheck": {
+                                    "type": "HasCardsInZone",
+                                    "zone": "Hand"
+                                }
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may sacrifice an artifact or discard a card. If you do, draw a card and this creature gets +2/+0 until end of turn."
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may sacrifice an artifact or discard a card. If you do, draw a card and this creature gets +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "rarity": "UNCOMMON",
+        "artist": "Tuan Duong Chu",
+        "flavorText": "He's gonna crack this thing wide open.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18da1a1d-e6ba-47e5-a545-0bacd427b782.jpg?1783912874"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -5161,6 +5439,68 @@
     ]
 }
 
+// Sanguine Savior
+{
+    "name": "Sanguine Savior",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Creature — Vampire Cleric",
+    "oracleText": "Flying, lifelink\nDisguise {W/B}{W/B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, another target creature you control gains lifelink until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{W/B}{W/B}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another target creature you control"
+                },
+                "descriptionOverride": "When this creature is turned face up, another target creature you control gains lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cba5503-ba99-43d8-8062-66d905e0d86b.jpg?1783912837"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Sanitation Automaton
 {
     "name": "Sanitation Automaton",
@@ -5898,6 +6238,69 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Undercity Eliminator
+{
+    "name": "Undercity Eliminator",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Gorgon Assassin",
+    "oracleText": "When this creature enters, you may sacrifice an artifact or creature. When you do, exile target creature an opponent controls.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Sacrifice",
+                        "filter": "creature|artifact"
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Exile"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, you may sacrifice an artifact or creature. When you do, exile target creature an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "rarity": "UNCOMMON",
+        "artist": "Quintin Gleim",
+        "flavorText": "With their guild shunned for opening the doors to Phyrexia, some among the Golgari embraced their status as pariahs and took out their bitterness on all who crossed their paths.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a67a4c5e-215b-4f03-87f7-c1af4f9f0a63.jpg?1783912889",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You don't choose a target at the time Undercity Eliminator's ability triggers. Rather, a second \"reflexive\" ability triggers when you sacrifice an artifact or creature this way. You choose a target for that ability as it goes on the stack. Each player may respond to this triggered ability as normal."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GleamingGeardrakeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GleamingGeardrakeScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gleaming Geardrake (MKM) — {U}{R} 1/1 Artifact Creature — Drake with flying, "when this creature
+ * enters, investigate", and "whenever you sacrifice an artifact, put a +1/+1 counter on this
+ * creature".
+ *
+ * The two abilities close a loop: the Clue the Drake makes on entry is itself an artifact, so
+ * cracking it for a card also grows the Drake. Nothing wires that together — the Clue's own
+ * "{2}, Sacrifice this token: Draw a card" routes through the same sacrifice hook as any other,
+ * which is exactly what the second test proves.
+ */
+class GleamingGeardrakeScenarioTest : ScenarioTestBase() {
+
+    private val clueAbilityId = PredefinedTokens.Clue.activatedAbilities.first().id
+
+    private fun counters(game: TestGame, name: String): Int =
+        game.state.getEntity(game.findPermanent(name)!!)
+            ?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun clue(game: TestGame) = game.state.getBattlefield()
+        .firstOrNull { game.state.getEntity(it)?.get<CardComponent>()?.name == "Clue" }
+
+    init {
+        test("entering investigates") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Gleaming Geardrake")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Gleaming Geardrake").error shouldBe null
+            game.resolveStack()
+
+            clue(game).shouldNotBeNull()
+            counters(game, "Gleaming Geardrake") shouldBe 0
+        }
+
+        test("cracking the Clue it made grows it") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Gleaming Geardrake")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Gleaming Geardrake").error shouldBe null
+            game.resolveStack()
+
+            val clueId = clue(game).shouldNotBeNull()
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = clueId, abilityId = clueAbilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            counters(game, "Gleaming Geardrake") shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OffenderAtLargeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OffenderAtLargeScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.OffenderAtLarge
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Offender at Large — {4}{R} 5/4 Giant Rogue with Disguise {4}{R} and "when this creature enters or
+ * is turned face up, up to one target creature gets +2/+0 until end of turn."
+ *
+ * One ability, two disjoint routes (CR 702.168d): the pump fires once on entry for a hard-cast
+ * copy and once on the flip for a disguised one — never twice. "Up to one target" is what makes
+ * the flip safe on an empty board: the ability still resolves with nothing chosen instead of being
+ * removed from the stack for want of a legal target.
+ */
+class OffenderAtLargeScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OffenderAtLarge))
+        return driver
+    }
+
+    test("hard-cast: the entry trigger pumps a chosen creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val card = driver.putCardInHand(player, "Offender at Large")
+        driver.giveMana(player, Color.RED, 5)
+
+        driver.castSpell(player, card).error shouldBe null
+        driver.bothPass()
+
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(player, listOf(bear)).error shouldBe null
+        driver.bothPass()
+
+        val offender = driver.findPermanent(player, "Offender at Large")
+        offender.shouldNotBeNull()
+        val projected = driver.state.projectedState
+        projected.getPower(offender) shouldBe 5
+        projected.getToughness(offender) shouldBe 4
+        projected.getPower(bear) shouldBe 4
+        projected.getToughness(bear) shouldBe 2
+    }
+
+    test("the disguise flip fires the same ability, and 'up to one' allows no target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val card = driver.putCardInHand(player, "Offender at Large")
+        driver.giveColorlessMana(player, 3)
+
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+
+        val offender = driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+
+        driver.giveMana(player, Color.RED, 5)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = offender,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+
+        // The flip fires the ability. The only creature around is the Offender itself; decline it.
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(player, emptyList()).error shouldBe null
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        projected.getPower(offender) shouldBe 5
+        projected.getToughness(offender) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RecklessDetectiveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RecklessDetectiveScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Reckless Detective (MKM) — "Whenever this creature attacks, you may sacrifice an artifact or
+ * discard a card. If you do, draw a card and this creature gets +2/+0 until end of turn."
+ *
+ * "**If** you do" (not "when you do") means the payoff runs inside the same resolution, so both
+ * branches of the choice fold the draw and the pump into themselves. The tests pin that the 0/3
+ * only swings for 2 when a cost was actually paid, and that the feasibility gates keep an
+ * unpayable branch off the menu — including the case where *neither* branch can be paid and the
+ * "you may" is never offered at all.
+ */
+class RecklessDetectiveScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private fun power(game: TestGame): Int =
+        stateProjector.project(game.state).getPower(game.findPermanent("Reckless Detective")!!) ?: 0
+
+    init {
+        test("sacrificing an artifact draws a card and swings for 2") {
+            val game = scenario()
+                .withPlayers("Attacker", "Defender")
+                .withCardOnBattlefield(1, "Reckless Detective", summoningSickness = false)
+                .withCardOnBattlefield(1, "Wrench")
+                .withCardInLibrary(1, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+
+            val handBefore = game.handSize(1)
+            game.declareAttackers(mapOf("Reckless Detective" to 2)).error shouldBe null
+            game.resolveStack()
+
+            // Only the sacrifice branch is payable (empty hand), so the choice collapses to it.
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Wrench") shouldBe true
+            game.handSize(1) shouldBe handBefore + 1
+            power(game) shouldBe 2
+        }
+
+        test("declining draws nothing and leaves a 0/3") {
+            val game = scenario()
+                .withPlayers("Attacker", "Defender")
+                .withCardOnBattlefield(1, "Reckless Detective", summoningSickness = false)
+                .withCardOnBattlefield(1, "Wrench")
+                .withCardInLibrary(1, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+
+            val handBefore = game.handSize(1)
+            game.declareAttackers(mapOf("Reckless Detective" to 2)).error shouldBe null
+            game.resolveStack()
+
+            game.answerYesNo(false).error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Wrench") shouldBe true
+            game.handSize(1) shouldBe handBefore
+            power(game) shouldBe 0
+        }
+
+        test("with no artifact the discard branch pays instead") {
+            val game = scenario()
+                .withPlayers("Attacker", "Defender")
+                .withCardOnBattlefield(1, "Reckless Detective", summoningSickness = false)
+                .withCardInHand(1, "Grizzly Bears")
+                .withCardInHand(1, "Savannah Lions")
+                .withCardInLibrary(1, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+
+            game.declareAttackers(mapOf("Reckless Detective" to 2)).error shouldBe null
+            game.resolveStack()
+
+            game.answerYesNo(true).error shouldBe null
+            // Two cards in hand, so the discard genuinely asks which one.
+            val bears = game.findCardsInHand(1, "Grizzly Bears").single()
+            game.selectCards(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+            game.isInHand(1, "Centaur Courser") shouldBe true
+            power(game) shouldBe 2
+        }
+
+        test("with nothing to pay, the 'you may' is never offered") {
+            val game = scenario()
+                .withPlayers("Attacker", "Defender")
+                .withCardOnBattlefield(1, "Reckless Detective", summoningSickness = false)
+                .withCardInLibrary(1, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .build()
+
+            game.declareAttackers(mapOf("Reckless Detective" to 2)).error shouldBe null
+            game.resolveStack()
+
+            // No artifact, no cards in hand — neither branch is feasible, so no prompt appears
+            // rather than a yes/no that would resolve into a free card.
+            game.hasPendingDecision() shouldBe false
+            game.handSize(1) shouldBe 0
+            power(game) shouldBe 0
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SanguineSaviorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SanguineSaviorScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.SanguineSavior
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Sanguine Savior — {1}{W}{B} 2/1 Vampire Cleric with flying, lifelink, Disguise {W/B}{W/B}, and
+ * "when this creature is turned face up, another target creature you control gains lifelink until
+ * end of turn."
+ *
+ * The trigger is face-up-only, unlike its "enters **or** is turned face up" neighbours, so the two
+ * lines diverge: hard-cast, it is just a flying lifelinker; disguised, flipping it also hands
+ * lifelink to a second creature. CR 702.168d — turning face up is not entering the battlefield —
+ * is what keeps the two apart.
+ */
+class SanguineSaviorScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SanguineSavior))
+        return driver
+    }
+
+    test("hard-cast: a 2/1 flying lifelinker whose trigger never fires") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val card = driver.putCardInHand(player, "Sanguine Savior")
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.giveMana(player, Color.BLACK, 2)
+
+        driver.castSpell(player, card).error shouldBe null
+        driver.bothPass()
+
+        val savior = driver.findPermanent(player, "Sanguine Savior")
+        savior.shouldNotBeNull()
+        val projected = driver.state.projectedState
+        projected.getPower(savior) shouldBe 2
+        projected.getToughness(savior) shouldBe 1
+        projected.hasKeyword(savior, Keyword.FLYING) shouldBe true
+        projected.hasKeyword(savior, Keyword.LIFELINK) shouldBe true
+        // No face-up trigger on the entry route — the Bears gain nothing.
+        projected.hasKeyword(bear, Keyword.LIFELINK) shouldBe false
+    }
+
+    test("the disguise line flips face up and hands lifelink to another creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val card = driver.putCardInHand(player, "Sanguine Savior")
+        driver.giveColorlessMana(player, 3)
+
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+
+        val savior = driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = savior,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+
+        // The face-up trigger asks for its target; only the Bears is legal ("another").
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(player, listOf(bear)).error shouldBe null
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        projected.getPower(savior) shouldBe 2
+        projected.hasKeyword(savior, Keyword.FLYING) shouldBe true
+        projected.hasKeyword(bear, Keyword.LIFELINK) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndercityEliminatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndercityEliminatorScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Undercity Eliminator (MKM) — "When this creature enters, you may sacrifice an artifact or
+ * creature. When you do, exile target creature an opponent controls."
+ *
+ * "**When** you do" is a CR 603.12 reflexive trigger, and what these tests pin is the resulting
+ * order: the enters trigger resolves into a bare yes/no with no target chosen, the sacrifice
+ * happens, and only *then* does a second ability go on the stack and ask for its target.
+ */
+class UndercityEliminatorScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("sacrificing a creature exiles a creature an opponent controls") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Undercity Eliminator")
+                .withLandsOnBattlefield(1, "Swamp", 5)
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Undercity Eliminator").error shouldBe null
+            game.resolveStack()
+
+            // CR 603.12: the enters trigger asks only "do you want to sacrifice?" — no target yet.
+            game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+            game.answerYesNo(true).error shouldBe null
+
+            // Two legal fodder permanents (the Bears and the Eliminator itself) — pick the Bears.
+            val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+            game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+            game.selectCards(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            // Now — and only now — the reflexive ability wants its target.
+            game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
+            val courser = game.findPermanent("Centaur Courser").shouldNotBeNull()
+            game.selectTargets(listOf(courser)).error shouldBe null
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+            game.isInExile(2, "Centaur Courser") shouldBe true
+            game.isOnBattlefield("Undercity Eliminator") shouldBe true
+        }
+
+        test("declining the sacrifice exiles nothing") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Undercity Eliminator")
+                .withLandsOnBattlefield(1, "Swamp", 5)
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Undercity Eliminator").error shouldBe null
+            game.resolveStack()
+            game.answerYesNo(false).error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Grizzly Bears") shouldBe true
+            game.isOnBattlefield("Centaur Courser") shouldBe true
+            game.isInExile(2, "Centaur Courser") shouldBe false
+        }
+
+        test("the Eliminator is legal fodder for its own ability") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Undercity Eliminator")
+                .withLandsOnBattlefield(1, "Swamp", 5)
+                .withCardOnBattlefield(2, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Undercity Eliminator").error shouldBe null
+            game.resolveStack()
+            game.answerYesNo(true).error shouldBe null
+            // Sole legal choice — it eats itself with no prompt.
+            game.resolveStack()
+
+            val courser = game.findPermanent("Centaur Courser").shouldNotBeNull()
+            game.selectTargets(listOf(courser)).error shouldBe null
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Undercity Eliminator") shouldBe true
+            game.isInExile(2, "Centaur Courser") shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
Adds five MKM cards, all built from existing SDK primitives — no new engine vocabulary.

| Card | Cost | Shape |
|---|---|---|
| Gleaming Geardrake | `{U}{R}` | Flying; investigate on entry; +1/+1 counter whenever you sacrifice an artifact |
| Offender at Large | `{4}{R}` | Disguise `{4}{R}`; enters-or-turned-face-up, up to one target creature gets +2/+0 |
| Reckless Detective | `{1}{R}` | Attack trigger: may sacrifice an artifact or discard, if you do draw + +2/+0 |
| Sanguine Savior | `{1}{W}{B}` | Flying, lifelink; Disguise `{W/B}{W/B}`; face-up grants another creature lifelink |
| Undercity Eliminator | `{3}{B}{B}` | Enters: may sacrifice an artifact or creature; when you do, exile target creature an opponent controls |

## Modelling notes

- **Undercity Eliminator** — "**When** you do" is a genuine CR 603.12 reflexive trigger, so it is a `ReflexiveTriggerEffect` whose `reflexiveTargetRequirements` pick the exile target *after* the sacrifice resolves. Scryfall's ruling says this explicitly. The action is a plain `SacrificeEffect` over `CreatureOrArtifact` (an effect, not a cost rail), and the Eliminator itself is legal fodder — the text says "an artifact or creature", not "another".
- **Reckless Detective** — "**If** you do" is a same-resolution continuation, not a second stack object, so this is the K'un-Lun Warrior shape: `MayEffect` over a `ChooseActionEffect` with the draw and pump folded into each branch. The `FeasibilityCheck`s do the real work — with no artifact and an empty hand the "you may" is never offered at all, rather than resolving into a free card.
- **Gleaming Geardrake** — `Triggers.YouSacrificeA(Artifact)` (per-permanent, counts the source) rather than the batched or "another" variants, matching the bare-article oracle text. Its own Clue is an artifact, so cracking it both draws and grows the Drake.
- **Sanguine Savior** — face-up-only trigger, unlike its "enters **or** is turned face up" neighbours; hard-casting deliberately gets nothing. `Targets.OtherCreatureYouControl` carries the "another".
- **Offender at Large** — one ability on `Triggers.or(EntersBattlefield, TurnedFaceUp)`, so it fires exactly once on either disjoint route (CR 702.168d). "Up to one target" is `optional = true`, which is what lets the flip resolve on an empty board.

## Verification

- `just build` — green.
- 13 new scenario tests across five files (one per card, per the one-card-one-test-file rule) — all passing. They cover both branches of each optional choice, the reflexive ordering, the disguise flip vs. hard-cast split, and the "never offered" feasibility path.
- MKM card snapshot re-blessed; only the five new cards move in the golden.
- `just check-card-printing` confirms MKM is the canonical (and only) printing for Undercity Eliminator and Reckless Detective; Scryfall rate-limited the remaining three, but their `prints_search_uri` listings were checked directly and each has MKM as its sole real-expansion printing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)