### PR TITLE
Fix optional trigger with a single legal player target resolving as mandatory

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -682,7 +682,16 @@ class TriggerProcessor(
 
         // Auto-select player targets when there's exactly one legal target and requirement is for exactly one target.
         // Only applies for single-target abilities (not multi-target).
-        if (allRequirements.size == 1) {
+        //
+        // NOT when the ability is `optional`. A targeted "you may" carries its consent solely through
+        // the target-selection decision's `minTargets = 0` (see `requirementInfos` below) — skipping
+        // that decision skips the decline, and the trigger goes on the stack as mandatory. That is
+        // fail-open: in a two-player game "you may have target opponent discard a card" (Ebon Dragon)
+        // never asked, it just made them discard. The optimization's premise — "there is only one
+        // choice, so don't prompt" — is false here: declining is a second choice. (An `optional`
+        // *requirement*, `TargetPlayer(optional = true)` for "up to one target player", already skips
+        // this branch via `effectiveMinCount == 0`.)
+        if (allRequirements.size == 1 && !ability.optional) {
             val isPlayerTarget = targetRequirement is com.wingedsheep.sdk.scripting.targets.TargetPlayer ||
                                  targetRequirement is com.wingedsheep.sdk.scripting.targets.TargetOpponent
             val legalTargets = allLegalTargets[0] ?: emptyList()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EbonDragonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EbonDragonScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Ebon Dragon (POR #91) — {5}{B}{B} Creature — Dragon, 5/4.
+ *
+ * "Flying
+ *  When this creature enters, you may have target opponent discard a card."
+ *
+ * The card is modelled as `optional = true` on the triggered ability plus a `TargetOpponent`
+ * requirement, which makes it the regression case for the fail-open bug in
+ * `TriggerProcessor.processTargetedTrigger`: with a single legal opponent the processor used to
+ * auto-select that opponent and put the trigger straight on the stack, skipping the
+ * target-selection decision whose `minTargets = 0` is what carries the "you may" decline. The
+ * opponent discarded whether or not the controller wanted them to.
+ *
+ * Both branches are covered — accepting discards, declining does not.
+ */
+class EbonDragonScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Ally Bear",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Ebon Dragon's optional ETB discard") {
+
+            test("accepting the may makes the sole opponent discard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Ebon Dragon")
+                    .withCardInHand(2, "Ally Bear")
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Ebon Dragon").error shouldBe null
+                game.resolveStack()
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the may/target; got ${game.state.pendingDecision}")
+
+                withClue("the optional trigger must offer the decline (minTargets = 0)") {
+                    targetDecision.targetRequirements.single().minTargets shouldBe 0
+                }
+
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(game.player2Id))))
+                game.resolveStack()
+
+                withClue("Player 2 should have discarded their only card") {
+                    game.handSize(2) shouldBe 0
+                    game.isInGraveyard(2, "Ally Bear") shouldBe true
+                }
+            }
+
+            test("declining the may leaves the opponent's hand alone") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Ebon Dragon")
+                    .withCardInHand(2, "Ally Bear")
+                    .withLandsOnBattlefield(1, "Swamp", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Ebon Dragon").error shouldBe null
+                game.resolveStack()
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the may/target; got ${game.state.pendingDecision}")
+
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to emptyList())))
+                game.resolveStack()
+
+                withClue("declining must not make Player 2 discard") {
+                    game.handSize(2) shouldBe 1
+                    game.isInGraveyard(2, "Ally Bear") shouldBe false
+                }
+
+                withClue("Ebon Dragon should still be on the battlefield") {
+                    game.isOnBattlefield("Ebon Dragon") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The bug

`TriggerProcessor.processTargetedTrigger` auto-selects the target when a trigger's single
requirement is a `TargetPlayer` / `TargetOpponent` with exactly one legal target, and calls
`putTriggerOnStack` directly — no decision.

For an ability declared `optional = true`, that decision is the *only* thing carrying the "you may".
`optional` is honoured further down by lowering the target-selection decision's `minTargets` to 0
(`requirementInfos`); declining is submitting zero targets. Skip the decision and the decline
disappears with it, and the trigger resolves as mandatory.

Fail-open, and invisible in a green build — in every two-player game Ebon Dragon's *"When this
creature enters, you may have target opponent discard a card"* never asked, it just made them
discard.

## The fix

Guard the auto-select on `!ability.optional`.

The optimization's premise — "there's only one legal choice, so don't prompt" — is false for an
optional ability: declining is a second choice. With the guard, an optional trigger takes the same
`minTargets = 0` path it already takes when two or more opponents exist, so two-player and
multiplayer now behave identically.

Deliberately narrow:

- An optional **requirement** (`TargetPlayer(optional = true)`, i.e. "up to one target player" —
  Torgaar, Veteran Ice Climber, Volatile Arsonist) already skipped this branch via
  `effectiveMinCount == 0`. Untouched.
- An explicit `MayEffect` already routes to `processMayThenTargetTrigger` further up, which always
  creates its own yes/no. Untouched — Disciple of the Vault, the card this was found from, keeps
  working exactly as before.
- Non-player targets never had auto-select at all.
- `elseEffect` on decline keeps working: `EffectAndTriggerContinuationResumer` handles the
  zero-target case, which the auto-select was bypassing too.

## Blast radius

A scan of every `triggeredAbility { }` in `mtg-sets` for ability-level `optional = true` combined
with a `TargetPlayer` / `TargetOpponent` requirement returns exactly one card: **Ebon Dragon**
(POR #91). It gets `EbonDragonScenarioTest`, covering both branches — accepting discards, declining
does not, and the trigger's requirement is asserted to carry `minTargets = 0`.

Reverting the one-line guard makes both tests fail (verified), so the test is a real regression
guard rather than a restatement of current behaviour.

## Verification

- `just test-class EbonDragonScenarioTest` — both tests pass; both fail without the fix.
- `just test-rules` — 10,225 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
