### PR TITLE
Show a reprint's own art on its back face and its tokens

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ArlinnKordReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ArlinnKordReprint.kt
@@ -8,8 +8,10 @@ val ArlinnKordReprint = Printing(
     name = "Arlinn Kord",
     setCode = "INR",
     collectorNumber = "230",
+    scryfallId = "e72d7c11-2165-4c72-80f3-3c1a7b4b5572",
     artist = "Winona Nelson",
     imageUri = "https://cards.scryfall.io/normal/front/e/7/e72d7c11-2165-4c72-80f3-3c1a7b4b5572.jpg?1783908089",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/e/7/e72d7c11-2165-4c72-80f3-3c1a7b4b5572.jpg?1783908089",
     releaseDate = "2025-01-24",
     rarity = Rarity.MYTHIC,
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GarrukRelentlessReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/GarrukRelentlessReprint.kt
@@ -15,6 +15,7 @@ val GarrukRelentlessReprint = Printing(
     scryfallId = "6897514f-e396-46d6-91e3-158366c741bb",
     artist = "Eric Deschamps",
     imageUri = "https://cards.scryfall.io/normal/front/6/8/6897514f-e396-46d6-91e3-158366c741bb.jpg?1783908104",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/6/8/6897514f-e396-46d6-91e3-158366c741bb.jpg?1783908104",
     releaseDate = "2025-01-24",
     rarity = Rarity.MYTHIC,
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HanweirWatchkeepReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HanweirWatchkeepReprint.kt
@@ -11,6 +11,7 @@ val HanweirWatchkeepReprint = Printing(
     scryfallId = "d067706b-e2cc-4ad5-b992-28222a8af4ad",
     artist = "Wayne Reynolds",
     imageUri = "https://cards.scryfall.io/normal/front/d/0/d067706b-e2cc-4ad5-b992-28222a8af4ad.jpg?1783908125",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/d/0/d067706b-e2cc-4ad5-b992-28222a8af4ad.jpg?1783908125",
     releaseDate = "2025-01-24",
     rarity = Rarity.COMMON,
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HuntmasterOfTheFellsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/HuntmasterOfTheFellsReprint.kt
@@ -11,6 +11,7 @@ val HuntmasterOfTheFellsReprint = Printing(
     scryfallId = "b3819a11-2f3e-4304-a1b0-6abf893c89c5",
     artist = "Chris Rahn",
     imageUri = "https://cards.scryfall.io/normal/front/b/3/b3819a11-2f3e-4304-a1b0-6abf893c89c5.jpg?1783908083",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/b/3/b3819a11-2f3e-4304-a1b0-6abf893c89c5.jpg?1783908083",
     releaseDate = "2025-01-24",
     rarity = Rarity.RARE,
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/KruinOutlawReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/KruinOutlawReprint.kt
@@ -11,6 +11,7 @@ val KruinOutlawReprint = Printing(
     scryfallId = "3c6ee666-9b5b-428a-9ddb-37c36a6272cb",
     artist = "David Rapoza",
     imageUri = "https://cards.scryfall.io/normal/front/3/c/3c6ee666-9b5b-428a-9ddb-37c36a6272cb.jpg?1783908121",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/3/c/3c6ee666-9b5b-428a-9ddb-37c36a6272cb.jpg?1783908121",
     releaseDate = "2025-01-24",
     rarity = Rarity.RARE,
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MayorOfAvabruckReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/MayorOfAvabruckReprint.kt
@@ -11,6 +11,7 @@ val MayorOfAvabruckReprint = Printing(
     scryfallId = "ef84540b-a132-4169-b3c0-b0edeb395c9b",
     artist = "Svetlin Velinov",
     imageUri = "https://cards.scryfall.io/normal/front/e/f/ef84540b-a132-4169-b3c0-b0edeb395c9b.jpg?1783908100",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/e/f/ef84540b-a132-4169-b3c0-b0edeb395c9b.jpg?1783908100",
     releaseDate = "2025-01-24",
     rarity = Rarity.RARE,
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ScornedVillagerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/ScornedVillagerReprint.kt
@@ -11,6 +11,7 @@ val ScornedVillagerReprint = Printing(
     scryfallId = "ee539a5e-2d10-4666-9b52-5064562dd233",
     artist = "Cynthia Sheppard",
     imageUri = "https://cards.scryfall.io/normal/front/e/e/ee539a5e-2d10-4666-9b52-5064562dd233.jpg?1783908096",
+    backFaceImageUri = "https://cards.scryfall.io/normal/back/e/e/ee539a5e-2d10-4666-9b52-5064562dd233.jpg?1783908096",
     releaseDate = "2025-01-24",
     rarity = Rarity.COMMON,
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/GarrukRelentless.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/GarrukRelentless.kt
@@ -60,6 +60,10 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *    [Effects.IfYouDo] with [SuccessCriterion.PermanentsSacrificed]. `Auto` can't infer a sacrifice
  *    (the graveyard's owner isn't known until the chooser picks), and `Always` would wrongly search on
  *    an empty board.
+ *  - **Neither Wolf declares an `imageUri`.** Both faces make a Wolf that Innistrad and Innistrad
+ *    Remastered each printed with their own illustration, so the art belongs to the set's
+ *    `tokenArt`, not to the script — baking one in mints Innistrad's Wolf out of a Remastered
+ *    Garruk. `TokenArtRegistry` keys off the printing the player brought and gets both right.
  *  - **The −3 counts creature cards in the graveyard at resolution** and freezes there — the ruling
  *    says the bonus doesn't change if that number changes later in the turn. A [DynamicAmount] fed to
  *    [Effects.ModifyStats] inside a `ForEachInGroup` gives both that and "only creatures you control
@@ -103,7 +107,6 @@ private val GarrukRelentlessFront = card("Garruk Relentless") {
             toughness = 2,
             colors = setOf(Color.GREEN),
             creatureTypes = setOf("Wolf"),
-            imageUri = "https://cards.scryfall.io/normal/front/8/9/89b89a55-3ea2-4186-b946-06831bc16169.jpg?1783907965",
         )
         description = "Create a 2/2 green Wolf creature token."
     }
@@ -141,7 +144,6 @@ private val GarrukTheVeilCursed = card("Garruk, the Veil-Cursed") {
             colors = setOf(Color.BLACK),
             creatureTypes = setOf("Wolf"),
             keywords = setOf(Keyword.DEATHTOUCH),
-            imageUri = "https://cards.scryfall.io/normal/front/6/8/6884b4a4-b1f8-4d3d-8b0a-0e1c04e9b0f9.jpg",
         )
         description = "Create a 1/1 black Wolf creature token with deathtouch."
     }

--- a/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/DoubleFacedPrintingArtTest.kt
+++ b/mtg-sets/src/test/kotlin/com/wingedsheep/mtg/sets/DoubleFacedPrintingArtTest.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets
+
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * Corpus-wide gate: **every `Printing` of a two-faced card declares `backFaceImageUri`.**
+ *
+ * A `Printing` row is the only place a *reprint's* art can live — the `CardDefinition` carries the
+ * card's earliest printing and nothing else. Omit the back-face URL and nothing breaks loudly:
+ * `CardEntityFactory` falls through to `cardDef.backFace.metadata.imageUri`, so the reprint quietly
+ * wears the original set's back face. That is how an Innistrad Remastered Garruk Relentless turned
+ * into an *Innistrad* Garruk, the Veil-Cursed the moment he flipped — six INR rows were missing the
+ * field, and only a player noticing the wrong illustration ever surfaced it.
+ *
+ * Front art is not checked here: a row with no `imageUri` at all falls back to the canonical art
+ * for *both* faces, which is a visibly incomplete row rather than the half-right state this catches.
+ */
+class DoubleFacedPrintingArtTest : FunSpec({
+
+    /** Canonical definition per card name — the printing rows only carry the name. */
+    val definitionsByName: Map<String, CardDefinition> =
+        MtgSetCatalog.all.flatMap { it.cards }.associateBy { it.name }
+
+    test("every printing of a two-faced card carries back-face art") {
+        val gaps = MtgSetCatalog.all.flatMap { set ->
+            set.printings
+                .filter { printing ->
+                    printing.backFaceImageUri == null &&
+                        definitionsByName[printing.name]?.isDoubleFaced == true
+                }
+                .map { "[${set.code}] ${it.name} (#${it.collectorNumber})" }
+        }
+
+        if (gaps.isNotEmpty()) {
+            println("=== printings of two-faced cards with no backFaceImageUri: ${gaps.size} ===")
+            gaps.sorted().forEach { println("  $it") }
+            println("--- add `backFaceImageUri` (Scryfall's `card_faces[1].image_uris.normal`) ---")
+        }
+        gaps.shouldBeEmpty()
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -1967,8 +1967,7 @@
                     ],
                     "creatureTypes": [
                         "Wolf"
-                    ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/8/9/89b89a55-3ea2-4186-b946-06831bc16169.jpg?1783907965"
+                    ]
                 },
                 "timing": "SorcerySpeed",
                 "isPlaneswalkerAbility": true,
@@ -2001,8 +2000,7 @@
                         ],
                         "keywords": [
                             "DEATHTOUCH"
-                        ],
-                        "imageUri": "https://cards.scryfall.io/normal/front/6/8/6884b4a4-b1f8-4d3d-8b0a-0e1c04e9b0f9.jpg"
+                        ]
                     },
                     "timing": "SorcerySpeed",
                     "isPlaneswalkerAbility": true,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardEntityFactory.kt
@@ -74,6 +74,10 @@ object CardEntityFactory {
                     ?: cardDef.backFace?.metadata?.imageUri
                     // Modal DFC backs aren't a separate CardDefinition; their art rides on the face.
                     ?: cardDef.cardFaces.firstOrNull { it.imageUri != null }?.imageUri,
+                // The set whose art this entity presents. `definitionId` above keeps the *oracle*
+                // definition's set on purpose, so this is the only place the pinned reprint's set
+                // survives onto the entity — and it's what makes a reprint mint its own set's tokens.
+                printingSetCode = printing?.setCode ?: cardDef.setCode,
                 hasNonManaActivatedAbility = cardDef.hasNonManaActivatedAbility,
                 hasActivatedAbility = cardDef.hasActivatedAbility,
                 // Original-printing set (canonical, not the pinned printing) — "originally printed in X".

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TransformEffectExecutor.kt
@@ -228,9 +228,16 @@ internal fun dfcBackFaceManaValue(frontDef: CardDefinition?, frontManaValue: Int
 
 /**
  * Build a fresh [CardComponent] for the given DFC face while preserving the permanent's
- * owner identity and inheriting the prior face's `imageUri` when the new face doesn't
- * declare its own. Shared by [TransformEffectExecutor] (CR 701.27 transform on the
- * battlefield) and [ReturnSelfFromExileTransformedExecutor] (CR 702.167 Craft return).
+ * owner identity and the art of the printing the player actually brought. Shared by
+ * [TransformEffectExecutor] (CR 701.27 transform on the battlefield) and
+ * [ReturnSelfFromExileTransformedExecutor] (CR 702.167 Craft return).
+ *
+ * **The two image fields swap on every flip.** `CardEntityFactory` stamps both from the chosen
+ * printing — `imageUri` is the face that's up, `backFaceImageUri` the other one — so trading them
+ * is exactly what turning the card over means, in either direction, and the pinned printing's art
+ * survives any number of flips. Falling through to `face.metadata.imageUri` instead (the old
+ * behaviour) reached for the *canonical* printing's art, which is why a transformed Innistrad
+ * Remastered Garruk Relentless came back wearing his original Innistrad face.
  *
  * @param manaValueOverride What [dfcBackFaceManaValue] returned when [face] is the **back** face;
  *   null when flipping to the front, which clears any override the back face carried.
@@ -251,7 +258,13 @@ internal fun buildCardComponentForDfcFace(
     colors = face.colors,
     ownerId = current.ownerId,
     spellEffect = face.spellEffect,
-    imageUri = face.metadata.imageUri ?: current.imageUri,
+    imageUri = current.backFaceImageUri ?: face.metadata.imageUri ?: current.imageUri,
+    backFaceImageUri = current.imageUri,
+    // Presentation and rules identity both belong to the whole card, not to the face that's up:
+    // the printing keeps minting its own token art after a flip, and "originally printed in X"
+    // (City in a Bottle) keeps matching a werewolf that transformed.
+    printingSetCode = current.printingSetCode,
+    originalSetCode = current.originalSetCode,
     // Carry the destination face's precomputed ability flags so predicates like
     // CardPredicate.HasActivatedAbility / HasNonManaActivatedAbility see the face that's actually up
     // (otherwise a transformed permanent silently reports the default `false`).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
@@ -78,14 +78,14 @@ class CreatePredefinedTokenExecutor(
         // A list, because a set may have printed the same token with several illustrations: the
         // batch is dealt out of it in order and wraps. Indexing by position in the batch keeps it
         // deterministic, so a replay re-simulates the same board. See CreateTokenExecutor.
-        val sourceCardDefinitionId = context.sourceId
+        val sourceCard = context.sourceId
             ?.let { state.getEntity(it) }
             ?.get<CardComponent>()
-            ?.cardDefinitionId
         val resolvedImageUris = effect.imageUri?.let(::listOf)
             ?: tokenArtRegistry?.resolveAll(
-                sourceCardDefinitionId = sourceCardDefinitionId,
+                sourceCardDefinitionId = sourceCard?.cardDefinitionId,
                 tokenName = effect.tokenType,
+                sourcePrintingSetCode = sourceCard?.printingSetCode,
             )?.takeIf { it.isNotEmpty() }
             ?: listOf(cardDef.metadata.imageUri)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -151,17 +151,17 @@ class CreateTokenExecutor(
         // this is a list: the batch is dealt out of it in order and wraps, which is why Release the
         // Dogs' four Dogs show Jumpstart's four Dog arts. Indexing by position in the batch keeps
         // it deterministic, so a replay re-simulates the same board.
-        val sourceCardDefinitionId = context.sourceId
+        val sourceCard = context.sourceId
             ?.let { state.getEntity(it) }
             ?.get<CardComponent>()
-            ?.cardDefinitionId
         val resolvedImageUris = effect.imageUri?.let(::listOf)
             ?: tokenArtRegistry?.resolveAll(
-                sourceCardDefinitionId = sourceCardDefinitionId,
+                sourceCardDefinitionId = sourceCard?.cardDefinitionId,
                 tokenName = tokenName.removeSuffix(" Token"),
                 power = tokenPower,
                 toughness = tokenToughness,
                 colors = effectiveColors,
+                sourcePrintingSetCode = sourceCard?.printingSetCode,
             )?.takeIf { it.isNotEmpty() }
             ?: listOf(TokenArt.forCreatureTypes(effectiveCreatureTypes))
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/TokenArtRegistry.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/registry/TokenArtRegistry.kt
@@ -65,10 +65,14 @@ class TokenArtRegistry {
     /**
      * Art for a token being created, or null when the creating card's set prints none that match.
      *
-     * @param sourceCardDefinitionId The creating entity's `CardComponent.cardDefinitionId`. Real
-     *   games key entities as `"Name#SET-CN"`, which names the *printing* the player brought —
-     *   that set wins, so a reprint mints its own token. Scenario builders key by bare name, which
+     * @param sourceCardDefinitionId The creating entity's `CardComponent.cardDefinitionId`, the
+     *   fallback when no printing is known. Real games key entities as `"Name#SET-CN"` naming the
+     *   *canonical* definition (that's deliberate — ability lookups resolve through it), so this
+     *   yields the set the card was first printed in. Scenario builders key by bare name, which
      *   falls back to [setByCardName].
+     * @param sourcePrintingSetCode The creating entity's `CardComponent.printingSetCode` — the
+     *   printing the player actually brought. Wins when known, which is what makes a reprint mint
+     *   its own set's token rather than the original's.
      * @param tokenName Token name as it will be created ("Cat", "Zombie Druid").
      */
     fun resolve(
@@ -77,7 +81,10 @@ class TokenArtRegistry {
         power: Int? = null,
         toughness: Int? = null,
         colors: Set<Color> = emptySet(),
-    ): String? = resolveAll(sourceCardDefinitionId, tokenName, power, toughness, colors).firstOrNull()
+        sourcePrintingSetCode: String? = null,
+    ): String? = resolveAll(
+        sourceCardDefinitionId, tokenName, power, toughness, colors, sourcePrintingSetCode,
+    ).firstOrNull()
 
     /**
      * Every art the creating card's set printed for this token, in declaration order; empty when
@@ -94,15 +101,20 @@ class TokenArtRegistry {
         power: Int? = null,
         toughness: Int? = null,
         colors: Set<Color> = emptySet(),
+        sourcePrintingSetCode: String? = null,
     ): List<String> {
-        val setCode = setCodeFor(sourceCardDefinitionId) ?: return emptyList()
+        val setCode = setCodeFor(sourceCardDefinitionId, sourcePrintingSetCode) ?: return emptyList()
         val rows = bySet[setCode] ?: return emptyList()
         return TokenPrinting.allMatches(rows, tokenName, power, toughness, colors)
             .map { it.imageUri }
     }
 
     /** Set code that should supply token art for a creating entity, or null if unknown. */
-    private fun setCodeFor(cardDefinitionId: String?): String? {
+    private fun setCodeFor(cardDefinitionId: String?, printingSetCode: String?): String? {
+        // The printing the player actually brought is the answer whenever it's known, and it's the
+        // only one that can be right for a reprint: a definition id keeps the *oracle* definition's
+        // coordinates, so an Innistrad Remastered Garruk still reads `#ISD-181` below.
+        if (printingSetCode != null && printingSetCode in bySet) return printingSetCode
         val id = cardDefinitionId ?: return null
         // "Name#SET-CN" — the printing the entity was built from. A bare "Name#CN" (definitions
         // with a collector number but no set) has no dash and correctly falls through to the name

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/CardComponents.kt
@@ -31,6 +31,18 @@ data class CardComponent(
     val imageUri: String? = null,
     val backFaceImageUri: String? = null,
     /**
+     * Set code of the printing this entity actually presents — the reprint the deck pinned when it
+     * pinned one, otherwise the canonical printing's set. Distinct from [originalSetCode], which is
+     * always the canonical set and is a *rules* characteristic ("originally printed in X"); this one
+     * is presentation, and is the set whose token art the card should mint.
+     *
+     * It can't be read back off [cardDefinitionId]: that id deliberately keeps the oracle
+     * definition's coordinates so ability lookups resolve, so a Garruk from an Innistrad Remastered
+     * pool is still keyed `Garruk Relentless#ISD-181`. Null only for entities minted outside
+     * `CardEntityFactory` (tokens, scenario builders).
+     */
+    val printingSetCode: String? = null,
+    /**
      * Precomputed from the card definition: does this card have at least one intrinsic
      * activated ability that isn't a mana ability (and isn't a loyalty ability)? Used by
      * static filters such as Tsabo's Web ("each land with an activated ability that isn't

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/registry/DfcReprintArtTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/registry/DfcReprintArtTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.registry
+
+import com.wingedsheep.engine.core.CardEntityFactory
+import com.wingedsheep.engine.handlers.effects.permanent.types.buildCardComponentForDfcFace
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.mtg.sets.MtgSetCatalog
+import com.wingedsheep.mtg.sets.definitions.isd.cards.GarrukRelentless
+import com.wingedsheep.mtg.sets.tokens.TokenArtData
+import com.wingedsheep.mtg.sets.tokens.TokenCreationSites
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.PrintingRef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * A reprint has to keep wearing its own art — on both faces, and on the tokens it makes.
+ *
+ * Garruk Relentless is the card that exposed both halves of this. Played out of an Innistrad
+ * Remastered pool he transformed into an *Innistrad* Garruk, the Veil-Cursed, and the Wolf he made
+ * showed no art at all. Two independent causes, one theme: the printing the player brought was
+ * being dropped in favour of the card's earliest printing.
+ *
+ * 1. The face swap rebuilt the `CardComponent` from `face.metadata.imageUri` — the canonical
+ *    definition's art — instead of the back-face art the printing stamped on the entity.
+ * 2. Token art keys off a set, and the only set the token executors could see was the one encoded
+ *    in `cardDefinitionId`, which deliberately names the *oracle* definition (`#ISD-181`). The
+ *    pinned reprint had nowhere to live until `CardComponent.printingSetCode`.
+ *
+ * (Garruk's own dead `imageUri` override — a Scryfall id that 404s — was the reason the Wolf came
+ * out blank rather than merely wearing the wrong set's art. `TokenArtCoverageTest` guards the
+ * corpus against art that resolves to nothing; this guards art that resolves to the wrong set.)
+ */
+class DfcReprintArtTest : FunSpec({
+
+    val inrFront = "https://cards.scryfall.io/normal/front/6/8/6897514f-e396-46d6-91e3-158366c741bb.jpg?1783908104"
+    val inrBack = "https://cards.scryfall.io/normal/back/6/8/6897514f-e396-46d6-91e3-158366c741bb.jpg?1783908104"
+    val inrBlackWolf = "https://cards.scryfall.io/normal/front/f/5/f5561f57-34e2-4c01-8094-0ecb101c7fa1.jpg?1783907968"
+    val isdBlackWolf = "https://cards.scryfall.io/normal/front/7/a/7a49607c-427a-474c-ad77-60cd05844b3c.jpg?1783940882"
+
+    val printingRegistry = PrintingRegistry().apply {
+        MtgSetCatalog.all.forEach { register(it.printings) }
+        MtgSetCatalog.all.forEach { set -> set.cards.forEach { registerSynthesizedDefault(it) } }
+    }
+
+    val tokenArtRegistry = TokenArtRegistry().apply {
+        for (set in MtgSetCatalog.all) {
+            register(set.code, TokenArtData.forSet(set), set.cards.map { it.name })
+        }
+    }
+
+    // A set's definitions are stamped with their set code when the registry is loaded
+    // (`GameBeansConfig.stamp`), not in `mtg-sets` — so a definition read straight out of the
+    // package, as here, has to be stamped to stand in for the one a real game holds.
+    val garruk = GarrukRelentless.copy(setCode = "ISD")
+
+    /** Garruk as an Innistrad Remastered pool would mint him: INR art, ISD oracle identity. */
+    fun remasteredGarruk(): CardComponent =
+        CardEntityFactory.create(
+            cardDef = garruk,
+            ownerId = EntityId("player-1"),
+            printingRef = PrintingRef("INR", "197"),
+            printingRegistry = printingRegistry,
+        ).get<CardComponent>()!!
+
+    test("a reprint's back face shows the reprint's art, and flipping back restores its front") {
+        val front = remasteredGarruk()
+        front.imageUri shouldBe inrFront
+        front.backFaceImageUri shouldBe inrBack
+
+        val back = buildCardComponentForDfcFace(front, garruk.backFace!!)
+        back.name shouldBe "Garruk, the Veil-Cursed"
+        back.imageUri shouldBe inrBack
+        // The other face is always the one image the card isn't currently showing, so a second
+        // flip has the front art to go back to.
+        back.backFaceImageUri shouldBe inrFront
+
+        val flippedBack = buildCardComponentForDfcFace(back, garruk)
+        flippedBack.imageUri shouldBe inrFront
+        flippedBack.backFaceImageUri shouldBe inrBack
+    }
+
+    test("the printing survives the flip, so the back face still mints the reprint's tokens") {
+        val front = remasteredGarruk()
+        front.printingSetCode shouldBe "INR"
+        // `cardDefinitionId` names the oracle definition on purpose — which is exactly why it can't
+        // be the source of token art for a reprint.
+        front.cardDefinitionId shouldBe "Garruk Relentless#ISD-181"
+
+        val back = buildCardComponentForDfcFace(front, garruk.backFace!!)
+        back.printingSetCode shouldBe "INR"
+        back.originalSetCode shouldBe "ISD"
+    }
+
+    test("the 1/1 black deathtouch Wolf resolves to the art of the set that printed the Garruk") {
+        fun wolfArt(printingSetCode: String?) = tokenArtRegistry.resolve(
+            sourceCardDefinitionId = "Garruk, the Veil-Cursed",
+            tokenName = "Wolf",
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            sourcePrintingSetCode = printingSetCode,
+        )
+
+        wolfArt("INR") shouldBe inrBlackWolf
+        wolfArt("ISD") shouldBe isdBlackWolf
+        // Without the printing there is nothing to key on: the back face's name is not a card name
+        // any set registers, so this is the null the executors fall through on.
+        wolfArt(null) shouldBe null
+    }
+
+    test("neither Wolf pins art onto the script, so the registry is what answers") {
+        // Walks the serialised card tree, so this covers the back face's Wolf too.
+        val sites = TokenCreationSites.of(GarrukRelentless)
+        sites.map { it.tokenName } shouldBe listOf("Wolf", "Wolf")
+        sites.mapNotNull { it.explicitImageUri } shouldBe emptyList()
+    }
+})


### PR DESCRIPTION
Garruk Relentless played out of an Innistrad Remastered pool transformed into an **Innistrad** Garruk, the Veil-Cursed, and the 1/1 black deathtouch Wolf he makes showed no art at all.

Three independent causes, one theme: the printing the player brought was being dropped in favour of the card's earliest printing.

## What was wrong

**1. Seven INR `Printing` rows carried no `backFaceImageUri`.** Every consumer then falls through to the canonical definition's back art. Nothing fails when that happens — the fallback always produces *an* image, just the wrong set's — so it took a player noticing the illustration.

Garruk Relentless, Arlinn Kord, Hanweir Watchkeep, Huntmaster of the Fells, Kruin Outlaw, Mayor of Avabruck, Scorned Villager. They were the only such rows in the whole corpus.

**2. The face swap discarded the printing's art.** `buildCardComponentForDfcFace` rebuilt the flipped `CardComponent` from `face.metadata.imageUri` — the *canonical* definition's art — throwing away the back-face art `CardEntityFactory` had already stamped on the entity. So even with (1) fixed, flipping still reached for Innistrad.

The two image fields now swap on every flip, which is exactly what turning a card over means. The pinned printing's art survives any number of flips, in either direction.

**3. Token art had no way to see the reprint.** Token art keys off a set, and the only set the executors could read was the one encoded in `cardDefinitionId` — which deliberately names the *oracle* definition (`Garruk Relentless#ISD-181`) so ability lookups resolve. The reprint's set had nowhere to live.

`CardComponent.printingSetCode` is now that place, and both token executors prefer it. This is what `TokenArtRegistry` has always documented itself as doing ("a reprint mints its own token") — it just had no input that could express it.

## Garruk's hardcoded token art

Both `CreateToken` sites pinned an `imageUri`, which beats the registry outright:

- the 1/1 black Wolf's pointed at a Scryfall id that **404s** — that's why it came out blank rather than merely wearing the wrong set's art;
- the 2/2 green Wolf's hardcoded *INR* art onto every printing, including Innistrad's own.

Both sets already declare correct Wolf rows in `tokens.json`, so removing the overrides lets the registry answer for both faces.

## Also

The flip no longer drops `originalSetCode`, so a transformed werewolf keeps matching "originally printed in Innistrad" (City in a Bottle).

## Tests

- `DoubleFacedPrintingArtTest` (mtg-sets) — corpus gate: every `Printing` of a two-faced card carries back-face art. This is what would have caught the original omission.
- `DfcReprintArtTest` (rules-engine) — the INR Garruk keeps INR art across a flip and back; the printing survives the flip; the 1/1 black Wolf resolves to INR's or ISD's art depending on which Garruk made it; neither Wolf pins art onto the script.

## Verification

- `just test` — 12,274 tests, 0 failures.
- `just rebless-cards` — ISD snapshot moved by exactly the two removed `imageUri` overrides, nothing else.
- All nine new/relied-on art URLs HEAD 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)