### PR TITLE
Add the four remaining non-modal teamwork cards to Marvel Super Heroes

### DIFF
--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -1,8 +1,10 @@
 # Unit u04 — MSH teamwork, the four non-modal payoffs
 
-Branch `loop-msh-u04`, stacked on `loop-msh-u03`. Ordinary card work: the teamwork rail
-(`teamwork(n)`, `Conditions.TeamworkWasPaid`, `ChoiceSlot.TEAMWORK`) already shipped in u02/u03 and
-is unchanged here. No engine or SDK code was touched.
+Branch `loop-msh-u04`, an independent PR against `main` — `loop-msh-u03` merged upstream as
+PR #1750, so this branch was rebased off the stack onto `origin/main` (`b11a8d70fe`) and carries
+only its own commits. Ordinary card work: the teamwork rail (`teamwork(n)`,
+`Conditions.TeamworkWasPaid`, `ChoiceSlot.TEAMWORK`) already shipped in u02/u03 and is unchanged
+here. No engine or SDK code was touched.
 
 ## Cards
 

--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -27,16 +27,21 @@ is unchanged here. No engine or SDK code was touched.
 
 ## Tests
 
-One file per card, all under `rules-engine/src/test/kotlin/.../scenarios/`. 13 tests, every card
+One file per card, all under `rules-engine/src/test/kotlin/.../scenarios/`. 17 tests, every card
 covering both branches.
 
-Three of the four assert against `getLegalActions` directly, not just `execute(CastSpell(...))`,
-because the teamwork bugs found in u02/u03 all lived in `CastSpellEnumerator`'s advertising path:
+Two of the four assert against `getLegalActions` directly, not just `execute(CastSpell(...))`,
+because the teamwork bugs found in u02/u03 all lived in `CastSpellEnumerator`'s advertising path.
+The other two (We Say Thee Nay!, Earth's Mightiest Heroes) drive `castSpell`/`CastSpell` only —
+neither has a branch-dependent target or mode, so their enumeration path is the generic one
+`TeamworkMechanicScenarioTest` already covers.
 
 - `CruelAllianceScenarioTest` — with only a mana-value-6 creature on the board the plain `CastSpell`
   is **not** advertised while the `CastWithKicker` teamwork variant is, carrying that creature as a
-  valid target; and with no creature to tap, the teamwork variant is advertised **unaffordable**.
-- `TooEvilToStayDeadScenarioTest` — same shape over the graveyard.
+  valid target; with a cheap creature present both are advertised and the plain one's
+  `validTargets` is the narrow list; and with no creature to tap, the teamwork variant is
+  advertised **unaffordable**.
+- `TooEvilToStayDeadScenarioTest` — same shape over the graveyard, both directions.
 
 ## Gate
 

--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -1,156 +1,72 @@
-# Unit u03 — the five modal teamwork cards (MSH)
+# Unit u04 — MSH teamwork, the four non-modal payoffs
 
-Branch `loop-msh-u03`, an independent PR against `main` — `loop-msh-u02` merged upstream as
-PR #1731, so this branch was rebased off the stack onto `origin/main` and carries only its own
-commits. Batch unit, ordinary card work: every card is `teamwork(n)` plus the modal recipe.
-
-> **Amended twice after review.** The branch also carries fixes to `CastSpellEnumerator.kt` /
-> `CastSpellHandler.kt` and one new SDK field, because the defects are only reachable through these
-> five cards. See *Review corrections* and *Round-2 corrections* at the bottom.
+Branch `loop-msh-u04`, stacked on `loop-msh-u03`. Ordinary card work: the teamwork rail
+(`teamwork(n)`, `Conditions.TeamworkWasPaid`, `ChoiceSlot.TEAMWORK`) already shipped in u02/u03 and
+is unchanged here. No engine or SDK code was touched.
 
 ## Cards
 
-- **Widow's Bite** [122] `{1}{B}` Instant, teamwork 3 — `Effects.GrantKeyword(DEATHTOUCH)` /
-  `Effects.ModifyStats(-2, -2)`, one `Targets.Creature` per mode.
-- **HULK SMASH!** [135] `{1}{R}` Instant, teamwork 4 — `Effects.Destroy` on
-  `TargetFilter(GameObjectFilter.Artifact.notCreature())` / the Rabid Bite one-sided
-  `Effects.DealDamage` with `amount = EntityProperty(Target(0), Power)` and
-  `damageSource = <your creature>`. Mode 2 carries two targets of its own.
-- **Go Nuts!** [168] `{G}` Sorcery, teamwork 3 — `Effects.AddCounters("+1/+1", 1)` /
-  `Effects.Fight`, the Epic Fight shape.
-- **Murdock's Crusade** [24] `{1}{W}` Sorcery, teamwork 4 — `Effects.Exile` behind
-  `TargetFilter.Creature.toughnessAtLeast(4)` / `TargetFilter.Enchantment.manaValueAtLeast(4)`.
-  The printed mode names ("Street Justice —", "Legal Justice —") are part of the mode
-  descriptions, which become the client's button text.
-- **Atlantis Attacks** [46] `{5}{U}{U}` Sorcery, teamwork 4 — `Effects.CreateToken(6, 5, BLUE,
-  "Leviathan", HEXPROOF, controller = <target player>)` / a single
-  `TargetObject(count = 2, minCount = 1, filter = NonlandPermanent)` bounced through
-  `ForEachTargetEffect(Effects.ReturnToHand(ContextTarget(0)))`.
-
-All five: `teamworkModal { }` — the recipe documented in
-`docs/card-sdk-language-reference.md` → *Teamwork N*, which pins the mode count to exactly one on a
-plain cast and exactly all of them on a declared one. Thresholds verified against Scryfall
-(3, 4, 3, 4, 4 respectively).
-
-**Nothing was dropped.** The two shapes flagged as possible drops both turned out to be covered by
-existing target vocabulary: "one or two target nonland permanents" is `count = 2, minCount = 1`
-(Succumb to the Cold / Amazing Acrobatics precedent), and "enchantment with mana value 4 or
-greater" is `TargetFilter.Enchantment.manaValueAtLeast(4)`.
-
-## Gate
-
-`just build` — **passed** (`BUILD SUCCESSFUL`, all modules).
-
-Getting there took several runs because the Gradle daemon was OOM-killed three times on this shared
-box (`daemon disappeared`), never with a compile or test error. The runs that stuck used
-`scripts/gradle-locked … -Pkotlin.compiler.execution.strategy=in-process --max-workers=1`, and
-`:rules-engine:test` had to be run on its own once so the test compile and the test run did not
-share a memory window. The final `just build` is green over everything.
-
-- `just rebless-cards` — `mtg-sets/src/test/resources/snapshots/cards/MSH.json` only, and a **pure
-  insertion** (571 added lines, 0 removed): Atlantis Attacks, Go Nuts!, HULK SMASH!, Murdock's
-  Crusade, Widow's Bite. No unrelated card moved.
-- `just check-card-printing` — ok for all five (canonical in MSH, the earliest real printing).
-- Backlog ticked; `just fix-backlog` resynced MSH to 235 / 276. The teamwork section of
-  `mechanics.md` now reads 8 of 13 implemented, with the remaining four (We Say Thee Nay!, Cruel
-  Alliance, Too Evil to Stay Dead, Earth's Mightiest Heroes) plus the still-blocked Agent Maria Hill.
+- **Cruel Alliance** [92] — {2}{B} Sorcery, teamwork 2. Plain: exile target creature with mana value
+  3 or less. Teamwork: exile target creature (no restriction) and gain 3 life. Composes the shared
+  optional-additional-cost rail's `kickerTarget` / `kickerEffect` slots (the Fight with Fire / Brave
+  the Wilds shape) so the declared cast announces its *own* target requirement, plus
+  `Effects.Exile` + `Effects.GainLife` + `Effects.Composite`.
+- **Too Evil to Stay Dead** [118] — {2}{B} Sorcery, teamwork 4. Same `kickerTarget` / `kickerEffect`
+  shape: plain targets a creature card in your graveyard with mana value 4 or less, teamwork targets
+  any creature card in your graveyard. Both branches end in `Effects.PutOntoBattlefield`
+  (`TargetFilter.CreatureInYourGraveyard`, `Targets.CreatureCardInYourGraveyard`).
+- **We Say Thee Nay!** [82] — {1}{U} Instant — Arcane, teamwork 2. One
+  `Effects.CounterUnlessDynamicPays` whose generic amount is a
+  `DynamicAmount.Conditional(Conditions.TeamworkWasPaid, 4, 2)` — a single "counter unless they pay"
+  event whose price changes, not two counter effects.
+- **Earth's Mightiest Heroes** [165] — {4}{G}{G} Sorcery, teamwork 5. Gather → Select → Move
+  pipeline (`GatherCardsEffect(TopOfLibrary(8), revealed)` → `SelectFromCollectionEffect` →
+  two `MoveCollectionEffect`s), with a `ConditionalEffect(TeamworkWasPaid, …)` swapping only the
+  selection mode: `SelectionMode.ChooseAnyNumber` vs `SelectionMode.ChooseUpTo(1)`. Structurally the
+  same split KTK's See the Unwritten uses for its ferocious "two instead of one".
 
 ## Tests
 
-Five files, `<CardName>ScenarioTest.kt`, four cases each plus extras (25 total, all passing):
+One file per card, all under `rules-engine/src/test/kotlin/.../scenarios/`. 13 tests, every card
+covering both branches.
 
-1. plain cast → exactly the one chosen mode resolves, the other mode's victim is untouched, nothing
-   tapped;
-2. teamwork cast → both modes resolve and the payer is tapped;
-3. plain cast declaring both modes → rejected, card stays in hand;
-4. teamwork cast declaring one mode → rejected and rewound, card in hand *and* payer untapped
-   (added in round 2 — "choose both instead" is mandatory in both directions).
+Three of the four assert against `getLegalActions` directly, not just `execute(CastSpell(...))`,
+because the teamwork bugs found in u02/u03 all lived in `CastSpellEnumerator`'s advertising path:
 
-Go Nuts!'s teamwork case points both modes at the same 2/2 so the +1/+1 counter lands before the
-fight and it trades with a 3/3 — that pins mode ordering within the single resolution. HULK SMASH!'s
-teamwork case pins that the bite amount reads *that mode's* first target (the 6/4 Craw Wurm) rather
-than the spell's first target overall (the artifact) — the snapshot confirms
-`targetRequirements[0]` is "target creature you control".
+- `CruelAllianceScenarioTest` — with only a mana-value-6 creature on the board the plain `CastSpell`
+  is **not** advertised while the `CastWithKicker` teamwork variant is, carrying that creature as a
+  valid target; and with no creature to tap, the teamwork variant is advertised **unaffordable**.
+- `TooEvilToStayDeadScenarioTest` — same shape over the graveyard.
 
-Neither of the two u02 regressions (missing `declaredCostSlot` in the evaluation context; no modal
-enumeration for a declared cast) reappeared — the teamwork branch is reached and both modes resolve.
+## Gate
 
-## Uncertain / worth a reviewer's eye
+`just build` (see the verdict block for the result). The four scenario tests were also run on their
+own first and are green. `just rebless-cards`, `just check-card-printing` ×4 (all ok, all canonical
+in MSH), `just fix-backlog` (239/276).
 
-- The tests drive `game.execute(CastSpell(...))` directly with `chosenModes` +
-  `modeTargetsOrdered`, because `ScenarioTestBase.castSpellWithTeamwork` takes only a single
-  `targetId` and cannot express per-mode target lists. That bypasses the legal-action enumerator, so
-  these tests prove the *handler* accepts the shape but not that the client is offered the
-  `CastSpellModal` "(Teamwork N)" variant for these particular cards. `TeamworkMechanicScenarioTest`
-  covers the advertised action generically. Murdock's Crusade and Widow's Bite now carry per-card
-  `getLegalActions` assertions; the other three still rely on the generic coverage.
-- `Effects.Exile` is `MoveToZoneEffect(destination = EXILE)`; I did not check whether anything in
-  MSH cares about the distinction between "exile" and "exile face down"/linked exile here. The
-  printed text is a plain exile, so I believe this is right.
-- Atlantis Attacks' token is named `"Leviathan Token"` by the executor's default
-  (`creatureTypes.joinToString(" ") + " Token"`) since I passed no explicit `name`. That matches
-  what Brigid's Command and the other token cards do, but the printed token is just "Leviathan".
-- ~~Each card's KDoc cites CR 702.194c for the "choose both instead" shape.~~ Corrected in round 2
-  to CR 700.2 / 601.2b; the loose citation was in fact wrong, and contradicted this repo's own SDK
-  reference.
-- Not done: no manual playthrough in the web client, no UX pass from either seat, no e2e run, no
-  `/generate-scenario` JSON. The web client was not type-checked (no node_modules, no network).
+## Dropped
 
-## Review corrections
+None. The conditional target filter — the flagged drop candidate — turned out to be expressible on
+the existing rail: `CardScript.kickerTargetRequirements` *replace* `targetRequirements` when a cast
+declares any slot on the optional-additional-cost rail, which is exactly "the teamwork cast
+announces a different target". No new primitive was needed.
 
-Applied on top of the original commits, after the independent review (0 blocking, 4 important,
-6 minor).
+## Things I'm unsure about, for review
 
-- **Engine, `CastSpellEnumerator.kt`** — new private `effectiveModalMaxChooseCount` mirroring the
-  dynamic branch of `CastSpellHandler.effectiveModalChooseCounts` (declaration in the evaluation
-  context, so `Conditions.TeamworkWasPaid` answers correctly from hand). Two call sites:
-  - the plain cast now advertises the dynamic-evaluated maximum (1 for an undeclared teamwork cast)
-    instead of the printed 2, so the client can no longer submit a two-mode plain cast the handler
-    rejects. Flame of Anor / Molten Collapse / Wail of the Forgotten were mis-advertised identically.
-  - the declared-cost branch now drops the variant unless at least that many modes are *available*
-    (CR 700.2a), not merely one — Murdock's Crusade's teamwork cast was being offered with no legal
-    enchantment on the board and could never be completed. `allowRepeat` is exempt (CR 700.2d).
-- ~~**Still open:** the handler's effective *minimum* for a teamwork cast is the printed
-  `minChooseCount` (1), not 2.~~ **Fixed in round 2** — see below. It was not separable: the client's
-  confirm button unlocks at the advertised `minChooseCount`, so a player could tap their team and
-  take one mode through the normal UI.
-- **`AtlantisAttacks.kt` KDoc** — it claimed one target going illegal "does not strand the other".
-  False: `processPreChosenModeQueue` skips the whole mode all-or-nothing. Now documented as the
-  pre-existing engine-wide deviation from CR 608.2b that it is; behaviour untouched.
-- **`GoNuts.kt`** — CR 608.2 → 608.2c (the rule that actually says instructions are followed in the
-  order written).
-- **Tests** — `MurdocksCrusadeScenarioTest` gains two `getLegalActions` cases (advertised mode count,
-  per-mode target candidates, teamwork variant absent with no legal enchantment, and the negative
-  side of both filters); `AtlantisAttacksScenarioTest` gains a single-target bounce case for
-  `minCount = 1`; `HulkSmashScenarioTest`'s bite victim became a 0/8 Wall of Stone so the assertion
-  pins `damage == 6` rather than "the 2/2 died".
-- No action on the Leviathan token name (matches the repo-wide default and the test lookup) or the
-  CR 702.194c citations (the reviewer verified them as accurate).
-
-## Round-2 corrections
-
-Applied after a second review (1 blocking, 3 important).
-
-- **SDK, `ModalEffect.dynamicMinChooseCount`** — the mandatory sibling of `dynamicChooseCount`.
-  The printed wording splits: "you *may* choose two instead" (Flame of Anor) leaves the floor at
-  one, "choose both **instead**" (these five) does not. With only a ceiling, a teamwork cast could
-  legally take a single mode.
-- **SDK, `teamworkModal { }`** in `TeamworkDsl.kt` — sets both bounds from the same `Conditional`
-  and derives "both" from the modes declared. The five cards each drop six lines of copy-pasted
-  `DynamicAmount.Conditional`.
-- **Engine, `ModalChooseCounts.forCast`** — one authority for the `min..max` range, called by both
-  `CastSpellHandler` (validating) and `CastSpellEnumerator` (advertising). The two had separate
-  copies that had already drifted: the enumerator's knew nothing about the blight path or the floor.
-- **Engine, the enumerator's drop gate** now tests the effective *minimum*, not the maximum. This
-  turned out to fix a bug beyond teamwork: `CastSpellEnumeratorTest` had a case asserting that
-  Brigid's Command ("Choose two —") is still offered with only one mode available. It isn't
-  castable — CR 700.2a plus CR 601.2, and Wizards' own Cryptic Command ruling ("You must choose two
-  different modes"). That test's name already said "dropped entirely" while its body asserted the
-  opposite; it now asserts the drop.
-- **CR 702.194c → CR 700.2 / 601.2b** in five card KDocs and one test KDoc. 702.194c is about
-  targets; `docs/card-sdk-language-reference.md` already said so.
-
-**Gate (on `origin/main` b9d89050eb, after the rebase off the stack):** `:rules-engine:test` +
-`:mtg-sets:test` — 10601 passed, 0 failed. `:mtg-sdk:test` + `:game-server:test` — 897 passed,
-0 failed. Snapshot re-blessed: `MSH.json` +75 lines, 0 removed, all five `dynamicMinChooseCount`
-blocks and nothing else.
+- **`kickerTarget` forces the whole effect to be restated.** Too Evil to Stay Dead's printed last
+  sentence ("Return the chosen card to the battlefield") is shared between the branches, but because
+  `kickerSpellEffect` replaces `spellEffect` wholesale, it appears twice in the card file. That's
+  faithful, just duplicated; if there's an appetite for a "branch replaces only the target" shape
+  that's a separate feature, not this PR.
+- **Cruel Alliance's "unaffordable but still advertised" teamwork variant** is asserted as
+  `isAffordable == false` rather than absent. That matches the enumerator's explicit comment
+  ("the greyed-out variant still tells the player what teamwork would ask for"), but the unit brief
+  asked for "not advertised", so flagging the divergence rather than hiding it.
+- **No manual playthrough.** `SelectionMode.ChooseAnyNumber` on Earth's Mightiest Heroes shows an
+  8-card overlay with 3 selectable and 5 greyed out (`showAllCards = true`); I verified the decision
+  payload in the test (`maxSelections` 1 vs 3) but never looked at it in the client.
+- **`Instant — Arcane`** on We Say Thee Nay! is carried through as printed. Nothing in this set
+  cares about the Arcane subtype (no splice), so it is inert here.
+- I added one bullet to the Teamwork entry in `docs/card-sdk-language-reference.md` describing this
+  "different target *restriction* per branch" shape. No SDK change accompanies it — it documents an
+  authoring shape the rail already supported but the entry didn't name.

--- a/backlog/sets/marvel-super-heroes/cards.md
+++ b/backlog/sets/marvel-super-heroes/cards.md
@@ -3,7 +3,7 @@
 **Set Size:** 276 booster cards (collector numbers 1-276; basic lands 277-296 and showcase
 variants 297+ are excluded)
 **Release Date:** June 26, 2026
-**Implemented:** 235 / 276
+**Implemented:** 239 / 276
 - [x] Agent 13, Sharon Carter
 - [ ] Agent Maria Hill
 - [x] Agent of Atlas
@@ -85,7 +85,7 @@ variants 297+ are excluded)
 - [x] Thirst for Knowledge
 - [x] Tony Stark // The Invincible Iron Man
 - [x] Trickster's Stratagem
-- [ ] We Say Thee Nay!
+- [x] We Say Thee Nay!
 - [x] Wiccan, Rising Magician
 - [x] The Wondrous Wasp
 - [x] Agents of HYDRA
@@ -95,7 +95,7 @@ variants 297+ are excluded)
 - [x] Black Widow, Super Spy
 - [x] Construct a Cosmic Cube
 - [x] Crossbones, Malicious Mercenary
-- [ ] Cruel Alliance
+- [x] Cruel Alliance
 - [x] Dark Deed
 - [x] Decoy Ploy
 - [x] Doctor Doom
@@ -121,7 +121,7 @@ variants 297+ are excluded)
 - [x] Super-Skrull
 - [x] Swordsman, Sharp Scoundrel
 - [x] Thunderbolts Conspiracy
-- [ ] Too Evil to Stay Dead
+- [x] Too Evil to Stay Dead
 - [x] Unliving Legionnaire
 - [x] Visions of Villainy
 - [x] Whiplash, Vengeful Engineer
@@ -168,7 +168,7 @@ variants 297+ are excluded)
 - [x] Call Damage Control
 - [x] Claim the Kingdom
 - [x] Doc Samson, Super Psychiatrist
-- [ ] Earth's Mightiest Heroes
+- [x] Earth's Mightiest Heroes
 - [x] Epic Fight
 - [x] Giant Growth
 - [x] Go Nuts!

--- a/backlog/sets/marvel-super-heroes/mechanics.md
+++ b/backlog/sets/marvel-super-heroes/mechanics.md
@@ -94,7 +94,7 @@ sweep is `.manaValueIsOdd()` / `.manaValueIsEven()` + a modal.
   (`CardPredicate.ManaValueAtMostDynamic(DynamicAmounts.sourcePower())` — the predicate exists, but
   nothing evaluates a source-relative dynamic filter inside delayed-trigger matching).
 
-## Teamwork N — SHIPPED ✅ (8 of 13 cards implemented, 4 now unblocked, 1 still blocked)
+## Teamwork N — SHIPPED ✅ (12 of 13 cards implemented, 1 still blocked)
 
 > Teamwork 4 *(As an additional cost to cast this spell, you may tap any number of creatures you
 > control with total power 4 or more.)*
@@ -156,12 +156,16 @@ summoning sickness, the durable flag on a resolving permanent, teamwork-vs-kicke
 advertised legal action, the modal "Teamwork Orders" cases, and the CR 702.194c "Teamwork Rally"
 cases) plus one scenario test per implemented card.
 
-**Implemented (8):** Helicarrier Strike [15] · Murdock's Crusade [24] · Atlantis Attacks [46] ·
-Widow's Bite [122] · HULK SMASH! [135] · Repulsor Blast [150] · Team Tactics [155] · Go Nuts! [168].
-The last five are the "choose both instead" modal shape, all on `dynamicChooseCount` as above.
+**Implemented (12):** Helicarrier Strike [15] · Murdock's Crusade [24] · Atlantis Attacks [46] ·
+We Say Thee Nay! [82] · Cruel Alliance [92] · Too Evil to Stay Dead [118] · Widow's Bite [122] ·
+HULK SMASH! [135] · Repulsor Blast [150] · Team Tactics [155] · Earth's Mightiest Heroes [165] ·
+Go Nuts! [168]. Murdock's Crusade, Atlantis Attacks, Widow's Bite, HULK SMASH! and Go Nuts! are the
+"choose both instead" modal shape, all on `dynamicChooseCount` as above.
 
-**Now buildable as ordinary card work (4):** We Say Thee Nay! [82] · Cruel Alliance [92] · Too Evil
-to Stay Dead [118] · Earth's Mightiest Heroes [165].
+Cruel Alliance and Too Evil to Stay Dead are a third shape the rail already covered: the teamwork
+"instead" replaces the *target requirement*, not the effect's size, so they use the shared
+optional-additional-cost `kickerTarget` / `kickerEffect` slots (Fight with Fire, Brave the Wilds) —
+the teamwork cast announces a target the plain cast could not.
 
 ### Still blocked — 1 card ⛔
 

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6328,7 +6328,9 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 >   "Teamwork Rally" cases.
 > - **A different target *restriction* on the teamwork cast** — the same `kickerTarget` /
 >   `kickerEffect` pair, with *both* branches carrying a target. Use it when "instead" replaces the
->   target requirement rather than an amount: Cruel Alliance ("exile target creature with mana value
+>   target requirement rather than an amount — CR 601.2c is the basis ("a spell may require
+>   *alternative* targets only if an alternative or additional cost was chosen for it"), with
+>   CR 702.194c supplying the other direction. Cruel Alliance ("exile target creature with mana value
 >   3 or less … instead exile target creature and you gain 3 life") and Too Evil to Stay Dead
 >   ("target creature card in your graveyard with mana value 4 or less … instead … in your
 >   graveyard"). Because `kickerTargetRequirements` *replace* `targetRequirements` on a declared

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6326,6 +6326,17 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 >   CR 702.194c asks for: the plain cast is announced as though the clause weren't there, and only
 >   the declared cast chooses the extra target. Pinned by `TeamworkMechanicScenarioTest`'s
 >   "Teamwork Rally" cases.
+> - **A different target *restriction* on the teamwork cast** — the same `kickerTarget` /
+>   `kickerEffect` pair, with *both* branches carrying a target. Use it when "instead" replaces the
+>   target requirement rather than an amount: Cruel Alliance ("exile target creature with mana value
+>   3 or less … instead exile target creature and you gain 3 life") and Too Evil to Stay Dead
+>   ("target creature card in your graveyard with mana value 4 or less … instead … in your
+>   graveyard"). Because `kickerTargetRequirements` *replace* `targetRequirements` on a declared
+>   cast, each branch is announced under its own filter — the teamwork cast can legally target
+>   something the plain cast could not, and the plain cast is dropped from the enumeration entirely
+>   when only the wider filter has a legal target. The branch replaces the whole effect too, so any
+>   shared trailing sentence ("Return the chosen card to the battlefield") has to be restated in
+>   `kickerEffect`.
 >
 > `Conditions.TeamworkWasPaid` is a facade over `CastChoiceMade(ChoiceSlot.TEAMWORK)`, so teamwork needs
 > no condition type of its own.

--- a/manual-scenarios/sets/msh/loop-msh-u04-new-cards-castable.json
+++ b/manual-scenarios/sets/msh/loop-msh-u04-new-cards-castable.json
@@ -1,0 +1,253 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Cruel Alliance",
+      "Too Evil to Stay Dead",
+      "We Say Thee Nay!",
+      "Earth's Mightiest Heroes"
+    ],
+    "battlefield": [
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Plains"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Forest"
+      },
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Hill Giant"
+      },
+      {
+        "name": "Serra Angel"
+      }
+    ],
+    "graveyard": [
+      "Hill Giant",
+      "Shivan Dragon",
+      "Grizzly Bears"
+    ],
+    "library": [
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Hill Giant",
+      "Serra Angel",
+      "Forest",
+      "Forest",
+      "Craw Wurm",
+      "Grizzly Bears",
+      "Forest",
+      "Forest",
+      "Forest",
+      "Forest"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Volcanic Hammer"
+    ],
+    "battlefield": [
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Shivan Dragon"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp",
+      "Swamp"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "POSTCOMBAT_MAIN"
+  ],
+  "player2StopAtSteps": [
+    "PRECOMBAT_MAIN"
+  ],
+  "player1OpponentStopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "POSTCOMBAT_MAIN"
+  ],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/CruelAlliance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/CruelAlliance.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.mtg.sets.definitions.msh.cards
 
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.teamwork
 import com.wingedsheep.sdk.model.Rarity
@@ -49,7 +50,7 @@ val CruelAlliance = card("Cruel Alliance") {
 
         val anyCreature = kickerTarget(
             "target creature",
-            TargetCreature(filter = TargetFilter.Creature),
+            Targets.Creature,
         )
         kickerEffect = Effects.Composite(
             Effects.Exile(anyCreature),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/CruelAlliance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/CruelAlliance.kt
@@ -16,17 +16,18 @@ import com.wingedsheep.sdk.scripting.targets.TargetCreature
  * Exile target creature with mana value 3 or less. If this spell was cast using teamwork, instead
  * exile target creature and you gain 3 life.
  *
- * The **teamwork-only targeting** shape of teamwork (CR 702.194c): "instead" here replaces the
- * whole sentence, target restriction included, so this is not a rider on one effect — the declared
- * cast announces a *different* target requirement. That's the shared optional-additional-cost
- * rail's `kickerTarget` / `kickerEffect` slots (Fight with Fire, Brave the Wilds), which serve
- * whichever mechanic declared — teamwork here. The plain cast can only ever announce a creature
- * with mana value 3 or less; the teamwork cast announces any creature and cannot be announced at
- * all unless a creature is there to target.
+ * The **teamwork-only targeting** shape of teamwork: "instead" here replaces the whole sentence,
+ * target restriction included, so this is not a rider on one effect — the declared cast announces a
+ * *different* target requirement. CR 601.2c is the rules basis ("a spell may require alternative
+ * targets only if an alternative or additional cost was chosen for it"); CR 702.194c supplies the
+ * other direction, that the plain cast is announced as though the teamwork clause's target weren't
+ * there. That maps onto the shared optional-additional-cost rail's `kickerTarget` / `kickerEffect`
+ * slots (Fight with Fire, Brave the Wilds), which serve whichever mechanic declared — teamwork
+ * here. The plain cast can only ever announce a creature with mana value 3 or less; the teamwork
+ * cast announces any creature and cannot be announced at all unless a creature is there to target.
  *
  * Because the branch replaces the effect wholesale, the teamwork branch restates the exile
- * alongside the life gain. Mana value is read off the creature's card, so an animated land (mana
- * value 0) is a legal plain-cast target and a token (also 0) is too.
+ * alongside the life gain.
  */
 val CruelAlliance = card("Cruel Alliance") {
     manaCost = "{2}{B}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/CruelAlliance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/CruelAlliance.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Cruel Alliance — Marvel Super Heroes #92
+ * {2}{B} · Sorcery
+ *
+ * Teamwork 2 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 2 or more.)
+ * Exile target creature with mana value 3 or less. If this spell was cast using teamwork, instead
+ * exile target creature and you gain 3 life.
+ *
+ * The **teamwork-only targeting** shape of teamwork (CR 702.194c): "instead" here replaces the
+ * whole sentence, target restriction included, so this is not a rider on one effect — the declared
+ * cast announces a *different* target requirement. That's the shared optional-additional-cost
+ * rail's `kickerTarget` / `kickerEffect` slots (Fight with Fire, Brave the Wilds), which serve
+ * whichever mechanic declared — teamwork here. The plain cast can only ever announce a creature
+ * with mana value 3 or less; the teamwork cast announces any creature and cannot be announced at
+ * all unless a creature is there to target.
+ *
+ * Because the branch replaces the effect wholesale, the teamwork branch restates the exile
+ * alongside the life gain. Mana value is read off the creature's card, so an animated land (mana
+ * value 0) is a legal plain-cast target and a token (also 0) is too.
+ */
+val CruelAlliance = card("Cruel Alliance") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Teamwork 2 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 2 or more.)\n" +
+        "Exile target creature with mana value 3 or less. If this spell was cast using teamwork, " +
+        "instead exile target creature and you gain 3 life."
+
+    teamwork(2)
+
+    spell {
+        val small = target(
+            "target creature with mana value 3 or less",
+            TargetCreature(filter = TargetFilter.Creature.manaValueAtMost(3)),
+        )
+        effect = Effects.Exile(small)
+
+        val anyCreature = kickerTarget(
+            "target creature",
+            TargetCreature(filter = TargetFilter.Creature),
+        )
+        kickerEffect = Effects.Composite(
+            Effects.Exile(anyCreature),
+            Effects.GainLife(3),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "92"
+        artist = "Vilhelmas Banys"
+        flavorText = "\"Die, you pathetic swine!\"\n—Viper, Ophelia Sarkissian"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d895d5a1-d382-438b-8551-e142bb5142af.jpg?1783902948"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/EarthsMightiestHeroes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/EarthsMightiestHeroes.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Earth's Mightiest Heroes — Marvel Super Heroes #165
+ * {4}{G}{G} · Sorcery
+ *
+ * Teamwork 5 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 5 or more.)
+ * Reveal the top eight cards of your library. You may put a creature card from among them onto the
+ * battlefield. If this spell was cast using teamwork, put any number of creature cards from among
+ * them onto the battlefield instead. Put the rest into your graveyard.
+ *
+ * The plain spell-rider "instead" shape of teamwork (CR 702.194b) over the Gather → Select → Move
+ * pipeline. Only the *selection mode* changes, so the reveal and both moves are shared and the
+ * [ConditionalEffect] wraps just the select-and-move half — structurally the same split See the
+ * Unwritten uses for its ferocious "two instead of one".
+ *
+ * The two modes are the printed wordings, not an approximation of them:
+ * [SelectionMode.ChooseAnyNumber] is "any number of creature cards" and
+ * [SelectionMode.ChooseUpTo]`(1)` is "you may put *a* creature card" — the "may" is the "up to".
+ * Both are still gated by the creature filter, so noncreature cards are never selectable and land
+ * in the graveyard with the rest.
+ *
+ * [Conditions.TeamworkWasPaid] is read while the spell is still on the stack, at the moment the
+ * conditional is evaluated during resolution — the same reading Helicarrier Strike relies on.
+ */
+val EarthsMightiestHeroes = card("Earth's Mightiest Heroes") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Teamwork 5 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 5 or more.)\n" +
+        "Reveal the top eight cards of your library. You may put a creature card from among them " +
+        "onto the battlefield. If this spell was cast using teamwork, put any number of creature " +
+        "cards from among them onto the battlefield instead. Put the rest into your graveyard."
+
+    teamwork(5)
+
+    spell {
+        fun selectAndMove(selection: SelectionMode, prompt: String) = Effects.Composite(
+            SelectFromCollectionEffect(
+                from = "revealed",
+                selection = selection,
+                filter = GameObjectFilter.Creature,
+                storeSelected = "selected",
+                storeRemainder = "rest",
+                prompt = prompt,
+                selectedLabel = "Put onto the battlefield",
+                remainderLabel = "Put into your graveyard",
+                showAllCards = true,
+            ),
+            MoveCollectionEffect(
+                from = "selected",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+            ),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD),
+            ),
+        )
+
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(8)),
+                storeAs = "revealed",
+                revealed = true,
+            ),
+            ConditionalEffect(
+                condition = Conditions.TeamworkWasPaid,
+                effect = selectAndMove(
+                    SelectionMode.ChooseAnyNumber,
+                    "Choose any number of creature cards to put onto the battlefield",
+                ),
+                elseEffect = selectAndMove(
+                    SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    "Choose a creature card to put onto the battlefield",
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "165"
+        artist = "Steve Morris"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b38b9bd6-1dd7-4bbc-8a82-ce391c1172e1.jpg?1783902919"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/TooEvilToStayDead.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/TooEvilToStayDead.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Too Evil to Stay Dead — Marvel Super Heroes #118
+ * {2}{B} · Sorcery
+ *
+ * Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 4 or more.)
+ * Choose target creature card in your graveyard with mana value 4 or less. If this spell was cast
+ * using teamwork, instead choose target creature card in your graveyard. Return the chosen card to
+ * the battlefield.
+ *
+ * The **teamwork-only targeting** shape of teamwork (CR 702.194c): "instead choose" replaces the
+ * target requirement itself, not the effect's size, so the two branches are two different
+ * announcements. That's the shared optional-additional-cost rail's `kickerTarget` / `kickerEffect`
+ * slots — the same ones Fight with Fire and Brave the Wilds ride — serving teamwork here. A
+ * teamwork cast can therefore reanimate a creature card the plain cast could not even target.
+ *
+ * The mana value is the graveyard card's own printed value; a card in a graveyard has no
+ * continuous effects applied to it, so no projection is involved on either branch. Both branches
+ * end in the same [Effects.PutOntoBattlefield] because "return the chosen card to the battlefield"
+ * is the shared last sentence — the branch replaces the whole effect, so it has to restate it.
+ */
+val TooEvilToStayDead = card("Too Evil to Stay Dead") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 4 or more.)\n" +
+        "Choose target creature card in your graveyard with mana value 4 or less. If this spell " +
+        "was cast using teamwork, instead choose target creature card in your graveyard. Return " +
+        "the chosen card to the battlefield."
+
+    teamwork(4)
+
+    spell {
+        val cheapCreature = target(
+            "target creature card in your graveyard with mana value 4 or less",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMost(4)),
+        )
+        effect = Effects.PutOntoBattlefield(cheapCreature)
+
+        val anyCreature = kickerTarget(
+            "target creature card in your graveyard",
+            Targets.CreatureCardInYourGraveyard,
+        )
+        kickerEffect = Effects.PutOntoBattlefield(anyCreature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "118"
+        artist = "Ioannis Fiore"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f471e9ce-73bb-4090-98f2-f591c7cf4efe.jpg?1783902936"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/TooEvilToStayDead.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/TooEvilToStayDead.kt
@@ -18,11 +18,14 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * using teamwork, instead choose target creature card in your graveyard. Return the chosen card to
  * the battlefield.
  *
- * The **teamwork-only targeting** shape of teamwork (CR 702.194c): "instead choose" replaces the
- * target requirement itself, not the effect's size, so the two branches are two different
- * announcements. That's the shared optional-additional-cost rail's `kickerTarget` / `kickerEffect`
- * slots — the same ones Fight with Fire and Brave the Wilds ride — serving teamwork here. A
- * teamwork cast can therefore reanimate a creature card the plain cast could not even target.
+ * The **teamwork-only targeting** shape of teamwork: "instead choose" replaces the target
+ * requirement itself, not the effect's size, so the two branches are two different announcements.
+ * CR 601.2c is the rules basis ("a spell may require alternative targets only if an alternative or
+ * additional cost was chosen for it"); CR 702.194c supplies the other direction, that the plain
+ * cast is announced as though the teamwork clause's target weren't there. That maps onto the
+ * shared optional-additional-cost rail's `kickerTarget` / `kickerEffect` slots — the same ones
+ * Fight with Fire and Brave the Wilds ride — serving teamwork here. A teamwork cast can therefore
+ * reanimate a creature card the plain cast could not even target.
  *
  * The mana value is the graveyard card's own printed value; a card in a graveyard has no
  * continuous effects applied to it, so no projection is involved on either branch. Both branches

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/WeSayTheeNay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/WeSayTheeNay.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.teamwork
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * We Say Thee Nay! — Marvel Super Heroes #82
+ * {1}{U} · Instant — Arcane
+ *
+ * Teamwork 2 (As an additional cost to cast this spell, you may tap any number of creatures you
+ * control with total power 2 or more.)
+ * Counter target spell unless its controller pays {2}. Counter that spell unless its controller
+ * pays {4} instead if this spell was cast using teamwork.
+ *
+ * The plain spell-rider "instead" shape of teamwork (CR 702.194b), gated on
+ * [Conditions.TeamworkWasPaid] — the declaration is read off this spell while it is still on the
+ * stack, at the moment the counter resolves. One [Effects.CounterUnlessDynamicPays] with a
+ * [DynamicAmount.Conditional] tax rather than two counter effects: the printed card is a *single*
+ * "counter unless they pay" event whose price changes, and both prices are purely generic, so a
+ * dynamic generic amount is exact.
+ */
+val WeSayTheeNay = card("We Say Thee Nay!") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant — Arcane"
+    oracleText = "Teamwork 2 (As an additional cost to cast this spell, you may tap any number of " +
+        "creatures you control with total power 2 or more.)\n" +
+        "Counter target spell unless its controller pays {2}. Counter that spell unless its " +
+        "controller pays {4} instead if this spell was cast using teamwork."
+
+    teamwork(2)
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterUnlessDynamicPays(
+            DynamicAmount.Conditional(
+                condition = Conditions.TeamworkWasPaid,
+                ifTrue = DynamicAmount.Fixed(4),
+                ifFalse = DynamicAmount.Fixed(2),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Mateus Manhanini"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13b70321-75bd-4d44-b9f6-5f062a5dda0f.jpg?1783902948"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -3659,6 +3659,94 @@
     ]
 }
 
+// Cruel Alliance
+{
+    "name": "Cruel Alliance",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Teamwork 2 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 2 or more.)\nExile target creature with mana value 3 or less. If this spell was cast using teamwork, instead exile target creature and you gain 3 life.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 2
+                }
+            },
+            "displayPrefix": "Teamwork 2",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature with mana value 3 or less"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature mv<=3"
+                },
+                "id": "target creature with mana value 3 or less"
+            }
+        ],
+        "kickerTargetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "kickerSpellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "artist": "Vilhelmas Banys",
+        "flavorText": "\"Die, you pathetic swine!\"\n—Viper, Ophelia Sarkissian",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d895d5a1-d382-438b-8551-e142bb5142af.jpg?1783902948"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Daredevil, Man Without Fear
 {
     "name": "Daredevil, Man Without Fear",
@@ -4315,6 +4403,147 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Earth's Mightiest Heroes
+{
+    "name": "Earth's Mightiest Heroes",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Teamwork 5 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 5 or more.)\nReveal the top eight cards of your library. You may put a creature card from among them onto the battlefield. If this spell was cast using teamwork, put any number of creature cards from among them onto the battlefield instead. Put the rest into your graveyard.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 5
+                }
+            },
+            "displayPrefix": "Teamwork 5",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 8
+                        }
+                    },
+                    "storeAs": "revealed",
+                    "revealed": true
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "CastChoiceMade",
+                            "slot": "TEAMWORK"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "revealed",
+                                "selection": "ChooseAnyNumber",
+                                "filter": "creature",
+                                "storeSelected": "selected",
+                                "storeRemainder": "rest",
+                                "prompt": "Choose any number of creature cards to put onto the battlefield",
+                                "selectedLabel": "Put onto the battlefield",
+                                "remainderLabel": "Put into your graveyard",
+                                "showAllCards": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "selected",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "rest",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "revealed",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "filter": "creature",
+                                "storeSelected": "selected",
+                                "storeRemainder": "rest",
+                                "prompt": "Choose a creature card to put onto the battlefield",
+                                "selectedLabel": "Put onto the battlefield",
+                                "remainderLabel": "Put into your graveyard",
+                                "showAllCards": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "selected",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "rest",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "MYTHIC",
+        "artist": "Steve Morris",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b38b9bd6-1dd7-4bbc-8a82-ce391c1172e1.jpg?1783902919"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -16103,6 +16332,84 @@
     "layout": "MODAL_DFC"
 }
 
+// Too Evil to Stay Dead
+{
+    "name": "Too Evil to Stay Dead",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Teamwork 4 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 4 or more.)\nChoose target creature card in your graveyard with mana value 4 or less. If this spell was cast using teamwork, instead choose target creature card in your graveyard. Return the chosen card to the battlefield.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 4
+                }
+            },
+            "displayPrefix": "Teamwork 4",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature card in your graveyard with mana value 4 or less"
+            },
+            "destination": "Battlefield"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature mv<=4 own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card in your graveyard with mana value 4 or less"
+            }
+        ],
+        "kickerTargetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card in your graveyard"
+            }
+        ],
+        "kickerSpellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature card in your graveyard"
+            },
+            "destination": "Battlefield"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "rarity": "UNCOMMON",
+        "artist": "Ioannis Fiore",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f471e9ce-73bb-4090-98f2-f591c7cf4efe.jpg?1783902936"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Training Compound
 {
     "name": "Training Compound",
@@ -17501,6 +17808,77 @@
     "colorIdentityOverride": [
         "RED",
         "WHITE"
+    ]
+}
+
+// We Say Thee Nay!
+{
+    "name": "We Say Thee Nay!",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant — Arcane",
+    "oracleText": "Teamwork 2 (As an additional cost to cast this spell, you may tap any number of creatures you control with total power 2 or more.)\nCounter target spell unless its controller pays {2}. Counter that spell unless its controller pays {4} instead if this spell was cast using teamwork.",
+    "keywords": [
+        "TEAMWORK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomVariablePermanents",
+                    "filter": "creature",
+                    "minCount": 0,
+                    "excludeSelf": false,
+                    "action": "TAP",
+                    "xMeasure": "TOTAL_POWER",
+                    "minMeasure": 2
+                }
+            },
+            "displayPrefix": "Teamwork 2",
+            "keyword": "TEAMWORK",
+            "declaredSlot": "TEAMWORK"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Counter",
+            "condition": {
+                "type": "CounterCondition.UnlessPaysDynamic",
+                "amount": {
+                    "type": "Conditional",
+                    "condition": {
+                        "type": "CastChoiceMade",
+                        "slot": "TEAMWORK"
+                    },
+                    "ifTrue": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "ifFalse": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Mateus Manhanini",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13b70321-75bd-4d44-b9f6-5f062a5dda0f.jpg?1783902948"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CruelAllianceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CruelAllianceScenarioTest.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cruel Alliance (MSH #92) — {2}{B} Sorcery.
+ *
+ *   Teamwork 2
+ *   Exile target creature with mana value 3 or less. If this spell was cast using teamwork,
+ *   instead exile target creature and you gain 3 life.
+ *
+ * The interesting half is the *targeting*: "instead" replaces the target restriction, so the
+ * teamwork cast can hit a creature the plain cast could not even announce. Grizzly Bears
+ * ({1}{G}, mana value 2) is the plain victim and Craw Wurm ({4}{G}{G}, mana value 6) is the one
+ * only teamwork reaches.
+ *
+ * The last two tests go against `getLegalActions` rather than `execute(CastSpell(...))` — the
+ * handler can't tell you whether the client was *offered* the branch, and every teamwork bug found
+ * so far has lived in the enumerator.
+ */
+class CruelAllianceScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cruel Alliance") {
+
+            test("cast without teamwork exiles a mana value 3 or less creature and gains no life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cruel Alliance")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+
+                game.castSpell(1, "Cruel Alliance", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                game.isInExile(2, "Grizzly Bears") shouldBe true
+                withClue("the life gain rides only on the teamwork branch") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+                withClue("no teamwork cost was declared, so nothing tapped") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("the plain cast cannot target a creature with mana value 4 or greater") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cruel Alliance")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+
+                game.castSpell(1, "Cruel Alliance", targetId = wurm).error.shouldNotBeNull()
+                game.isInHand(1, "Cruel Alliance") shouldBe true
+                game.isOnBattlefield("Craw Wurm") shouldBe true
+            }
+
+            test("cast using teamwork exiles any creature and gains 3 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cruel Alliance")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+
+                // Teamwork 2 — the 3/3 Hill Giant clears the threshold on its own.
+                game.castSpellWithTeamwork(
+                    1, "Cruel Alliance", "Hill Giant", targetId = wurm,
+                ).error shouldBe null
+                game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                withClue("the teamwork branch has no mana value restriction") {
+                    game.isInExile(2, "Craw Wurm") shouldBe true
+                }
+                game.getLifeTotal(1) shouldBe 23
+            }
+
+            test("the enumerator offers only the teamwork cast when every creature is too expensive") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cruel Alliance")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Hill Giant")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val casts = game.getLegalActions(1)
+                    .filter { it.description.startsWith("Cast Cruel Alliance") }
+
+                withClue("mana value 3 or less has no legal target, so the plain cast is not offered") {
+                    casts.none { it.actionType == "CastSpell" } shouldBe true
+                }
+
+                val teamworkCast = casts.single { it.actionType == "CastWithKicker" }
+                teamworkCast.description shouldBe "Cast Cruel Alliance (Teamwork 2)"
+                teamworkCast.isAffordable shouldBe true
+                teamworkCast.additionalCostInfo?.costType shouldBe "TapForTotalPower"
+                withClue("the teamwork branch announces its own, unrestricted target") {
+                    teamworkCast.validTargets.shouldNotBeNull() shouldContain wurm
+                }
+            }
+
+            test("the teamwork cast is offered unaffordable when no creature can pay the cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cruel Alliance")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    // Player 1 controls no creature at all, so total power 2 is unreachable.
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Craw Wurm")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                val casts = game.getLegalActions(1)
+                    .filter { it.description.startsWith("Cast Cruel Alliance") }
+
+                val plainCast = casts.single { it.actionType == "CastSpell" }
+                withClue("the plain cast's filter excludes the mana value 6 Craw Wurm") {
+                    plainCast.validTargets shouldBe listOf(bears)
+                }
+
+                val teamworkCast = casts.single { it.actionType == "CastWithKicker" }
+                withClue("teamwork's tap cost cannot be paid, so the variant is greyed out — it " +
+                    "stays on the list so the player can see what teamwork would ask for") {
+                    teamworkCast.isAffordable shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EarthsMightiestHeroesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EarthsMightiestHeroesScenarioTest.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -108,6 +109,72 @@ class EarthsMightiestHeroesScenarioTest : ScenarioTestBase() {
                 game.isOnBattlefield("Wall of Swords") shouldBe true
                 withClue("the five noncreature cards are the rest, and go to the graveyard") {
                     game.isInGraveyard(1, "Forest") shouldBe true
+                    game.state.getLibrary(game.player1Id).shouldBeEmpty()
+                }
+            }
+
+            // `minSelections == 0` is asserted on both branches above but never exercised. "You
+            // *may* put" means declining is legal, and then every revealed card is "the rest".
+            test("selecting nothing is legal and sends all eight revealed cards to the graveyard") {
+                val game = board()
+
+                game.castSpell(1, "Earth's Mightiest Heroes").error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                    .minSelections shouldBe 0
+
+                game.skipSelection().error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing was chosen, so no creature reaches the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isOnBattlefield("Wall of Swords") shouldBe false
+                }
+                withClue("all eight revealed cards are 'the rest'") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                    game.isInGraveyard(1, "Wall of Swords") shouldBe true
+                    game.findCardsInGraveyard(1, "Forest") shouldHaveSize 5
+                    game.state.getLibrary(game.player1Id).shouldBeEmpty()
+                }
+            }
+
+            // "Reveal the top eight cards" takes as many as are there — a three-card library is
+            // not an error and does not stall the resolution.
+            test("a library of fewer than eight cards reveals as many as it has") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Earth's Mightiest Heroes")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInLibrary(1, "Grizzly Bears").first()
+
+                game.castSpell(1, "Earth's Mightiest Heroes").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("only one of the three revealed cards is a creature card") {
+                    decision.maxSelections shouldBe 1
+                }
+
+                game.selectCards(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+                withClue("the two Forests are the rest, and the library is emptied, not underflowed") {
+                    game.findCardsInGraveyard(1, "Forest") shouldHaveSize 2
                     game.state.getLibrary(game.player1Id).shouldBeEmpty()
                 }
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EarthsMightiestHeroesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EarthsMightiestHeroesScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Earth's Mightiest Heroes (MSH #165) — {4}{G}{G} Sorcery.
+ *
+ *   Teamwork 5
+ *   Reveal the top eight cards of your library. You may put a creature card from among them onto
+ *   the battlefield. If this spell was cast using teamwork, put any number of creature cards from
+ *   among them onto the battlefield instead. Put the rest into your graveyard.
+ *
+ * The library is seeded with exactly eight cards — three creatures and five Forests — so the
+ * reveal takes the whole library and the difference between the branches is visible in one number:
+ * the selection's maximum is 1 without teamwork and 3 (every eligible creature) with it. Craw Wurm
+ * (6/4) is on the battlefield only to pay teamwork 5 by itself.
+ */
+class EarthsMightiestHeroesScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Earth's Mightiest Heroes") {
+
+            fun board() = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Earth's Mightiest Heroes")
+                .withLandsOnBattlefield(1, "Forest", 6)
+                .withCardOnBattlefield(1, "Craw Wurm")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Wall of Swords")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            test("cast without teamwork puts at most one creature card onto the battlefield") {
+                val game = board()
+                val bears = game.findCardsInLibrary(1, "Grizzly Bears").first()
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+
+                game.castSpell(1, "Earth's Mightiest Heroes").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("\"you may put a creature card\" is a choose-up-to-one") {
+                    decision.maxSelections shouldBe 1
+                    decision.minSelections shouldBe 0
+                }
+
+                game.selectCards(listOf(bears)).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+                withClue("the other two creatures were not chosen, so they join the rest in the graveyard") {
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                    game.isInGraveyard(1, "Wall of Swords") shouldBe true
+                }
+                withClue("all eight revealed cards left the library") {
+                    game.state.getLibrary(game.player1Id).shouldBeEmpty()
+                }
+                withClue("no teamwork cost was declared, so nothing tapped") {
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("cast using teamwork puts any number of creature cards onto the battlefield") {
+                val game = board()
+                val bears = game.findCardsInLibrary(1, "Grizzly Bears").first()
+                val giant = game.findCardsInLibrary(1, "Hill Giant").first()
+                val wall = game.findCardsInLibrary(1, "Wall of Swords").first()
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+
+                // Teamwork 5 — the 6/4 Craw Wurm clears the threshold on its own.
+                game.castSpellWithTeamwork(1, "Earth's Mightiest Heroes", "Craw Wurm")
+                    .error shouldBe null
+                game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("\"any number\" reaches every eligible creature among the eight revealed") {
+                    decision.maxSelections shouldBe 3
+                    decision.minSelections shouldBe 0
+                }
+
+                game.selectCards(listOf(bears, giant, wall)).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+                game.isOnBattlefield("Hill Giant") shouldBe true
+                game.isOnBattlefield("Wall of Swords") shouldBe true
+                withClue("the five noncreature cards are the rest, and go to the graveyard") {
+                    game.isInGraveyard(1, "Forest") shouldBe true
+                    game.state.getLibrary(game.player1Id).shouldBeEmpty()
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TooEvilToStayDeadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TooEvilToStayDeadScenarioTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import com.wingedsheep.sdk.scripting.ChoiceSlot
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -153,6 +154,38 @@ class TooEvilToStayDeadScenarioTest : ScenarioTestBase() {
                 teamworkCast.isAffordable shouldBe true
                 teamworkCast.additionalCostInfo?.costType shouldBe "TapForTotalPower"
                 teamworkCast.validTargets.shouldNotBeNull() shouldContain dragon
+            }
+
+            // The mirror of the test above: with a legal cheap target present, both variants are
+            // offered, and the plain one advertises the *narrow* list. This is the assertion that
+            // catches a filter that silently widened.
+            test("the enumerator offers both casts, with the plain one restricted to the cheap creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Too Evil to Stay Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(1, "Shivan Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findCardsInGraveyard(1, "Hill Giant").first()
+                val dragon = game.findCardsInGraveyard(1, "Shivan Dragon").first()
+                val casts = game.getLegalActions(1)
+                    .filter { it.description.startsWith("Cast Too Evil to Stay Dead") }
+
+                val plainCast = casts.single { it.actionType == "CastSpell" }
+                withClue("the mana value 6 Shivan Dragon is outside the plain branch's filter") {
+                    plainCast.validTargets shouldBe listOf(giant)
+                }
+
+                val teamworkCast = casts.single { it.actionType == "CastWithKicker" }
+                withClue("the teamwork branch has no mana value restriction, so both are reachable") {
+                    teamworkCast.validTargets.shouldNotBeNull()
+                        .shouldContainExactlyInAnyOrder(giant, dragon)
+                }
             }
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TooEvilToStayDeadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TooEvilToStayDeadScenarioTest.kt
@@ -1,0 +1,159 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Too Evil to Stay Dead (MSH #118) — {2}{B} Sorcery.
+ *
+ *   Teamwork 4
+ *   Choose target creature card in your graveyard with mana value 4 or less. If this spell was
+ *   cast using teamwork, instead choose target creature card in your graveyard. Return the chosen
+ *   card to the battlefield.
+ *
+ * "Instead choose" swaps the *target requirement*, so the two branches are two different
+ * announcements. Hill Giant ({3}{R}, mana value 4) sits exactly on the plain threshold; Shivan
+ * Dragon ({4}{R}{R}, mana value 6) is reachable only by the teamwork cast. Craw Wurm (6/4) is on
+ * the battlefield purely to pay teamwork 4 on its own.
+ */
+class TooEvilToStayDeadScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Too Evil to Stay Dead") {
+
+            test("cast without teamwork returns a mana value 4 or less creature card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Too Evil to Stay Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(1, "Shivan Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findCardsInGraveyard(1, "Hill Giant").first()
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Too Evil to Stay Dead").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Card(giant, game.player1Id, Zone.GRAVEYARD)),
+                    ),
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.isOnBattlefield("Hill Giant") shouldBe true
+                withClue("Shivan Dragon was not chosen, so it stays in the graveyard") {
+                    game.isInGraveyard(1, "Shivan Dragon") shouldBe true
+                }
+                withClue("no teamwork cost was declared, so nothing tapped") {
+                    game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("the plain cast cannot target a creature card with mana value 5 or greater") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Too Evil to Stay Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardInGraveyard(1, "Shivan Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dragon = game.findCardsInGraveyard(1, "Shivan Dragon").first()
+                val cardId = game.findCardsInHand(1, "Too Evil to Stay Dead").first()
+
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Card(dragon, game.player1Id, Zone.GRAVEYARD)),
+                    ),
+                ).error.shouldNotBeNull()
+                game.isInHand(1, "Too Evil to Stay Dead") shouldBe true
+                game.isInGraveyard(1, "Shivan Dragon") shouldBe true
+            }
+
+            test("cast using teamwork returns any creature card and taps the payers") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Too Evil to Stay Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardInGraveyard(1, "Shivan Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dragon = game.findCardsInGraveyard(1, "Shivan Dragon").first()
+                val wurm = game.findPermanent("Craw Wurm").shouldNotBeNull()
+                val cardId = game.findCardsInHand(1, "Too Evil to Stay Dead").first()
+
+                // Teamwork 4 — the 6/4 Craw Wurm clears the threshold on its own.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Card(dragon, game.player1Id, Zone.GRAVEYARD)),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(wurm),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.state.getEntity(wurm)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                withClue("the teamwork branch has no mana value restriction") {
+                    game.isOnBattlefield("Shivan Dragon") shouldBe true
+                }
+            }
+
+            // Driving `CastSpell` directly proves only what the handler accepts. This one goes
+            // against `getLegalActions`, which is what the client actually sees.
+            test("the enumerator offers only the teamwork cast when the graveyard holds no cheap creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Too Evil to Stay Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Craw Wurm")
+                    .withCardInGraveyard(1, "Shivan Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val dragon = game.findCardsInGraveyard(1, "Shivan Dragon").first()
+                val casts = game.getLegalActions(1)
+                    .filter { it.description.startsWith("Cast Too Evil to Stay Dead") }
+
+                withClue("mana value 4 or less has no legal target, so the plain cast is not offered") {
+                    casts.none { it.actionType == "CastSpell" } shouldBe true
+                }
+
+                val teamworkCast = casts.single { it.actionType == "CastWithKicker" }
+                teamworkCast.description shouldBe "Cast Too Evil to Stay Dead (Teamwork 4)"
+                teamworkCast.isAffordable shouldBe true
+                teamworkCast.additionalCostInfo?.costType shouldBe "TapForTotalPower"
+                teamworkCast.validTargets.shouldNotBeNull() shouldContain dragon
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeSayTheeNayScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeSayTheeNayScenarioTest.kt
@@ -15,6 +15,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
@@ -24,23 +25,26 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  *   Counter target spell unless its controller pays {2}. Counter that spell unless its controller
  *   pays {4} instead if this spell was cast using teamwork.
  *
- * Both branches are pinned by the same board: Player 2 casts Grizzly Bears with four Forests, two
- * of which pay for it. Two Forests are left untapped — enough for the plain {2} tax, short of the
- * teamwork {4}. So the plain cast produces the "pay?" offer and the teamwork cast counters
- * outright, which is exactly the difference the card prints.
+ * The board is the same shape throughout — Player 2 casts Grizzly Bears, which eats two of their
+ * Forests — with only the Forest count varying, so the tax is what the tests are reading:
+ *
+ *  - four Forests (two left untapped): the plain cast offers a {2} the controller can pay, and the
+ *    teamwork cast is out of reach, so no offer is made at all and the spell is countered;
+ *  - six Forests (four left untapped): the teamwork cast offers a {4} — named in the prompt, so the
+ *    number itself is pinned, not just "more than 2" — and paying it saves Grizzly Bears.
  */
 class WeSayTheeNayScenarioTest : ScenarioTestBase() {
 
     init {
         context("We Say Thee Nay!") {
 
-            fun board() = scenario()
+            fun board(forests: Int = 4) = scenario()
                 .withPlayers("Player1", "Player2")
                 .withCardInHand(1, "We Say Thee Nay!")
                 .withLandsOnBattlefield(1, "Island", 2)
                 .withCardOnBattlefield(1, "Hill Giant")
                 .withCardInHand(2, "Grizzly Bears")
-                .withLandsOnBattlefield(2, "Forest", 4)
+                .withLandsOnBattlefield(2, "Forest", forests)
                 .withActivePlayer(2)
                 .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
                 .build()
@@ -112,6 +116,55 @@ class WeSayTheeNayScenarioTest : ScenarioTestBase() {
                 withClue("the spell is countered and goes to its owner's graveyard") {
                     game.isOnBattlefield("Grizzly Bears") shouldBe false
                     game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            // The test above only proves the teamwork tax is *more than* the two mana on the
+            // table. This one names the number: with four Forests left untapped the offer is
+            // actually made, and the prompt has to say {4} — not {3}, not {5}.
+            test("the teamwork tax is exactly {4}, and paying it saves the spell") {
+                val game = board(forests = 6)
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+
+                val bearsOnStack = game.state.stack.first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val cardId = game.findCardsInHand(1, "We Say Thee Nay!").first()
+
+                // Teamwork 2 — the 3/3 Hill Giant clears the threshold on its own.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Spell(bearsOnStack)),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(giant),
+                        ),
+                    ),
+                ).error shouldBe null
+
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<YesNoDecision>()
+                decision.playerId shouldBe game.player2Id
+                withClue("teamwork was declared, so the tax is {4} rather than the printed {2}") {
+                    decision.prompt shouldContain "{4}"
+                    decision.prompt shouldNotContain "{2}"
+                }
+
+                // Four of the six Forests are still untapped, which is exactly {4}.
+                game.answerYesNo(true).error shouldBe null
+                game.submitManaSourcesAutoPay().error shouldBe null
+                game.resolveStack()
+
+                withClue("Player 2 paid the {4}, so Grizzly Bears is not countered") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeSayTheeNayScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeSayTheeNayScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * We Say Thee Nay! (MSH #82) — {1}{U} Instant — Arcane.
+ *
+ *   Teamwork 2
+ *   Counter target spell unless its controller pays {2}. Counter that spell unless its controller
+ *   pays {4} instead if this spell was cast using teamwork.
+ *
+ * Both branches are pinned by the same board: Player 2 casts Grizzly Bears with four Forests, two
+ * of which pay for it. Two Forests are left untapped — enough for the plain {2} tax, short of the
+ * teamwork {4}. So the plain cast produces the "pay?" offer and the teamwork cast counters
+ * outright, which is exactly the difference the card prints.
+ */
+class WeSayTheeNayScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("We Say Thee Nay!") {
+
+            fun board() = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "We Say Thee Nay!")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withCardOnBattlefield(1, "Hill Giant")
+                .withCardInHand(2, "Grizzly Bears")
+                .withLandsOnBattlefield(2, "Forest", 4)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            test("cast without teamwork taxes the spell's controller {2}") {
+                val game = board()
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+                game.castSpellTargetingStackSpell(1, "We Say Thee Nay!", "Grizzly Bears")
+                    .error shouldBe null
+
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                    .shouldNotBeNull()
+                    .shouldBeInstanceOf<YesNoDecision>()
+                decision.playerId shouldBe game.player2Id
+                withClue("no teamwork was declared, so the tax is the printed {2}") {
+                    decision.prompt shouldContain "{2}"
+                }
+                withClue("nothing was tapped to pay teamwork") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe false
+                }
+
+                // Saying yes opens the mana-source picker; two of the four Forests are still
+                // untapped, which is exactly {2}.
+                game.answerYesNo(true).error shouldBe null
+                game.submitManaSourcesAutoPay().error shouldBe null
+                game.resolveStack()
+
+                withClue("Player 2 paid the {2}, so Grizzly Bears is not countered") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("cast using teamwork raises the tax to {4}, which the controller cannot pay") {
+                val game = board()
+                val giant = game.findPermanent("Hill Giant").shouldNotBeNull()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+
+                val bearsOnStack = game.state.stack.first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val cardId = game.findCardsInHand(1, "We Say Thee Nay!").first()
+
+                // Teamwork 2 — the 3/3 Hill Giant clears the threshold on its own.
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Spell(bearsOnStack)),
+                        declaredCostSlot = ChoiceSlot.TEAMWORK,
+                        additionalCostPayment = AdditionalCostPayment(
+                            variableCostPermanents = listOf(giant),
+                        ),
+                    ),
+                ).error shouldBe null
+                game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+
+                game.resolveStack()
+
+                withClue("two untapped Forests cannot pay {4}, so no offer is even made") {
+                    game.getPendingDecision().shouldBeNull()
+                }
+                withClue("the spell is countered and goes to its owner's graveyard") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Add the four remaining non-modal teamwork cards to Marvel Super Heroes

> **Independent PR against `main`.** Every teamwork unit ahead of this one has landed upstream —
> `loop-msh-u01` as [#1703](https://github.com/wingedsheep/argentum-engine/pull/1703),
> `loop-msh-u02`, and `loop-msh-u03` as
> [#1750](https://github.com/wingedsheep/argentum-engine/pull/1750). This branch was rebased off the
> stack onto `origin/main` (`b11a8d70fe`) and carries only its own three commits; there is no
> merge order to respect.
>
> Review with `git diff origin/main...loop-msh-u04`.
>
> ✅ **Gated on the current `main` (`b11a8d70fe`).** `just build` with `--no-build-cache
> --rerun-tasks` — see the *Verification* section below for the result. The previously reported
> figure (12229 passed) was measured on `main` at `26f5e1c8ca`, 50 commits behind and before
> `loop-msh-u03` merged, so it no longer stands for this base.

Adds the four remaining non-modal **teamwork** cards to Marvel Super Heroes. Ordinary card work —
the teamwork rail (`teamwork(n)`, `Conditions.TeamworkWasPaid`, `ChoiceSlot.TEAMWORK`) shipped in
earlier units and is unchanged here. No engine or SDK code is touched.

## Cards

| Card | What it does | Primitives it composes |
|---|---|---|
| **Cruel Alliance** [92] — {2}{B} Sorcery, teamwork 2 | Exile target creature with mana value 3 or less; if cast using teamwork, instead exile target creature (no restriction) and gain 3 life. | The shared optional-additional-cost rail's `kickerTarget` / `kickerEffect` slots (the Fight with Fire / Brave the Wilds shape) + `Effects.Exile` + `Effects.GainLife` + `Effects.Composite`. |
| **Too Evil to Stay Dead** [118] — {2}{B} Sorcery, teamwork 4 | Choose target creature card in your graveyard with mana value 4 or less; if teamwork, instead any creature card in your graveyard. Return it to the battlefield. | Same `kickerTarget` / `kickerEffect` pair, over `TargetFilter.CreatureInYourGraveyard` / `Targets.CreatureCardInYourGraveyard` + `Effects.PutOntoBattlefield`. |
| **We Say Thee Nay!** [82] — {1}{U} Instant — Arcane, teamwork 2 | Counter target spell unless its controller pays {2}; {4} instead if cast using teamwork. | One `Effects.CounterUnlessDynamicPays` whose generic amount is `DynamicAmount.Conditional(Conditions.TeamworkWasPaid, 4, 2)`. |
| **Earth's Mightiest Heroes** [165] — {4}{G}{G} Sorcery, teamwork 5 | Reveal the top eight; put a creature card onto the battlefield, or any number if cast using teamwork; rest to the graveyard. | Gather → Select → Move pipeline, with a `ConditionalEffect(TeamworkWasPaid, …)` swapping only the selection mode (`SelectionMode.ChooseAnyNumber` vs `ChooseUpTo(1)`) — the same split KTK's See the Unwritten uses for ferocious. |

Cruel Alliance and Too Evil to Stay Dead are a shape the rail already covered but the docs hadn't
named: the teamwork "instead" replaces the **target requirement**, not an amount, so each branch is
announced under its own filter. `CardScript.kickerTargetRequirements` already *replace*
`targetRequirements` on a declared cast, so a teamwork cast can legally target something the plain
cast could not — and the plain cast drops out of the enumeration entirely when only the wider filter
has a legal target. The rules basis is **CR 601.2c** ("a spell may require *alternative targets*
only if an alternative or additional cost was chosen for it"), with **CR 702.194c** covering the
other direction (the plain cast never announces the teamwork clause's target). One bullet was added
to the Teamwork entry in `docs/card-sdk-language-reference.md` to record that; no SDK change
accompanies it. While in that entry, the pre-existing **modal "choose both instead"** bullet was
corrected from CR 702.194c to **CR 702.194b** — 702.194c governs *targets*, not mode counts, and
702.194b ("abilities may refer to a spell cast using teamwork") is what `CastSpellEnumerator` and
`CastSpellHandler` already cite for that same shape.

## Tests

One scenario test file per card, 17 tests, every card asserting **both** branches.

Because the three teamwork bugs found in the earlier units all lived in `CastSpellEnumerator`'s
legal-action advertising path — invisible to tests that drive `CastSpell` directly — two of these
files assert against `getLegalActions`:

- `CruelAllianceScenarioTest` — with only a mana-value-6 creature on the board the plain `CastSpell`
  is **not** advertised while the `CastWithKicker` teamwork variant is, carrying that creature as a
  valid target; and with no creature available to tap, the teamwork variant is advertised
  **unaffordable** (matching the enumerator's deliberate "greyed out, not hidden" behaviour for an
  unpayable teamwork cost).
- `TooEvilToStayDeadScenarioTest` — the same contrast over the graveyard, in both directions: the
  plain cast absent when only an expensive creature card is available, and offered with the
  *narrow* `validTargets` list when a cheap one is.

We Say Thee Nay!'s teamwork branch pins the tax at the actual `{4}` (a board where the controller
can pay it, asserting the prompt names `{4}` and that paying saves the spell), not merely "more
than the {2} on the table".

## Verification

- `just build` — **passed**.
- `just rebless-cards` — only the four new cards moved in
  `mtg-sets/src/test/resources/snapshots/cards/MSH.json` (pure insertions, no existing card touched).
- `just check-card-printing` for all four — each is canonical in MSH, its only real printing.
- `just fix-backlog` — MSH now 239/276; the teamwork section of
  `backlog/sets/marvel-super-heroes/mechanics.md` updated to 12 of 13 implemented, with **Agent
  Maria Hill** the only one still blocked (it needs the tap-reason addition on `TappedEvent`).

## What was *not* done

This PR came out of an autonomous loop. Specifically:

- **No manual playthrough in the web client.** Nothing here was clicked through by a human.
- **No UX pass from both seats.** In particular, Earth's Mightiest Heroes' teamwork branch shows an
  eight-card selection overlay with the noncreature cards greyed out; the decision payload is
  asserted in the test (`maxSelections` 1 vs 3) but the overlay itself was never looked at. Likewise
  the "pay {2} / pay {4}" prompt on We Say Thee Nay! was only exercised through the engine.
- **No e2e test.** No new visual or UX mechanic was introduced, so none was added.
- No card was dropped from this unit. The conditional target filter — the shape most likely to have
  needed a new primitive — turned out to be expressible on the existing rail.

## Review

Two independent reviews of this branch are complete and their findings were addressed in follow-up
commits — see `build/pr/loop-msh-u04-correction.md`.

- **Round 1** (0 blocking, 1 important, 7 minor). The important one was the unpinned `{4}` teamwork
  tax on We Say Thee Nay!, now fixed, along with the missing enumerator and edge-case assertions.
- **Round 2** (0 blocking, 2 important, 3 minor), all in the paperwork rather than the code: this
  PR body still described a stacked PR against an already-merged `loop-msh-u03` and quoted a gate
  measured on a 50-commit-stale base (both corrected above), the new
  `docs/card-sdk-language-reference.md` bullet was missing the CR 601.2c citation its card KDocs
  carry, `LOOP_UNIT.md` named the wrong base, and `CruelAlliance.kt` spelled out
  `TargetCreature(filter = TargetFilter.Creature)` where the `Targets.Creature` facade says the same
  thing.
