### PR TITLE
Add five The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheArkenstone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheArkenstone.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * The Arkenstone // Seek the Heart — The Hobbit #170
+ * {5} · Legendary Artifact · Mythic
+ *
+ * Creatures you control get +1/+1.
+ * At the beginning of your end step, draw a card.
+ *
+ * Adventure: Seek the Heart — {2}{W}, Sorcery — Adventure
+ * Search your library for a legendary creature card, reveal it, put it into your hand, then shuffle.
+ *
+ * Modeling notes:
+ *  - The anthem is a group [ModifyStats] over `Creature.youControl()`, not an attachment bonus:
+ *    The Arkenstone is a bare artifact with no Equipment subtype, so nothing is ever attached to it.
+ *  - Both halves are plain compositions — the Adventure is the Time of Need script verbatim.
+ *  - (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ *    caster cast it as the artifact while it remains in exile.)
+ */
+val TheArkenstone = card("The Arkenstone") {
+    manaCost = "{5}"
+    // Colorless front face, but the Adventure's {2}{W} puts the whole card in white's identity.
+    colorIdentity = "W"
+    typeLine = "Legendary Artifact"
+    oracleText = "Creatures you control get +1/+1.\n" +
+        "At the beginning of your end step, draw a card."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.DrawCards(1)
+        description = "Draw a card."
+    }
+
+    adventure("Seek the Heart") {
+        manaCost = "{2}{W}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Search your library for a legendary creature card, reveal it, put it into " +
+            "your hand, then shuffle. (Then exile this card. You may cast the artifact later " +
+            "from exile.)"
+        spell {
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Creature.legendary(),
+                destination = SearchDestination.HAND,
+                reveal = true
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "170"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a56a88ba-fcfa-4b56-bdae-a080b297b871.jpg?1783902783"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheGreatGoblin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheGreatGoblin.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * The Great Goblin — The Hobbit #158
+ * {1}{B/R}{B/R} · Legendary Creature — Goblin Noble · Rare
+ * 3/2
+ *
+ * Whenever you put one or more counters on a Goblin, Orc, or Army you control, The Great Goblin
+ * deals 2 damage to target opponent.
+ * Whenever another Goblin, Orc, or Army you control dies, exile the top card of your library. You
+ * may play it until the end of your next turn.
+ *
+ * Modeling notes:
+ *  - The counters trigger is [Triggers.countersPlacedOn] with `firstTimeEachTurn = false`: the
+ *    printed wording has no once-per-turn gate, so every batch of counters fires it again. It is
+ *    "one or more counters", so a single placement of three counters still fires exactly once — the
+ *    engine's `CountersPlacedEvent` is already per-placement, not per-counter.
+ *  - `placedBy = Player.You` carries the "**you** put" scope (CR 122.6a). It can't come from the
+ *    recipient filter: an opponent's effect putting counters on a Goblin *you control* matches the
+ *    filter but is not your placement, and must not fire. Amass is the common in-set source, and
+ *    since amass is worded as "that player puts", an opponent amassing their own Army correctly
+ *    leaves The Great Goblin cold even though [AzogMoriasRuin] made them do it.
+ *  - The Great Goblin is itself a Goblin and the first ability has no "another", so counters landing
+ *    on it (a +1/+1 counter from an Equipment, say) fire it — hence [TriggerBinding.ANY] and a
+ *    filter with no self-exclusion.
+ *  - The death trigger *is* "another", so it takes [TriggerBinding.OTHER]; it is per-creature
+ *    (not the batched `OneOrMore…Die` shape), matching the printed singular wording — a board wipe
+ *    that kills three Goblins exiles three cards.
+ *  - Both abilities use one OR over subtypes ([GameObjectFilter.withAnySubtype]) rather than three
+ *    filters; an Orc Army satisfies it once, not twice. See [GoblinTown] for the same idiom.
+ *  - The impulse window is [MayPlayExpiry.UntilEndOfNextTurn], turn-keyed, so it survives both the
+ *    end of the current turn and The Great Goblin leaving the battlefield.
+ */
+val TheGreatGoblin = card("The Great Goblin") {
+    manaCost = "{1}{B/R}{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Goblin Noble"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever you put one or more counters on a Goblin, Orc, or Army you control, " +
+        "The Great Goblin deals 2 damage to target opponent.\n" +
+        "Whenever another Goblin, Orc, or Army you control dies, exile the top card of your " +
+        "library. You may play it until the end of your next turn."
+
+    triggeredAbility {
+        trigger = Triggers.countersPlacedOn(
+            filter = GameObjectFilter.Creature.youControl()
+                .withAnySubtype("Goblin", "Orc", "Army"),
+            counterType = Counters.ANY,
+            firstTimeEachTurn = false,
+            binding = TriggerBinding.ANY,
+            placedBy = Player.You,
+        )
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.DealDamage(2, opponent)
+        description = "The Great Goblin deals 2 damage to target opponent."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl()
+                .withAnySubtype("Goblin", "Orc", "Army"),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Patterns.Exile.impulse(count = 1, expiry = MayPlayExpiry.UntilEndOfNextTurn)
+        description = "Exile the top card of your library. You may play it until the end of your " +
+            "next turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "158"
+        artist = "Miklós Ligeti"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78d8f53e-537d-4eaa-99e3-cac57fa53d22.jpg?1784798171"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheLonelyMountain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheLonelyMountain.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * The Lonely Mountain — The Hobbit #187
+ * Land — Mountain · Rare
+ *
+ * ({T}: Add {R}.)
+ * This land enters tapped unless you control an Equipment.
+ * {4}{R}, {T}: Create a 2/2 red Dwarf creature token. This ability costs {1} less to activate for
+ * each Equipment you control. Activate only as a sorcery.
+ *
+ * Modeling notes:
+ *  - The `{T}: Add {R}` is **not** authored: it is intrinsic to the Mountain land type (CR 305.6),
+ *    the same way [com.wingedsheep.mtg.sets.definitions.gpt.cards.StompingGround] gets both of its
+ *    mana abilities. Writing it out would double the ability.
+ *  - The entry clause is a self-replacement with an `unlessCondition`, so the check happens as the
+ *    land enters rather than as a triggered untap afterwards — a land put onto the battlefield by
+ *    another effect is gated the same way.
+ *  - The discount rides [com.wingedsheep.sdk.scripting.ActivatedAbility.genericCostReduction] (the
+ *    Qiqirn Merchant shape): the count of Equipment you control is evaluated once at activation and
+ *    reduces only the `{4}` — the `{R}` pip is never touched (CR 118.9a), so five Equipment leave the
+ *    ability costing `{R}`, not free. The legal-action enumerator applies the same reduction, so what
+ *    the client shows as affordable is what actually gets paid.
+ *  - "Equipment" is `Artifact.withSubtype("Equipment")` in both places, which is the projected
+ *    subtype — an artifact that has *become* an Equipment counts, and a token Equipment counts too.
+ */
+val TheLonelyMountain = card("The Lonely Mountain") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Land — Mountain"
+    oracleText = "({T}: Add {R}.)\n" +
+        "This land enters tapped unless you control an Equipment.\n" +
+        "{4}{R}, {T}: Create a 2/2 red Dwarf creature token. This ability costs {1} less to " +
+        "activate for each Equipment you control. Activate only as a sorcery."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.YouControl(
+                GameObjectFilter.Artifact.withSubtype("Equipment")
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{R}"), Costs.Tap)
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dwarf"),
+            imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537",
+        )
+        genericCostReduction = DynamicAmounts.battlefield(
+            Player.You,
+            GameObjectFilter.Artifact.withSubtype("Equipment")
+        ).count()
+        timing = TimingRule.SorcerySpeed
+        description = "Create a 2/2 red Dwarf creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "187"
+        artist = "Leon Tukker"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b39ebc4d-a01a-4401-ab3a-bf6142c93b47.jpg?1784543511"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilSindarinLiege.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilSindarinLiege.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Thranduil, Sindarin Liege // Silvan Rally — The Hobbit #166
+ * {2}{G/U}{G/U} · Legendary Creature — Elf Noble · Uncommon
+ * 2/3
+ *
+ * Other Elves you control get +1/+1.
+ * Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token.
+ *
+ * Adventure: Silvan Rally — {1}{G/U}{G/U}, Sorcery — Adventure
+ * Mill four cards, then put up to two land cards from among them into your hand.
+ *
+ * Modeling notes:
+ *  - The lord is `excludeSelf = true` on the [GroupFilter]: Thranduil is himself an Elf and the
+ *    printed wording is "**Other** Elves", so he must not pump himself. Same shape as Mabel, Heir to
+ *    Cragflame; see [ThranduilsCompany] for the sibling landfall wiring in this set.
+ *  - **Landfall** is [Triggers.LandYouControlEnters] — every land entering under your control, not
+ *    just the ones you play, so a land put onto the battlefield by another spell counts.
+ *  - The Adventure is a mill → select → move pipeline over the *same* collection: the milled cards
+ *    are already in the graveyard when the selection happens ("from among them" is a reference to
+ *    those four specific cards, not to the graveyard at large), which is why the second step reads
+ *    `from = "milled"` rather than re-gathering. `ChooseUpTo(2)` carries the "up to", so milling
+ *    zero or one land — or choosing to take none — is legal.
+ *  - `Patterns.Library.mill` is used rather than a hand-rolled gather so the move is flagged as a
+ *    real mill (`isMill = true`) and any "whenever you mill" watcher sees it.
+ *  - (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ *    caster cast it as the creature while it remains in exile.)
+ */
+val ThranduilSindarinLiege = card("Thranduil, Sindarin Liege") {
+    manaCost = "{2}{G/U}{G/U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Elf Noble"
+    power = 2
+    toughness = 3
+    oracleText = "Other Elves you control get +1/+1.\n" +
+        "Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.ELF).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elf"),
+            imageUri = "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812",
+        )
+        description = "Landfall — Whenever a land you control enters, create a 1/1 green Elf " +
+            "creature token."
+    }
+
+    adventure("Silvan Rally") {
+        manaCost = "{1}{G/U}{G/U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Mill four cards, then put up to two land cards from among them into your " +
+            "hand. (Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.Composite(
+                Patterns.Library.mill(4),
+                SelectFromCollectionEffect(
+                    from = "milled",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    filter = GameObjectFilter.Land,
+                    storeSelected = "toHand",
+                    showAllCards = true,
+                    prompt = "Put up to two land cards into your hand",
+                    selectedLabel = "Put in hand",
+                    remainderLabel = "Leave in graveyard"
+                ),
+                MoveCollectionEffect(
+                    from = "toHand",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "166"
+        artist = "Justyna Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/481870ee-d1f7-421b-86e1-570ea933bbbc.jpg?1785412747"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilsDecree.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilsDecree.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Thranduil's Decree — The Hobbit #56
+ * {4}{U}{U} · Instant · Uncommon
+ *
+ * Counter target spell. If a permanent spell is countered this way, exile it instead of putting it
+ * into its owner's graveyard. You may cast that card without paying its mana cost for as long as it
+ * remains exiled.
+ *
+ * Modeling notes:
+ *  - The exile rider is conditional on the countered spell being a *permanent* spell, so the two
+ *    counter destinations are a [ConditionalEffect] rather than a single
+ *    `CounterSpellToExile`: an instant or sorcery countered by the Decree goes to its owner's
+ *    graveyard as usual and is never castable from exile. [Conditions.TargetMatchesFilter] is
+ *    evaluated at resolution, while the countered spell is still on the stack, and the predicate
+ *    evaluator reads the stack object's own card types — the same path Dissipate's sibling shapes
+ *    take through `ChosenTarget.Spell`.
+ *  - The free-cast permission is `CounterDestination.Exile(grantFreeCast = true)` (Kheru
+ *    Spellsnatcher's rider): the Decree's controller — not the countered spell's — may cast the
+ *    exiled card without paying its mana cost, and the permission lasts exactly as long as the card
+ *    stays in exile, matching the printed "for as long as it remains exiled".
+ *  - A spell that can't be countered is unaffected by either branch; the counter simply does
+ *    nothing, and no exile happens (CR 701.5a).
+ */
+val ThranduilsDecree = card("Thranduil's Decree") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. If a permanent spell is countered this way, exile it " +
+        "instead of putting it into its owner's graveyard. You may cast that card without paying " +
+        "its mana cost for as long as it remains exiled."
+
+    spell {
+        target = Targets.Spell
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(GameObjectFilter.Permanent),
+            effect = Effects.CounterSpellToExile(grantFreeCast = true),
+            elseEffect = Effects.CounterSpell()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "56"
+        artist = "Javier Charro"
+        flavorText = "\"I have a right to know what brings you here, and if you will not tell me " +
+            "now, I will keep you all in prison until you have learned sense and manners!\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4ded4c1-0e3e-47c5-8fdc-e7c187f68b12.jpg?1784760181"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -7372,6 +7372,106 @@
     ]
 }
 
+// The Arkenstone
+{
+    "name": "The Arkenstone",
+    "manaCost": "{5}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Creatures you control get +1/+1.\nAt the beginning of your end step, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Draw a card."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "MYTHIC",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a56a88ba-fcfa-4b56-bdae-a080b297b871.jpg?1783902783"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Seek the Heart",
+            "manaCost": "{2}{W}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Search your library for a legendary creature card, reveal it, put it into your hand, then shuffle. (Then exile this card. You may cast the artifact later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        "IsLegendary"
+                                    ]
+                                }
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // The Black Arrow
 {
     "name": "The Black Arrow",
@@ -7546,6 +7646,169 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// The Great Goblin
+{
+    "name": "The Great Goblin",
+    "manaCost": "{1}{B/R}{B/R}",
+    "typeLine": "Legendary Creature — Goblin Noble",
+    "oracleText": "Whenever you put one or more counters on a Goblin, Orc, or Army you control, The Great Goblin deals 2 damage to target opponent.\nWhenever another Goblin, Orc, or Army you control dies, exile the top card of your library. You may play it until the end of your next turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CountersPlacedEvent",
+                    "counterType": "any",
+                    "filter": "creature Goblin|Orc|Army ctrl:you",
+                    "placedBy": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "The Great Goblin deals 2 damage to target opponent."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Goblin|Orc|Army ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled",
+                            "expiry": {
+                                "type": "UntilControllerStep",
+                                "step": "CLEANUP",
+                                "includeCurrentTurn": false
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Exile the top card of your library. You may play it until the end of your next turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "rarity": "RARE",
+        "artist": "Miklós Ligeti",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78d8f53e-537d-4eaa-99e3-cac57fa53d22.jpg?1784798171"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
+// The Lonely Mountain
+{
+    "name": "The Lonely Mountain",
+    "manaCost": "",
+    "typeLine": "Land — Mountain",
+    "oracleText": "({T}: Add {R}.)\nThis land enters tapped unless you control an Equipment.\n{4}{R}, {T}: Create a 2/2 red Dwarf creature token. This ability costs {1} less to activate for each Equipment you control. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Dwarf"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537"
+                },
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Create a 2/2 red Dwarf creature token.",
+                "genericCostReduction": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "artifact Equipment"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact Equipment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "RARE",
+        "artist": "Leon Tukker",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b39ebc4d-a01a-4401-ab3a-bf6142c93b47.jpg?1784543511"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -8249,6 +8512,182 @@
     "colorIdentityOverride": [
         "GREEN",
         "BLUE"
+    ]
+}
+
+// Thranduil's Decree
+{
+    "name": "Thranduil's Decree",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. If a permanent spell is countered this way, exile it instead of putting it into its owner's graveyard. You may cast that card without paying its mana cost for as long as it remains exiled.",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "filter": "permanent"
+                }
+            },
+            "then": {
+                "type": "Counter",
+                "counterDestination": {
+                    "type": "CounterDestination.Exile",
+                    "grantFreeCast": true
+                }
+            },
+            "otherwise": "Counter"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "UNCOMMON",
+        "artist": "Javier Charro",
+        "flavorText": "\"I have a right to know what brings you here, and if you will not tell me now, I will keep you all in prison until you have learned sense and manners!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4ded4c1-0e3e-47c5-8fdc-e7c187f68b12.jpg?1784760181"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Thranduil, Sindarin Liege
+{
+    "name": "Thranduil, Sindarin Liege",
+    "manaCost": "{2}{G/U}{G/U}",
+    "typeLine": "Legendary Creature — Elf Noble",
+    "oracleText": "Other Elves you control get +1/+1.\nLandfall — Whenever a land you control enters, create a 1/1 green Elf creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Elf"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Elf ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "UNCOMMON",
+        "artist": "Justyna Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/481870ee-d1f7-421b-86e1-570ea933bbbc.jpg?1785412747"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Silvan Rally",
+            "manaCost": "{1}{G/U}{G/U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Mill four cards, then put up to two land cards from among them into your hand. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 4
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "milled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "filter": "land",
+                            "storeSelected": "toHand",
+                            "prompt": "Put up to two land cards into your hand",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Leave in graveyard",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThranduilsDecreeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThranduilsDecreeScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Thranduil's Decree — "Counter target spell. If a permanent spell is countered this way, exile it
+ * instead of putting it into its owner's graveyard. You may cast that card without paying its mana
+ * cost for as long as it remains exiled."
+ *
+ * The card composes an existing `ConditionalEffect` over `Conditions.TargetMatchesFilter`, but it is
+ * the first one to evaluate that condition against a **spell on the stack** rather than a
+ * battlefield permanent — `ConditionEvaluator.evaluateTargetFilterMatch` has to route
+ * `ChosenTarget.Spell` to the spell entity and read its printed card types. Both branches are
+ * covered here because getting the condition backwards would silently swap the two destinations.
+ */
+class ThranduilsDecreeScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("a countered permanent spell is exiled and its caster's opponent may recast it free") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Thranduil's Decree")
+                .withLandsOnBattlefield(1, "Island", 6)
+                .withCardInHand(2, "Grizzly Bears")
+                .withLandsOnBattlefield(2, "Forest", 2)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(2, "Grizzly Bears").error shouldBe null
+            game.passPriority() // P2 passes so P1 can respond
+
+            val bearsId = game.state.stack.first()
+            val decreeId = game.state.getHand(game.player1Id).first()
+            val cast = game.execute(
+                CastSpell(game.player1Id, decreeId, targets = listOf(ChosenTarget.Spell(bearsId)))
+            )
+            withClue("Countering a creature spell should be legal: ${cast.error}") {
+                cast.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("A permanent spell goes to exile, not to its owner's graveyard") {
+                game.isInExile(2, "Grizzly Bears") shouldBe true
+                game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+            }
+            withClue("It never reached the battlefield — it was countered, not blinked") {
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+            }
+
+            val exiled = game.state.getZone(game.player2Id, Zone.EXILE).first { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+            }
+            val freeCast = game.state.getEntity(exiled)?.get<PlayWithoutPayingCostComponent>()
+            withClue("The Decree's controller — not the Bears' owner — may cast it for free") {
+                freeCast shouldNotBe null
+                freeCast!!.controllerId shouldBe game.player1Id
+                freeCast.permanent shouldBe true
+            }
+        }
+
+        test("a countered instant goes to its owner's graveyard, with no exile and no free cast") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Thranduil's Decree")
+                .withLandsOnBattlefield(1, "Island", 6)
+                .withCardInHand(2, "Lightning Bolt")
+                .withLandsOnBattlefield(2, "Mountain", 1)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+            game.passPriority()
+
+            val boltId = game.state.stack.first()
+            val decreeId = game.state.getHand(game.player1Id).first()
+            val cast = game.execute(
+                CastSpell(game.player1Id, decreeId, targets = listOf(ChosenTarget.Spell(boltId)))
+            )
+            withClue("Countering an instant should be legal: ${cast.error}") {
+                cast.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("Only *permanent* spells are exiled by the Decree") {
+                game.isInGraveyard(2, "Lightning Bolt") shouldBe true
+                game.isInExile(2, "Lightning Bolt") shouldBe false
+            }
+            withClue("The bolt was countered, so its damage never happened") {
+                game.getLifeTotal(1) shouldBe 20
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five HOB cards, all built from existing SDK primitives — no new engine vocabulary.

## Cards

| Card | Shape |
|---|---|
| **The Great Goblin** `{1}{B/R}{B/R}` | `countersPlacedOn(placedBy = Player.You, firstTimeEachTurn = false)` over a Goblin/Orc/Army OR-filter, plus a per-creature `OTHER`-bound dies trigger feeding `Patterns.Exile.impulse(UntilEndOfNextTurn)` |
| **The Arkenstone // Seek the Heart** `{5}` | Group `ModifyStats` anthem + end-step draw; the Adventure is the Time of Need search verbatim |
| **The Lonely Mountain** (Land — Mountain) | `EntersTapped(unlessCondition = you control an Equipment)` + `genericCostReduction` keyed to the Equipment count (Qiqirn Merchant shape) |
| **Thranduil's Decree** `{4}{U}{U}` | `ConditionalEffect` over `TargetMatchesFilter(Permanent)` choosing between `CounterSpellToExile(grantFreeCast = true)` and a plain `CounterSpell` |
| **Thranduil, Sindarin Liege // Silvan Rally** `{2}{G/U}{G/U}` | `excludeSelf` lord + landfall Elf token; the Adventure is a mill → select → move pipeline over the milled collection |

## Modeling notes worth a look

- **The Great Goblin** — `placedBy = Player.You` carries the "**you** put" scope (CR 122.6a); it can't come from the recipient filter, since an opponent putting counters on a Goblin *you control* matches the filter but is not your placement. The first ability has no "another" and the Goblin is itself a Goblin, so counters landing on it do fire it; the death trigger *is* "another" and takes `TriggerBinding.OTHER`.
- **The Lonely Mountain** — the `{T}: Add {R}` is intrinsic to the Mountain land type (CR 305.6) and is deliberately not authored; writing it out would double the ability. The discount reduces only the `{4}`, never the `{R}` pip (CR 118.9a).
- **Thranduil's Decree** — the exile rider is conditional on the countered spell being a *permanent* spell, so this is a branch rather than a bare `CounterSpellToExile`: an instant or sorcery goes to its owner's graveyard as usual and is never castable from exile.

## Tests

Thranduil's Decree is the first card to evaluate `TargetMatchesFilter` against a **spell on the stack** rather than a battlefield permanent, so `ThranduilsDecreeScenarioTest` covers both destinations — getting the condition backwards would silently swap them:

- a countered creature spell lands in exile with a `PlayWithoutPayingCostComponent` naming the Decree's controller (not the spell's owner);
- a countered instant lands in its owner's graveyard, with no exile and no free cast.

The other four are built purely from existing primitives and are covered by the snapshot and lint nets.

## Verification

- `just build` — green
- `just test-class ThranduilsDecreeScenarioTest` — 2/2 passing, no compiler warnings
- `just rebless-cards` — HOB golden diff is **additions only**, exactly these five cards
- `just check-card-printing` — clean for all five (each is canonical in HOB, its only real printing)
- Every mechanical field (mana cost, type line, P/T, rarity, collector number, artist, image URI, color identity, Adventure face) and the full oracle text re-checked field-by-field against Scryfall; all image URIs HTTP 200

## Not in scope

Most of the remaining HOB backlog needs new keywords — **recruit**, **storied** / enduring story, and **hone** counters — which is `add-feature` work rather than `add-card`, so those cards were left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)