### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2426,6 +2426,15 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `eachPlayerDrawsX(includeController?, includeOpponents?)` — Howling Mine shape.
 - `eachPlayerMayDraw(maxCards, lifePerCardNotDrawn?)` — optional group draw with a tax.
 - `exileFromHand(count?, target)` — exile N from hand.
+- `revealHandAndExileChosen(target?, filter?, prompt?, storeChosenAs?, storeExiledAs?)` — "Target opponent
+  reveals their hand. You choose a nonland card from it. Exile that card." (Cruelclaw's Heist, Soul Search).
+  Thoughtseize with exile instead of discard. The chooser is always the **controller**, not the revealing
+  player — that asymmetry is the pattern, so it is not derived from `target` the way `exileFromHand` derives
+  its chooser. `storeChosenAs` (default `"chosenCard"`) holds the selection *before* the move;
+  `storeExiledAs` holds the cards that actually reached exile, and is the key any rider should read
+  (`ConditionalEffect(CollectionContainsMatch("exiledCard", Filters.ManaValueAtMost(1)), …)` for Soul
+  Search's "if the card's mana value is 1 or less") — it is empty when the hand held no matching card,
+  which is exactly when nothing should happen.
 
 **Sacrifice / destroy**
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -22,6 +22,7 @@ import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.MoveType
 import com.wingedsheep.sdk.scripting.effects.RepeatDynamicTimesEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
@@ -698,6 +699,50 @@ object HandPatterns {
             )
         )
     )
+
+    /**
+     * "Target opponent reveals their hand. You choose a [filter] card from it. Exile that card."
+     * — the Thoughtseize shape with exile instead of discard (Cruelclaw's Heist, Soul Search).
+     *
+     * The chooser is always the *controller*, not the revealing player: that asymmetry is what the
+     * pattern is, so it is deliberately not derived from [target] the way [exileFromHand] derives
+     * its chooser.
+     *
+     * @param storeChosenAs pipeline key holding the chosen card *before* the move.
+     * @param storeExiledAs when non-null, pipeline key holding the cards that actually reached
+     *   exile — the key to read for any rider that keys off the exiled card ("if the card's mana
+     *   value is 1 or less …"), since it is empty when nothing was chosen or nothing moved.
+     */
+    fun revealHandAndExileChosen(
+        target: EffectTarget = EffectTarget.ContextTarget(0),
+        filter: GameObjectFilter = GameObjectFilter.Nonland,
+        prompt: String = "Choose a nonland card to exile",
+        storeChosenAs: String = "chosenCard",
+        storeExiledAs: String? = null,
+    ): CompositeEffect {
+        val player = effectTargetToPlayer(target)
+        return CompositeEffect(
+            listOf(
+                RevealHandEffect(target),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, player, filter),
+                    storeAs = "${storeChosenAs}Candidates"
+                ),
+                SelectFromCollectionEffect(
+                    from = "${storeChosenAs}Candidates",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    storeSelected = storeChosenAs,
+                    prompt = prompt
+                ),
+                MoveCollectionEffect(
+                    from = storeChosenAs,
+                    destination = CardDestination.ToZone(Zone.EXILE, player),
+                    storeMovedAs = storeExiledAs
+                )
+            )
+        )
+    }
 
     /**
      * Target player exiles cards from their hand.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CruelclawsHeist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CruelclawsHeist.kt
@@ -1,27 +1,15 @@
 package com.wingedsheep.mtg.sets.definitions.blb.cards
 
-import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.effects.CardDestination
-import com.wingedsheep.sdk.scripting.effects.CardSource
-import com.wingedsheep.sdk.scripting.effects.Chooser
 import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
-import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
 import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
 import com.wingedsheep.sdk.scripting.effects.Mode
-import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
-import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
-import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
-import com.wingedsheep.sdk.scripting.effects.SelectionMode
-import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
  * Cruelclaw's Heist
@@ -46,24 +34,7 @@ val CruelclawsHeist = card("Cruelclaw's Heist") {
         "Target opponent reveals their hand. You choose a nonland card from it. Exile that card. If the gift was promised, you may cast that card for as long as it remains exiled, and mana of any type can be spent to cast it."
 
     // Common pipeline for both modes: reveal hand, choose nonland, exile
-    val revealChooseExile = listOf(
-        RevealHandEffect(EffectTarget.ContextTarget(0)),
-        GatherCardsEffect(
-            source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0), GameObjectFilter.Nonland),
-            storeAs = "nonlandCards"
-        ),
-        SelectFromCollectionEffect(
-            from = "nonlandCards",
-            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
-            chooser = Chooser.Controller,
-            storeSelected = "chosenCard",
-            prompt = "Choose a nonland card to exile"
-        ),
-        MoveCollectionEffect(
-            from = "chosenCard",
-            destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0))
-        )
-    )
+    val revealChooseExile = listOf(Patterns.Hand.revealHandAndExileChosen())
 
     spell {
         effect = Patterns.Mechanic.giftSpell(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ConvenientTarget.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ConvenientTarget.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Convenient Target — Murders at Karlov Manor #119
+ * {R} · Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, suspect enchanted creature.
+ * Enchanted creature gets +1/+1.
+ * {2}{R}: Return this card from your graveyard to your hand.
+ *
+ * A one-mana Aura that is genuinely playable on an *opponent's* creature as removal-adjacent tempo
+ * (suspected creatures can't block) as well as on your own as a pump-plus-menace. Note the +1/+1
+ * applies either way, so pointing it at an opponent is a real trade.
+ *
+ * Suspect is one-shot and **permanent**, not an Aura-bound continuous effect: per the printed
+ * ruling, if the Aura later leaves the battlefield the creature stays suspected. So the suspect is
+ * an enters trigger with [EffectTarget.EnchantedCreature] and `Duration.Permanent` (the default on
+ * [Effects.Suspect]), not a static ability — modelling it statically would incorrectly un-suspect
+ * the creature when the Aura died. Only the +1/+1 is the static half.
+ *
+ * The Aura enters attached to whatever it targeted on cast, so the enters trigger doesn't target
+ * again — "enchanted creature" is a self-referential pointer, and an Aura that somehow entered
+ * unattached simply has nothing to suspect.
+ *
+ * The graveyard ability makes the Aura's own death a recurring engine; it's `activateFromZone =
+ * Zone.GRAVEYARD` at instant speed, which is how the card is printed (no "activate only as a
+ * sorcery" clause).
+ */
+val ConvenientTarget = card("Convenient Target") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, suspect enchanted creature. (It has menace and can't block.)\n" +
+        "Enchanted creature gets +1/+1.\n" +
+        "{2}{R}: Return this card from your graveyard to your hand."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Suspect(EffectTarget.EnchantedCreature)
+        description = "When this Aura enters, suspect enchanted creature."
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EnchantedCreature)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        effect = Effects.Move(EffectTarget.Self, Zone.HAND)
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d2cf2ae-9152-41c4-9dc4-a19da5812869.jpg?1783912885"
+
+        ruling(
+            "2024-02-02",
+            "If Convenient Target leaves the battlefield, the creature it was enchanting will " +
+                "still be suspected until that creature leaves the battlefield or another effect " +
+                "causes it to no longer be suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until " +
+                "it leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+        ruling("2024-02-02", "If a creature is already suspected, suspecting it again won't have any effect.")
+        ruling(
+            "2024-02-02",
+            "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected " +
+                "creature, it won't be suspected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GadgetTechnician.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GadgetTechnician.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gadget Technician — Murders at Karlov Manor #204
+ * {2}{U}{R} · Creature — Goblin Artificer · 3/2
+ *
+ * When this creature enters or is turned face up, create a 1/1 colorless Thopter artifact creature
+ * token with flying.
+ * Disguise {U/R}{U/R}
+ *
+ * "Enters **or** is turned face up" is one triggered ability with two trigger conditions, so it is
+ * [Triggers.or] over the two event patterns rather than two `triggeredAbility` blocks. The two
+ * readings are indistinguishable in play — turning face up is a special action and not entering
+ * (CR 701.34), so a permanent can never satisfy both at once — but the single ability is what the
+ * card actually prints, and it keeps the client's ability list matching the oracle text.
+ *
+ * The disguise cost is hybrid {U/R}{U/R}, which is the whole point of the card in limited: a mono-U
+ * or mono-R deck can still flip it, so the two-mana flip is available in either half of the pair
+ * even though the hard cast needs both colors.
+ */
+val GadgetTechnician = card("Gadget Technician") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Goblin Artificer"
+    oracleText = "When this creature enters or is turned face up, create a 1/1 colorless Thopter " +
+        "artifact creature token with flying.\n" +
+        "Disguise {U/R}{U/R} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)"
+    power = 3
+    toughness = 2
+
+    disguise = "{U/R}{U/R}"
+
+    triggeredAbility {
+        trigger = Triggers.or(Triggers.EntersBattlefield, Triggers.TurnedFaceUp)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = emptySet(),
+            creatureTypes = setOf("Thopter"),
+            keywords = setOf(Keyword.FLYING),
+            artifactToken = true,
+            name = "Thopter",
+            imageUri = "https://cards.scryfall.io/normal/front/f/8/f80c5f0a-5573-4dc2-8791-35e35bdf4c78.jpg?1783912602"
+        )
+        description = "When this creature enters or is turned face up, create a 1/1 colorless " +
+            "Thopter artifact creature token with flying."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "204"
+        artist = "Caio Monteiro"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b489a54-ee43-4962-be7b-16e0e28800e0.jpg?1783912848"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "If a face-down creature loses its abilities, it can't be turned face up with a " +
+                "disguise ability because it will no longer have a disguise ability (or a " +
+                "disguise cost) once face up."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PrivateEye.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PrivateEye.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Private Eye — Murders at Karlov Manor #223
+ * {1}{W}{U} · Creature — Homunculus Detective · 3/3
+ *
+ * Other Detectives you control get +1/+1.
+ * Whenever you draw your second card each turn, target Detective can't be blocked this turn.
+ *
+ * The lord half is the standard `excludeSelf = true` [GroupFilter] — Private Eye is itself a
+ * Detective, and "other" is what keeps it from pumping itself.
+ *
+ * The second half is [Triggers.NthCardDrawn] with `n = 2`, which is the CR 121.2 "your second card
+ * each turn" shape rather than "the second time you draw this turn": a single draw-two crosses the
+ * threshold and fires the trigger exactly once, and cards put into hand without the word "draw"
+ * (CR 121.5) never advance the count. Because MKM's Detective deck is built on investigate — Clues
+ * sacrificed for extra draws — this reliably fires on the turn you crack one.
+ *
+ * "Target Detective" is unrestricted by controller: it may be an opponent's Detective, which is
+ * rarely what you want but is what the card says. Evasion is granted with the
+ * [AbilityFlag.CANT_BE_BLOCKED] grant rather than a keyword, since "can't be blocked" is not a
+ * keyword ability.
+ */
+val PrivateEye = card("Private Eye") {
+    manaCost = "{1}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Homunculus Detective"
+    oracleText = "Other Detectives you control get +1/+1.\n" +
+        "Whenever you draw your second card each turn, target Detective can't be blocked this turn."
+    power = 3
+    toughness = 3
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        val detective = target(
+            "detective",
+            TargetCreature(filter = TargetFilter.Creature.withSubtype(Subtype.DETECTIVE))
+        )
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, detective)
+        description = "Whenever you draw your second card each turn, target Detective can't be " +
+            "blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "223"
+        artist = "Vincent Christiaens"
+        flavorText = "\"Yep. It's a vase, all right.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b6a50807-058e-45dc-847c-8ffd13b1bd48.jpg?1783912840"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SoulSearch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SoulSearch.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Soul Search — Murders at Karlov Manor #232
+ * {W}{B} · Sorcery
+ *
+ * Target opponent reveals their hand. You choose a nonland card from it. Exile that card. If the
+ * card's mana value is 1 or less, create a 1/1 white and black Spirit creature token with flying.
+ *
+ * A Thoughtseize whose "consolation prize" fires exactly when the pick was cheap — so the card is
+ * never dead: hitting a one-drop nets a body, hitting a bomb nets the bomb.
+ *
+ * Reuses [Patterns.Hand.revealHandAndExileChosen] (the Cruelclaw's Heist shape). The rider reads
+ * `storeExiledAs`, not the pre-move selection: the collection of cards that *actually reached
+ * exile* is empty when the opponent's hand held no nonland card at all, which is exactly when the
+ * card says nothing happens. Reading the pre-move key would mint a Spirit off a selection the move
+ * never completed.
+ *
+ * Both printed rulings are about how mana value is computed on the exiled card rather than about
+ * this spell's structure — {X} counts as 0 outside the stack (CR 202.3b) and a card with no mana
+ * cost has mana value 0 — so both land in the "1 or less" branch. The engine's own mana-value read
+ * already follows CR 202.3, so the filter is a plain [Filters.ManaValueAtMost]; the rulings are
+ * recorded as metadata rather than special-cased.
+ */
+val SoulSearch = card("Soul Search") {
+    manaCost = "{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You choose a nonland card from it. Exile " +
+        "that card. If the card's mana value is 1 or less, create a 1/1 white and black Spirit " +
+        "creature token with flying."
+
+    spell {
+        target("opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            Patterns.Hand.revealHandAndExileChosen(storeExiledAs = "exiledCard"),
+            ConditionalEffect(
+                condition = Conditions.CollectionContainsMatch("exiledCard", Filters.ManaValueAtMost(1)),
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.WHITE, Color.BLACK),
+                    creatureTypes = setOf("Spirit"),
+                    keywords = setOf(Keyword.FLYING),
+                    name = "Spirit",
+                    imageUri = "https://cards.scryfall.io/normal/front/f/4/f4588570-bde4-4c2f-8469-81a3e15fb57b.jpg?1783912607"
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "232"
+        artist = "A. M. Sartor"
+        flavorText = "Taking a secret to your grave still doesn't make it safe from the Orzhov."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f852937-381d-4445-99d3-2ecb8af6bb6a.jpg?1783912838"
+
+        ruling("2024-02-02", "If the exiled card has {X} in its mana cost, X is 0.")
+        ruling("2024-02-02", "If the exiled card doesn't have a mana cost, its mana value is 0.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TunnelTipster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TunnelTipster.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tunnel Tipster — Murders at Karlov Manor #180
+ * {1}{G} · Creature — Mole Scout · 1/1
+ *
+ * At the beginning of your end step, if a face-down creature entered the battlefield under your
+ * control this turn, put a +1/+1 counter on this creature.
+ * {T}: Add {G}.
+ *
+ * The end-step clause is an **intervening-if** (CR 603.4), so it is a `triggerCondition` rather
+ * than a gate inside the effect: with no face-down creature having entered this turn the ability
+ * never goes on the stack at all.
+ *
+ * The condition reads [Conditions.PermanentEnteredFaceDownThisTurn], the per-player face-down-entered
+ * tracker. Its name says "permanent" where the card says "creature", but the two coincide by
+ * construction: a face-down permanent on the battlefield is always a 2/2 colorless creature with no
+ * name (CR 708.2), so any permanent that entered face down entered as a creature.
+ *
+ * Per the printed ruling the tracker is a *historical* fact about the turn — the face-down creature
+ * having since been turned face up, or having left the battlefield, doesn't retract it; and a
+ * creature that entered face **up** and was turned face down later never sets it. That is exactly
+ * the entered-this-turn semantics the tracker records, which is why this can't be modelled as a
+ * battlefield scan for face-down creatures.
+ */
+val TunnelTipster = card("Tunnel Tipster") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Mole Scout"
+    oracleText = "At the beginning of your end step, if a face-down creature entered the " +
+        "battlefield under your control this turn, put a +1/+1 counter on this creature.\n" +
+        "{T}: Add {G}."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.PermanentEnteredFaceDownThisTurn
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "At the beginning of your end step, if a face-down creature entered the " +
+            "battlefield under your control this turn, put a +1/+1 counter on this creature."
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "180"
+        artist = "Leesha Hannigan"
+        flavorText = "\"When your perp goes underground, I know where to find 'em.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3e29b890-35b9-4e2a-9b4c-9417ca7db31d.jpg?1783912858"
+
+        ruling(
+            "2024-02-02",
+            "Tunnel Tipster's first ability will trigger as long as a face-down creature entered " +
+                "the battlefield under your control this turn, even if that creature has turned " +
+                "face up or left the battlefield since. A creature that enters the battlefield " +
+                "face up and turns face down later in the turn won't cause Tunnel Tipster's first " +
+                "ability to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -3864,44 +3864,49 @@
                     "effect": {
                         "type": "Composite",
                         "effects": [
-                            "RevealHand",
                             {
-                                "type": "GatherCards",
-                                "source": {
-                                    "type": "FromZone",
-                                    "zone": "Hand",
-                                    "player": {
-                                        "type": "ContextPlayer",
-                                        "index": 0
+                                "type": "Composite",
+                                "effects": [
+                                    "RevealHand",
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            },
+                                            "filter": "nonland"
+                                        },
+                                        "storeAs": "chosenCardCandidates"
                                     },
-                                    "filter": "nonland"
-                                },
-                                "storeAs": "nonlandCards"
-                            },
-                            {
-                                "type": "SelectFromCollection",
-                                "from": "nonlandCards",
-                                "selection": {
-                                    "type": "ChooseExactly",
-                                    "count": {
-                                        "type": "Fixed",
-                                        "amount": 1
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "chosenCardCandidates",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "chosenCard",
+                                        "prompt": "Choose a nonland card to exile"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "chosenCard",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        }
                                     }
-                                },
-                                "storeSelected": "chosenCard",
-                                "prompt": "Choose a nonland card to exile"
-                            },
-                            {
-                                "type": "MoveCollection",
-                                "from": "chosenCard",
-                                "destination": {
-                                    "type": "ToZone",
-                                    "zone": "Exile",
-                                    "player": {
-                                        "type": "ContextPlayer",
-                                        "index": 0
-                                    }
-                                }
+                                ]
                             }
                         ]
                     },
@@ -3932,44 +3937,49 @@
                                             "index": 0
                                         }
                                     },
-                                    "RevealHand",
                                     {
-                                        "type": "GatherCards",
-                                        "source": {
-                                            "type": "FromZone",
-                                            "zone": "Hand",
-                                            "player": {
-                                                "type": "ContextPlayer",
-                                                "index": 0
+                                        "type": "Composite",
+                                        "effects": [
+                                            "RevealHand",
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "FromZone",
+                                                    "zone": "Hand",
+                                                    "player": {
+                                                        "type": "ContextPlayer",
+                                                        "index": 0
+                                                    },
+                                                    "filter": "nonland"
+                                                },
+                                                "storeAs": "chosenCardCandidates"
                                             },
-                                            "filter": "nonland"
-                                        },
-                                        "storeAs": "nonlandCards"
-                                    },
-                                    {
-                                        "type": "SelectFromCollection",
-                                        "from": "nonlandCards",
-                                        "selection": {
-                                            "type": "ChooseExactly",
-                                            "count": {
-                                                "type": "Fixed",
-                                                "amount": 1
+                                            {
+                                                "type": "SelectFromCollection",
+                                                "from": "chosenCardCandidates",
+                                                "selection": {
+                                                    "type": "ChooseExactly",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    }
+                                                },
+                                                "storeSelected": "chosenCard",
+                                                "prompt": "Choose a nonland card to exile"
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "chosenCard",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Exile",
+                                                    "player": {
+                                                        "type": "ContextPlayer",
+                                                        "index": 0
+                                                    }
+                                                }
                                             }
-                                        },
-                                        "storeSelected": "chosenCard",
-                                        "prompt": "Choose a nonland card to exile"
-                                    },
-                                    {
-                                        "type": "MoveCollection",
-                                        "from": "chosenCard",
-                                        "destination": {
-                                            "type": "ToZone",
-                                            "zone": "Exile",
-                                            "player": {
-                                                "type": "ContextPlayer",
-                                                "index": 0
-                                            }
-                                        }
+                                        ]
                                     },
                                     {
                                         "type": "GrantMayPlayFromExile",

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -611,6 +611,105 @@
     ]
 }
 
+// Convenient Target
+{
+    "name": "Convenient Target",
+    "manaCost": "{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, suspect enchanted creature. (It has menace and can't block.)\nEnchanted creature gets +1/+1.\n{2}{R}: Return this card from your graveyard to your hand.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SetSuspected",
+                            "target": "EnchantedCreature"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": "EnchantedCreature",
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": "EnchantedCreature",
+                            "duration": "Permanent"
+                        }
+                    ],
+                    "descriptionOverride": "enchanted creature becomes suspected"
+                },
+                "descriptionOverride": "When this Aura enters, suspect enchanted creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Hand"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "UNCOMMON",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d2cf2ae-9152-41c4-9dc4-a19da5812869.jpg?1783912885",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If Convenient Target leaves the battlefield, the creature it was enchanting will still be suspected until that creature leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature is already suspected, suspecting it again won't have any effect."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected creature, it won't be suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cornered Crook
 {
     "name": "Cornered Crook",
@@ -1885,6 +1984,86 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Gadget Technician
+{
+    "name": "Gadget Technician",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Creature — Goblin Artificer",
+    "oracleText": "When this creature enters or is turned face up, create a 1/1 colorless Thopter artifact creature token with flying.\nDisguise {U/R}{U/R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{U/R}{U/R}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AnyOfEvents",
+                    "events": [
+                        {
+                            "type": "ZoneChangeEvent",
+                            "to": "Battlefield"
+                        },
+                        "TurnFaceUpEvent"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Thopter"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "name": "Thopter",
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/8/f80c5f0a-5573-4dc2-8791-35e35bdf4c78.jpg?1783912602",
+                    "artifactToken": true
+                },
+                "descriptionOverride": "When this creature enters or is turned face up, create a 1/1 colorless Thopter artifact creature token with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "204",
+        "artist": "Caio Monteiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b489a54-ee43-4962-be7b-16e0e28800e0.jpg?1783912848",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a face-down creature loses its abilities, it can't be turned face up with a disguise ability because it will no longer have a disguise ability (or a disguise cost) once face up."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 
@@ -4317,6 +4496,68 @@
     ]
 }
 
+// Private Eye
+{
+    "name": "Private Eye",
+    "manaCost": "{1}{W}{U}",
+    "typeLine": "Creature — Homunculus Detective",
+    "oracleText": "Other Detectives you control get +1/+1.\nWhenever you draw your second card each turn, target Detective can't be blocked this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "detective"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature Detective"
+                    },
+                    "id": "detective"
+                },
+                "descriptionOverride": "Whenever you draw your second card each turn, target Detective can't be blocked this turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Detective ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "UNCOMMON",
+        "artist": "Vincent Christiaens",
+        "flavorText": "\"Yep. It's a vase, all right.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b6a50807-058e-45dc-847c-8ffd13b1bd48.jpg?1783912840"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Rakish Scoundrel
 {
     "name": "Rakish Scoundrel",
@@ -5841,6 +6082,121 @@
     ]
 }
 
+// Soul Search
+{
+    "name": "Soul Search",
+    "manaCost": "{W}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target opponent reveals their hand. You choose a nonland card from it. Exile that card. If the card's mana value is 1 or less, create a 1/1 white and black Spirit creature token with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        "RevealHand",
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "filter": "nonland"
+                            },
+                            "storeAs": "chosenCardCandidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "chosenCardCandidates",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "chosenCard",
+                            "prompt": "Choose a nonland card to exile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "chosenCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeMovedAs": "exiledCard"
+                        }
+                    ]
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "CollectionContainsMatch",
+                            "collection": "exiledCard",
+                            "filter": "mv<=1"
+                        }
+                    },
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE",
+                            "BLACK"
+                        ],
+                        "creatureTypes": [
+                            "Spirit"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ],
+                        "name": "Spirit",
+                        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4588570-bde4-4c2f-8469-81a3e15fb57b.jpg?1783912607"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "UNCOMMON",
+        "artist": "A. M. Sartor",
+        "flavorText": "Taking a secret to your grave still doesn't make it safe from the Orzhov.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f852937-381d-4445-99d3-2ecb8af6bb6a.jpg?1783912838",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If the exiled card has {X} in its mana cost, X is 0."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If the exiled card doesn't have a mana cost, its mana value is 0."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Surveillance Monitor
 {
     "name": "Surveillance Monitor",
@@ -6192,6 +6548,65 @@
     },
     "colorIdentityOverride": [
         "WHITE",
+        "GREEN"
+    ]
+}
+
+// Tunnel Tipster
+{
+    "name": "Tunnel Tipster",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Mole Scout",
+    "oracleText": "At the beginning of your end step, if a face-down creature entered the battlefield under your control this turn, put a +1/+1 counter on this creature.\n{T}: Add {G}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": "PermanentEnteredFaceDownThisTurn",
+                "descriptionOverride": "At the beginning of your end step, if a face-down creature entered the battlefield under your control this turn, put a +1/+1 counter on this creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "artist": "Leesha Hannigan",
+        "flavorText": "\"When your perp goes underground, I know where to find 'em.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3e29b890-35b9-4e2a-9b4c-9417ca7db31d.jpg?1783912858",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Tunnel Tipster's first ability will trigger as long as a face-down creature entered the battlefield under your control this turn, even if that creature has turned face up or left the battlefield since. A creature that enters the battlefield face up and turns face down later in the turn won't cause Tunnel Tipster's first ability to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
         "GREEN"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CantBlockExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CantBlockExecutor.kt
@@ -27,7 +27,10 @@ class CantBlockExecutor : EffectExecutor<CantBlockEffect> {
         effect: CantBlockEffect,
         context: EffectContext
     ): EffectResult {
-        val entityId = TargetResolutionUtils.resolveTarget(effect.target, context)
+        // State-aware overload, matching SetSuspectedExecutor and GrantKeywordExecutor — the three
+        // sub-effects of Effects.Suspect must resolve the *same* target, and the attachment-relative
+        // ones (EnchantedCreature) only resolve with state in hand.
+        val entityId = TargetResolutionUtils.resolveTarget(effect.target, context, state)
             ?: return EffectResult.success(state)
         val container = state.getEntity(entityId)
             ?: return EffectResult.success(state)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/SetSuspectedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/SetSuspectedExecutor.kt
@@ -34,7 +34,10 @@ class SetSuspectedExecutor : EffectExecutor<SetSuspectedEffect> {
         effect: SetSuspectedEffect,
         context: EffectContext
     ): EffectResult {
-        val entityId = TargetResolutionUtils.resolveTarget(effect.target, context)
+        // State-aware overload: the attachment-relative targets (EnchantedCreature — Convenient
+        // Target's "suspect enchanted creature") resolve only against the battlefield, and the
+        // state-less overload returns null for them, which would silently drop the whole suspect.
+        val entityId = TargetResolutionUtils.resolveTarget(effect.target, context, state)
             ?: return EffectResult.success(state)
         state.getEntity(entityId)?.get<CardComponent>()
             ?: return EffectResult.success(state)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1571,6 +1571,24 @@ class StackResolver(
             updated
         }
 
+        // "A face-down creature entered the battlefield under your control this turn" (Tunnel
+        // Tipster, Oblivious Bookworm). The per-player counter is also bumped by the
+        // MoveToZone/MoveCollection face-down paths (manifest, cloak) in ZoneTransitionService;
+        // a morph/disguise *cast* resolves through here instead and never touches that service,
+        // so without this the tracker would miss the most common face-down entry of all.
+        // Cleared at the turn boundary by CleanupPhaseManager.
+        if (spellComponent.castFaceDown) {
+            newState = newState.updateEntity(controllerId) { playerContainer ->
+                val existing = playerContainer
+                    .get<com.wingedsheep.engine.state.components.player.PermanentEnteredFaceDownThisTurnComponent>()
+                    ?: com.wingedsheep.engine.state.components.player.PermanentEnteredFaceDownThisTurnComponent()
+                playerContainer.with(
+                    com.wingedsheep.engine.state.components.player
+                        .PermanentEnteredFaceDownThisTurnComponent(existing.count + 1)
+                )
+            }
+        }
+
         // CR 707.10f token-copy riders: register the delayed "sacrifice this token" trigger after
         // the permanent enters. The token shares the resolving spell-copy's entity id, so the
         // delayed trigger targets `spellId` directly.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConvenientTargetScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConvenientTargetScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.ConvenientTarget
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Convenient Target (MKM #119) — {R} Enchantment — Aura.
+ *
+ * "Enchant creature
+ *  When this Aura enters, suspect enchanted creature.
+ *  Enchanted creature gets +1/+1.
+ *  {2}{R}: Return this card from your graveyard to your hand."
+ *
+ * The claim under test is that the two halves have **different lifetimes**. The +1/+1 is an Aura-bound
+ * continuous effect and dies with the Aura; the suspect is a one-shot that permanently designates the
+ * creature, and per the printed ruling survives the Aura leaving the battlefield. Modelling suspect as a
+ * static ability would pass a naive "is it suspected?" check while silently un-suspecting the creature the
+ * moment the Aura died — so the second test is the one that actually distinguishes the implementations.
+ */
+class ConvenientTargetScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ConvenientTarget)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Cast the Aura onto [host] and let the enters trigger resolve. Returns the Aura's entity id. */
+    fun enchant(driver: GameTestDriver, player: EntityId, host: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Convenient Target")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpellWithTargets(player, card, listOf(ChosenTarget.Permanent(host))).error shouldBe null
+        driver.bothPass()
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+        return driver.findPermanent(player, "Convenient Target")!!
+    }
+
+    test("it suspects and pumps the creature it enchants") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        withClue("baseline: a plain 3/3 that is not suspected") {
+            projector.project(driver.state).isSuspected(courser) shouldBe false
+        }
+
+        enchant(driver, player, courser)
+
+        val projected = projector.project(driver.state)
+        withClue("the enters trigger suspected the enchanted creature (CR 701.60a)") {
+            projected.isSuspected(courser) shouldBe true
+            projected.hasKeyword(courser, Keyword.MENACE) shouldBe true
+            projected.cantBlock(courser) shouldBe true
+        }
+        withClue("and the static half is a straight +1/+1") {
+            projected.getPower(courser) shouldBe 4
+            projected.getToughness(courser) shouldBe 4
+        }
+    }
+
+    test("losing the Aura drops the +1/+1 but not the suspected designation") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        val aura = enchant(driver, player, courser)
+        driver.moveToGraveyard(aura)
+
+        val projected = projector.project(driver.state)
+        withClue("the Aura's continuous effect is gone with it") {
+            projected.getPower(courser) shouldBe 3
+            projected.getToughness(courser) shouldBe 3
+        }
+        withClue("but suspect was a one-shot designation and outlives the Aura (printed ruling)") {
+            projected.isSuspected(courser) shouldBe true
+            projected.cantBlock(courser) shouldBe true
+        }
+    }
+
+    test("{2}{R} buys it back out of the graveyard") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        val aura = enchant(driver, player, courser)
+        driver.moveToGraveyard(aura)
+        driver.getGraveyardCardNames(player) shouldContain "Convenient Target"
+
+        val abilityId = ConvenientTarget.script.activatedAbilities.single().id
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveColorlessMana(player, 2)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = aura, abilityId = abilityId)
+        ).error shouldBe null
+        driver.bothPass()
+
+        withClue("the Aura is back in hand, ready to suspect something else") {
+            driver.findCardInHand(player, "Convenient Target") shouldBe aura
+            driver.getGraveyardCardNames(player).contains("Convenient Target") shouldBe false
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GadgetTechnicianScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GadgetTechnicianScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.GadgetTechnician
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gadget Technician (MKM #204) — {2}{U}{R} 3/2 Goblin Artificer, Disguise {U/R}{U/R}.
+ *
+ * "When this creature enters **or is turned face up**, create a 1/1 colorless Thopter artifact
+ *  creature token with flying."
+ *
+ * The whole point of the test is that both halves of the disjunctive trigger fire — the shape a
+ * naive `Triggers.EntersBattlefield` would silently half-implement, since a card cast face down and
+ * flipped never enters again (CR 701.34) and would produce no Thopter at all.
+ *
+ * The third test pins the other direction: a *face-down* Gadget Technician has no abilities
+ * (CR 708.2), so entering the battlefield face down must not make a Thopter either. Together they
+ * fence the trigger to exactly the two events the card prints.
+ */
+class GadgetTechnicianScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GadgetTechnician)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun thopters(driver: GameTestDriver, player: EntityId): Int =
+        driver.getPermanents(player).count {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == "Thopter"
+        }
+
+    /** Cast it face down for {3} and return the resulting face-down permanent. */
+    fun castFaceDown(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Gadget Technician")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    test("hard-casting it makes a Thopter — the enters half of the trigger") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val card = driver.putCardInHand(player, "Gadget Technician")
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveColorlessMana(player, 2)
+        driver.castSpell(player, card).error shouldBe null
+        driver.bothPass()
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+
+        driver.findPermanent(player, "Gadget Technician").shouldNotBeNull()
+        withClue("the enters trigger resolved into exactly one Thopter") {
+            thopters(driver, player) shouldBe 1
+        }
+    }
+
+    test("turning it face up makes a Thopter — the flip half of the trigger") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val technician = castFaceDown(driver, player)
+        withClue("a face-down permanent has no abilities (CR 708.2), so entering made no Thopter") {
+            thopters(driver, player) shouldBe 0
+        }
+
+        // Disguise {U/R}{U/R} — two blue pays both hybrid pips.
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = technician,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+
+        withClue("turning face up is not entering (CR 701.34) — only the second half can have fired") {
+            thopters(driver, player) shouldBe 1
+        }
+        driver.state.getEntity(technician)?.has<FaceDownComponent>() shouldBe false
+    }
+
+    test("the hybrid disguise cost is payable with either color alone") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val technician = castFaceDown(driver, player)
+
+        driver.giveMana(player, Color.RED, 2)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = technician,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+
+        withClue("{U/R}{U/R} takes two red just as happily as two blue") {
+            driver.state.getEntity(technician)?.has<FaceDownComponent>() shouldBe false
+            thopters(driver, player) shouldBe 1
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrivateEyeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrivateEyeScenarioTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.NoviceInspector
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.PrivateEye
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Private Eye (MKM #223) — {1}{W}{U} 3/3 Homunculus Detective.
+ *
+ * "Other Detectives you control get +1/+1.
+ *  Whenever you draw your second card each turn, target Detective can't be blocked this turn."
+ *
+ * Two claims, one per ability. The lord must be **other**-scoped — Private Eye is itself a Detective,
+ * so a missing `excludeSelf` would quietly make it a 4/4. And the payoff must key off the *second*
+ * card drawn each turn (CR 121.2), not off any draw, so the first draw of the turn has to be inert.
+ *
+ * Draws are driven by a free instant so the only variable under test is the draw count.
+ */
+class PrivateEyeScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A free instant: the cast costs nothing, so nothing but the draw count moves.
+    val drawOne = card("Private Eye Draw One Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Draw a card."
+        spell { effect = Effects.DrawCards(1) }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(PrivateEye, NoviceInspector, drawOne))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun drawACard(driver: GameTestDriver, player: EntityId) {
+        val card = driver.putCardInHand(player, "Private Eye Draw One Test")
+        driver.castSpell(player, card).error shouldBe null
+        driver.bothPass()
+    }
+
+    test("the lord pumps other Detectives but never itself") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val eye = driver.putCreatureOnBattlefield(player, "Private Eye")
+        val inspector = driver.putCreatureOnBattlefield(player, "Novice Inspector")
+        val courser = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        val projected = projector.project(driver.state)
+        withClue("Novice Inspector is a 1/2 Human Detective, so it gets +1/+1") {
+            projected.getPower(inspector) shouldBe 2
+            projected.getToughness(inspector) shouldBe 3
+        }
+        withClue("\"other\" excludes the Eye itself — it stays a printed 3/3") {
+            projected.getPower(eye) shouldBe 3
+            projected.getToughness(eye) shouldBe 3
+        }
+        withClue("a non-Detective is untouched") {
+            projected.getPower(courser) shouldBe 3
+            projected.getToughness(courser) shouldBe 3
+        }
+    }
+
+    test("the second draw of the turn makes a Detective unblockable; the first does not") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(player, "Private Eye")
+        val inspector = driver.putCreatureOnBattlefield(player, "Novice Inspector")
+
+        drawACard(driver, player)
+        withClue("one draw doesn't reach NthCardDrawn(2)") {
+            driver.stackSize shouldBe 0
+            projector.project(driver.state)
+                .hasKeyword(inspector, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+        }
+
+        drawACard(driver, player)
+
+        // The trigger targets a Detective; with two on the battlefield the choice is a real decision.
+        (driver.pendingDecision as? ChooseTargetsDecision)?.let {
+            driver.submitTargetSelection(player, listOf(inspector))
+        }
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+
+        withClue("the second draw fired the trigger and the chosen Detective is unblockable") {
+            projector.project(driver.state)
+                .hasKeyword(inspector, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+        }
+    }
+
+    test("the grant is until end of turn only") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(player, "Private Eye")
+        val inspector = driver.putCreatureOnBattlefield(player, "Novice Inspector")
+
+        drawACard(driver, player)
+        drawACard(driver, player)
+        (driver.pendingDecision as? ChooseTargetsDecision)?.let {
+            driver.submitTargetSelection(player, listOf(inspector))
+        }
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+        projector.project(driver.state)
+            .hasKeyword(inspector, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+
+        driver.passPriorityUntil(Step.END)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        withClue("\"this turn\" expired in the cleanup step") {
+            projector.project(driver.state)
+                .hasKeyword(inspector, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulSearchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulSearchScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.SoulSearch
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Soul Search (MKM #232) — {W}{B} Sorcery.
+ *
+ * "Target opponent reveals their hand. You choose a nonland card from it. Exile that card. If the
+ *  card's mana value is 1 or less, create a 1/1 white and black Spirit creature token with flying."
+ *
+ * Three things worth pinning:
+ *  - the selection is restricted to **nonland** cards, so lands are never offered;
+ *  - the Spirit rider keys off the *exiled* card's mana value, so an expensive pick mints nothing;
+ *  - an all-lands hand exiles nothing **and** makes no Spirit — the fail-open shape, where a rider
+ *    reading the pre-move selection instead of what actually reached exile would hand out a free body.
+ */
+class SoulSearchScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(SoulSearch)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun nameOf(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    fun spirits(driver: GameTestDriver, player: EntityId): Int =
+        driver.getPermanents(player).count { nameOf(driver, it) == "Spirit" }
+
+    /** Cast Soul Search at [opponent] and stop on the "choose a nonland card" decision. */
+    fun castAt(driver: GameTestDriver, player: EntityId, opponent: EntityId) {
+        val card = driver.putCardInHand(player, "Soul Search")
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.giveMana(player, Color.BLACK, 1)
+        driver.castSpellWithTargets(player, card, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+        driver.bothPass()
+    }
+
+    test("a one-mana pick is exiled and pays off with a Spirit") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        // Savannah Lions is {W} (mana value 1); Centaur Courser is {2}{G} (mana value 3).
+        driver.putCardInHand(opponent, "Savannah Lions")
+        driver.putCardInHand(opponent, "Centaur Courser")
+        driver.putCardInHand(opponent, "Swamp")
+
+        castAt(driver, player, opponent)
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        withClue("only nonland cards are choosable — the Swamp must not be offered") {
+            decision.options.mapNotNull { nameOf(driver, it) }.sorted() shouldBe
+                listOf("Centaur Courser", "Savannah Lions")
+        }
+
+        val lions = decision.options.single { nameOf(driver, it) == "Savannah Lions" }
+        driver.submitCardSelection(player, listOf(lions))
+
+        withClue("the chosen card is exiled from the opponent's hand") {
+            driver.getExileCardNames(opponent) shouldContain "Savannah Lions"
+            driver.findCardInHand(opponent, "Savannah Lions") shouldBe null
+        }
+        withClue("mana value 1 clears the bar, so the caster gets the Spirit") {
+            spirits(driver, player) shouldBe 1
+        }
+    }
+
+    test("an expensive pick is exiled but mints no Spirit") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        driver.putCardInHand(opponent, "Savannah Lions")
+        driver.putCardInHand(opponent, "Centaur Courser")
+
+        castAt(driver, player, opponent)
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        val courser = decision.options.single { nameOf(driver, it) == "Centaur Courser" }
+        driver.submitCardSelection(player, listOf(courser))
+
+        withClue("the Courser is gone all the same") {
+            driver.getExileCardNames(opponent) shouldContain "Centaur Courser"
+        }
+        withClue("mana value 3 is above the bar — no consolation body") {
+            spirits(driver, player) shouldBe 0
+        }
+    }
+
+    test("an all-lands hand exiles nothing and makes nothing") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        driver.putCardInHand(opponent, "Swamp")
+        driver.putCardInHand(opponent, "Swamp")
+
+        castAt(driver, player, opponent)
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+
+        withClue("there was no nonland card to take") {
+            driver.getExileCardNames(opponent).contains("Swamp") shouldBe false
+        }
+        withClue("and nothing reached exile, so the rider must not fire") {
+            spirits(driver, player) shouldBe 0
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TunnelTipsterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TunnelTipsterScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.GadgetTechnician
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.TunnelTipster
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tunnel Tipster (MKM #180) — {1}{G} 1/1 Mole Scout.
+ *
+ * "At the beginning of your end step, **if a face-down creature entered the battlefield under your
+ *  control this turn**, put a +1/+1 counter on this creature.
+ *  {T}: Add {G}."
+ *
+ * The intervening-if (CR 603.4) is the whole card, so the tests pin both arms of it: an end step
+ * with no face-down entry must not put a counter, and one preceded by a face-down cast must. A
+ * Gadget Technician cast face down for {3} is the fixture that flips the tracker.
+ *
+ * The third test is the load-bearing negative from the printed ruling: the condition is a
+ * *historical* fact about the turn, so it must not be re-read as "a face-down creature is on the
+ * battlefield now" — flipping the face-down creature face up before the end step still grows the
+ * Tipster.
+ */
+class TunnelTipsterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(TunnelTipster, GadgetTechnician))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun castFaceDown(driver: GameTestDriver, player: EntityId) {
+        val card = driver.putCardInHand(player, "Gadget Technician")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+    }
+
+    /** Walk to the end step and let the (possible) trigger resolve. */
+    fun runEndStep(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END)
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+    }
+
+    test("no face-down creature entered — the trigger never goes on the stack") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val tipster = driver.putCreatureOnBattlefield(player, "Tunnel Tipster")
+
+        runEndStep(driver)
+
+        withClue("the intervening-if failed, so no counter") {
+            plusOneCounters(driver, tipster) shouldBe 0
+        }
+    }
+
+    test("a face-down creature entered this turn — the end step grows the Tipster") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val tipster = driver.putCreatureOnBattlefield(player, "Tunnel Tipster")
+
+        castFaceDown(driver, player)
+        runEndStep(driver)
+
+        withClue("the face-down entry satisfied the intervening-if") {
+            plusOneCounters(driver, tipster) shouldBe 1
+        }
+    }
+
+    test("the condition is historical — the tracker survives into the same turn's end step") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val tipster = driver.putCreatureOnBattlefield(player, "Tunnel Tipster")
+
+        castFaceDown(driver, player)
+        runEndStep(driver)
+        plusOneCounters(driver, tipster) shouldBe 1
+
+        // Round the table back to this player without casting anything face down.
+        do {
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+            if (driver.activePlayer != player) driver.passPriorityUntil(Step.END)
+        } while (driver.activePlayer != player)
+
+        runEndStep(driver)
+
+        withClue("the tracker is cleared each turn, so a clean turn adds nothing") {
+            plusOneCounters(driver, tipster) shouldBe 1
+        }
+    }
+
+    test("{T}: Add {G} is a mana ability that fills the pool") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val tipster = driver.putCreatureOnBattlefield(player, "Tunnel Tipster")
+        driver.removeSummoningSickness(tipster)
+
+        val abilityId = TunnelTipster.script.activatedAbilities.single().id
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = tipster, abilityId = abilityId)
+        ).error shouldBe null
+
+        withClue("a mana ability doesn't use the stack — the green is in the pool immediately") {
+            driver.stackSize shouldBe 0
+            driver.state.getEntity(player)?.get<ManaPoolComponent>()?.green shouldBe 1
+        }
+        driver.isTapped(tipster) shouldBe true
+    }
+})


### PR DESCRIPTION
Five MKM cards, one scenario test file each. MKM goes 110 → 115 / 276.

| Card | Cost | What it needed |
|---|---|---|
| **Gadget Technician** | {2}{U}{R} 3/2 | `Triggers.or(EntersBattlefield, TurnedFaceUp)` + hybrid disguise `{U/R}{U/R}` |
| **Tunnel Tipster** | {1}{G} 1/1 | end-step intervening-if on the face-down-entered tracker + `{T}: Add {G}` |
| **Convenient Target** | {R} Aura | ETB suspect on the enchanted creature, `ModifyStats`, `{2}{R}` self-return from graveyard |
| **Soul Search** | {W}{B} | reveal → choose nonland → exile, with a mana-value-gated Spirit rider |
| **Private Eye** | {1}{W}{U} 3/3 | `excludeSelf` Detective lord + `NthCardDrawn(2)` → `CANT_BE_BLOCKED` |

All five are MKM-original printings (`just check-card-printing` clean on each), and every oracle text is a byte-exact match against Scryfall.

## Engine fixes these surfaced

**1. A morph/disguise cast never set the face-down-entered tracker.**
`PermanentEnteredFaceDownThisTurnComponent` was only incremented by the `MoveToZone` / `MoveCollection` face-down paths in `ZoneTransitionService` — i.e. manifest and cloak. A face-down *spell* resolves through `StackResolver` instead and never touches that service, so the tracker stayed at zero for the most common face-down entry there is. Tunnel Tipster's intervening-if reads it; **Oblivious Bookworm (DSK) was silently affected too** and is fixed by the same change.

**2. `Effects.Suspect` dropped two of its three sub-effects on an attachment-relative target.**
`SetSuspectedExecutor` and `CantBlockExecutor` resolved through the state-less `resolveTarget` overload, which returns `null` for `EnchantedCreature` / `EquippedCreature` / `ChosenCreature`. `GrantKeywordExecutor` already used the state-aware path, so `Effects.Suspect(EnchantedCreature)` would have granted menace and nothing else — no designation, no can't-block. Both now use the state-aware overload. This is the `resolveTarget`-needs-state bug shape again.

## SDK

`Patterns.Hand.revealHandAndExileChosen(...)` — the "target opponent reveals their hand, you choose a nonland card from it, exile that card" pipeline, previously inlined in Cruelclaw's Heist and now a second user in Soul Search. The chooser is deliberately hardcoded to the controller (that asymmetry *is* the pattern), and `storeExiledAs` exposes what actually reached exile so a rider like Soul Search's "if the card's mana value is 1 or less" can't fire off a selection that never moved. Documented in `docs/card-sdk-language-reference.md`.

**Cruelclaw's Heist moves onto the shared pattern.** Its effect tree is structurally identical afterwards — one nested `Composite` plus a renamed internal gather key — and that is the entire BLB golden diff. The MKM golden diff is purely additive (zero removed lines).

## Verification

- `just build` — green
- `just test` — full suite green
- `just check` — green
- `just rebless-cards` — only Cruelclaw's Heist moved in BLB, only the five new cards in MKM (verified by diffing the goldens before reblessing)
- `just check-card-printing` — clean for all five

🤖 Generated with [Claude Code](https://claude.com/claude-code)