### PR TITLE
Add the five modal teamwork cards, and make "choose both instead" mandatory

### DIFF
--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -1,12 +1,12 @@
 # Unit u03 — the five modal teamwork cards (MSH)
 
-Branch `loop-msh-u03`, stacked on `loop-msh-u02`. Batch unit, ordinary card work: every card is
-`teamwork(n)` plus the documented modal recipe. **No new SDK vocabulary** — the card diff is five card
-files, five test files, the MSH snapshot, and two backlog files.
+Branch `loop-msh-u03`, an independent PR against `main` — `loop-msh-u02` merged upstream as
+PR #1731, so this branch was rebased off the stack onto `origin/main` and carries only its own
+commits. Batch unit, ordinary card work: every card is `teamwork(n)` plus the modal recipe.
 
-> **Amended after review.** The branch also carries two fixes to `CastSpellEnumerator.kt`, which is
-> `loop-msh-u02`'s code rather than this unit's, because both defects are only reachable through
-> these five cards and the two branches merge in order. See *Review corrections* at the bottom.
+> **Amended twice after review.** The branch also carries fixes to `CastSpellEnumerator.kt` /
+> `CastSpellHandler.kt` and one new SDK field, because the defects are only reachable through these
+> five cards. See *Review corrections* and *Round-2 corrections* at the bottom.
 
 ## Cards
 
@@ -27,9 +27,9 @@ files, five test files, the MSH snapshot, and two backlog files.
   `TargetObject(count = 2, minCount = 1, filter = NonlandPermanent)` bounced through
   `ForEachTargetEffect(Effects.ReturnToHand(ContextTarget(0)))`.
 
-All five: `modal(chooseCount = 2, minChooseCount = 1, dynamicChooseCount =
-DynamicAmount.Conditional(Conditions.TeamworkWasPaid, Fixed(2), Fixed(1)))` — the recipe documented
-in `docs/card-sdk-language-reference.md` → *Teamwork N*. Thresholds verified against Scryfall
+All five: `teamworkModal { }` — the recipe documented in
+`docs/card-sdk-language-reference.md` → *Teamwork N*, which pins the mode count to exactly one on a
+plain cast and exactly all of them on a declared one. Thresholds verified against Scryfall
 (3, 4, 3, 4, 4 respectively).
 
 **Nothing was dropped.** The two shapes flagged as possible drops both turned out to be covered by
@@ -57,12 +57,14 @@ share a memory window. The final `just build` is green over everything.
 
 ## Tests
 
-Five files, `<CardName>ScenarioTest.kt`, three cases each (15 total, all passing):
+Five files, `<CardName>ScenarioTest.kt`, four cases each plus extras (25 total, all passing):
 
 1. plain cast → exactly the one chosen mode resolves, the other mode's victim is untouched, nothing
    tapped;
 2. teamwork cast → both modes resolve and the payer is tapped;
-3. plain cast declaring both modes → rejected, card stays in hand.
+3. plain cast declaring both modes → rejected, card stays in hand;
+4. teamwork cast declaring one mode → rejected and rewound, card in hand *and* payer untapped
+   (added in round 2 — "choose both instead" is mandatory in both directions).
 
 Go Nuts!'s teamwork case points both modes at the same 2/2 so the +1/+1 counter lands before the
 fight and it trades with a 3/3 — that pins mode ordering within the single resolution. HULK SMASH!'s
@@ -80,17 +82,17 @@ enumeration for a declared cast) reappeared — the teamwork branch is reached a
   `targetId` and cannot express per-mode target lists. That bypasses the legal-action enumerator, so
   these tests prove the *handler* accepts the shape but not that the client is offered the
   `CastSpellModal` "(Teamwork N)" variant for these particular cards. `TeamworkMechanicScenarioTest`
-  covers the advertised action generically; I did not add a per-card enumerator assertion.
+  covers the advertised action generically. Murdock's Crusade and Widow's Bite now carry per-card
+  `getLegalActions` assertions; the other three still rely on the generic coverage.
 - `Effects.Exile` is `MoveToZoneEffect(destination = EXILE)`; I did not check whether anything in
   MSH cares about the distinction between "exile" and "exile face down"/linked exile here. The
   printed text is a plain exile, so I believe this is right.
 - Atlantis Attacks' token is named `"Leviathan Token"` by the executor's default
   (`creatureTypes.joinToString(" ") + " Token"`) since I passed no explicit `name`. That matches
   what Brigid's Command and the other token cards do, but the printed token is just "Leviathan".
-- Each card's KDoc cites CR 702.194c for the "choose both instead" shape. 702.194c is strictly
-  about *targets* being skipped when teamwork wasn't used; that is exactly what
-  `dynamicChooseCount` produces here, and it matches the wording already in
-  `backlog/.../mechanics.md`, but it is a slightly loose citation.
+- ~~Each card's KDoc cites CR 702.194c for the "choose both instead" shape.~~ Corrected in round 2
+  to CR 700.2 / 601.2b; the loose citation was in fact wrong, and contradicted this repo's own SDK
+  reference.
 - Not done: no manual playthrough in the web client, no UX pass from either seat, no e2e run, no
   `/generate-scenario` JSON. The web client was not type-checked (no node_modules, no network).
 
@@ -108,11 +110,10 @@ Applied on top of the original commits, after the independent review (0 blocking
   - the declared-cost branch now drops the variant unless at least that many modes are *available*
     (CR 700.2a), not merely one — Murdock's Crusade's teamwork cast was being offered with no legal
     enchantment on the board and could never be completed. `allowRepeat` is exempt (CR 700.2d).
-- **Still open:** the handler's effective *minimum* for a teamwork cast is the printed
-  `minChooseCount` (1), not 2, so a directly-submitted one-mode teamwork cast is still accepted.
-  Making "choose both instead" mandatory needs an SDK shape that raises the floor as well as the
-  ceiling; `dynamicChooseCount` deliberately only raises the ceiling (Flame of Anor prints "you *may*
-  choose two instead"). Separate feature work.
+- ~~**Still open:** the handler's effective *minimum* for a teamwork cast is the printed
+  `minChooseCount` (1), not 2.~~ **Fixed in round 2** — see below. It was not separable: the client's
+  confirm button unlocks at the advertised `minChooseCount`, so a player could tap their team and
+  take one mode through the normal UI.
 - **`AtlantisAttacks.kt` KDoc** — it claimed one target going illegal "does not strand the other".
   False: `processPreChosenModeQueue` skips the whole mode all-or-nothing. Now documented as the
   pre-existing engine-wide deviation from CR 608.2b that it is; behaviour untouched.
@@ -125,3 +126,31 @@ Applied on top of the original commits, after the independent review (0 blocking
   pins `damage == 6` rather than "the 2/2 died".
 - No action on the Leviathan token name (matches the repo-wide default and the test lookup) or the
   CR 702.194c citations (the reviewer verified them as accurate).
+
+## Round-2 corrections
+
+Applied after a second review (1 blocking, 3 important).
+
+- **SDK, `ModalEffect.dynamicMinChooseCount`** — the mandatory sibling of `dynamicChooseCount`.
+  The printed wording splits: "you *may* choose two instead" (Flame of Anor) leaves the floor at
+  one, "choose both **instead**" (these five) does not. With only a ceiling, a teamwork cast could
+  legally take a single mode.
+- **SDK, `teamworkModal { }`** in `TeamworkDsl.kt` — sets both bounds from the same `Conditional`
+  and derives "both" from the modes declared. The five cards each drop six lines of copy-pasted
+  `DynamicAmount.Conditional`.
+- **Engine, `ModalChooseCounts.forCast`** — one authority for the `min..max` range, called by both
+  `CastSpellHandler` (validating) and `CastSpellEnumerator` (advertising). The two had separate
+  copies that had already drifted: the enumerator's knew nothing about the blight path or the floor.
+- **Engine, the enumerator's drop gate** now tests the effective *minimum*, not the maximum. This
+  turned out to fix a bug beyond teamwork: `CastSpellEnumeratorTest` had a case asserting that
+  Brigid's Command ("Choose two —") is still offered with only one mode available. It isn't
+  castable — CR 700.2a plus CR 601.2, and Wizards' own Cryptic Command ruling ("You must choose two
+  different modes"). That test's name already said "dropped entirely" while its body asserted the
+  opposite; it now asserts the drop.
+- **CR 702.194c → CR 700.2 / 601.2b** in five card KDocs and one test KDoc. 702.194c is about
+  targets; `docs/card-sdk-language-reference.md` already said so.
+
+**Gate (on `origin/main` b9d89050eb, after the rebase off the stack):** `:rules-engine:test` +
+`:mtg-sets:test` — 10601 passed, 0 failed. `:mtg-sdk:test` + `:game-server:test` — 897 passed,
+0 failed. Snapshot re-blessed: `MSH.json` +75 lines, 0 removed, all five `dynamicMinChooseCount`
+blocks and nothing else.

--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -1,118 +1,91 @@
-# u02 — Teamwork N (MSH)
+# Unit u03 — the five modal teamwork cards (MSH)
 
-Branch `loop-msh-u02`, stacked on `loop-msh-u01` (its two commits are the intended base).
+Branch `loop-msh-u03`, stacked on `loop-msh-u02`. Batch unit, ordinary card work: every card is
+`teamwork(n)` plus the documented modal recipe. **No new SDK vocabulary, no engine change** — the
+diff is five card files, five test files, the MSH snapshot, and two backlog files.
 
-## The primitive
+## Cards
 
-**Teamwork N (CR 702.194)** — an optional additional cast cost ("tap any number of creatures you
-control with total power N or more", 702.194a) plus a durable "cast using teamwork" fact (702.194b).
+- **Widow's Bite** [122] `{1}{B}` Instant, teamwork 3 — `Effects.GrantKeyword(DEATHTOUCH)` /
+  `Effects.ModifyStats(-2, -2)`, one `Targets.Creature` per mode.
+- **HULK SMASH!** [135] `{1}{R}` Instant, teamwork 4 — `Effects.Destroy` on
+  `TargetFilter(GameObjectFilter.Artifact.notCreature())` / the Rabid Bite one-sided
+  `Effects.DealDamage` with `amount = EntityProperty(Target(0), Power)` and
+  `damageSource = <your creature>`. Mode 2 carries two targets of its own.
+- **Go Nuts!** [168] `{G}` Sorcery, teamwork 3 — `Effects.AddCounters("+1/+1", 1)` /
+  `Effects.Fight`, the Epic Fight shape.
+- **Murdock's Crusade** [24] `{1}{W}` Sorcery, teamwork 4 — `Effects.Exile` behind
+  `TargetFilter.Creature.toughnessAtLeast(4)` / `TargetFilter.Enchantment.manaValueAtLeast(4)`.
+  The printed mode names ("Street Justice —", "Legal Justice —") are part of the mode
+  descriptions, which become the client's button text.
+- **Atlantis Attacks** [46] `{5}{U}{U}` Sorcery, teamwork 4 — `Effects.CreateToken(6, 5, BLUE,
+  "Leviathan", HEXPROOF, controller = <target player>)` / a single
+  `TargetObject(count = 2, minCount = 1, filter = NonlandPermanent)` bounced through
+  `ForEachTargetEffect(Effects.ReturnToHand(ContextTarget(0)))`.
 
-Authoring is one line: `card { teamwork(2) }`
-(`mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/TeamworkDsl.kt`), the same shape as
-`bargain()`.
+All five: `modal(chooseCount = 2, minChooseCount = 1, dynamicChooseCount =
+DynamicAmount.Conditional(Conditions.TeamworkWasPaid, Fixed(2), Fixed(1)))` — the recipe documented
+in `docs/card-sdk-language-reference.md` → *Teamwork N*. Thresholds verified against Scryfall
+(3, 4, 3, 4, 4 respectively).
 
-### What it reuses
-
-- **The kicker/bargain rail.** `KeywordAbility.OptionalAdditionalCost` with
-  `declaredSlot = ChoiceSlot.TEAMWORK`. No new keyword-ability type, no new cast action, no new
-  `actionType` (the variant is a `CastWithKicker` labelled "(Teamwork N)"), no new modal machinery.
-  The slot is what makes "cast using teamwork" a different fact from "kicked"/"bargained".
-- **`Conditions.TeamworkWasPaid`** is a one-line facade over `CastChoiceMade(ChoiceSlot.TEAMWORK)` —
-  no new `Condition` subtype, exactly like `WasBargained`.
-- **The crew selection.** "Tap any number of creatures you control with total power N or greater" is
-  the crew payment. `rules-engine/.../mechanics/cost/VariablePermanentsCost.kt` is the single shared
-  answer to "which permanents can pay / what do they measure", mirroring `CrewEnumerator`: untapped
-  only (CR 701.26a), controlled by the payer, matched **and summed through projected state**, no
-  summoning-sickness check (CR 302.6 is about the `{T}` symbol, not a tap paid as a cost). Both cast
-  enumerators, the cast validator, `CostHandler`, `ActivateAbilityHandler.variableCostX` and the AI
-  read it.
-- **The crew/saddle client payload.** `TapForPowerCreatureData` / `TapForPowerCreatureInfo`, now also
-  carried on `AdditionalCostData`/`AdditionalCostInfo` under `costType = "TapForTotalPower"`.
-- **`AdditionalCostPayment.variableCostPermanents`**, the existing variable-count payment channel.
-
-### What genuinely had to be added
-
-- SDK: `Keyword.TEAMWORK`, `ChoiceSlot.TEAMWORK`, `Conditions.TeamworkWasPaid`,
-  `Costs.additional.TapForTotalPower(n)`, `teamwork(n)` DSL helper.
-- SDK cost atom: `PermanentCostAction.TAP`, `VariableCostMeasure.TOTAL_POWER`, and a
-  `VariablePermanents.minMeasure` field — a floor on the *measure* rather than the count. Existing
-  atom descriptions are unchanged (`minCount` defaults keep the old wording).
-- Engine: `CostAtom.VariablePermanents` is now a **spell** additional cost, not only an
-  activated-ability cost — validation + payment branches in `CastSpellHandler`, `paymentSatisfied`,
-  `CostHandler.canPayAdditionalCost`, and a `TAP` payment branch in
-  `CostHandler.payVariablePermanentsList` (SACRIFICE/EXILE branches on the cast path go through the
-  existing sacrifice/zone-transition helpers).
-- Enumerators: a `VariablePermanents` branch in `CastSpellEnumerator.enumerateKicker` and the
-  matching one in `CastFromZoneEnumerator`, plus the "(Teamwork N)" label.
-- AI: a `"TapForTotalPower"` branch in `Strategist.withAutomaticPayments` — biggest-power-first until
-  the threshold is met, so the AI taps as few bodies as possible.
-- Client: a `TapForTotalPower` case in the `costPayment` pipeline phase writing
-  `variableCostPermanents`, `requiredTotalPower` / `powerByEntityId` on `TargetingState`, and a
-  total-power confirm gate + "power 2/2" progress readout in `TargetingOverlay`. Powers come from the
-  server; the client derives nothing.
-- Docs: `docs/card-sdk-language-reference.md` (Teamwork N section, the cost-atom axes, the
-  `Costs.additional.TapForTotalPower` bullet, the `TeamworkWasPaid` condition), plus the
-  `## Teamwork N` section of `backlog/sets/marvel-super-heroes/mechanics.md` marked shipped.
-
-## The cards
-
-- **Helicarrier Strike** [15] `{W}` Instant — 2 damage to target attacking or blocking creature, 4
-  instead if cast using teamwork. Composes `teamwork(2)` + `Effects.DealDamage` fed a
-  `DynamicAmount.Conditional(Conditions.TeamworkWasPaid, 4, 2)`. Deliberately one damage event rather
-  than 2+2, so prevention shields and damage triggers see what the printed card does.
-- **Repulsor Blast** [150] `{3}{R}` Sorcery — 5 damage to target creature; if cast using teamwork,
-  also 2 to that creature's controller. Composes `teamwork(2)` + `Effects.DealDamage` +
-  `ConditionalEffect(TeamworkWasPaid, DealDamage(2, EffectTarget.TargetController))`.
-- **Team Tactics** [155] `{1}{R}` Instant — target creature gains double strike; also trample if cast
-  using teamwork. Composes `teamwork(1)` + two `Effects.GrantKeyword` grants, the second under a
-  `ConditionalEffect`.
-
-All three are MSH-only printings (checked on Scryfall), so MSH is canonical for each.
-
-## Tests
-
-- `TeamworkMechanicScenarioTest` — multi-creature payment, single-creature payment, declining the
-  cost, an unmet threshold, an already-tapped creature, an opponent's creature, a lord's bonus
-  counting toward the threshold (projected power), summoning sickness not mattering, the flag
-  surviving onto a resolving permanent, the intervening-if not firing without teamwork,
-  teamwork-vs-kicked separation, declaring teamwork on a card that lacks it, and the advertised
-  legal action (candidates, threshold, affordability, label). Plus the modal "choose both instead"
-  cases ("Teamwork Orders") and the CR 702.194c teamwork-only-target cases ("Teamwork Rally": only
-  the declared cast announces the clause's target, the plain cast spares it, and declaring teamwork
-  without it is rewound).
-- `HelicarrierStrikeScenarioTest`, `RepulsorBlastScenarioTest`, `TeamTacticsScenarioTest` — one file
-  per card, each asserting both branches.
-- New fixture: `ScenarioTestBase.castSpellWithTeamwork(...)`.
+**Nothing was dropped.** The two shapes flagged as possible drops both turned out to be covered by
+existing target vocabulary: "one or two target nonland permanents" is `count = 2, minCount = 1`
+(Succumb to the Cold / Amazing Acrobatics precedent), and "enchantment with mana value 4 or
+greater" is `TargetFilter.Enchantment.manaValueAtLeast(4)`.
 
 ## Gate
 
-`just test` — see the final report for the result.
+`just build` — **passed** (`BUILD SUCCESSFUL`, all modules).
 
-## Things I'm unsure about / would like reviewed
+Getting there took several runs because the Gradle daemon was OOM-killed three times on this shared
+box (`daemon disappeared`), never with a compile or test error. The runs that stuck used
+`scripts/gradle-locked … -Pkotlin.compiler.execution.strategy=in-process --max-workers=1`, and
+`:rules-engine:test` had to be run on its own once so the test compile and the test run did not
+share a memory window. The final `just build` is green over everything.
 
-- **The web client was not type-checked.** `web-client/node_modules` is absent and there is no
-  network in this container, so `just client-typecheck` cannot run. The client changes are small and
-  reviewed by eye, but they are unverified by a compiler.
-- **No manual playthrough, no e2e.** Nobody has clicked a teamwork cast in the real client. The
-  cost-payment phase reuses the existing on-battlefield targeting overlay with a new confirm gate;
-  the "power 2/2" readout and the greyed-out unaffordable variant are untested visually.
-- **Cost-vs-target announcement order — resolved on review; there is no deviation.** CR 702.194a
-  says teamwork payment follows the additional-cost rules in **601.2b and 601.2f–h** ("601.2b–f",
-  written here originally and in the first commit message, is not a range the rule uses). The
-  declaration belongs at 601.2b, *before* targets at 601.2c, and CR 702.194c explicitly requires it
-  there. The engine already does that: the cast variant carrying `declaredCostSlot` is chosen before
-  any pipeline phase, cost and target validation both run against the pre-payment state, and the
-  taps are applied only after validation in one atomic action. Only the *client's* collection order
-  (cost widget before target picker) differs, with no rules consequence.
-- **`CostAtom.VariablePermanents` on the cast path now handles all three actions.** Only `TAP` has a
-  card and a test; the `SACRIFICE` and `EXILE` cast-path branches exist because the `when` is
-  exhaustive and reuse the existing helpers, but nothing exercises them. Same for the third
-  unreachable branch, `TAP` in `CostHandler.payVariablePermanentsList` — no printed card pays a TAP
-  `VariablePermanents` cost from an activated ability yet. All three kept, reviewed and accepted.
-- **`selectionCount` for the teamwork atom is 0** (`minCount = 0`), since the count is free. Nothing
-  in the cast path reads it, but it is a slightly odd value for a cost that always selects at least
-  one permanent in practice.
-- **mtgish bridge: declined deliberately.** The corpus (`mtgish-tooling/data/mtgish.lines.json`) has
-  no `Teamwork` keyword rule tag — the only teamwork-related tag is
-  `WhenAPermanentBecomesTappedToPayATeamworkCost` on Agent Maria Hill, which belongs to a later unit.
-  There is no IR tag for this keyword to map, so no bridge/emitter entry was added.
+- `just rebless-cards` — `mtg-sets/src/test/resources/snapshots/cards/MSH.json` only, and a **pure
+  insertion** (571 added lines, 0 removed): Atlantis Attacks, Go Nuts!, HULK SMASH!, Murdock's
+  Crusade, Widow's Bite. No unrelated card moved.
+- `just check-card-printing` — ok for all five (canonical in MSH, the earliest real printing).
+- Backlog ticked; `just fix-backlog` resynced MSH to 235 / 276. The teamwork section of
+  `mechanics.md` now reads 8 of 13 implemented, with the remaining four (We Say Thee Nay!, Cruel
+  Alliance, Too Evil to Stay Dead, Earth's Mightiest Heroes) plus the still-blocked Agent Maria Hill.
+
+## Tests
+
+Five files, `<CardName>ScenarioTest.kt`, three cases each (15 total, all passing):
+
+1. plain cast → exactly the one chosen mode resolves, the other mode's victim is untouched, nothing
+   tapped;
+2. teamwork cast → both modes resolve and the payer is tapped;
+3. plain cast declaring both modes → rejected, card stays in hand.
+
+Go Nuts!'s teamwork case points both modes at the same 2/2 so the +1/+1 counter lands before the
+fight and it trades with a 3/3 — that pins mode ordering within the single resolution. HULK SMASH!'s
+teamwork case pins that the bite amount reads *that mode's* first target (the 6/4 Craw Wurm) rather
+than the spell's first target overall (the artifact) — the snapshot confirms
+`targetRequirements[0]` is "target creature you control".
+
+Neither of the two u02 regressions (missing `declaredCostSlot` in the evaluation context; no modal
+enumeration for a declared cast) reappeared — the teamwork branch is reached and both modes resolve.
+
+## Uncertain / worth a reviewer's eye
+
+- The tests drive `game.execute(CastSpell(...))` directly with `chosenModes` +
+  `modeTargetsOrdered`, because `ScenarioTestBase.castSpellWithTeamwork` takes only a single
+  `targetId` and cannot express per-mode target lists. That bypasses the legal-action enumerator, so
+  these tests prove the *handler* accepts the shape but not that the client is offered the
+  `CastSpellModal` "(Teamwork N)" variant for these particular cards. `TeamworkMechanicScenarioTest`
+  covers the advertised action generically; I did not add a per-card enumerator assertion.
+- `Effects.Exile` is `MoveToZoneEffect(destination = EXILE)`; I did not check whether anything in
+  MSH cares about the distinction between "exile" and "exile face down"/linked exile here. The
+  printed text is a plain exile, so I believe this is right.
+- Atlantis Attacks' token is named `"Leviathan Token"` by the executor's default
+  (`creatureTypes.joinToString(" ") + " Token"`) since I passed no explicit `name`. That matches
+  what Brigid's Command and the other token cards do, but the printed token is just "Leviathan".
+- Each card's KDoc cites CR 702.194c for the "choose both instead" shape. 702.194c is strictly
+  about *targets* being skipped when teamwork wasn't used; that is exactly what
+  `dynamicChooseCount` produces here, and it matches the wording already in
+  `backlog/.../mechanics.md`, but it is a slightly loose citation.
+- Not done: no manual playthrough in the web client, no UX pass from either seat, no e2e run, no
+  `/generate-scenario` JSON. The web client was not type-checked (no node_modules, no network).

--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -1,8 +1,12 @@
 # Unit u03 — the five modal teamwork cards (MSH)
 
 Branch `loop-msh-u03`, stacked on `loop-msh-u02`. Batch unit, ordinary card work: every card is
-`teamwork(n)` plus the documented modal recipe. **No new SDK vocabulary, no engine change** — the
-diff is five card files, five test files, the MSH snapshot, and two backlog files.
+`teamwork(n)` plus the documented modal recipe. **No new SDK vocabulary** — the card diff is five card
+files, five test files, the MSH snapshot, and two backlog files.
+
+> **Amended after review.** The branch also carries two fixes to `CastSpellEnumerator.kt`, which is
+> `loop-msh-u02`'s code rather than this unit's, because both defects are only reachable through
+> these five cards and the two branches merge in order. See *Review corrections* at the bottom.
 
 ## Cards
 
@@ -89,3 +93,35 @@ enumeration for a declared cast) reappeared — the teamwork branch is reached a
   `backlog/.../mechanics.md`, but it is a slightly loose citation.
 - Not done: no manual playthrough in the web client, no UX pass from either seat, no e2e run, no
   `/generate-scenario` JSON. The web client was not type-checked (no node_modules, no network).
+
+## Review corrections
+
+Applied on top of the original commits, after the independent review (0 blocking, 4 important,
+6 minor).
+
+- **Engine, `CastSpellEnumerator.kt`** — new private `effectiveModalMaxChooseCount` mirroring the
+  dynamic branch of `CastSpellHandler.effectiveModalChooseCounts` (declaration in the evaluation
+  context, so `Conditions.TeamworkWasPaid` answers correctly from hand). Two call sites:
+  - the plain cast now advertises the dynamic-evaluated maximum (1 for an undeclared teamwork cast)
+    instead of the printed 2, so the client can no longer submit a two-mode plain cast the handler
+    rejects. Flame of Anor / Molten Collapse / Wail of the Forgotten were mis-advertised identically.
+  - the declared-cost branch now drops the variant unless at least that many modes are *available*
+    (CR 700.2a), not merely one — Murdock's Crusade's teamwork cast was being offered with no legal
+    enchantment on the board and could never be completed. `allowRepeat` is exempt (CR 700.2d).
+- **Still open:** the handler's effective *minimum* for a teamwork cast is the printed
+  `minChooseCount` (1), not 2, so a directly-submitted one-mode teamwork cast is still accepted.
+  Making "choose both instead" mandatory needs an SDK shape that raises the floor as well as the
+  ceiling; `dynamicChooseCount` deliberately only raises the ceiling (Flame of Anor prints "you *may*
+  choose two instead"). Separate feature work.
+- **`AtlantisAttacks.kt` KDoc** — it claimed one target going illegal "does not strand the other".
+  False: `processPreChosenModeQueue` skips the whole mode all-or-nothing. Now documented as the
+  pre-existing engine-wide deviation from CR 608.2b that it is; behaviour untouched.
+- **`GoNuts.kt`** — CR 608.2 → 608.2c (the rule that actually says instructions are followed in the
+  order written).
+- **Tests** — `MurdocksCrusadeScenarioTest` gains two `getLegalActions` cases (advertised mode count,
+  per-mode target candidates, teamwork variant absent with no legal enchantment, and the negative
+  side of both filters); `AtlantisAttacksScenarioTest` gains a single-target bounce case for
+  `minCount = 1`; `HulkSmashScenarioTest`'s bite victim became a 0/8 Wall of Stone so the assertion
+  pins `damage == 6` rather than "the 2/2 died".
+- No action on the Leviathan token name (matches the repo-wide default and the test lookup) or the
+  CR 702.194c citations (the reviewer verified them as accurate).

--- a/backlog/sets/marvel-super-heroes/cards.md
+++ b/backlog/sets/marvel-super-heroes/cards.md
@@ -3,7 +3,7 @@
 **Set Size:** 276 booster cards (collector numbers 1-276; basic lands 277-296 and showcase
 variants 297+ are excluded)
 **Release Date:** June 26, 2026
-**Implemented:** 230 / 276
+**Implemented:** 235 / 276
 - [x] Agent 13, Sharon Carter
 - [ ] Agent Maria Hill
 - [x] Agent of Atlas
@@ -27,7 +27,7 @@ variants 297+ are excluded)
 - [x] The Mind Stone
 - [x] Mockingbird, Ace Agent
 - [x] Monica Rambeau // Photon, Living Light
-- [ ] Murdock's Crusade
+- [x] Murdock's Crusade
 - [ ] Nick Fury, Agent of S.H.I.E.L.D.
 - [x] Night Nurse, Healer of Heroes
 - [x] Okoye, Dora Milaje Leader
@@ -49,7 +49,7 @@ variants 297+ are excluded)
 - [x] Aerial Doombot
 - [x] A.I.M. Scientists
 - [x] Atlantean Cavalry
-- [ ] Atlantis Attacks
+- [x] Atlantis Attacks
 - [x] Attuma, Atlantean Warlord
 - [x] Bold Biochemist
 - [x] Bruce Banner // The Incredible Hulk
@@ -125,7 +125,7 @@ variants 297+ are excluded)
 - [x] Unliving Legionnaire
 - [x] Visions of Villainy
 - [x] Whiplash, Vengeful Engineer
-- [ ] Widow's Bite
+- [x] Widow's Bite
 - [x] Yellowjacket, Heartless Marauder
 - [x] Avengers Disassembled
 - [x] Blazing Crescendo
@@ -138,7 +138,7 @@ variants 297+ are excluded)
 - [x] Hawkeye's Bow
 - [x] Hex Magic
 - [x] Hire a Crew
-- [ ] HULK SMASH!
+- [x] HULK SMASH!
 - [x] Human Torch, Johnny Storm
 - [x] HYDRA Assault Robot
 - [x] Iron Fist, Living Weapon
@@ -171,7 +171,7 @@ variants 297+ are excluded)
 - [ ] Earth's Mightiest Heroes
 - [x] Epic Fight
 - [x] Giant Growth
-- [ ] Go Nuts!
+- [x] Go Nuts!
 - [x] Guerrilla Gorilla
 - [x] Hellcat, Undying Vigilante
 - [x] Hercules, Prince of Power

--- a/backlog/sets/marvel-super-heroes/mechanics.md
+++ b/backlog/sets/marvel-super-heroes/mechanics.md
@@ -94,7 +94,7 @@ sweep is `.manaValueIsOdd()` / `.manaValueIsEven()` + a modal.
   (`CardPredicate.ManaValueAtMostDynamic(DynamicAmounts.sourcePower())` — the predicate exists, but
   nothing evaluates a source-relative dynamic filter inside delayed-trigger matching).
 
-## Teamwork N — SHIPPED ✅ (3 of 13 cards implemented, 9 now unblocked, 1 still blocked)
+## Teamwork N — SHIPPED ✅ (8 of 13 cards implemented, 4 now unblocked, 1 still blocked)
 
 > Teamwork 4 *(As an additional cost to cast this spell, you may tap any number of creatures you
 > control with total power 4 or more.)*
@@ -156,12 +156,12 @@ summoning sickness, the durable flag on a resolving permanent, teamwork-vs-kicke
 advertised legal action, the modal "Teamwork Orders" cases, and the CR 702.194c "Teamwork Rally"
 cases) plus one scenario test per implemented card.
 
-**Implemented (3):** Helicarrier Strike [15] · Repulsor Blast [150] · Team Tactics [155].
+**Implemented (8):** Helicarrier Strike [15] · Murdock's Crusade [24] · Atlantis Attacks [46] ·
+Widow's Bite [122] · HULK SMASH! [135] · Repulsor Blast [150] · Team Tactics [155] · Go Nuts! [168].
+The last five are the "choose both instead" modal shape, all on `dynamicChooseCount` as above.
 
-**Now buildable as ordinary card work (9):** Murdock's Crusade [24] · Atlantis Attacks [46] · We Say
-Thee Nay! [82] · Cruel Alliance [92] · Too Evil to Stay Dead [118] · Widow's Bite [122] ·
-HULK SMASH! [135] · Earth's Mightiest Heroes [165] · Go Nuts! [168]. The modal ones use
-`dynamicChooseCount` as above.
+**Now buildable as ordinary card work (4):** We Say Thee Nay! [82] · Cruel Alliance [92] · Too Evil
+to Stay Dead [118] · Earth's Mightiest Heroes [165].
 
 ### Still blocked — 1 card ⛔
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6300,21 +6300,24 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 >   effect, for a genuinely additional event (Repulsor Blast's 2 damage to the creature's controller,
 >   Team Tactics' extra trample grant).
 > - **Modal "choose both instead"** (CR 700.2 governs the mode count; the declaration it branches on
->   is made under CR 601.2b — *not* CR 702.194c, which is about targets) — a `modal { }` block with
->   `chooseCount = 2, minChooseCount = 1` and
->   `dynamicChooseCount = DynamicAmount.Conditional(Conditions.TeamworkWasPaid, DynamicAmount.Fixed(2),
->   DynamicAmount.Fixed(1))`: the plain cast picks one mode, the teamwork cast picks both. The same
->   `dynamicChooseCount` shape LCI's Molten Collapse and Wail of the Forgotten use, with one
->   difference that matters — those two read the *battlefield*, while this reads the declaration made
->   by the very cast being validated, so `CastSpellHandler.effectiveModalChooseCounts` evaluates it
->   with `declaredCostSlot` in the context (the durable cast-choices bag doesn't exist until the spell
->   resolves). The declared cast is enumerated as a `CastSpellModal` variant labelled "(Teamwork N)"
->   carrying both the modes and the teamwork cost payload, so the client collects modes and then the
->   taps. Both variants advertise the `chooseCount` this cast can actually reach: `CastSpellEnumerator`
->   evaluates the same dynamic with the same declaration (none on the plain variant, `TEAMWORK` on the
->   declared one), so the plain cast is offered as choose-**one**. The handler stays the authority; the
->   enumeration just no longer offers a mode count it would reject. For the same reason a declared
->   variant is dropped unless at least that many modes are actually available — "choose both" can't be
+>   is made under CR 601.2b — *not* CR 702.194c, which is about targets) — `teamworkModal { }`, a
+>   `modal { }` block wired for exactly that wording: the plain cast picks one mode, the teamwork
+>   cast picks all of them. It sets **both** `dynamicChooseCount` and `dynamicMinChooseCount` to the
+>   same `Conditional` on `Conditions.TeamworkWasPaid`, because "instead" is mandatory — a ceiling
+>   alone would let a player tap their team and then take a single mode. "Both" comes from the modes
+>   declared, so a three-mode printing needs no new recipe.
+>
+>   Related to the `dynamicChooseCount` shape LCI's Molten Collapse and Wail of the Forgotten use,
+>   with two differences that matter. Those read the *battlefield*, while this reads the declaration
+>   made by the very cast being validated, so the count is evaluated with `declaredCostSlot` in the
+>   context (the durable cast-choices bag doesn't exist until the spell resolves). And those print
+>   "may", so they set no floor.
+>
+>   The declared cast is enumerated as a `CastSpellModal` variant labelled "(Teamwork N)" carrying
+>   both the modes and the teamwork cost payload, so the client collects modes and then the taps.
+>   Both variants advertise the range `ModalChooseCounts` says that cast reaches — `1..1` plain,
+>   `2..2` declared — so the client's confirm button unlocks on exactly the legal counts. A declared
+>   variant is dropped unless that many modes are actually available: "choose both" can't be
 >   satisfied when one mode has no legal target (CR 700.2a).
 > - **Permanent** — an enters-the-battlefield trigger with
 >   `triggerCondition = Conditions.TeamworkWasPaid`; CR 603.4 keeps it off the stack entirely otherwise.
@@ -7344,7 +7347,7 @@ answer it and would silently return `false`.
   after the trigger fires makes no token. See §8's `triggerZones`.
 - `WasKicked` — cast with kicker / multikicker / offspring (i.e. an `OptionalAdditionalCost` with `branchesEffect = true` whose extra cost was paid). FlashKicker payments are intentionally invisible to this condition.
 - `WasBargained` — the spell's **bargain** additional cost was declared as it was cast (CR 702.166b, Wilds of Eldraine). A facade over `CastChoiceMade(ChoiceSlot.BARGAINED)`, so bargain needs no condition type of its own. Reads the durable flag on a resolved permanent (an "if it was bargained" enters trigger) *and* the declaration carried on a still-on-the-stack spell (an "if this spell was bargained" rider), and is also the condition a `CostGating.OnlyIf` cost reduction gates on. Never true for a merely kicked spell.
-- `TeamworkWasPaid` — the spell was cast **using teamwork** (CR 702.194b, Marvel Super Heroes): its optional "tap any number of creatures you control with total power N or more" additional cost was declared as it was cast. A facade over `CastChoiceMade(ChoiceSlot.TEAMWORK)`, so teamwork needs no condition type of its own. Reads the declaration carried on a still-on-the-stack spell (an "if this spell was cast using teamwork" rider) *and* the durable flag on a resolved permanent, and is the condition a modal's `dynamicChooseCount` gates on for "choose one; if cast using teamwork, choose both instead". Never true for a merely kicked or bargained spell.
+- `TeamworkWasPaid` — the spell was cast **using teamwork** (CR 702.194b, Marvel Super Heroes): its optional "tap any number of creatures you control with total power N or more" additional cost was declared as it was cast. A facade over `CastChoiceMade(ChoiceSlot.TEAMWORK)`, so teamwork needs no condition type of its own. Reads the declaration carried on a still-on-the-stack spell (an "if this spell was cast using teamwork" rider) *and* the durable flag on a resolved permanent, and is the condition `teamworkModal { }` gates both ends of the mode count on for "choose one; if cast using teamwork, choose both instead". Never true for a merely kicked or bargained spell.
 - `SneakCostWasPaid` — the source was cast for its `Sneak` cost (CR 702.190 — mana + returning an unblocked attacker). Reads the durable `ChoiceSlot.SNEAK` flag on a resolved permanent, falling back to the resolution context for a non-permanent spell's own effect. Backs riders like Leonardo, Leader in Blue and The Last Ronin's Technique.
 - `WebSlungCostWasPaid` — the source was cast using web-slinging (CR 702.188 — mana + returning a tapped creature you control). Reads the durable `ChoiceSlot.WEB_SLUNG` flag on a resolved permanent, falling back to the resolution context for a non-permanent spell's own effect. Backs riders like *Spiders-Man, Heroic Horde* and *Scarlet Spider, Ben Reilly*; the latter also reads the returned creature's mana value via `DynamicAmount.CastChoice(ChoiceSlot.WEB_SLUNG_RETURNED_MV)`.
 - `MayhemCostWasPaid` — the source was cast from the graveyard for its Mayhem cost (CR 702.187). Reads the durable `ChoiceSlot.MAYHEM_CAST` flag on a resolved permanent, falling back to the resolution context (`wasMayhem`) for a non-permanent spell's own effect. Backs riders like *Sandman's Quicksand* ("if this spell's mayhem cost was paid, creatures your opponents control get -2/-2 instead").
@@ -8702,11 +8705,10 @@ reminder via the card's `oracleText` (the `TIERED_REMINDER` constant holds the c
 Fire / Ice / Thunder / Restoration Magic, Tifa's / Vincent's Limit Break (FIN).
 
 **Cast-time conditional choose count** — for modal *spells* the same `dynamicChooseCount`
-field is evaluated against the battlefield **at cast time** (in `CastSpellHandler`,
-`effectiveModalChooseCounts`), and — unlike `chooseUpToDynamic` — it keeps the `minChooseCount`
-floor instead of forcing `0`. The effective upper bound is `eval.coerceIn(minChooseCount,
-modes.size)`. This models "Choose one. If [condition] as you cast this spell, you may choose
-two instead." (Flame of Anor): pass it via the DSL with
+field is evaluated against the battlefield **at cast time**, and — unlike `chooseUpToDynamic` — it
+keeps a floor instead of forcing `0`. Both ends are clamped to `[minChooseCount, modes.size]`. This
+models "Choose one. If [condition] as you cast this spell, you **may** choose two instead."
+(Flame of Anor): pass it via the DSL with
 `modal(chooseCount = 2, minChooseCount = 1, dynamicChooseCount = …) { … }`. Combine a
 `DynamicAmount.Conditional` with a control condition, e.g.
 
@@ -8721,6 +8723,21 @@ modal(
     )
 ) { /* modes */ }
 ```
+
+**…and the mandatory variant.** `dynamicMinChooseCount` is the same thing for the *lower* bound,
+because the printed wording splits. "You **may** choose two instead" leaves the floor at one — set
+`dynamicChooseCount` alone. "Choose both **instead**" does not — set both to the same
+`DynamicAmount`, or the player pays the extra cost and then takes a single mode, which no printed
+card allows. `teamworkModal { }` is the recipe for the Marvel Super Heroes teamwork modals and does
+exactly that, deriving "both" from the modes declared.
+
+> **One authority for the count.** `ModalChooseCounts.forCast` computes the `min..max` range, and
+> both `CastSpellHandler` (validating a submitted cast) and `CastSpellEnumerator` (advertising one)
+> call it. Keep it that way: when the enumerator had its own copy, it drifted — it knew nothing
+> about the blight path or the floor, so it offered counts the handler rejected and dropped
+> variants the handler would have taken. A mode with no legal target can't be chosen (CR 700.2a),
+> so the enumerator drops a variant when fewer than `min` modes are available, unless `allowRepeat`
+> lets one mode fill every pick (CR 700.2d).
 
 **Modal triggered abilities (CR 603.3c / 700.2b).** *Every* modal triggered ability picks its
 mode — and each chosen mode's targets, CR 603.3d — as the ability is put onto the stack, the same

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6310,8 +6310,12 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 >   with `declaredCostSlot` in the context (the durable cast-choices bag doesn't exist until the spell
 >   resolves). The declared cast is enumerated as a `CastSpellModal` variant labelled "(Teamwork N)"
 >   carrying both the modes and the teamwork cost payload, so the client collects modes and then the
->   taps. The advertised `chooseCount` is the printed maximum on both variants; the handler is the
->   authority that narrows it to 1 without the declaration.
+>   taps. Both variants advertise the `chooseCount` this cast can actually reach: `CastSpellEnumerator`
+>   evaluates the same dynamic with the same declaration (none on the plain variant, `TEAMWORK` on the
+>   declared one), so the plain cast is offered as choose-**one**. The handler stays the authority; the
+>   enumeration just no longer offers a mode count it would reject. For the same reason a declared
+>   variant is dropped unless at least that many modes are actually available — "choose both" can't be
+>   satisfied when one mode has no legal target (CR 700.2a).
 > - **Permanent** — an enters-the-battlefield trigger with
 >   `triggerCondition = Conditions.TeamworkWasPaid`; CR 603.4 keeps it off the stack entirely otherwise.
 > - **Teamwork-only clause with its own target** — declare it with `kickerTarget(...)` / `kickerEffect`

--- a/manual-scenarios/sets/msh/loop-msh-u03-new-cards-castable.json
+++ b/manual-scenarios/sets/msh/loop-msh-u03-new-cards-castable.json
@@ -1,0 +1,85 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Widow's Bite",
+      "HULK SMASH!",
+      "Go Nuts!",
+      "Murdock's Crusade",
+      "Atlantis Attacks"
+    ],
+    "battlefield": [
+      { "name": "Plains" },
+      { "name": "Plains" },
+      { "name": "Plains" },
+      { "name": "Plains" },
+      { "name": "Island" },
+      { "name": "Island" },
+      { "name": "Island" },
+      { "name": "Island" },
+      { "name": "Swamp" },
+      { "name": "Swamp" },
+      { "name": "Swamp" },
+      { "name": "Swamp" },
+      { "name": "Mountain" },
+      { "name": "Mountain" },
+      { "name": "Mountain" },
+      { "name": "Mountain" },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Forest" },
+      { "name": "Craw Wurm" },
+      { "name": "Serra Angel" },
+      { "name": "Serra Angel" },
+      { "name": "Hill Giant" },
+      { "name": "Hill Giant" },
+      { "name": "Grizzly Bears" },
+      { "name": "Grizzly Bears" }
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      { "name": "Mountain" },
+      { "name": "Mountain" },
+      { "name": "Mountain" },
+      { "name": "Serra Angel" },
+      { "name": "Craw Wurm" },
+      { "name": "Hill Giant" },
+      { "name": "Grizzly Bears" },
+      { "name": "Wall of Stone" },
+      { "name": "Feldon's Cane" },
+      { "name": "Feldon's Cane" },
+      { "name": "Orcish Oriflamme" },
+      { "name": "Lifeforce" }
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1224,6 +1224,7 @@ class SpellBuilder {
         additionalCostPerExtraMode: com.wingedsheep.sdk.scripting.costs.CostAtom? = null,
         chooseAllIfBlightPaid: Boolean = false,
         dynamicChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null,
+        dynamicMinChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null,
         init: ModalBuilder.() -> Unit
     ) {
         val builder = ModalBuilder(
@@ -1233,7 +1234,8 @@ class SpellBuilder {
             additionalManaCostPerExtraMode,
             additionalCostPerExtraMode,
             chooseAllIfBlightPaid,
-            dynamicChooseCount
+            dynamicChooseCount,
+            dynamicMinChooseCount
         )
         builder.init()
         effect = builder.build()
@@ -1292,7 +1294,8 @@ class ModalBuilder(
     private val additionalManaCostPerExtraMode: String? = null,
     private val additionalCostPerExtraMode: com.wingedsheep.sdk.scripting.costs.CostAtom? = null,
     private val chooseAllIfBlightPaid: Boolean = false,
-    private val dynamicChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null
+    private val dynamicChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null,
+    private val dynamicMinChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null
 ) {
     private val modes: MutableList<Mode> = mutableListOf()
 
@@ -1321,7 +1324,8 @@ class ModalBuilder(
             additionalManaCostPerExtraMode = additionalManaCostPerExtraMode,
             additionalCostPerExtraMode = additionalCostPerExtraMode,
             chooseAllIfBlightPaid = chooseAllIfBlightPaid,
-            dynamicChooseCount = dynamicChooseCount
+            dynamicChooseCount = dynamicChooseCount,
+            dynamicMinChooseCount = dynamicMinChooseCount
         )
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/TeamworkDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/TeamworkDsl.kt
@@ -4,6 +4,8 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Add Teamwork [n] (CR 702.194, Marvel Super Heroes) — "As an additional cost to cast this spell,
@@ -31,10 +33,8 @@ import com.wingedsheep.sdk.scripting.KeywordAbility
  * The card supplies its own payoff; teamwork derives nothing:
  * - A **plain rider** — gate the extra clause on [Conditions.TeamworkWasPaid]
  *   (Helicarrier Strike: "If this spell was cast using teamwork, it deals 4 damage instead").
- * - A **modal "choose both instead"** (CR 700.2 for the mode count, declared per CR 601.2b) — a
- *   `modal { }` block with
- *   `dynamicChooseCount = DynamicAmount.Conditional(Conditions.TeamworkWasPaid, 2, 1)`, so the
- *   teamwork cast picks two modes and the plain cast one.
+ * - A **modal "choose both instead"** (CR 700.2 for the mode count, declared per CR 601.2b) —
+ *   [teamworkModal], which is a `modal { }` block wired for exactly that wording.
  * - A **teamwork-only clause with its own target** (CR 702.194c) — the rail's shared `kickerEffect`
  *   / `kickerTarget` slots in the `spell { }` block, which serve whichever mechanic declared, so
  *   the plain cast is announced as though the clause weren't there.
@@ -47,5 +47,36 @@ fun CardBuilder.teamwork(n: Int) {
             keyword = Keyword.TEAMWORK,
             declaredSlot = ChoiceSlot.TEAMWORK,
         )
+    )
+}
+
+/**
+ * "Choose one. If this spell was cast using teamwork, choose both instead." — the modal payoff
+ * shape, for a spell that also declares [teamwork].
+ *
+ * The plain cast chooses one mode; the declared cast chooses *all* of them, and the "instead"
+ * makes that mandatory rather than an allowance. Both bounds therefore ride the same
+ * [DynamicAmount.Conditional] on [Conditions.TeamworkWasPaid]: a ceiling alone would let a player
+ * tap their team and then take a single mode.
+ *
+ * "Both" is read off the modes actually declared, so a three-mode printing needs no new recipe.
+ * The count is decided at cast time from the declaration this very cast made (CR 601.2b), not from
+ * the battlefield — see [ModalEffect.dynamicChooseCount] for why that needs `declaredCostSlot` in
+ * the evaluation context.
+ */
+fun SpellBuilder.teamworkModal(init: ModalBuilder.() -> Unit) {
+    val builder = ModalBuilder(chooseCount = 1, minChooseCount = 1)
+    builder.init()
+    val base = builder.build()
+    val bothIfTeamwork = DynamicAmount.Conditional(
+        condition = Conditions.TeamworkWasPaid,
+        ifTrue = DynamicAmount.Fixed(base.modes.size),
+        ifFalse = DynamicAmount.Fixed(1),
+    )
+    effect = base.copy(
+        chooseCount = base.modes.size,
+        minChooseCount = 1,
+        dynamicChooseCount = bothIfTeamwork,
+        dynamicMinChooseCount = bothIfTeamwork,
     )
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -167,14 +167,27 @@ data class ModalEffect(
      *   for "choose up to X" where X depends on game state rather than the cast (Riku of Many
      *   Paths — X is the number of modes the triggering modal spell chose). See
      *   [chooseUpToDynamic].
-     * - **Cast-time** (modal *spells*, `CastSpellHandler.effectiveModalChooseCounts`): the
-     *   [minChooseCount] floor is preserved, so the effective range is
-     *   `[minChooseCount, eval.coerceIn(minChooseCount, modes.size)]`. Models "Choose one. If
-     *   [condition] as you cast this spell, you may choose two instead." (Flame of Anor):
-     *   `chooseCount = 2, minChooseCount = 1` with a [DynamicAmount.Conditional] that yields
-     *   2 when the condition holds, else 1.
+     * - **Cast-time** (modal *spells*, `ModalChooseCounts.forCast`): the floor comes from
+     *   [dynamicMinChooseCount] if set and [minChooseCount] otherwise, so the effective range is
+     *   `[floor, eval.coerceIn(floor, modes.size)]`. Models "Choose one. If [condition] as you cast
+     *   this spell, you **may** choose two instead." (Flame of Anor): `chooseCount = 2,
+     *   minChooseCount = 1` with a [DynamicAmount.Conditional] that yields 2 when the condition
+     *   holds, else 1.
      */
     val dynamicChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null,
+    /**
+     * Optional runtime-evaluated *lower* bound, the mandatory sibling of [dynamicChooseCount].
+     * Evaluated the same way, at the same cast-time site, and clamped the same way.
+     *
+     * The two exist because the printed wording splits: "you **may** choose two instead" leaves the
+     * floor at one (Flame of Anor — set [dynamicChooseCount] alone), while "choose both **instead**"
+     * does not (the Marvel Super Heroes teamwork modals — set both to the same [DynamicAmount], as
+     * `teamworkModal { }` does). With only a ceiling, a player who paid the extra cost could still
+     * take a single mode, which no printed card allows.
+     *
+     * Ignored at the resolution-time site, where [minChooseCount] is already treated as 0.
+     */
+    val dynamicMinChooseCount: com.wingedsheep.sdk.scripting.values.DynamicAmount? = null,
     /**
      * "Choose one that hasn't been chosen" (e.g., Gandalf the Grey). When `true`, the
      * engine remembers which modes the *source permanent* has already chosen across the

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AtlantisAttacks.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AtlantisAttacks.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Atlantis Attacks — Marvel Super Heroes #46
+ * {5}{U}{U} · Sorcery · Common
+ *
+ * Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 4 or more.)
+ * Choose one. If this spell was cast using teamwork, choose both instead.
+ * • Target player creates a 6/5 blue Leviathan creature token with hexproof.
+ * • Return one or two target nonland permanents to their owners' hands.
+ *
+ * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
+ * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
+ * was declared.
+ *
+ * "One or two target nonland permanents" is a single requirement with `count = 2, minCount = 1`,
+ * so the two chosen permanents must be different (CR 601.2c) and the bounce runs per surviving
+ * target via [ForEachTargetEffect] — one target becoming illegal does not strand the other.
+ */
+val AtlantisAttacks = card("Atlantis Attacks") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 4 or more.)\n" +
+        "Choose one. If this spell was cast using teamwork, choose both instead.\n" +
+        "• Target player creates a 6/5 blue Leviathan creature token with hexproof.\n" +
+        "• Return one or two target nonland permanents to their owners' hands."
+
+    teamwork(4)
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.TeamworkWasPaid,
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1),
+            ),
+        ) {
+            mode("Target player creates a 6/5 blue Leviathan creature token with hexproof") {
+                val player = target("target player", TargetPlayer())
+                effect = Effects.CreateToken(
+                    power = 6,
+                    toughness = 5,
+                    colors = setOf(Color.BLUE),
+                    creatureTypes = setOf("Leviathan"),
+                    keywords = setOf(Keyword.HEXPROOF),
+                    controller = player,
+                    imageUri = "https://cards.scryfall.io/normal/front/7/1/71211c95-8698-4570-abf7-3579988a329e.jpg?1783902803",
+                )
+            }
+            mode("Return one or two target nonland permanents to their owners' hands") {
+                target(
+                    "one or two target nonland permanents",
+                    TargetObject(count = 2, minCount = 1, filter = TargetFilter.NonlandPermanent),
+                )
+                effect = ForEachTargetEffect(
+                    listOf(Effects.ReturnToHand(EffectTarget.ContextTarget(0))),
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Alexander Skripnikov"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40bc4380-055d-4913-93cb-280c9c1d1a87.jpg?1783902962"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AtlantisAttacks.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AtlantisAttacks.kt
@@ -2,17 +2,16 @@ package com.wingedsheep.mtg.sets.definitions.msh.cards
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.dsl.teamworkModal
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetObject
 import com.wingedsheep.sdk.scripting.targets.TargetPlayer
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Atlantis Attacks — Marvel Super Heroes #46
@@ -24,9 +23,9 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * • Target player creates a 6/5 blue Leviathan creature token with hexproof.
  * • Return one or two target nonland permanents to their owners' hands.
  *
- * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
- * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
- * was declared.
+ * The modal shape of teamwork — [teamworkModal] narrows the printed "choose both" to one mode
+ * unless the teamwork cost was declared. CR 700.2 governs the mode count; the declaration it
+ * branches on is made under CR 601.2b (*not* CR 702.194c, which is about targets).
  *
  * "One or two target nonland permanents" is a single requirement with `count = 2, minCount = 1`,
  * so the two chosen permanents must be different (CR 601.2c), and [ForEachTargetEffect] repeats the
@@ -51,15 +50,7 @@ val AtlantisAttacks = card("Atlantis Attacks") {
     teamwork(4)
 
     spell {
-        modal(
-            chooseCount = 2,
-            minChooseCount = 1,
-            dynamicChooseCount = DynamicAmount.Conditional(
-                condition = Conditions.TeamworkWasPaid,
-                ifTrue = DynamicAmount.Fixed(2),
-                ifFalse = DynamicAmount.Fixed(1),
-            ),
-        ) {
+        teamworkModal {
             mode("Target player creates a 6/5 blue Leviathan creature token with hexproof") {
                 val player = target("target player", TargetPlayer())
                 effect = Effects.CreateToken(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AtlantisAttacks.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/AtlantisAttacks.kt
@@ -29,8 +29,14 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * was declared.
  *
  * "One or two target nonland permanents" is a single requirement with `count = 2, minCount = 1`,
- * so the two chosen permanents must be different (CR 601.2c) and the bounce runs per surviving
- * target via [ForEachTargetEffect] — one target becoming illegal does not strand the other.
+ * so the two chosen permanents must be different (CR 601.2c), and [ForEachTargetEffect] repeats the
+ * bounce once per chosen target.
+ *
+ * Known deviation: if one of the two chosen permanents is illegal on resolution, the engine skips
+ * this whole mode instead of bouncing the still-legal one. CR 608.2b wants the partial effect to
+ * happen; `processPreChosenModeQueue` re-validates each mode all-or-nothing and says so in its own
+ * comment. Pre-existing and engine-wide (`ecl/cards/WanderwineFarewell.kt` has the same exposure),
+ * not specific to this card.
  */
 val AtlantisAttacks = card("Atlantis Attacks") {
     manaCost = "{5}{U}{U}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/GoNuts.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/GoNuts.kt
@@ -22,8 +22,8 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
  * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
  * was declared. Modes resolve in printed order, so a teamwork cast that puts the counter on the
- * same creature that then fights sends the bigger body into the fight (CR 608.2 — the modes are one
- * resolution, applied in order).
+ * same creature that then fights sends the bigger body into the fight (CR 608.2c — the modes are one
+ * resolution, and its controller follows the instructions in the order written).
  */
 val GoNuts = card("Go Nuts!") {
     manaCost = "{G}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/GoNuts.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/GoNuts.kt
@@ -1,13 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.msh.cards
 
 import com.wingedsheep.sdk.core.Counters
-import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.dsl.teamworkModal
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Go Nuts! — Marvel Super Heroes #168
@@ -19,9 +18,11 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * • Put a +1/+1 counter on target creature.
  * • Target creature you control fights target creature an opponent controls.
  *
- * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
- * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
- * was declared. Modes resolve in printed order, so a teamwork cast that puts the counter on the
+ * The modal shape of teamwork — [teamworkModal] narrows the printed "choose both" to one mode
+ * unless the teamwork cost was declared. CR 700.2 governs the mode count; the declaration it
+ * branches on is made under CR 601.2b (*not* CR 702.194c, which is about targets).
+ *
+ * Modes resolve in printed order, so a teamwork cast that puts the counter on the
  * same creature that then fights sends the bigger body into the fight (CR 608.2c — the modes are one
  * resolution, and its controller follows the instructions in the order written).
  */
@@ -38,15 +39,7 @@ val GoNuts = card("Go Nuts!") {
     teamwork(3)
 
     spell {
-        modal(
-            chooseCount = 2,
-            minChooseCount = 1,
-            dynamicChooseCount = DynamicAmount.Conditional(
-                condition = Conditions.TeamworkWasPaid,
-                ifTrue = DynamicAmount.Fixed(2),
-                ifFalse = DynamicAmount.Fixed(1),
-            ),
-        ) {
+        teamworkModal {
             mode("Put a +1/+1 counter on target creature") {
                 val creature = target("target creature", Targets.Creature)
                 effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/GoNuts.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/GoNuts.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Go Nuts! — Marvel Super Heroes #168
+ * {G} · Sorcery · Common
+ *
+ * Teamwork 3 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 3 or more.)
+ * Choose one. If this spell was cast using teamwork, choose both instead.
+ * • Put a +1/+1 counter on target creature.
+ * • Target creature you control fights target creature an opponent controls.
+ *
+ * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
+ * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
+ * was declared. Modes resolve in printed order, so a teamwork cast that puts the counter on the
+ * same creature that then fights sends the bigger body into the fight (CR 608.2 — the modes are one
+ * resolution, applied in order).
+ */
+val GoNuts = card("Go Nuts!") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Teamwork 3 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 3 or more.)\n" +
+        "Choose one. If this spell was cast using teamwork, choose both instead.\n" +
+        "• Put a +1/+1 counter on target creature.\n" +
+        "• Target creature you control fights target creature an opponent controls."
+
+    teamwork(3)
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.TeamworkWasPaid,
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1),
+            ),
+        ) {
+            mode("Put a +1/+1 counter on target creature") {
+                val creature = target("target creature", Targets.Creature)
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            }
+            mode("Target creature you control fights target creature an opponent controls") {
+                val yours = target("target creature you control", Targets.CreatureYouControl)
+                val theirs = target(
+                    "target creature an opponent controls",
+                    Targets.CreatureOpponentControls,
+                )
+                effect = Effects.Fight(yours, theirs)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Ignatius Budi"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/152a7b5b-2d95-45d3-8fd9-0ca1d5a79f8b.jpg?1783902918"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/HulkSmash.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/HulkSmash.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * HULK SMASH! — Marvel Super Heroes #135
+ * {1}{R} · Instant · Common
+ *
+ * Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 4 or more.)
+ * Choose one. If this spell was cast using teamwork, choose both instead.
+ * • Destroy target noncreature artifact.
+ * • Target creature you control deals damage equal to its power to target creature an opponent
+ *   controls.
+ *
+ * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
+ * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
+ * was declared.
+ *
+ * Mode 2 is the Rabid Bite shape — one-sided damage whose source is the attacking creature, so
+ * deathtouch/lifelink on it apply and the victim deals nothing back. Its amount reads *this*
+ * mode's first target ([EntityReference.Target]`(0)` is scoped to the mode's own target list), and
+ * it is read at resolution, so a pump between cast and resolution counts.
+ */
+val HulkSmash = card("HULK SMASH!") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 4 or more.)\n" +
+        "Choose one. If this spell was cast using teamwork, choose both instead.\n" +
+        "• Destroy target noncreature artifact.\n" +
+        "• Target creature you control deals damage equal to its power to target creature an " +
+        "opponent controls."
+
+    teamwork(4)
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.TeamworkWasPaid,
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1),
+            ),
+        ) {
+            mode("Destroy target noncreature artifact") {
+                val artifact = target(
+                    "target noncreature artifact",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact.notCreature())),
+                )
+                effect = Effects.Destroy(artifact)
+            }
+            mode(
+                "Target creature you control deals damage equal to its power to target creature " +
+                    "an opponent controls",
+            ) {
+                val yours = target("target creature you control", Targets.CreatureYouControl)
+                val theirs = target(
+                    "target creature an opponent controls",
+                    Targets.CreatureOpponentControls,
+                )
+                effect = Effects.DealDamage(
+                    amount = DynamicAmount.EntityProperty(
+                        EntityReference.Target(0),
+                        EntityNumericProperty.Power,
+                    ),
+                    target = theirs,
+                    damageSource = yours,
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/374ffb3e-0753-4682-936a-ae6921ace475.jpg?1783902929"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/HulkSmash.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/HulkSmash.kt
@@ -1,10 +1,10 @@
 package com.wingedsheep.mtg.sets.definitions.msh.cards
 
-import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.dsl.teamworkModal
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
@@ -24,9 +24,9 @@ import com.wingedsheep.sdk.scripting.values.EntityReference
  * • Target creature you control deals damage equal to its power to target creature an opponent
  *   controls.
  *
- * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
- * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
- * was declared.
+ * The modal shape of teamwork — [teamworkModal] narrows the printed "choose both" to one mode
+ * unless the teamwork cost was declared. CR 700.2 governs the mode count; the declaration it
+ * branches on is made under CR 601.2b (*not* CR 702.194c, which is about targets).
  *
  * Mode 2 is the Rabid Bite shape — one-sided damage whose source is the attacking creature, so
  * deathtouch/lifelink on it apply and the victim deals nothing back. Its amount reads *this*
@@ -47,15 +47,7 @@ val HulkSmash = card("HULK SMASH!") {
     teamwork(4)
 
     spell {
-        modal(
-            chooseCount = 2,
-            minChooseCount = 1,
-            dynamicChooseCount = DynamicAmount.Conditional(
-                condition = Conditions.TeamworkWasPaid,
-                ifTrue = DynamicAmount.Fixed(2),
-                ifFalse = DynamicAmount.Fixed(1),
-            ),
-        ) {
+        teamworkModal {
             mode("Destroy target noncreature artifact") {
                 val artifact = target(
                     "target noncreature artifact",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/MurdocksCrusade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/MurdocksCrusade.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Murdock's Crusade — Marvel Super Heroes #24
+ * {1}{W} · Sorcery · Common
+ *
+ * Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 4 or more.)
+ * Choose one. If this spell was cast using teamwork, choose both instead.
+ * • Street Justice — Exile target creature with toughness 4 or greater.
+ * • Legal Justice — Exile target enchantment with mana value 4 or greater.
+ *
+ * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
+ * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
+ * was declared. The printed mode names are part of each mode's description, which is what the
+ * client shows on the mode buttons.
+ *
+ * Both restrictions are ordinary target filters — toughness is read from **projected** state, so a
+ * creature pumped to toughness 4 is a legal target and one shrunk below 4 stops being one; mana
+ * value is the enchantment card's own, unaffected by cost reduction.
+ */
+val MurdocksCrusade = card("Murdock's Crusade") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 4 or more.)\n" +
+        "Choose one. If this spell was cast using teamwork, choose both instead.\n" +
+        "• Street Justice — Exile target creature with toughness 4 or greater.\n" +
+        "• Legal Justice — Exile target enchantment with mana value 4 or greater."
+
+    teamwork(4)
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.TeamworkWasPaid,
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1),
+            ),
+        ) {
+            mode("Street Justice — Exile target creature with toughness 4 or greater") {
+                val creature = target(
+                    "target creature with toughness 4 or greater",
+                    TargetCreature(filter = TargetFilter.Creature.toughnessAtLeast(4)),
+                )
+                effect = Effects.Exile(creature)
+            }
+            mode("Legal Justice — Exile target enchantment with mana value 4 or greater") {
+                val enchantment = target(
+                    "target enchantment with mana value 4 or greater",
+                    TargetPermanent(filter = TargetFilter.Enchantment.manaValueAtLeast(4)),
+                )
+                effect = Effects.Exile(enchantment)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Gal Or"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98df64ca-39c3-47e6-8143-4106c8e9cf59.jpg?1783902970"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/MurdocksCrusade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/MurdocksCrusade.kt
@@ -1,14 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.msh.cards
 
-import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.dsl.teamworkModal
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Murdock's Crusade — Marvel Super Heroes #24
@@ -20,10 +19,12 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * • Street Justice — Exile target creature with toughness 4 or greater.
  * • Legal Justice — Exile target enchantment with mana value 4 or greater.
  *
- * The modal shape of teamwork (CR 702.194c): the cast-time [DynamicAmount.Conditional] on
- * [Conditions.TeamworkWasPaid] narrows the printed `chooseCount = 2` to 1 unless the teamwork cost
- * was declared. The printed mode names are part of each mode's description, which is what the
- * client shows on the mode buttons.
+ * The modal shape of teamwork — [teamworkModal] narrows the printed "choose both" to one mode
+ * unless the teamwork cost was declared. CR 700.2 governs the mode count; the declaration it
+ * branches on is made under CR 601.2b (*not* CR 702.194c, which is about targets).
+ *
+ * The printed mode names are part of each mode's description, which is what the client shows on
+ * the mode buttons.
  *
  * Both restrictions are ordinary target filters — toughness is read from **projected** state, so a
  * creature pumped to toughness 4 is a legal target and one shrunk below 4 stops being one; mana
@@ -42,15 +43,7 @@ val MurdocksCrusade = card("Murdock's Crusade") {
     teamwork(4)
 
     spell {
-        modal(
-            chooseCount = 2,
-            minChooseCount = 1,
-            dynamicChooseCount = DynamicAmount.Conditional(
-                condition = Conditions.TeamworkWasPaid,
-                ifTrue = DynamicAmount.Fixed(2),
-                ifFalse = DynamicAmount.Fixed(1),
-            ),
-        ) {
+        teamworkModal {
             mode("Street Justice — Exile target creature with toughness 4 or greater") {
                 val creature = target(
                     "target creature with toughness 4 or greater",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/WidowsBite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/WidowsBite.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Widow's Bite — Marvel Super Heroes #122
+ * {1}{B} · Instant · Common
+ *
+ * Teamwork 3 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 3 or more.)
+ * Choose one. If this spell was cast using teamwork, choose both instead.
+ * • Target creature gains deathtouch until end of turn.
+ * • Target creature gets -2/-2 until end of turn.
+ *
+ * The modal shape of teamwork (CR 702.194c): `chooseCount = 2, minChooseCount = 1` is the printed
+ * maximum and floor, and the cast-time [DynamicAmount.Conditional] on
+ * [Conditions.TeamworkWasPaid] narrows the effective count to exactly 1 without the declaration
+ * and exactly 2 with it. Each mode carries its own "target creature", so the teamwork cast may
+ * point them at two different creatures — or at the same one, since separate mode requirements are
+ * separate instances of the word "target" (CR 601.2c).
+ */
+val WidowsBite = card("Widow's Bite") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Teamwork 3 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 3 or more.)\n" +
+        "Choose one. If this spell was cast using teamwork, choose both instead.\n" +
+        "• Target creature gains deathtouch until end of turn.\n" +
+        "• Target creature gets -2/-2 until end of turn."
+
+    teamwork(3)
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.TeamworkWasPaid,
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1),
+            ),
+        ) {
+            mode("Target creature gains deathtouch until end of turn") {
+                val creature = target("target creature", Targets.Creature)
+                effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, creature)
+            }
+            mode("Target creature gets -2/-2 until end of turn") {
+                val creature = target("target creature", Targets.Creature)
+                effect = Effects.ModifyStats(-2, -2, creature)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Borja Pindado"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbee18af-9ade-4251-81a1-f6e7ffbf480f.jpg?1783902935"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/WidowsBite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/WidowsBite.kt
@@ -1,13 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.msh.cards
 
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.dsl.teamworkModal
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Widow's Bite — Marvel Super Heroes #122
@@ -19,12 +18,13 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * • Target creature gains deathtouch until end of turn.
  * • Target creature gets -2/-2 until end of turn.
  *
- * The modal shape of teamwork (CR 702.194c): `chooseCount = 2, minChooseCount = 1` is the printed
- * maximum and floor, and the cast-time [DynamicAmount.Conditional] on
- * [Conditions.TeamworkWasPaid] narrows the effective count to exactly 1 without the declaration
- * and exactly 2 with it. Each mode carries its own "target creature", so the teamwork cast may
- * point them at two different creatures — or at the same one, since separate mode requirements are
- * separate instances of the word "target" (CR 601.2c).
+ * The modal shape of teamwork — [teamworkModal] pins the effective count to exactly 1 without the
+ * declaration and exactly 2 with it. CR 700.2 governs the mode count; the declaration it branches
+ * on is made under CR 601.2b (*not* CR 702.194c, which is about targets).
+ *
+ * Each mode carries its own "target creature", so the teamwork cast may point them at two
+ * different creatures — or at the same one, since separate mode requirements are separate
+ * instances of the word "target" (CR 601.2c).
  */
 val WidowsBite = card("Widow's Bite") {
     manaCost = "{1}{B}"
@@ -39,15 +39,7 @@ val WidowsBite = card("Widow's Bite") {
     teamwork(3)
 
     spell {
-        modal(
-            chooseCount = 2,
-            minChooseCount = 1,
-            dynamicChooseCount = DynamicAmount.Conditional(
-                condition = Conditions.TeamworkWasPaid,
-                ifTrue = DynamicAmount.Fixed(2),
-                ifFalse = DynamicAmount.Fixed(1),
-            ),
-        ) {
+        teamworkModal {
             mode("Target creature gains deathtouch until end of turn") {
                 val creature = target("target creature", Targets.Creature)
                 effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, creature)

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -1191,6 +1191,21 @@
                     "type": "Fixed",
                     "amount": 1
                 }
+            },
+            "dynamicMinChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
             }
         }
     },
@@ -5176,6 +5191,21 @@
                     "type": "Fixed",
                     "amount": 1
                 }
+            },
+            "dynamicMinChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
             }
         }
     },
@@ -5494,6 +5524,21 @@
             "chooseCount": 2,
             "minChooseCount": 1,
             "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            },
+            "dynamicMinChooseCount": {
                 "type": "Conditional",
                 "condition": {
                     "type": "CastChoiceMade",
@@ -9414,6 +9459,21 @@
             "chooseCount": 2,
             "minChooseCount": 1,
             "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            },
+            "dynamicMinChooseCount": {
                 "type": "Conditional",
                 "condition": {
                     "type": "CastChoiceMade",
@@ -17833,6 +17893,21 @@
             "chooseCount": 2,
             "minChooseCount": 1,
             "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            },
+            "dynamicMinChooseCount": {
                 "type": "Conditional",
                 "condition": {
                     "type": "CastChoiceMade",

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -1087,6 +1087,123 @@
     ]
 }
 
+// Atlantis Attacks
+{
+    "name": "Atlantis Attacks",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Target player creates a 6/5 blue Leviathan creature token with hexproof.\n• Return one or two target nonland permanents to their owners' hands.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 4
+                }
+            },
+            "displayPrefix": "Teamwork 4",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 6,
+                        "toughness": 5,
+                        "colors": [
+                            "BLUE"
+                        ],
+                        "creatureTypes": [
+                            "Leviathan"
+                        ],
+                        "keywords": [
+                            "HEXPROOF"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71211c95-8698-4570-abf7-3579988a329e.jpg?1783902803",
+                        "controller": {
+                            "type": "BoundVariable",
+                            "name": "target player"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target player"
+                        }
+                    ],
+                    "description": "Target player creates a 6/5 blue Leviathan creature token with hexproof"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Hand"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "count": 2,
+                            "minCount": 1,
+                            "filter": {
+                                "baseFilter": "nonland permanent"
+                            },
+                            "id": "one or two target nonland permanents"
+                        }
+                    ],
+                    "description": "Return one or two target nonland permanents to their owners' hands"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Alexander Skripnikov",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40bc4380-055d-4913-93cb-280c9c1d1a87.jpg?1783902962"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Attuma, Atlantean Warlord
 {
     "name": "Attuma, Atlantean Warlord",
@@ -4958,6 +5075,120 @@
     ]
 }
 
+// Go Nuts!
+{
+    "name": "Go Nuts!",
+    "manaCost": "{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Teamwork 3 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 3 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Put a +1/+1 counter on target creature.\n• Target creature you control fights target creature an opponent controls.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 3
+                }
+            },
+            "displayPrefix": "Teamwork 3",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target creature"
+                        }
+                    ],
+                    "description": "Put a +1/+1 counter on target creature"
+                },
+                {
+                    "effect": {
+                        "type": "Fight",
+                        "target1": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        },
+                        "target2": {
+                            "type": "BoundVariable",
+                            "name": "target creature an opponent controls"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        },
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            },
+                            "id": "target creature an opponent controls"
+                        }
+                    ],
+                    "description": "Target creature you control fights target creature an opponent controls"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Ignatius Budi",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/152a7b5b-2d95-45d3-8fd9-0ca1d5a79f8b.jpg?1783902918"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Grim Reaper, Lethal Legionnaire
 {
     "name": "Grim Reaper, Lethal Legionnaire",
@@ -5160,6 +5391,133 @@
         "imageUri": "https://cards.scryfall.io/normal/front/3/4/3496d0d4-3fab-4ea4-8986-afe5a7155ec6.jpg?1783902891"
     },
     "colorIdentityOverride": []
+}
+
+// HULK SMASH!
+{
+    "name": "HULK SMASH!",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Destroy target noncreature artifact.\n• Target creature you control deals damage equal to its power to target creature an opponent controls.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 4
+                }
+            },
+            "displayPrefix": "Teamwork 4",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target noncreature artifact"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsArtifact",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsCreature"
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "target noncreature artifact"
+                        }
+                    ],
+                    "description": "Destroy target noncreature artifact"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Power"
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature an opponent controls"
+                        },
+                        "damageSource": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        },
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            },
+                            "id": "target creature an opponent controls"
+                        }
+                    ],
+                    "description": "Target creature you control deals damage equal to its power to target creature an opponent controls"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Chris Rahn",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/374ffb3e-0753-4682-936a-ae6921ace475.jpg?1783902929"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // HYDRA Assault Robot
@@ -8976,6 +9334,109 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Murdock's Crusade
+{
+    "name": "Murdock's Crusade",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Street Justice — Exile target creature with toughness 4 or greater.\n• Legal Justice — Exile target enchantment with mana value 4 or greater.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 4
+                }
+            },
+            "displayPrefix": "Teamwork 4",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature with toughness 4 or greater"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature tou>=4"
+                            },
+                            "id": "target creature with toughness 4 or greater"
+                        }
+                    ],
+                    "description": "Street Justice — Exile target creature with toughness 4 or greater"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target enchantment with mana value 4 or greater"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment mv>=4"
+                            },
+                            "id": "target enchantment with mana value 4 or greater"
+                        }
+                    ],
+                    "description": "Legal Justice — Exile target enchantment with mana value 4 or greater"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Gal Or",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98df64ca-39c3-47e6-8143-4106c8e9cf59.jpg?1783902970"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -17285,6 +17746,116 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Widow's Bite
+{
+    "name": "Widow's Bite",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Teamwork 3 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 3 or more.)\nChoose one. If this spell was cast using teamwork, choose both instead.\n• Target creature gains deathtouch until end of turn.\n• Target creature gets -2/-2 until end of turn.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 3
+                }
+            },
+            "displayPrefix": "Teamwork 3",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "DEATHTOUCH",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target creature"
+                        }
+                    ],
+                    "description": "Target creature gains deathtouch until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target creature"
+                        }
+                    ],
+                    "description": "Target creature gets -2/-2 until end of turn"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "TEAMWORK"
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Borja Pindado",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbee18af-9ade-4251-81a1-f6e7ffbf480f.jpg?1783902935"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -26,6 +26,7 @@ import com.wingedsheep.engine.mechanics.EmergeCasts
 import com.wingedsheep.engine.mechanics.SpliceCasts
 import com.wingedsheep.engine.mechanics.EscalateCosts
 import com.wingedsheep.engine.mechanics.FlashbackGrants
+import com.wingedsheep.engine.mechanics.ModalChooseCounts
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.mechanics.MayhemGrants
 import com.wingedsheep.engine.mechanics.SneakWindow
@@ -1540,53 +1541,26 @@ class CastSpellHandler(
     }
 
     /**
-     * Compute the effective `[minChooseCount, chooseCount]` range for a modal spell,
-     * accounting for `ModalEffect.chooseAllIfBlightPaid` and `ModalEffect.dynamicChooseCount`.
+     * The effective `[min, max]` range of mode counts this cast may choose.
      *
-     * - `chooseAllIfBlightPaid`: when the flag is set and the player paid the spell's optional
-     *   `BlightOrPay` cost via blight, the player must choose all modes; otherwise the regular
-     *   range applies.
-     * - `dynamicChooseCount`: evaluated against cast-time battlefield state to produce the upper
-     *   bound (clamped to `[minChooseCount, modes.size]`). Models the printed "Choose one. If you
-     *   control a Wizard as you cast this spell, you may choose two instead." pattern (Flame of
-     *   Anor) — `minChooseCount` stays the mandatory floor, unlike the resolution-time
-     *   `chooseUpToDynamic` shape which always allows declining to 0.
-     *
-     * The evaluation context carries the *declaration being cast* ([CastSpell.declaredCostSlot]),
-     * because a mode count may branch on the optional additional cost this very cast declared —
-     * "Choose one. If this spell was cast using teamwork, choose both instead" (CR 702.194b).
-     * `Conditions.TeamworkWasPaid` / `CastChoiceMade` answers from that field while the card is
-     * still in hand; the durable `CastChoicesComponent` it otherwise reads only exists once the
-     * spell has resolved, so without this the teamwork branch could never be taken.
+     * Delegates to [ModalChooseCounts], the authority the legal-action enumerator also uses, so an
+     * advertised cast and a validated one can't disagree.
      */
     private fun effectiveModalChooseCounts(
         state: GameState,
         modalEffect: ModalEffect,
         action: CastSpell
     ): Pair<Int, Int> {
-        if (modalEffect.chooseAllIfBlightPaid) {
-            val blightPaid = action.additionalCostPayment?.blightTargets?.isNotEmpty() == true
-            return if (blightPaid) {
-                modalEffect.modes.size to modalEffect.modes.size
-            } else {
-                modalEffect.minChooseCount to modalEffect.minChooseCount
-            }
-        }
-        val dynamic = modalEffect.dynamicChooseCount
-        if (dynamic != null) {
-            val context = EffectContext(
-                sourceId = action.cardId,
-                controllerId = action.playerId,
-                targets = emptyList(),
-                xValue = 0,
-                declaredCostSlot = action.declaredCostSlot
-            )
-            val evaluated = DynamicAmountEvaluator(conditionEvaluator = conditionEvaluator)
-                .evaluate(state, dynamic, context)
-            val max = evaluated.coerceIn(modalEffect.minChooseCount, modalEffect.modes.size)
-            return modalEffect.minChooseCount to max
-        }
-        return modalEffect.minChooseCount to modalEffect.chooseCount
+        val range = ModalChooseCounts.forCast(
+            state = state,
+            modalEffect = modalEffect,
+            cardId = action.cardId,
+            controllerId = action.playerId,
+            declaredCostSlot = action.declaredCostSlot,
+            blightPaid = action.additionalCostPayment?.blightTargets?.isNotEmpty() == true,
+            conditionEvaluator = conditionEvaluator
+        )
+        return range.first to range.last
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -20,6 +20,8 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
@@ -994,8 +996,15 @@ class CastSpellEnumerator : ActionEnumerator {
                     val escalatePayability = EscalateCosts.payability(
                         state, playerId, cardId, variantEffect, context.costUtils, context.predicateEvaluator
                     )
-                    val effectiveChooseCount = if (escalatePayability == null) variantEffect.chooseCount
-                        else minOf(variantEffect.chooseCount, 1 + escalatePayability.maxExtraModes)
+                    // The printed maximum, narrowed by whatever the *undeclared* cast can actually
+                    // reach: a cast-time `dynamicChooseCount` gated on a declaration that wasn't
+                    // made ("...choose both instead" with no teamwork) yields 1 here, matching what
+                    // `CastSpellHandler.effectiveModalChooseCounts` will enforce on the submit.
+                    val dynamicMax = effectiveModalMaxChooseCount(
+                        context, variantEffect, cardId, playerId, declaredCostSlot = null
+                    )
+                    val effectiveChooseCount = if (escalatePayability == null) dynamicMax
+                        else minOf(dynamicMax, 1 + escalatePayability.maxExtraModes)
 
                     // If every mode is unavailable, the spell can't legally be cast —
                     // drop the action entirely rather than offering an unplayable UI.
@@ -2123,10 +2132,10 @@ class CastSpellEnumerator : ActionEnumerator {
                 // declaration and this branch's cost info; the client collects modes and then the
                 // teamwork payment, exactly as it already does for the blight-path modal variant.
                 //
-                // The advertised `chooseCount` is the printed maximum, as on the undeclared path;
-                // `CastSpellHandler.effectiveModalChooseCounts` is the authority that narrows it
-                // per declaration (1 without teamwork, 2 with), the same split Flame of Anor and
-                // Molten Collapse already rely on.
+                // The advertised `chooseCount` is the printed maximum narrowed for *this*
+                // declaration by [effectiveModalMaxChooseCount] (1 without teamwork, 2 with), so
+                // it agrees with `CastSpellHandler.effectiveModalChooseCounts` — which stays the
+                // authority — the same split Flame of Anor and Molten Collapse already rely on.
                 val kickerModalEffect = kickerSpellEffect as? ModalEffect
                 if (kickerModalEffect != null) {
                     val kickerModeEnumerations = kickerModalEffect.modes.mapIndexed { modeIndex, mode ->
@@ -2143,7 +2152,22 @@ class CastSpellEnumerator : ActionEnumerator {
                             cachedSources = context.availableManaSources
                         )
                     }
-                    if (kickerModeEnumerations.none { it.available }) continue
+                    // The declaration is what raises the mode count, so evaluate the dynamic with
+                    // *this* slot in context — teamwork declared yields the printed "choose both".
+                    val kickerChooseCount = effectiveModalMaxChooseCount(
+                        context, kickerModalEffect, cardId, playerId, declaredCostSlot = declaredSlot
+                    )
+                    // A mode with no legal target can't be chosen (CR 700.2a), and the modes a
+                    // declared cast must choose are fixed by the declaration — "choose both
+                    // instead" is not optional. So the declared variant is only castable when at
+                    // least that many modes are actually available; offering it with fewer (the
+                    // old gate only dropped it when *every* mode was unavailable) advertises a
+                    // cast that can never be completed — Murdock's Crusade's teamwork variant with
+                    // no mana-value-4 enchantment on the battlefield. `allowRepeat` is exempt: one
+                    // available mode can legally fill every pick (CR 700.2d).
+                    val availableModeCount = kickerModeEnumerations.count { it.available }
+                    val requiredModeCount = if (kickerModalEffect.allowRepeat) 1 else kickerChooseCount
+                    if (availableModeCount < requiredModeCount) continue
                     result.add(LegalAction(
                         actionType = "CastSpellModal",
                         description = "Cast ${cardComponent.name} ($kickLabel)",
@@ -2155,8 +2179,8 @@ class CastSpellEnumerator : ActionEnumerator {
                         hasXCost = kickedHasXCost,
                         maxAffordableX = kickedMaxAffordableX,
                         modalEnumeration = ModalLegalEnumeration(
-                            chooseCount = kickerModalEffect.chooseCount,
-                            minChooseCount = kickerModalEffect.minChooseCount,
+                            chooseCount = kickerChooseCount,
+                            minChooseCount = minOf(kickerModalEffect.minChooseCount, kickerChooseCount),
                             allowRepeat = kickerModalEffect.allowRepeat,
                             modes = kickerModeEnumerations.map { modeEnum ->
                                 ModalEnumerationMode(
@@ -2541,6 +2565,45 @@ class CastSpellEnumerator : ActionEnumerator {
         val autoTapPreview: List<EntityId>?,
         val descriptionSuffix: String
     )
+
+    /**
+     * The maximum number of modes the cast handler will actually accept for this modal spell
+     * under the declaration [declaredCostSlot] (null for a plain, undeclared cast).
+     *
+     * Mirrors the dynamic branch of `CastSpellHandler.effectiveModalChooseCounts`, including its
+     * evaluation context: [ModalEffect.dynamicChooseCount] may branch on the optional additional
+     * cost *this cast* declares — "Choose one. If this spell was cast using teamwork, choose both
+     * instead" (CR 702.194b) — so the slot has to be in the context or the condition answers as
+     * though nothing was declared.
+     *
+     * Enumerating without this made the plain cast of every such card advertise the printed
+     * maximum (2) while the handler enforced 1, so the client offered a two-mode selection the
+     * server then rejected with "Too many modes chosen".
+     *
+     * [ModalEffect.chooseAllIfBlightPaid] is deliberately not handled here: the blight path is
+     * declared through `additionalCostPayment` at submit time rather than through a
+     * [ChoiceSlot], and the enumerator already surfaces it as its own pre-narrowed
+     * [ModalCastVariant].
+     */
+    private fun effectiveModalMaxChooseCount(
+        context: EnumerationContext,
+        modalEffect: ModalEffect,
+        cardId: EntityId,
+        playerId: EntityId,
+        declaredCostSlot: ChoiceSlot?
+    ): Int {
+        val dynamic = modalEffect.dynamicChooseCount ?: return modalEffect.chooseCount
+        val effectContext = EffectContext(
+            sourceId = cardId,
+            controllerId = playerId,
+            targets = emptyList(),
+            xValue = 0,
+            declaredCostSlot = declaredCostSlot
+        )
+        val evaluated = DynamicAmountEvaluator(conditionEvaluator = context.conditionEvaluator)
+            .evaluate(context.state, dynamic, effectContext)
+        return evaluated.coerceIn(modalEffect.minChooseCount, modalEffect.modes.size)
+    }
 
     private data class ModeEnumeration(
         val modeIndex: Int,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -13,6 +13,7 @@ import com.wingedsheep.engine.legalactions.TargetInfo
 import com.wingedsheep.engine.legalactions.utils.SelectionCostPresentation
 import com.wingedsheep.engine.mechanics.cost.VariablePermanentsCost
 import com.wingedsheep.engine.mechanics.EscalateCosts
+import com.wingedsheep.engine.mechanics.ModalChooseCounts
 import com.wingedsheep.engine.mechanics.ModalDfcCasts
 import com.wingedsheep.engine.mechanics.SpliceCasts
 import com.wingedsheep.engine.state.ZoneKey
@@ -20,8 +21,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
-import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
-import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
@@ -996,20 +995,22 @@ class CastSpellEnumerator : ActionEnumerator {
                     val escalatePayability = EscalateCosts.payability(
                         state, playerId, cardId, variantEffect, context.costUtils, context.predicateEvaluator
                     )
-                    // The printed maximum, narrowed by whatever the *undeclared* cast can actually
-                    // reach: a cast-time `dynamicChooseCount` gated on a declaration that wasn't
-                    // made ("...choose both instead" with no teamwork) yields 1 here, matching what
-                    // `CastSpellHandler.effectiveModalChooseCounts` will enforce on the submit.
-                    val dynamicMax = effectiveModalMaxChooseCount(
+                    // What the *undeclared* cast can actually reach: a cast-time count gated on a
+                    // declaration that wasn't made ("...choose both instead" with no teamwork)
+                    // yields 1..1 here, which is what the handler will enforce on the submit.
+                    val plainCounts = effectiveModalChooseCounts(
                         context, variantEffect, cardId, playerId, declaredCostSlot = null
                     )
-                    val effectiveChooseCount = if (escalatePayability == null) dynamicMax
-                        else minOf(dynamicMax, 1 + escalatePayability.maxExtraModes)
+                    val effectiveChooseCount = if (escalatePayability == null) plainCounts.last
+                        else minOf(plainCounts.last, 1 + escalatePayability.maxExtraModes)
+                    val effectiveMinChooseCount = minOf(plainCounts.first, effectiveChooseCount)
 
-                    // If every mode is unavailable, the spell can't legally be cast —
-                    // drop the action entirely rather than offering an unplayable UI.
-                    val hasAnyAvailable = enumerationModes.any { it.available }
-                    if (hasAnyAvailable) {
+                    // A mode with no legal target can't be chosen (CR 700.2a), so the cast is only
+                    // offerable when enough modes are available to satisfy the floor. `allowRepeat`
+                    // is exempt: one available mode can legally fill every pick (CR 700.2d).
+                    val availableModeCount = enumerationModes.count { it.available }
+                    val requiredModeCount = if (variantEffect.allowRepeat) 1 else effectiveMinChooseCount
+                    if (availableModeCount >= requiredModeCount && availableModeCount > 0) {
                         result.add(LegalAction(
                             actionType = "CastSpellModal",
                             description = "Cast ${cardComponent.name}${variant.descriptionSuffix}",
@@ -1026,7 +1027,7 @@ class CastSpellEnumerator : ActionEnumerator {
                             autoTapPreview = variant.autoTapPreview,
                             modalEnumeration = ModalLegalEnumeration(
                                 chooseCount = effectiveChooseCount,
-                                minChooseCount = minOf(variantEffect.minChooseCount, effectiveChooseCount),
+                                minChooseCount = effectiveMinChooseCount,
                                 allowRepeat = variantEffect.allowRepeat,
                                 additionalManaCostPerExtraMode = variantEffect.additionalManaCostPerExtraMode,
                                 additionalCostPerExtraMode = escalatePayability?.costData,
@@ -2132,10 +2133,9 @@ class CastSpellEnumerator : ActionEnumerator {
                 // declaration and this branch's cost info; the client collects modes and then the
                 // teamwork payment, exactly as it already does for the blight-path modal variant.
                 //
-                // The advertised `chooseCount` is the printed maximum narrowed for *this*
-                // declaration by [effectiveModalMaxChooseCount] (1 without teamwork, 2 with), so
-                // it agrees with `CastSpellHandler.effectiveModalChooseCounts` — which stays the
-                // authority — the same split Flame of Anor and Molten Collapse already rely on.
+                // The advertised range is what [ModalChooseCounts] says *this* declaration reaches
+                // (1..1 without teamwork, 2..2 with), the same authority the cast handler
+                // validates against — so the client is never offered a count the server rejects.
                 val kickerModalEffect = kickerSpellEffect as? ModalEffect
                 if (kickerModalEffect != null) {
                     val kickerModeEnumerations = kickerModalEffect.modes.mapIndexed { modeIndex, mode ->
@@ -2152,22 +2152,22 @@ class CastSpellEnumerator : ActionEnumerator {
                             cachedSources = context.availableManaSources
                         )
                     }
-                    // The declaration is what raises the mode count, so evaluate the dynamic with
-                    // *this* slot in context — teamwork declared yields the printed "choose both".
-                    val kickerChooseCount = effectiveModalMaxChooseCount(
+                    // The declaration is what moves the mode count, so evaluate it with *this* slot
+                    // in context — teamwork declared yields the printed "choose both", on both ends
+                    // of the range, because "instead" makes it mandatory rather than an allowance.
+                    val kickerCounts = effectiveModalChooseCounts(
                         context, kickerModalEffect, cardId, playerId, declaredCostSlot = declaredSlot
                     )
-                    // A mode with no legal target can't be chosen (CR 700.2a), and the modes a
-                    // declared cast must choose are fixed by the declaration — "choose both
-                    // instead" is not optional. So the declared variant is only castable when at
-                    // least that many modes are actually available; offering it with fewer (the
-                    // old gate only dropped it when *every* mode was unavailable) advertises a
-                    // cast that can never be completed — Murdock's Crusade's teamwork variant with
-                    // no mana-value-4 enchantment on the battlefield. `allowRepeat` is exempt: one
-                    // available mode can legally fill every pick (CR 700.2d).
+                    // A mode with no legal target can't be chosen (CR 700.2a), so the declared
+                    // variant is only castable when enough modes are available to satisfy the
+                    // floor; offering it with fewer (the old gate only dropped it when *every* mode
+                    // was unavailable) advertises a cast that can never be completed — Murdock's
+                    // Crusade's teamwork variant with no mana-value-4 enchantment on the
+                    // battlefield. `allowRepeat` is exempt: one available mode can legally fill
+                    // every pick (CR 700.2d).
                     val availableModeCount = kickerModeEnumerations.count { it.available }
-                    val requiredModeCount = if (kickerModalEffect.allowRepeat) 1 else kickerChooseCount
-                    if (availableModeCount < requiredModeCount) continue
+                    val requiredModeCount = if (kickerModalEffect.allowRepeat) 1 else kickerCounts.first
+                    if (availableModeCount < requiredModeCount || availableModeCount == 0) continue
                     result.add(LegalAction(
                         actionType = "CastSpellModal",
                         description = "Cast ${cardComponent.name} ($kickLabel)",
@@ -2179,8 +2179,8 @@ class CastSpellEnumerator : ActionEnumerator {
                         hasXCost = kickedHasXCost,
                         maxAffordableX = kickedMaxAffordableX,
                         modalEnumeration = ModalLegalEnumeration(
-                            chooseCount = kickerChooseCount,
-                            minChooseCount = minOf(kickerModalEffect.minChooseCount, kickerChooseCount),
+                            chooseCount = kickerCounts.last,
+                            minChooseCount = kickerCounts.first,
                             allowRepeat = kickerModalEffect.allowRepeat,
                             modes = kickerModeEnumerations.map { modeEnum ->
                                 ModalEnumerationMode(
@@ -2567,43 +2567,30 @@ class CastSpellEnumerator : ActionEnumerator {
     )
 
     /**
-     * The maximum number of modes the cast handler will actually accept for this modal spell
-     * under the declaration [declaredCostSlot] (null for a plain, undeclared cast).
+     * The mode counts the cast handler will accept for this modal spell under the declaration
+     * [declaredCostSlot] (null for a plain, undeclared cast).
      *
-     * Mirrors the dynamic branch of `CastSpellHandler.effectiveModalChooseCounts`, including its
-     * evaluation context: [ModalEffect.dynamicChooseCount] may branch on the optional additional
-     * cost *this cast* declares — "Choose one. If this spell was cast using teamwork, choose both
-     * instead" (CR 702.194b) — so the slot has to be in the context or the condition answers as
-     * though nothing was declared.
-     *
-     * Enumerating without this made the plain cast of every such card advertise the printed
-     * maximum (2) while the handler enforced 1, so the client offered a two-mode selection the
-     * server then rejected with "Too many modes chosen".
-     *
-     * [ModalEffect.chooseAllIfBlightPaid] is deliberately not handled here: the blight path is
-     * declared through `additionalCostPayment` at submit time rather than through a
-     * [ChoiceSlot], and the enumerator already surfaces it as its own pre-narrowed
+     * Thin wrapper over [ModalChooseCounts] — the same authority `CastSpellHandler` validates
+     * against — so an advertised cast is one the handler would take. `blightPaid` is always false
+     * here: the blight path is declared through `additionalCostPayment` at submit time rather than
+     * through a [ChoiceSlot], and the enumerator already surfaces it as its own pre-narrowed
      * [ModalCastVariant].
      */
-    private fun effectiveModalMaxChooseCount(
+    private fun effectiveModalChooseCounts(
         context: EnumerationContext,
         modalEffect: ModalEffect,
         cardId: EntityId,
         playerId: EntityId,
         declaredCostSlot: ChoiceSlot?
-    ): Int {
-        val dynamic = modalEffect.dynamicChooseCount ?: return modalEffect.chooseCount
-        val effectContext = EffectContext(
-            sourceId = cardId,
-            controllerId = playerId,
-            targets = emptyList(),
-            xValue = 0,
-            declaredCostSlot = declaredCostSlot
-        )
-        val evaluated = DynamicAmountEvaluator(conditionEvaluator = context.conditionEvaluator)
-            .evaluate(context.state, dynamic, effectContext)
-        return evaluated.coerceIn(modalEffect.minChooseCount, modalEffect.modes.size)
-    }
+    ): IntRange = ModalChooseCounts.forCast(
+        state = context.state,
+        modalEffect = modalEffect,
+        cardId = cardId,
+        controllerId = playerId,
+        declaredCostSlot = declaredCostSlot,
+        blightPaid = false,
+        conditionEvaluator = context.conditionEvaluator
+    )
 
     private data class ModeEnumeration(
         val modeIndex: Int,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ModalChooseCounts.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ModalChooseCounts.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+
+/**
+ * How many modes a *cast* of a modal spell may and must choose (CR 700.2a, CR 700.2d).
+ *
+ * The single authority for the question, shared by the two places that ask it: `CastSpellHandler`
+ * validating a submitted cast, and `CastSpellEnumerator` advertising one. They used to compute it
+ * separately and had already drifted — the enumerator knew nothing about the blight path and
+ * nothing about the floor, so it offered mode counts the handler rejected and dropped variants the
+ * handler would have taken.
+ *
+ * Three shapes, in precedence order:
+ *
+ * - [ModalEffect.chooseAllIfBlightPaid] — all modes when the spell's `BlightOrPay` cost went down
+ *   the blight path, the printed floor otherwise (Pyrrhic Strike).
+ * - [ModalEffect.dynamicChooseCount] / [ModalEffect.dynamicMinChooseCount] — evaluated against
+ *   cast-time state. The ceiling alone is "you *may* choose two instead" (Flame of Anor); both
+ *   together are "choose both **instead**" (the teamwork modals), which is mandatory.
+ * - Neither — the printed `[minChooseCount, chooseCount]`.
+ *
+ * The evaluation context carries [declaredCostSlot], the declaration *this cast* is making, because
+ * a count may branch on it: `Conditions.TeamworkWasPaid` has to answer while the card is still in
+ * hand, and the durable `CastChoicesComponent` it otherwise reads only exists once the spell has
+ * resolved (CR 601.2b).
+ */
+object ModalChooseCounts {
+
+    /**
+     * The inclusive `min..max` range of mode counts this cast may choose. Both ends are clamped to
+     * `[minChooseCount, modes.size]`, and `min` never exceeds `max`.
+     */
+    fun forCast(
+        state: GameState,
+        modalEffect: ModalEffect,
+        cardId: EntityId,
+        controllerId: EntityId,
+        declaredCostSlot: ChoiceSlot?,
+        blightPaid: Boolean,
+        conditionEvaluator: ConditionEvaluator
+    ): IntRange {
+        if (modalEffect.chooseAllIfBlightPaid) {
+            return if (blightPaid) {
+                modalEffect.modes.size..modalEffect.modes.size
+            } else {
+                modalEffect.minChooseCount..modalEffect.minChooseCount
+            }
+        }
+
+        val dynamicMax = modalEffect.dynamicChooseCount
+        if (dynamicMax == null) {
+            return modalEffect.minChooseCount..modalEffect.chooseCount
+        }
+
+        val context = EffectContext(
+            sourceId = cardId,
+            controllerId = controllerId,
+            targets = emptyList(),
+            xValue = 0,
+            declaredCostSlot = declaredCostSlot
+        )
+        val evaluator = DynamicAmountEvaluator(conditionEvaluator = conditionEvaluator)
+        fun evaluate(amount: com.wingedsheep.sdk.scripting.values.DynamicAmount) =
+            evaluator.evaluate(state, amount, context)
+                .coerceIn(modalEffect.minChooseCount, modalEffect.modes.size)
+
+        val max = evaluate(dynamicMax)
+        val min = modalEffect.dynamicMinChooseCount?.let { evaluate(it) } ?: modalEffect.minChooseCount
+        return minOf(min, max)..max
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/CastSpellEnumeratorTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/CastSpellEnumeratorTest.kt
@@ -462,10 +462,15 @@ class CastSpellEnumeratorTest : FunSpec({
         enumeration.unavailableIndices.size shouldBe 2
     }
 
-    test("choose-N modal spell is dropped entirely when every mode is unavailable") {
-        // No creatures anywhere, no Kithkin. Mode 1 (target player) still works,
-        // but let's construct a case where the spell still surfaces since
-        // mode 1 has no prerequisites — so just verify mode 1 remains available.
+    test("choose-N modal spell is dropped when fewer modes are available than it must choose") {
+        // Brigid's Command is "Choose two —", so `minChooseCount` is 2 and repeats are not
+        // allowed. With no creatures and no Kithkin anywhere, only mode 1 (target player) has a
+        // legal target; a mode that would be illegal can't be chosen (CR 700.2a), so there is no
+        // legal pair to announce and the cast can't be proposed at all (CR 601.2). Wizards' own
+        // Cryptic Command ruling states the same: "You must choose two different modes."
+        //
+        // The gate is the effective *minimum*, not the maximum: a "choose one or both" spell in
+        // this position is still castable for its one available mode.
         val driver = setupP1(
             hand = listOf("Brigid's Command"),
             battlefield = listOf("Forest", "Plains", "Forest"),
@@ -474,13 +479,7 @@ class CastSpellEnumeratorTest : FunSpec({
 
         val casts = driver.enumerateFor(driver.player1).castActionsFor("Brigid's Command")
 
-        casts shouldHaveSize 1
-        val enumeration = casts.single().modalEnumeration.shouldNotBeNull()
-        // Player target stays available; everything else requires a creature we don't control or a Kithkin or an opponent creature.
-        enumeration.modes[1].available shouldBe true
-        enumeration.unavailableIndices shouldContain 0
-        enumeration.unavailableIndices shouldContain 2
-        enumeration.unavailableIndices shouldContain 3
+        casts.shouldBeEmpty()
     }
 
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AtlantisAttacksScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AtlantisAttacksScenarioTest.kt
@@ -163,6 +163,44 @@ class AtlantisAttacksScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("choosing one mode with teamwork declared is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Atlantis Attacks")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Atlantis Attacks").first()
+
+                // "Choose both instead" is not an allowance — a cast that declared teamwork owes
+                // both modes, so a one-mode submission is illegal (CR 601.2, 700.2a).
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Player(game.player1Id)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(game.player1Id))),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(wurm),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+
+                withClue("the rejected cast is rewound whole — no token was created") {
+                    game.isInHand(1, "Atlantis Attacks") shouldBe true
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+                    game.findPermanent("Leviathan Token") shouldBe null
+                }
+            }
+
             test("choosing both modes without teamwork is rejected") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AtlantisAttacksScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AtlantisAttacksScenarioTest.kt
@@ -118,6 +118,51 @@ class AtlantisAttacksScenarioTest : ScenarioTestBase() {
                 game.isInHand(2, "Sol Ring") shouldBe true
             }
 
+            test("the bounce mode accepts a single target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Atlantis Attacks")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Atlantis Attacks").first()
+
+                // "One or two target nonland permanents" — `minCount = 1`, so one is enough.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Player(game.player1Id),
+                            ChosenTarget.Permanent(bears),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Player(game.player1Id)),
+                            listOf(ChosenTarget.Permanent(bears)),
+                        ),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(wurm),
+                        ),
+                    ),
+                ).error shouldBe null
+
+                game.resolveStack()
+
+                game.isInHand(2, "Grizzly Bears") shouldBe true
+                withClue("only one target was chosen, so the second permanent stays put") {
+                    game.isOnBattlefield("Sol Ring") shouldBe true
+                }
+            }
+
             test("choosing both modes without teamwork is rejected") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AtlantisAttacksScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AtlantisAttacksScenarioTest.kt
@@ -1,0 +1,157 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Atlantis Attacks (MSH #46) — {5}{U}{U} Sorcery.
+ *
+ *   Teamwork 4
+ *   Choose one. If this spell was cast using teamwork, choose both instead.
+ *   • Target player creates a 6/5 blue Leviathan creature token with hexproof.
+ *   • Return one or two target nonland permanents to their owners' hands.
+ *
+ * The bounce mode is a single "one or two target" requirement, so the teamwork case takes both an
+ * opposing creature and an opposing artifact in one mode.
+ */
+class AtlantisAttacksScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Atlantis Attacks") {
+
+            test("cast without teamwork resolves only the one chosen mode") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Atlantis Attacks")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Atlantis Attacks").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Player(game.player1Id)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(game.player1Id))),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                val token = game.findPermanent("Leviathan Token").shouldNotBeNull()
+                game.state.projectedState.getPower(token) shouldBe 6
+                game.state.projectedState.getToughness(token) shouldBe 5
+                game.state.projectedState.hasKeyword(token, Keyword.HEXPROOF) shouldBe true
+
+                withClue("the bounce mode was not chosen, so the board is untouched") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Sol Ring") shouldBe true
+                }
+                withClue("no teamwork was declared, so nothing tapped") {
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("cast using teamwork resolves both modes and bounces two permanents") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Atlantis Attacks")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val solRing = game.findPermanent("Sol Ring").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Atlantis Attacks").first()
+
+                // Teamwork 4 — the 6/4 Craw Wurm clears the threshold on its own.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Player(game.player1Id),
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(solRing),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Player(game.player1Id)),
+                            listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(solRing)),
+                        ),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(wurm),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                game.findPermanent("Leviathan Token").shouldNotBeNull()
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+                game.isOnBattlefield("Sol Ring") shouldBe false
+                game.isInHand(2, "Grizzly Bears") shouldBe true
+                game.isInHand(2, "Sol Ring") shouldBe true
+            }
+
+            test("choosing both modes without teamwork is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Atlantis Attacks")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val solRing = game.findPermanent("Sol Ring").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Atlantis Attacks").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Player(game.player1Id),
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(solRing),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Player(game.player1Id)),
+                            listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(solRing)),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+                game.isInHand(1, "Atlantis Attacks") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoNutsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoNutsScenarioTest.kt
@@ -115,6 +115,45 @@ class GoNutsScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("choosing one mode with teamwork declared is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Go Nuts!")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Go Nuts!").first()
+
+                // "Choose both instead" is not an allowance — a cast that declared teamwork owes
+                // both modes, so a one-mode submission is illegal (CR 601.2, 700.2a).
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(bears))),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(giant),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+
+                withClue("the rejected cast is rewound whole — no counter landed either") {
+                    game.isInHand(1, "Go Nuts!") shouldBe true
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe false
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                }
+            }
+
             test("choosing both modes without teamwork is rejected") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoNutsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoNutsScenarioTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Go Nuts! (MSH #168) — {G} Sorcery.
+ *
+ *   Teamwork 3
+ *   Choose one. If this spell was cast using teamwork, choose both instead.
+ *   • Put a +1/+1 counter on target creature.
+ *   • Target creature you control fights target creature an opponent controls.
+ *
+ * The teamwork case deliberately points both modes at the same 2/2: the counter lands first, so it
+ * is a 3/3 that trades with the opposing 3/3 — which pins that the modes resolve in printed order
+ * within one resolution.
+ */
+class GoNutsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Go Nuts!") {
+
+            test("cast without teamwork resolves only the one chosen mode") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Go Nuts!")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Go Nuts!").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(bears))),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.state.projectedState.getPower(bears) shouldBe 3
+                game.state.projectedState.getToughness(bears) shouldBe 3
+                withClue("the fight mode was not chosen, so nobody took damage") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Centaur Courser") shouldBe true
+                }
+                withClue("no teamwork was declared, so nothing tapped") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("cast using teamwork resolves both modes, counter before fight") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Go Nuts!")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val courser = game.findPermanent("Centaur Courser").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Go Nuts!").first()
+
+                // Teamwork 3 — the 3/3 Hill Giant clears the threshold on its own.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(courser),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(bears)),
+                            listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(courser)),
+                        ),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(giant),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                withClue("the counter made the Bears a 3/3, so it trades with the 3/3 Courser") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                }
+            }
+
+            test("choosing both modes without teamwork is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Go Nuts!")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val courser = game.findPermanent("Centaur Courser").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Go Nuts!").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(courser),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(bears)),
+                            listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(courser)),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+                game.isInHand(1, "Go Nuts!") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HulkSmashScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HulkSmashScenarioTest.kt
@@ -1,0 +1,155 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * HULK SMASH! (MSH #135) — {1}{R} Instant.
+ *
+ *   Teamwork 4
+ *   Choose one. If this spell was cast using teamwork, choose both instead.
+ *   • Destroy target noncreature artifact.
+ *   • Target creature you control deals damage equal to its power to target creature an opponent
+ *     controls.
+ *
+ * The bite mode carries two targets of its own, so these cases also pin that the damage amount
+ * reads *that mode's* first target (the 6/4 Craw Wurm) rather than the modal spell's first target
+ * overall (the artifact).
+ */
+class HulkSmashScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("HULK SMASH!") {
+
+            test("cast without teamwork resolves only the one chosen mode") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "HULK SMASH!")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val solRing = game.findPermanent("Sol Ring").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "HULK SMASH!").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(solRing)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(solRing))),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Sol Ring") shouldBe false
+                withClue("the bite mode was not chosen, so the 2/2 survives") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("no teamwork was declared, so nothing tapped") {
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("cast using teamwork resolves both modes") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "HULK SMASH!")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val solRing = game.findPermanent("Sol Ring").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "HULK SMASH!").first()
+
+                // Teamwork 4 — the 6/4 Craw Wurm clears the threshold on its own, and being tapped
+                // as a cost does not stop it dealing the bite damage.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(solRing),
+                            ChosenTarget.Permanent(wurm),
+                            ChosenTarget.Permanent(bears),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(solRing)),
+                            listOf(ChosenTarget.Permanent(wurm), ChosenTarget.Permanent(bears)),
+                        ),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(wurm),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                game.isOnBattlefield("Sol Ring") shouldBe false
+                withClue("6 damage from the Craw Wurm kills the 2/2") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("choosing both modes without teamwork is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "HULK SMASH!")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val solRing = game.findPermanent("Sol Ring").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "HULK SMASH!").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(solRing),
+                            ChosenTarget.Permanent(wurm),
+                            ChosenTarget.Permanent(bears),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(solRing)),
+                            listOf(ChosenTarget.Permanent(wurm), ChosenTarget.Permanent(bears)),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+                game.isInHand(1, "HULK SMASH!") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HulkSmashScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HulkSmashScenarioTest.kt
@@ -119,6 +119,45 @@ class HulkSmashScenarioTest : ScenarioTestBase() {
                 }
             }
 
+            test("choosing one mode with teamwork declared is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "HULK SMASH!")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Sol Ring")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val solRing = game.findPermanent("Sol Ring").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "HULK SMASH!").first()
+
+                // "Choose both instead" is not an allowance — a cast that declared teamwork owes
+                // both modes, so a one-mode submission is illegal (CR 601.2, 700.2a).
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(solRing)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(solRing))),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(wurm),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+
+                withClue("the rejected cast is rewound whole") {
+                    game.isInHand(1, "HULK SMASH!") shouldBe true
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+                    game.isOnBattlefield("Sol Ring") shouldBe true
+                }
+            }
+
             test("choosing both modes without teamwork is rejected") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HulkSmashScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HulkSmashScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
@@ -73,14 +74,16 @@ class HulkSmashScenarioTest : ScenarioTestBase() {
                     .withLandsOnBattlefield(1, "Mountain", 2)
                     .withCardOnBattlefield(1, "Craw Wurm")
                     .withCardOnBattlefield(2, "Sol Ring")
-                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    // 0/8: it survives the bite, so the marked damage pins the *amount* at the
+                    // Craw Wurm's power. A 2/2 victim would die to any positive amount.
+                    .withCardOnBattlefield(2, "Wall of Stone")
                     .withActivePlayer(1)
                     .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                     .build()
 
                 val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
                 val solRing = game.findPermanent("Sol Ring").shouldNotBeNull()
-                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val wall = game.findPermanent("Wall of Stone").shouldNotBeNull()
                 val cardId = game.findCardsInHand(1, "HULK SMASH!").first()
 
                 // Teamwork 4 — the 6/4 Craw Wurm clears the threshold on its own, and being tapped
@@ -92,12 +95,12 @@ class HulkSmashScenarioTest : ScenarioTestBase() {
                         targets = listOf(
                             ChosenTarget.Permanent(solRing),
                             ChosenTarget.Permanent(wurm),
-                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(wall),
                         ),
                         chosenModes = listOf(0, 1),
                         modeTargetsOrdered = listOf(
                             listOf(ChosenTarget.Permanent(solRing)),
-                            listOf(ChosenTarget.Permanent(wurm), ChosenTarget.Permanent(bears)),
+                            listOf(ChosenTarget.Permanent(wurm), ChosenTarget.Permanent(wall)),
                         ),
                         declaredCostSlot = ChoiceSlot.TEAMWORK,
                         additionalCostPayment = AdditionalCostPayment(
@@ -110,8 +113,9 @@ class HulkSmashScenarioTest : ScenarioTestBase() {
                 game.resolveStack()
 
                 game.isOnBattlefield("Sol Ring") shouldBe false
-                withClue("6 damage from the Craw Wurm kills the 2/2") {
-                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                withClue("the bite amount is the Craw Wurm's power, not the artifact's or zero") {
+                    game.state.getEntity(wall)?.get<DamageComponent>()?.amount shouldBe 6
+                    game.isOnBattlefield("Wall of Stone") shouldBe true
                 }
             }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MurdocksCrusadeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MurdocksCrusadeScenarioTest.kt
@@ -112,6 +112,45 @@ class MurdocksCrusadeScenarioTest : ScenarioTestBase() {
                 game.isInExile(2, "Castle") shouldBe true
             }
 
+            test("choosing one mode with teamwork declared is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Murdock's Crusade")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Wall of Swords")
+                    .withCardOnBattlefield(2, "Castle")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val wall = game.findPermanent("Wall of Swords").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Murdock's Crusade").first()
+
+                // "Choose both instead" is not an allowance — a cast that declared teamwork owes
+                // both modes, so a one-mode submission is illegal (CR 601.2, 700.2a).
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(wall)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(wall))),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(wurm),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+
+                withClue("the rejected cast is rewound whole") {
+                    game.isInHand(1, "Murdock's Crusade") shouldBe true
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+                    game.isOnBattlefield("Wall of Swords") shouldBe true
+                }
+            }
+
             test("choosing both modes without teamwork is rejected") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MurdocksCrusadeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MurdocksCrusadeScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Murdock's Crusade (MSH #24) — {1}{W} Sorcery.
+ *
+ *   Teamwork 4
+ *   Choose one. If this spell was cast using teamwork, choose both instead.
+ *   • Street Justice — Exile target creature with toughness 4 or greater.
+ *   • Legal Justice — Exile target enchantment with mana value 4 or greater.
+ *
+ * Wall of Swords (3/5) and Castle ({3}{W}, mana value 4) are the two legal victims; Grizzly Bears
+ * (2/2) is on the board as the control that the toughness restriction actually restricts.
+ */
+class MurdocksCrusadeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Murdock's Crusade") {
+
+            test("cast without teamwork resolves only the one chosen mode") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Murdock's Crusade")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Wall of Swords")
+                    .withCardOnBattlefield(2, "Castle")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val wall = game.findPermanent("Wall of Swords").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Murdock's Crusade").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(wall)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(wall))),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.isInExile(2, "Wall of Swords") shouldBe true
+                withClue("Legal Justice was not chosen, so the enchantment stays") {
+                    game.isOnBattlefield("Castle") shouldBe true
+                }
+                withClue("no teamwork was declared, so nothing tapped") {
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("cast using teamwork resolves both modes") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Murdock's Crusade")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Wall of Swords")
+                    .withCardOnBattlefield(2, "Castle")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val wall = game.findPermanent("Wall of Swords").shouldNotBeNull()
+                val castle = game.findPermanent("Castle").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Murdock's Crusade").first()
+
+                // Teamwork 4 — the 6/4 Craw Wurm clears the threshold on its own.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(wall),
+                            ChosenTarget.Permanent(castle),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(wall)),
+                            listOf(ChosenTarget.Permanent(castle)),
+                        ),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(wurm),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                game.isInExile(2, "Wall of Swords") shouldBe true
+                game.isInExile(2, "Castle") shouldBe true
+            }
+
+            test("choosing both modes without teamwork is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Murdock's Crusade")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Wall of Swords")
+                    .withCardOnBattlefield(2, "Castle")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wall = game.findPermanent("Wall of Swords").shouldNotBeNull()
+                val castle = game.findPermanent("Castle").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Murdock's Crusade").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(wall),
+                            ChosenTarget.Permanent(castle),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(wall)),
+                            listOf(ChosenTarget.Permanent(castle)),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+                game.isInHand(1, "Murdock's Crusade") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MurdocksCrusadeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MurdocksCrusadeScenarioTest.kt
@@ -9,6 +9,9 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -141,6 +144,89 @@ class MurdocksCrusadeScenarioTest : ScenarioTestBase() {
                     ),
                 ).error.shouldNotBeNull()
                 game.isInHand(1, "Murdock's Crusade") shouldBe true
+            }
+
+            // The three tests above drive `execute(CastSpell(...))` and so prove only what the
+            // *handler* accepts. These two go against `getLegalActions`, which is what the client
+            // actually sees, and pin the two halves the handler can't: the advertised mode count
+            // on the plain cast, and whether the teamwork variant is offered at all.
+
+            test("the enumerator advertises one mode plainly, two with teamwork, and filters each mode's targets") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Murdock's Crusade")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Wall of Swords")
+                    .withCardOnBattlefield(2, "Castle")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val castle = game.findPermanent("Castle").shouldNotBeNull()
+
+                val modalCasts = game.getLegalActions(1).filter { it.actionType == "CastSpellModal" }
+
+                val plainCast = modalCasts
+                    .firstOrNull { it.additionalCostInfo?.costType != "TapForTotalPower" }
+                    .shouldNotBeNull()
+                val plainModal = plainCast.modalEnumeration.shouldNotBeNull()
+                withClue("no teamwork declared, so the dynamic count is 1 — advertising 2 would let " +
+                    "the client submit a two-mode cast the handler then rejects") {
+                    plainModal.chooseCount shouldBe 1
+                    plainModal.minChooseCount shouldBe 1
+                }
+
+                val teamworkCast = modalCasts
+                    .firstOrNull { it.additionalCostInfo?.costType == "TapForTotalPower" }
+                    .shouldNotBeNull()
+                teamworkCast.description shouldBe "Cast Murdock's Crusade (Teamwork 4)"
+                val teamworkModal = teamworkCast.modalEnumeration.shouldNotBeNull()
+                teamworkModal.chooseCount shouldBe 2
+                teamworkModal.modes.map { it.available } shouldBe listOf(true, true)
+
+                // Per-mode target enumeration: each mode carries its own requirement, and each
+                // filter excludes the permanent it is supposed to exclude.
+                val streetJustice = teamworkModal.modes[0].targetRequirements.single()
+                withClue("toughness 4 or greater: the 6/4 Craw Wurm qualifies, the 2/2 Bears do not") {
+                    streetJustice.validTargets shouldContain wurm
+                    streetJustice.validTargets shouldNotContain bears
+                }
+                val legalJustice = teamworkModal.modes[1].targetRequirements.single()
+                withClue("mana value 4 or greater: {3}{W} Castle qualifies") {
+                    legalJustice.validTargets shouldBe listOf(castle)
+                }
+            }
+
+            test("the teamwork variant is not offered when only one mode has a legal target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Murdock's Crusade")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardOnBattlefield(2, "Wall of Swords")
+                    // {G}{G}, mana value 2 — an enchantment, but under the threshold.
+                    .withCardOnBattlefield(2, "Lifeforce")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val modalCasts = game.getLegalActions(1).filter { it.actionType == "CastSpellModal" }
+
+                withClue("teamwork means choosing both modes, and Legal Justice has no legal " +
+                    "target (CR 700.2a), so the teamwork cast could never be completed") {
+                    modalCasts.none { it.additionalCostInfo?.costType == "TapForTotalPower" } shouldBe true
+                }
+
+                // The plain one-mode cast is still on offer — Street Justice has a victim.
+                val plainCast = modalCasts.single()
+                val plainModal = plainCast.modalEnumeration.shouldNotBeNull()
+                plainModal.chooseCount shouldBe 1
+                plainModal.modes.map { it.available } shouldBe listOf(true, false)
+                plainModal.modes[1].targetRequirements.single().validTargets.shouldBeEmpty()
             }
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WidowsBiteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WidowsBiteScenarioTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Widow's Bite (MSH #122) — {1}{B} Instant.
+ *
+ *   Teamwork 3
+ *   Choose one. If this spell was cast using teamwork, choose both instead.
+ *   • Target creature gains deathtouch until end of turn.
+ *   • Target creature gets -2/-2 until end of turn.
+ *
+ * Pins all three branches of the modal teamwork shape (CR 702.194c): one mode on a plain cast, both
+ * modes on a teamwork cast, and a plain cast that asks for both being rejected outright.
+ */
+class WidowsBiteScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Widow's Bite") {
+
+            test("cast without teamwork resolves only the one chosen mode") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Widow's Bite")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+                val courser = game.findPermanent("Centaur Courser").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Widow's Bite").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(courser)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(courser))),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.state.projectedState.hasKeyword(courser, Keyword.DEATHTOUCH) shouldBe true
+                withClue("the -2/-2 mode was not chosen, so the 2/2 is untouched") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+                withClue("no teamwork was declared, so nothing tapped") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("cast using teamwork resolves both modes") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Widow's Bite")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+                val courser = game.findPermanent("Centaur Courser").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Widow's Bite").first()
+
+                // Teamwork 3 — the 3/3 Hill Giant clears the threshold on its own.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(courser),
+                            ChosenTarget.Permanent(bears),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(courser)),
+                            listOf(ChosenTarget.Permanent(bears)),
+                        ),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(giant),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                game.state.projectedState.hasKeyword(courser, Keyword.DEATHTOUCH) shouldBe true
+                withClue("-2/-2 kills the 2/2") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("choosing both modes without teamwork is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Widow's Bite")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Widow's Bite").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(
+                            ChosenTarget.Permanent(courser),
+                            ChosenTarget.Permanent(bears),
+                        ),
+                        chosenModes = listOf(0, 1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(courser)),
+                            listOf(ChosenTarget.Permanent(bears)),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+                game.isInHand(1, "Widow's Bite") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WidowsBiteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WidowsBiteScenarioTest.kt
@@ -21,8 +21,9 @@ import io.kotest.matchers.shouldBe
  *   • Target creature gains deathtouch until end of turn.
  *   • Target creature gets -2/-2 until end of turn.
  *
- * Pins all three branches of the modal teamwork shape (CR 702.194c): one mode on a plain cast, both
- * modes on a teamwork cast, and a plain cast that asks for both being rejected outright.
+ * Pins all four branches of the modal teamwork shape: one mode on a plain cast, both modes on a
+ * teamwork cast, and each cast asking for the other's mode count being rejected outright — "choose
+ * both instead" is mandatory in both directions (CR 700.2, declared per CR 601.2b).
  */
 class WidowsBiteScenarioTest : ScenarioTestBase() {
 
@@ -111,6 +112,77 @@ class WidowsBiteScenarioTest : ScenarioTestBase() {
                 game.state.projectedState.hasKeyword(courser, Keyword.DEATHTOUCH) shouldBe true
                 withClue("-2/-2 kills the 2/2") {
                     game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("choosing one mode with teamwork declared is rejected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Widow's Bite")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+                val courser = game.findPermanent("Centaur Courser").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Widow's Bite").first()
+
+                // "Choose both instead" is not an allowance — a cast that declared teamwork owes
+                // both modes, so a one-mode submission is illegal (CR 601.2, 700.2a).
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(courser)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(courser))),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(giant),
+                        ),
+                    ),
+                ).error.shouldNotBeNull()
+
+                withClue("the rejected cast is rewound whole — the card stays in hand and the " +
+                    "creature tapped to pay for it is untapped again") {
+                    game.isInHand(1, "Widow's Bite") shouldBe true
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("the enumerator advertises the teamwork variant as choose-exactly-two") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Widow's Bite")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val modalCasts = game.getLegalActions(1).filter { it.actionType == "CastSpellModal" }
+
+                val plain = modalCasts
+                    .firstOrNull { it.additionalCostInfo?.costType != "TapForTotalPower" }
+                    .shouldNotBeNull()
+                    .modalEnumeration.shouldNotBeNull()
+                plain.minChooseCount shouldBe 1
+                plain.chooseCount shouldBe 1
+
+                val teamwork = modalCasts
+                    .firstOrNull { it.additionalCostInfo?.costType == "TapForTotalPower" }
+                    .shouldNotBeNull()
+                    .modalEnumeration.shouldNotBeNull()
+                withClue("both ends of the advertised range move with the declaration, so the " +
+                    "client's confirm button can't unlock on a single mode") {
+                    teamwork.minChooseCount shouldBe 2
+                    teamwork.chooseCount shouldBe 2
                 }
             }
 


### PR DESCRIPTION
# The five modal teamwork cards (MSH), and a mandatory floor for "choose both instead"

Marvel Super Heroes' five `teamwork(n)` modal cards — Murdock's Crusade [24], Atlantis Attacks [46],
Widow's Bite [122], HULK SMASH! [135], Go Nuts! [168] — plus the engine work they exposed.

> **No longer stacked.** Its prerequisite `loop-msh-u02` (Teamwork N itself) merged as
> [#1731](https://github.com/wingedsheep/argentum-engine/pull/1731), so this branch was rebased off
> the stack onto `main` and is an ordinary PR against `main`. Five commits, 23 files.
>
> ✅ **Gated on `main` at `b9d89050eb`, after the rebase.** `--no-build-cache`, mandatory here or
> Gradle serves a stale `:mtg-sdk` compile and passes falsely.
>
> | Modules | Result |
> |---|---|
> | `:rules-engine:test` + `:mtg-sets:test` | **10601 passed, 0 failed** |
> | `:mtg-sdk:test` + `:game-server:test` | **897 passed, 0 failed** |

## The cards

All five print the same shape:

> Teamwork N *(As an additional cost to cast this spell, you may tap any number of creatures you
> control with total power N or more.)*
> **Choose one. If this spell was cast using teamwork, choose both instead.**

| Card | Cost | Modes |
|---|---|---|
| Murdock's Crusade [24] | `{1}{W}` Sorcery, teamwork 4 | exile creature toughness ≥ 4 / exile enchantment mana value ≥ 4 |
| Atlantis Attacks [46] | `{5}{U}{U}` Sorcery, teamwork 4 | target player creates a 6/5 hexproof Leviathan / bounce one or two nonland permanents |
| Widow's Bite [122] | `{1}{B}` Instant, teamwork 3 | grant deathtouch / −2/−2 |
| HULK SMASH! [135] | `{1}{R}` Instant, teamwork 4 | destroy noncreature artifact / Rabid Bite one-sided damage |
| Go Nuts! [168] | `{G}` Sorcery, teamwork 3 | +1/+1 counter / fight |

No new card-specific engine types — every mode composes existing vocabulary (`ForEachTargetEffect`,
`TargetObject(count = 2, minCount = 1)`, `TargetFilter.Enchantment.manaValueAtLeast`, the Rabid Bite
`damageSource` shape). Oracle text, mana costs, rarities, collector numbers and artists verified
against Scryfall; `just check-card-printing` clean on all five (canonical in MSH, the earliest real
printing).

## "Choose both instead" is mandatory — and wasn't

`ModalEffect.dynamicChooseCount` raises only the **ceiling**. It models Flame of Anor's "you *may*
choose two instead", so the floor stayed at the printed 1 — a player could declare teamwork, tap
their team, and then take a single mode. Not theoretical: the enumerator advertised
`minChooseCount = 1` on the teamwork variant and `ModalModeSelector` unlocks confirm at
`totalChosen >= minChooseCount`, so it was reachable through normal play.

- **`ModalEffect.dynamicMinChooseCount`** — the mandatory sibling. Same evaluation, same clamping,
  lower bound. The two exist because the printed wording splits: "may choose two instead" leaves the
  floor at one, "choose both **instead**" does not.
- **`teamworkModal { }`** (`TeamworkDsl.kt`) wires a modal block for that wording, setting both
  bounds from one `Conditional` and deriving "both" from the modes declared — a three-mode printing
  needs no new recipe. The five cards each shed six lines of copy-pasted `DynamicAmount.Conditional`.

## One authority for the mode count

`CastSpellHandler` (validating a submitted cast) and `CastSpellEnumerator` (advertising one) had
separate implementations of "how many modes can this cast choose", and they had already drifted —
the enumerator's knew nothing about the blight path and nothing about the floor. Both now call
**`ModalChooseCounts.forCast`**, which returns the `min..max` range.

The enumerator also now drops a modal variant when fewer than the **minimum** modes are available,
not the maximum. Gating on the maximum happened to be right for these cards only because the floor
was wrong.

### That fix reaches beyond teamwork

It failed an existing test — and the test was wrong. `CastSpellEnumeratorTest` asserted that
**Brigid's Command** ("Choose two —") is still offered with only one mode available. It isn't
castable: a mode that would be illegal can't be chosen (CR 700.2a), so there is no legal pair to
announce and the cast can't be proposed (CR 601.2). Wizards' own Cryptic Command ruling says the
same — *"You must choose two different modes."* The test's name already read "dropped entirely"
while its body asserted the opposite; it now asserts the drop.

## Tests

One file per card, `<CardName>ScenarioTest.kt`, four cases each plus extras — 25 in total:

1. plain cast → exactly the one chosen mode resolves, the other mode's victim untouched, nothing
   tapped;
2. teamwork cast → both modes resolve, payer tapped;
3. plain cast asking for both modes → rejected, card stays in hand;
4. **teamwork cast asking for one mode → rejected and rewound**, card in hand *and* payer untapped.

Rule corners worth naming:

- **Go Nuts!** points both modes at the same 2/2 so the counter lands before the fight and it trades
  with a 3/3 — pinning mode ordering within one resolution (CR 608.2c).
- **HULK SMASH!** bites a 0/8 Wall of Stone, so the assertion is `damage == 6` rather than "the 2/2
  died" — that pins the *amount*, and thereby that `EntityReference.Target(0)` is scoped to the
  mode's own target list rather than the spell's first target overall.
- **Murdock's Crusade** and **Widow's Bite** assert against `getLegalActions`, covering the half the
  handler-driven tests structurally can't: the advertised range at both ends, per-mode target
  candidates with negative controls on both filters, and the teamwork variant being absent when only
  one mode has a legal target.

## Also in here

- CR **702.194c → CR 700.2 / 601.2b** in five card KDocs and one test KDoc. 702.194c is about
  *targets*; the mode count is CR 700.2 branching on the CR 601.2b declaration —
  `docs/card-sdk-language-reference.md` already said exactly that, and the KDocs contradicted it.
- `docs/card-sdk-language-reference.md` updated in the same change: the mandatory variant, the
  `teamworkModal` recipe, and the one-authority rule.
- A manual playtest scenario (`manual-scenarios/sets/msh/loop-msh-u03-new-cards-castable.json`)
  whose board is sized for the teamwork casts, not just the mana — disjoint payers totalling 18
  power, and every mode's target restriction represented with a negative control beside it.
- Backlog ticked: MSH 235 / 276, teamwork 8 of 13 implemented.

## Not done

No manual playthrough in the web client, no UX pass, no e2e run. The web client was not
type-checked (no `node_modules` in this environment). No client changes are in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
