### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/ConsumeSpiritReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/ConsumeSpiritReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Consume Spirit reprint in 10E. Canonical CardDefinition lives in Mirrodin (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.ConsumeSpirit`.
+ */
+val ConsumeSpirit10eReprint = Printing(
+    oracleId = "861fa80d-99e0-4332-a2b8-5aa959fd41a4",
+    name = "Consume Spirit",
+    setCode = "10E",
+    collectorNumber = "131",
+    scryfallId = "b8117171-08a7-44f6-9c14-12e8b96c7632",
+    artist = "Matt Thompson",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b8117171-08a7-44f6-9c14-12e8b96c7632.jpg?1783943042",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/ContaminatedBondReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/ContaminatedBondReprint.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Contaminated Bond reprint in 10E. Canonical CardDefinition lives in Mirrodin (its earliest real
+ * printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.ContaminatedBond`.
+ */
+val ContaminatedBond10eReprint = Printing(
+    oracleId = "56aeaee8-e014-485e-b7ad-e26ade663bcf",
+    name = "Contaminated Bond",
+    setCode = "10E",
+    collectorNumber = "132",
+    scryfallId = "a56b6552-367e-4b0b-9095-42322843b1b2",
+    artist = "Thomas M. Baxa",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a56b6552-367e-4b0b-9095-42322843b1b2.jpg?1783943040",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.COMMON,
+)
+
+val ContaminatedBond10eReprintB = Printing(
+    oracleId = "56aeaee8-e014-485e-b7ad-e26ade663bcf",
+    name = "Contaminated Bond",
+    setCode = "10E",
+    collectorNumber = "132★",
+    scryfallId = "67f5ba76-b6dd-46cb-8b5f-415da19986e0",
+    artist = "Thomas M. Baxa",
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67f5ba76-b6dd-46cb-8b5f-415da19986e0.jpg?1783943040",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BarterInBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BarterInBloodReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barter in Blood reprint in Avacyn Restored. Canonical CardDefinition lives in Mirrodin (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.BarterInBlood`.
+ */
+val BarterInBloodAvrReprint = Printing(
+    oracleId = "9167998d-5cac-47d7-99f2-f38122f7b8e7",
+    name = "Barter in Blood",
+    setCode = "AVR",
+    collectorNumber = "85",
+    scryfallId = "39b4fab6-73ce-4a56-a305-4d2e93dbb4ee",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39b4fab6-73ce-4a56-a305-4d2e93dbb4ee.jpg?1783940706",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BarterInBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BarterInBloodReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barter in Blood reprint in Commander 2015. Canonical CardDefinition lives in Mirrodin (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.BarterInBlood`.
+ */
+val BarterInBloodC15Reprint = Printing(
+    oracleId = "9167998d-5cac-47d7-99f2-f38122f7b8e7",
+    name = "Barter in Blood",
+    setCode = "C15",
+    collectorNumber = "115",
+    scryfallId = "2bc350c9-0c1e-40a1-bb08-1b2e1f37320e",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2bc350c9-0c1e-40a1-bb08-1b2e1f37320e.jpg?1783938087",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/BarterInBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/BarterInBloodReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barter in Blood reprint in Duel Decks: Blessed vs. Cursed. Canonical CardDefinition lives in
+ * Mirrodin (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mrd.cards.BarterInBlood`.
+ */
+val BarterInBloodDdqReprint = Printing(
+    oracleId = "9167998d-5cac-47d7-99f2-f38122f7b8e7",
+    name = "Barter in Blood",
+    setCode = "DDQ",
+    collectorNumber = "52",
+    scryfallId = "cb3411cb-8c43-4f06-8583-49dd9ba5db63",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb3411cb-8c43-4f06-8583-49dd9ba5db63.jpg?1783937842",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BarterInBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BarterInBloodReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barter in Blood reprint in Jumpstart. Canonical CardDefinition lives in Mirrodin (its earliest
+ * real printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.BarterInBlood`.
+ */
+val BarterInBloodJmpReprint = Printing(
+    oracleId = "9167998d-5cac-47d7-99f2-f38122f7b8e7",
+    name = "Barter in Blood",
+    setCode = "JMP",
+    collectorNumber = "202",
+    scryfallId = "23986add-b33d-4bad-86f3-e2d0f99cf949",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/23986add-b33d-4bad-86f3-e2d0f99cf949.jpg?1783930436",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VedalkenArchmageReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/VedalkenArchmageReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vedalken Archmage reprint in Jumpstart. Canonical CardDefinition lives in Mirrodin (its earliest
+ * real printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.VedalkenArchmage`.
+ */
+val VedalkenArchmageJmpReprint = Printing(
+    oracleId = "568cf486-0261-4634-ac36-a6507101b2d0",
+    name = "Vedalken Archmage",
+    setCode = "JMP",
+    collectorNumber = "187",
+    scryfallId = "508b3cb7-b434-4524-8ef0-7db7f7f22edd",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/508b3cb7-b434-4524-8ef0-7db7f7f22edd.jpg?1783930442",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ConsumeSpiritReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ConsumeSpiritReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Consume Spirit reprint in Magic 2010. Canonical CardDefinition lives in Mirrodin (its earliest
+ * real printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.ConsumeSpirit`.
+ */
+val ConsumeSpiritM10Reprint = Printing(
+    oracleId = "861fa80d-99e0-4332-a2b8-5aa959fd41a4",
+    name = "Consume Spirit",
+    setCode = "M10",
+    collectorNumber = "89",
+    scryfallId = "5db2f958-947b-4b52-a5cd-e8f8b5576803",
+    artist = "Justin Sweet",
+    imageUri = "https://cards.scryfall.io/normal/front/5/d/5db2f958-947b-4b52-a5cd-e8f8b5576803.jpg?1783942385",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ConsumeSpiritReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ConsumeSpiritReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Consume Spirit reprint in Magic 2012. Canonical CardDefinition lives in Mirrodin (its earliest
+ * real printing), `com.wingedsheep.mtg.sets.definitions.mrd.cards.ConsumeSpirit`.
+ */
+val ConsumeSpiritM12Reprint = Printing(
+    oracleId = "861fa80d-99e0-4332-a2b8-5aa959fd41a4",
+    name = "Consume Spirit",
+    setCode = "M12",
+    collectorNumber = "88",
+    scryfallId = "ef144439-fc8e-4844-8ebb-3e36e05ac9a0",
+    artist = "Justin Sweet",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef144439-fc8e-4844-8ebb-3e36e05ac9a0.jpg?1783941083",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BarterInBlood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BarterInBlood.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Barter in Blood — Mirrodin #57
+ * {2}{B}{B} · Sorcery
+ *
+ * Each player sacrifices two creatures of their choice.
+ *
+ * The Deadly Brew / Rise of the Witch-king edict shape at `count = 2`: one
+ * [Effects.Sacrifice] over [Player.Each]. Nothing is targeted — the spell is castable even
+ * when no player controls a creature, and no player can be made an illegal "target".
+ *
+ * "Of their choice" is the executor's default: a player controlling more than two creatures is
+ * prompted to pick exactly two, and a player controlling two or fewer sacrifices all of them
+ * without a prompt (CR 608.2c does-as-much-as-it-can — the Scryfall ruling spells this out: a
+ * player with a single creature sacrifices that one).
+ *
+ * Known deviation: the printed card has every player choose in APNAP order and then sacrifices
+ * everything simultaneously. The engine walks the players one at a time, so a later player's
+ * choice is made with the earlier sacrifices already resolved. This is the same approximation
+ * the existing multi-player edicts ship with and only shows up when a sacrifice triggers
+ * something that changes a later chooser's board.
+ */
+val BarterInBlood = card("Barter in Blood") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Each player sacrifices two creatures of their choice."
+
+    spell {
+        effect = Effects.Sacrifice(
+            GameObjectFilter.Creature,
+            count = 2,
+            target = EffectTarget.PlayerRef(Player.Each)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "Paolo Parente"
+        flavorText = "\"In the game of conquest, who cares about the pawns if the king yet reigns?\"\n" +
+            "—Geth, keeper of the Vault"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/beccbb2c-ca1d-4b72-9eca-a64a313fd830.jpg?1783944550"
+
+        ruling(
+            "2012-05-01",
+            "The active player chooses which creatures will be sacrificed first, then each other " +
+                "player in turn order does the same. Then all creatures are sacrificed simultaneously."
+        )
+        ruling("2012-05-01", "If a player controls only one creature, that creature is sacrificed.")
+        ruling(
+            "2012-05-01",
+            "Barter in Blood doesn't target any creatures and may be cast even if a player " +
+                "controls fewer than two creatures."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ConsumeSpirit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ConsumeSpirit.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Consume Spirit — Mirrodin #60
+ * {X}{1}{B} · Sorcery
+ *
+ * Spend only black mana on X.
+ * Consume Spirit deals X damage to any target and you gain X life.
+ *
+ * The Soul Burn shape: `xManaRestriction = {BLACK}` confines the `{X}` portion of the cost to
+ * black sources (colorless mana can pay the `{1}` but never X), and the spell resolves as a
+ * [Effects.Composite] of [Effects.DealXDamage] and [Effects.GainLife].
+ *
+ * The life gain is [DynamicAmount.XValue] — the chosen X — not the damage actually dealt. Per the
+ * ruling, prevention or damage redirection does not shrink the life gain. (Soul Burn's sibling
+ * reads [DynamicAmount.ManaSpentOnX] instead, because *its* gain is scoped to the black portion
+ * of a two-color restriction; here the whole restriction is black, so plain X is the faithful
+ * reading and stays correct when X is paid with e.g. a Cabal Coffers activation.)
+ *
+ * One target for the whole spell: if it is illegal on resolution the spell doesn't resolve at all
+ * and no life is gained, which falls out of the engine's standard fizzle path rather than needing
+ * any wiring here.
+ */
+val ConsumeSpirit = card("Consume Spirit") {
+    manaCost = "{X}{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Spend only black mana on X.\n" +
+        "Consume Spirit deals X damage to any target and you gain X life."
+
+    spell {
+        xManaRestriction = setOf(Color.BLACK)
+        target = Targets.Any
+        effect = Effects.Composite(
+            Effects.DealXDamage(EffectTarget.ContextTarget(0)),
+            Effects.GainLife(DynamicAmount.XValue)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Matt Thompson"
+        flavorText = "Mephidross changes all who dwell there, taking their lives and adding them to its own."
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f375a49c-806a-4d8b-9513-6b4afc19497b.jpg?1783944549"
+
+        ruling(
+            "2009-10-01",
+            "The amount of life you gain is equal to the number chosen for X, not the amount of " +
+                "damage Consume Spirit deals (in case some of it is prevented)."
+        )
+        ruling(
+            "2009-10-01",
+            "If the targeted permanent or player is an illegal target by the time Consume Spirit " +
+                "would resolve, the entire spell doesn't resolve. You won't gain any life."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ContaminatedBond.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ContaminatedBond.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/** "its controller loses 3 life" — the granted ability is controlled by the enchanted creature's
+ *  controller, so [EffectTarget.Controller] is exactly "its controller". */
+private val controllerLosesThree = Effects.LoseLife(3, EffectTarget.Controller)
+
+/**
+ * Contaminated Bond — Mirrodin #61
+ * {1}{B} · Enchantment — Aura
+ *
+ * Enchant creature
+ * Whenever enchanted creature attacks or blocks, its controller loses 3 life.
+ *
+ * A punisher Aura: it goes on a creature you *don't* control and taxes its owner for using it.
+ * That makes the controller distinction load-bearing rather than incidental — the life loss must
+ * hit the creature's controller, never the Aura's.
+ *
+ * One printed ability with two trigger conditions, so it is the Super-Soldier Serum idiom: two
+ * [GrantTriggeredAbility] statics over [Filters.EnchantedCreature], one for [Triggers.Attacks]
+ * and one for [Triggers.Blocks]. Installing the triggers *on the creature* rather than keeping
+ * them on the Aura is required, not stylistic — the engine's `AttachmentTriggerDetector` has no
+ * block branch, so an `ATTACHED`-bound blocks trigger would never fire. It also lands the
+ * controller question on the right answer for free: the granted ability's controller is the
+ * creature's controller, which is what [EffectTarget.Controller] reads.
+ *
+ * "Attacks or blocks" is two separate triggers, and a creature that attacks this turn and blocks
+ * on the crawl-back does lose its controller 3 life each time. A creature that blocks two
+ * attackers at once still only triggers the blocks half once (it "blocks" a single time).
+ */
+val ContaminatedBond = card("Contaminated Bond") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Whenever enchanted creature attacks or blocks, its controller loses 3 life."
+
+    auraTarget = Targets.Creature
+
+    // "Whenever enchanted creature attacks ..."
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = controllerLosesThree,
+                descriptionOverride = "Whenever this creature attacks, its controller loses 3 life.",
+            ),
+            filter = Filters.EnchantedCreature,
+        )
+    }
+
+    // "... or blocks, its controller loses 3 life."
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.Blocks.event,
+                binding = Triggers.Blocks.binding,
+                effect = controllerLosesThree,
+                descriptionOverride = "Whenever this creature blocks, its controller loses 3 life.",
+            ),
+            filter = Filters.EnchantedCreature,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "61"
+        artist = "Thomas M. Baxa"
+        flavorText = "This leash disciplines the master."
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1a64356-3064-47a2-80be-5e2f56c85556.jpg?1783944549"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ToothOfChissGoria.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ToothOfChissGoria.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Tooth of Chiss-Goria — Mirrodin #264
+ * {3} · Artifact
+ *
+ * Flash
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * {T}: Target creature gets +1/+0 until end of turn.
+ *
+ * The Galvanic Key shape (flash artifact with a tap ability) plus the stock
+ * [KeywordAbility.Affinity] over [CardType.ARTIFACT]. Flash and affinity together are the whole
+ * point of the cycle: with three other artifacts out this is a free combat trick cast at instant
+ * speed, and it can be activated the turn it enters because the ability's only cost is {T} on a
+ * non-creature permanent — summoning sickness never applies to an artifact that isn't a creature.
+ */
+val ToothOfChissGoria = card("Tooth of Chiss-Goria") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Flash\n" +
+        "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "{T}: Target creature gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLASH)
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(1, 0, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "264"
+        artist = "Alan Pollack"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db5a91db-1b86-4471-badc-884142c355ca.jpg?1783944497"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/VedalkenArchmage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/VedalkenArchmage.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Vedalken Archmage — Mirrodin #55
+ * {2}{U}{U} · Creature — Vedalken Wizard · 0/2
+ *
+ * Whenever you cast an artifact spell, draw a card.
+ *
+ * [Triggers.youCastSpell] over [GameObjectFilter.Artifact] — a cast trigger, so it fires as the
+ * spell goes on the stack and the draw resolves *above* it. It is not once per turn and has no
+ * "you may": every artifact spell you cast draws, including one that is later countered or that
+ * never resolves.
+ */
+val VedalkenArchmage = card("Vedalken Archmage") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Vedalken Wizard"
+    power = 0
+    toughness = 2
+    oracleText = "Whenever you cast an artifact spell, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Artifact)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "55"
+        artist = "Kev Walker"
+        flavorText = "\"The Knowledge Pool knows. Memnarch understands.\"\n—Janus, speaker of the synod"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b38da97-5141-4de6-bd7f-3fcbf46cfd96.jpg?1783944550"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -274,6 +274,49 @@
     ]
 }
 
+// Barter in Blood
+{
+    "name": "Barter in Blood",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player sacrifices two creatures of their choice.",
+    "script": {
+        "spellEffect": {
+            "type": "ForceSacrifice",
+            "filter": "creature",
+            "count": 2,
+            "target": {
+                "type": "PlayerRef",
+                "player": "Each"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "rarity": "UNCOMMON",
+        "artist": "Paolo Parente",
+        "flavorText": "\"In the game of conquest, who cares about the pawns if the king yet reigns?\"\n—Geth, keeper of the Vault",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/beccbb2c-ca1d-4b72-9eca-a64a313fd830.jpg?1783944550",
+        "rulings": [
+            {
+                "date": "2012-05-01",
+                "text": "The active player chooses which creatures will be sacrificed first, then each other player in turn order does the same. Then all creatures are sacrificed simultaneously."
+            },
+            {
+                "date": "2012-05-01",
+                "text": "If a player controls only one creature, that creature is sacrificed."
+            },
+            {
+                "date": "2012-05-01",
+                "text": "Barter in Blood doesn't target any creatures and may be cast even if a player controls fewer than two creatures."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Battlegrowth
 {
     "name": "Battlegrowth",
@@ -555,6 +598,117 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Consume Spirit
+{
+    "name": "Consume Spirit",
+    "manaCost": "{X}{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Spend only black mana on X.\nConsume Spirit deals X damage to any target and you gain X life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": "XValue"
+                }
+            ]
+        },
+        "targetRequirements": [
+            "AnyTarget"
+        ],
+        "xManaRestriction": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Matt Thompson",
+        "flavorText": "Mephidross changes all who dwell there, taking their lives and adding them to its own.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f375a49c-806a-4d8b-9513-6b4afc19497b.jpg?1783944549",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "The amount of life you gain is equal to the number chosen for X, not the amount of damage Consume Spirit deals (in case some of it is prevented)."
+            },
+            {
+                "date": "2009-10-01",
+                "text": "If the targeted permanent or player is an illegal target by the time Consume Spirit would resolve, the entire spell doesn't resolve. You won't gain any life."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Contaminated Bond
+{
+    "name": "Contaminated Bond",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhenever enchanted creature attacks or blocks, its controller loses 3 life.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Controller"
+                    },
+                    "descriptionOverride": "Whenever this creature attacks, its controller loses 3 life."
+                }
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "trigger": "BlockEvent",
+                    "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "target": "Controller"
+                    },
+                    "descriptionOverride": "Whenever this creature blocks, its controller loses 3 life."
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "artist": "Thomas M. Baxa",
+        "flavorText": "This leash disciplines the master.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1a64356-3064-47a2-80be-5e2f56c85556.jpg?1783944549"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -5081,6 +5235,62 @@
     ]
 }
 
+// Tooth of Chiss-Goria
+{
+    "name": "Tooth of Chiss-Goria",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Flash\nAffinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n{T}: Target creature gets +1/+0 until end of turn.",
+    "keywords": [
+        "FLASH",
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "264",
+        "artist": "Alan Pollack",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db5a91db-1b86-4471-badc-884142c355ca.jpg?1783944497"
+    },
+    "colorIdentityOverride": []
+}
+
 // Tower of Champions
 {
     "name": "Tower of Champions",
@@ -5422,6 +5632,51 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Vedalken Archmage
+{
+    "name": "Vedalken Archmage",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Vedalken Wizard",
+    "oracleText": "Whenever you cast an artifact spell, draw a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsArtifact"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "flavorText": "\"The Knowledge Pool knows. Memnarch understands.\"\n—Janus, speaker of the synod",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b38da97-5141-4de6-bd7f-3fcbf46cfd96.jpg?1783944550"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarterInBloodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarterInBloodScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.BarterInBlood
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Barter in Blood (MRD #57) — "Each player sacrifices two creatures of their choice."
+ *
+ * The interesting cases are the two the `count = 1` edicts never reach: a player who must *choose*
+ * two out of more (the prompt has to demand exactly two, not one), and a player who controls fewer
+ * than two, who sacrifices as many as they can rather than nothing at all (CR 608.2c / the printed
+ * ruling "if a player controls only one creature, that creature is sacrificed").
+ */
+class BarterInBloodScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + BarterInBlood)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.castBarter(caster: com.wingedsheep.sdk.model.EntityId) {
+        val card = putCardInHand(caster, "Barter in Blood")
+        giveMana(caster, Color.BLACK, 4)
+        castSpell(caster, card).isSuccess shouldBe true
+        bothPass()
+    }
+
+    test("each player with exactly two creatures loses both, no prompt") {
+        val d = driver()
+        val bear1 = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val bear2 = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        val bear3 = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val bear4 = d.putCreatureOnBattlefield(d.player2, "Centaur Courser")
+
+        d.castBarter(d.player1)
+
+        withClue("two-for-two is exact, so the executor auto-sacrifices without asking") {
+            d.pendingDecision shouldBe null
+        }
+        listOf(bear1, bear2, bear3, bear4).forEach {
+            d.state.getBattlefield().contains(it) shouldBe false
+        }
+    }
+
+    test("a player controlling three creatures must choose exactly two") {
+        val d = driver()
+        val keep = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears")
+        val give1 = d.putCreatureOnBattlefield(d.player1, "Centaur Courser")
+        val give2 = d.putCreatureOnBattlefield(d.player1, "Hill Giant")
+        // player2 controls exactly two, so only player1 is prompted.
+        d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.putCreatureOnBattlefield(d.player2, "Centaur Courser")
+
+        d.castBarter(d.player1)
+
+        val decision = d.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe d.player1
+        withClue("'sacrifices two' is not an edict for one — the choice is exactly two") {
+            decision.minSelections shouldBe 2
+            decision.maxSelections shouldBe 2
+        }
+
+        d.submitCardSelection(d.player1, listOf(give1, give2))
+
+        d.state.getBattlefield().contains(keep) shouldBe true
+        d.state.getBattlefield().contains(give1) shouldBe false
+        d.state.getBattlefield().contains(give2) shouldBe false
+        withClue("player2's two creatures went too") {
+            d.getPermanents(d.player2).none { d.getCardName(it) == "Grizzly Bears" } shouldBe true
+        }
+    }
+
+    test("a player controlling one creature sacrifices it; one controlling none loses nothing") {
+        val d = driver()
+        val lone = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        // player1 controls no creatures at all.
+
+        d.castBarter(d.player1)
+
+        d.pendingDecision shouldBe null
+        withClue("CR 608.2c: sacrifice as many as you can, not zero") {
+            d.state.getBattlefield().contains(lone) shouldBe false
+            d.getGraveyardCardNames(d.player2).contains("Grizzly Bears") shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConsumeSpiritScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConsumeSpiritScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.ConsumeSpirit
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Consume Spirit (MRD #60) — "Spend only black mana on X. Consume Spirit deals X damage to any
+ * target and you gain X life."
+ *
+ * The Soul Burn plumbing at a single-colour restriction. Two things are worth pinning: the life
+ * gain is the *chosen X* (Soul Burn's is the black mana spent on X, a different `DynamicAmount`,
+ * and swapping them here would look identical in the common case), and X really is black-only —
+ * generic mana can pay the `{1}` but never the `{X}`.
+ */
+class ConsumeSpiritScenarioTest : FunSpec({
+
+    fun driver(deck: Deck = Deck.of("Swamp" to 40)): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ConsumeSpirit)
+        d.initMirrorMatch(deck = deck, skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("deals X to the target and gains X life") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        val spell = d.putCardInHand(me, "Consume Spirit")
+        // {X}{1}{B} at X=3 → 5 black mana total.
+        d.giveMana(me, Color.BLACK, 5)
+        d.castXSpell(me, spell, xValue = 3, targets = listOf(opp))
+        d.bothPass()
+
+        d.getLifeTotal(opp) shouldBe 17
+        withClue("life gained is X, per the ruling — not the damage that actually landed") {
+            d.getLifeTotal(me) shouldBe 23
+        }
+    }
+
+    test("X=0 is legal and does nothing") {
+        val d = driver()
+        val me = d.player1
+        val opp = d.player2
+
+        val spell = d.putCardInHand(me, "Consume Spirit")
+        d.giveMana(me, Color.BLACK, 2)
+        d.castXSpell(me, spell, xValue = 0, targets = listOf(opp))
+        d.bothPass()
+
+        d.getLifeTotal(opp) shouldBe 20
+        d.getLifeTotal(me) shouldBe 20
+    }
+
+    test("kills a creature and still gains the full X") {
+        val d = driver()
+        val me = d.player1
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears") // 2/2
+
+        val spell = d.putCardInHand(me, "Consume Spirit")
+        d.giveMana(me, Color.BLACK, 6)
+        d.castXSpell(me, spell, xValue = 4, targets = listOf(bear))
+        d.bothPass()
+
+        d.state.getBattlefield().contains(bear) shouldBe false
+        withClue("4 damage to a 2/2 still gains 4, not 2") {
+            d.getLifeTotal(me) shouldBe 24
+        }
+    }
+
+    test("X can be paid only with black mana") {
+        val d = driver(Deck.of("Swamp" to 20, "Forest" to 20))
+        val me = d.player1
+        d.putLandOnBattlefield(me, "Swamp")
+        repeat(4) { d.putLandOnBattlefield(me, "Forest") }
+
+        val registry = CardRegistry().apply { register(TestCards.all + ConsumeSpirit) }
+        val solver = ManaSolver(registry)
+        val cost = ManaCost.parse("{X}{1}{B}")
+        val blackOnly = setOf(Color.BLACK)
+
+        withClue("the lone Swamp is consumed by the mandatory {B}, leaving nothing black for X") {
+            solver.canPay(d.state, me, cost, xValue = 1, xManaRestriction = blackOnly).shouldBeFalse()
+        }
+        withClue("without the restriction the green mana covers X=1 easily") {
+            solver.canPay(d.state, me, cost, xValue = 1).shouldBeTrue()
+        }
+
+        // A second Swamp frees one black source for X.
+        d.putLandOnBattlefield(me, "Swamp")
+        solver.canPay(d.state, me, cost, xValue = 1, xManaRestriction = blackOnly).shouldBeTrue()
+        solver.canPay(d.state, me, cost, xValue = 2, xManaRestriction = blackOnly).shouldBeFalse()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ContaminatedBondScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ContaminatedBondScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.ContaminatedBond
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Contaminated Bond (MRD #61) — "Whenever enchanted creature attacks or blocks, its controller
+ * loses 3 life."
+ *
+ * A punisher Aura goes on someone *else's* creature, so the two things that can silently break it
+ * are (a) the blocks half never firing — the engine's attachment trigger detector has no block
+ * branch, which is why the card grants the triggers to the creature instead of keeping them on the
+ * Aura — and (b) the life loss landing on the Aura's controller rather than the creature's. Both
+ * are pinned here from the enchanter's seat.
+ */
+class ContaminatedBondScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + ContaminatedBond)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.enchant(caster: EntityId, creature: EntityId) {
+        val aura = putCardInHand(caster, "Contaminated Bond")
+        giveMana(caster, Color.BLACK, 2)
+        castSpell(caster, aura, listOf(creature)).isSuccess shouldBe true
+        bothPass()
+    }
+
+    fun resolveStack(d: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && d.state.stack.isNotEmpty() && !d.isPaused) d.bothPass()
+    }
+
+    test("the enchanted creature's controller loses 3 when it attacks — not the enchanter") {
+        val d = driver()
+        val victim = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears") // 2/2
+        d.removeSummoningSickness(victim)
+        // player1 owns the Aura but controls no creature, so the only combat this game is
+        // player2 swinging back on their own turn.
+        d.enchant(d.player1, victim)
+
+        val enchanterLifeBefore = d.getLifeTotal(d.player1)
+        val victimLifeBefore = d.getLifeTotal(d.player2)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        withClue("only player2 has a legal attacker, so combat lands on their turn") {
+            d.activePlayer shouldBe d.player2
+        }
+        d.declareAttackers(d.player2, listOf(victim), defendingPlayer = d.player1).error shouldBe null
+        resolveStack(d)
+
+        // The trigger resolves in the declare-attackers step, before any combat damage, so the
+        // enchanter's life is a clean read of "did the loss land on the wrong player".
+        withClue("'its controller' is the creature's controller") {
+            d.getLifeTotal(d.player2) shouldBe victimLifeBefore - 3
+        }
+        withClue("the Aura's controller pays nothing for the trigger") {
+            d.getLifeTotal(d.player1) shouldBe enchanterLifeBefore
+        }
+    }
+
+    test("the blocks half fires too") {
+        val d = driver()
+        val attacker = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears") // 2/2
+        val victim = d.putCreatureOnBattlefield(d.player2, "Centaur Courser") // 3/3, survives
+        d.removeSummoningSickness(attacker)
+        d.enchant(d.player1, victim)
+
+        val victimLifeBefore = d.getLifeTotal(d.player2)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.activePlayer shouldBe d.player1
+        d.declareAttackers(d.player1, listOf(attacker), defendingPlayer = d.player2).error shouldBe null
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareBlockers(d.player2, mapOf(victim to listOf(attacker)))
+        resolveStack(d)
+
+        withClue("blocking triggers the Bond; the block itself keeps all combat damage off player2") {
+            d.getLifeTotal(d.player2) shouldBe victimLifeBefore - 3
+        }
+    }
+
+    test("an unenchanted creature attacking costs its controller nothing") {
+        val d = driver()
+        val plain = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.removeSummoningSickness(plain)
+
+        val before = d.getLifeTotal(d.player2)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.activePlayer shouldBe d.player2
+        d.declareAttackers(d.player2, listOf(plain), defendingPlayer = d.player1).error shouldBe null
+        resolveStack(d)
+
+        withClue("negative control: the trigger comes from the Aura, not from attacking") {
+            d.getLifeTotal(d.player2) shouldBe before
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ToothOfChissGoriaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ToothOfChissGoriaScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.ToothOfChissGoria
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tooth of Chiss-Goria (MRD #264) — flash artifact, affinity for artifacts, `{T}`: target creature
+ * gets +1/+0 until end of turn.
+ *
+ * Affinity shaving the whole `{3}` and the tap ability being usable the turn the artifact lands are
+ * what make this a free combat trick, so both are asserted. The pump is checked to expire at
+ * end of turn as well — a permanent-duration mis-wiring would otherwise pass the obvious test.
+ */
+class ToothOfChissGoriaScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Tooth of Chiss-Goria") {
+
+            test("affinity for artifacts shaves the generic cost; three artifacts make it free") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Tooth of Chiss-Goria")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val calculator = CostCalculator(cardRegistry)
+                val tooth = cardRegistry.requireCard("Tooth of Chiss-Goria")
+
+                withClue("nothing on the battlefield — the printed {3}") {
+                    calculator.calculateEffectiveCost(game.state, tooth, game.player1Id)
+                        .genericAmount shouldBe 3
+                }
+            }
+
+            test("three artifacts you control reduce it to nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Tooth of Chiss-Goria")
+                    .withCardOnBattlefield(1, "Tooth of Chiss-Goria")
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withCardOnBattlefield(1, "Fireshrieker")
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    game.state,
+                    cardRegistry.requireCard("Tooth of Chiss-Goria"),
+                    game.player1Id,
+                )
+
+                withClue("affinity only shaves generic, and {3} is entirely generic") {
+                    cost.genericAmount shouldBe 0
+                }
+            }
+
+            test("{T} gives target creature +1/+0 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    // No summoningSickness flag needed: a noncreature artifact can tap the turn
+                    // it enters, which is the whole point of pairing flash with this ability.
+                    .withCardOnBattlefield(1, "Tooth of Chiss-Goria")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tooth = game.findPermanent("Tooth of Chiss-Goria")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val pump = ToothOfChissGoria.activatedAbilities[0].id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tooth,
+                        abilityId = pump,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val pumped = projector.project(game.state)
+                pumped.getPower(bears) shouldBe 3
+                withClue("+1/+0 leaves toughness alone") { pumped.getToughness(bears) shouldBe 2 }
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                withClue("the bonus is 'until end of turn' — it expires in cleanup") {
+                    projector.project(game.state).getPower(bears) shouldBe 2
+                }
+            }
+
+            test("it has flash") {
+                withClue("flash is what lets the pump be held up as a combat trick") {
+                    cardRegistry.requireCard("Tooth of Chiss-Goria")
+                        .keywords.contains(Keyword.FLASH) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VedalkenArchmageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VedalkenArchmageScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.VedalkenArchmage
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vedalken Archmage (MRD #55) — "Whenever you cast an artifact spell, draw a card."
+ *
+ * A *cast* trigger with a card-type filter, so the two ways it can go wrong are the filter being
+ * ignored (a non-artifact spell drawing) and the trigger being wired to resolution rather than
+ * casting (an artifact that gets countered drawing nothing). Both are pinned.
+ */
+class VedalkenArchmageScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + VedalkenArchmage)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun resolveStack(d: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && d.state.stack.isNotEmpty() && !d.isPaused) d.bothPass()
+    }
+
+    test("casting an artifact spell draws a card") {
+        val d = driver()
+        val me = d.player1
+        d.putCreatureOnBattlefield(me, "Vedalken Archmage")
+
+        val bonesplitter = d.putCardInHand(me, "Bonesplitter")
+        val handBefore = d.getHand(me).size
+
+        d.giveColorlessMana(me, 1)
+        d.castSpell(me, bonesplitter).isSuccess shouldBe true
+        resolveStack(d)
+
+        withClue("Bonesplitter left the hand (-1) and the trigger drew one (+1)") {
+            d.getHand(me).size shouldBe handBefore
+        }
+        d.state.getBattlefield().contains(bonesplitter) shouldBe true
+    }
+
+    test("casting a nonartifact spell draws nothing") {
+        val d = driver()
+        val me = d.player1
+        d.putCreatureOnBattlefield(me, "Vedalken Archmage")
+
+        val bolt = d.putCardInHand(me, "Lightning Bolt")
+        val handBefore = d.getHand(me).size
+
+        d.giveMana(me, Color.RED, 1)
+        d.castSpell(me, bolt, listOf(d.player2)).isSuccess shouldBe true
+        resolveStack(d)
+
+        withClue("the filter is artifacts only — the hand just shrinks by the Bolt") {
+            d.getHand(me).size shouldBe handBefore - 1
+        }
+    }
+
+    test("an opponent's artifact spell doesn't trigger it") {
+        val d = driver()
+        val me = d.player1
+        d.putCreatureOnBattlefield(me, "Vedalken Archmage")
+
+        // Equipment is sorcery-speed, so hand the turn to player2 before they cast it.
+        d.passPriorityUntil(Step.END)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.activePlayer shouldBe d.player2
+
+        val theirs = d.putCardInHand(d.player2, "Bonesplitter")
+        val handBefore = d.getHand(me).size
+
+        d.giveColorlessMana(d.player2, 1)
+        d.castSpell(d.player2, theirs).isSuccess shouldBe true
+        resolveStack(d)
+
+        withClue("'whenever YOU cast' — the Archmage's controller, not any player") {
+            d.getHand(me).size shouldBe handBefore
+        }
+    }
+})


### PR DESCRIPTION
Five Mirrodin cards, all built from existing SDK primitives — no new effects, triggers, or keywords.

| Card | Shape |
|---|---|
| **Barter in Blood** `{2}{B}{B}` | `Effects.Sacrifice(Creature, count = 2, Player.Each)` — the Deadly Brew edict at count 2 |
| **Consume Spirit** `{X}{1}{B}` | Soul Burn shape with `xManaRestriction = {BLACK}` |
| **Contaminated Bond** `{1}{B}` | Aura; two `GrantTriggeredAbility` statics over `Filters.EnchantedCreature` |
| **Tooth of Chiss-Goria** `{3}` | Galvanic Key + `KeywordAbility.Affinity(ARTIFACT)` |
| **Vedalken Archmage** `{2}{U}{U}` | `Triggers.youCastSpell(GameObjectFilter.Artifact)` |

MRD goes from 138/291 to 143/291.

## Notes on the two non-obvious ones

**Contaminated Bond** grants its attacks/blocks triggers *to the enchanted creature* rather than
keeping them on the Aura. That isn't stylistic — the engine's `AttachmentTriggerDetector` has no
block branch, so an `ATTACHED`-bound blocks trigger would never fire. It also answers "its
controller" correctly for free: the granted ability's controller is the creature's controller,
which is exactly what a punisher Aura needs, since it goes on a creature you don't control.

**Consume Spirit** gains `DynamicAmount.XValue` (the chosen X), not the damage that actually
landed — the printed ruling is explicit that prevention doesn't shrink the life gain. Soul Burn's
sibling reads `ManaSpentOnX` instead because *its* gain is scoped to the black half of a two-colour
restriction; here the whole restriction is black, so plain X is the faithful reading.

## Known deviation

Barter in Blood walks the players one at a time rather than having everyone choose in APNAP order
and then sacrificing simultaneously. This is the approximation the existing multi-player edicts
(Deadly Brew, Rise of the Witch-king) already ship with, and it only shows up when one player's
sacrifice triggers something that changes a later chooser's board. Documented in the card's KDoc.

## Reprint rows

Eight `Printing` rows added for these cards' already-scaffolded reprint sets — AVR/C15/DDQ/JMP
(Barter in Blood), 10E/M10/M12 (Consume Spirit), 10E ×2 including the ★ variant (Contaminated
Bond), JMP (Vedalken Archmage). `just check-card-printing` is clean for all five.

## Verification

- `just build` — green (includes `mtg-sets:test`: snapshot, lint, facade-boundary, discovery)
- Five new scenario tests, one per card, all passing:
  - `BarterInBloodScenarioTest` — exactly-two auto-sacrifice, choose-2-of-3 prompt bounds, and the
    CR 608.2c case where a player with one creature sacrifices it rather than nothing
  - `ConsumeSpiritScenarioTest` — damage + life gain, X=0, overkill still gains full X, and the
    black-only X restriction through `ManaSolver.canPay`
  - `ContaminatedBondScenarioTest` — the attacks half, the blocks half, life loss landing on the
    creature's controller and not the enchanter, plus an unenchanted negative control
  - `ToothOfChissGoriaScenarioTest` — affinity cost reduction (3 → 0), the pump, its end-of-turn
    expiry, and flash
  - `VedalkenArchmageScenarioTest` — artifact draws, nonartifact doesn't, opponent's artifact doesn't
- `just rebless-cards` — only these five cards moved in `snapshots/cards/MRD.json`
- `just card-status --set MRD` — 138 → 143

🤖 Generated with [Claude Code](https://claude.com/claude-code)