### PR TITLE
Add five Mirrodin cards, with defender-relative block evasion

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5188,6 +5188,20 @@ staticAbility {
   via `Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE, target, duration)`;
   `BlockPhaseManager.validateMaxBlockersRequirements` reads the projected flag (cap = 1) alongside the
   printed `CantBeBlockedByMoreThan` static, taking the smaller cap.
+- `CantBeBlockedIfDefenderControls(permanentFilter, minCount = 1, filter = GroupFilter.source())` —
+  the **landwalk shape generalized past land types**: the affected creature can't be blocked while the
+  *defending player* controls at least `minCount` permanents matching `permanentFilter` (Neurok Spy's
+  "can't be blocked as long as defending player controls an artifact" =
+  `CantBeBlockedIfDefenderControls(GameObjectFilter.Artifact)`). Resolved by
+  `CantBeBlockedIfDefenderControlsRule` from the attacker's printed self-scoped statics plus granted
+  ones in `GameState.grantedStaticAbilities`. The candidate set is the *defending player's* projected
+  battlefield and each candidate is matched with the projection in hand, so type-changing effects
+  (Ensoul Artifact, March of the Machines) and control changes both count; the filter is evaluated
+  with the defender bound as "you", so it needs no controller predicate of its own.
+  **Defender-relative, not "any opponent"** — `Conditions.OpponentControls(filter)` wrapped around
+  `CantBeBlocked` is existential across opponents and only coincides with this in a two-player game.
+  The basic landwalk keywords (`Keyword.FORESTWALK` and friends, plus `NONBASIC_LANDWALK`) keep their
+  own keyword-driven `LandwalkRule` fast path rather than desugaring to this.
 - `CantBlockCreaturesWithGreaterPower(filter = source())` — blocker-side evasion (Spitfire Handler): this
   creature can't block creatures whose projected power exceeds its own.
 - `CantBeBlockedByCreaturesWithLessPower(filter = source())` — attacker-side dual (Formation Breaker): this

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/BlockingStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/BlockingStaticAbilities.kt
@@ -272,3 +272,40 @@ data class CantBeBlockedUnlessDefenderSharesCreatureType(
 ) : StaticAbility {
     override val description: String = "can't be blocked unless defending player controls $minSharedCount or more creatures that share a creature type"
 }
+
+/**
+ * This creature can't be blocked as long as the **defending player** controls at least
+ * [minCount] permanents matching [permanentFilter] — the landwalk shape generalized past land
+ * types. Neurok Spy: "can't be blocked as long as defending player controls an artifact."
+ *
+ * Defender-relative, not "any opponent": the count is taken against the player (or the controller
+ * of the planeswalker/battle) this creature is attacking, so in a multiplayer pod attacking a
+ * player with no artifact leaves the Spy blockable even while another opponent has ten.
+ * `Conditions.OpponentControls(...)` is the existential mirror and is *not* a substitute here.
+ *
+ * The basic landwalk keywords ([com.wingedsheep.sdk.core.Keyword.FORESTWALK] and friends) keep
+ * their own keyword-driven fast path in the engine rather than desugaring to this; use this type
+ * for the non-land members of the family.
+ *
+ * @property permanentFilter What the defending player must control for the evasion to switch on.
+ * @property minCount How many matching permanents the defending player needs (default 1, "an X").
+ * @property filter What this ability applies to (default: the source creature).
+ */
+@SerialName("CantBeBlockedIfDefenderControls")
+@Serializable
+data class CantBeBlockedIfDefenderControls(
+    val permanentFilter: GameObjectFilter,
+    val minCount: Int = 1,
+    val filter: GroupFilter = GroupFilter.source()
+) : StaticAbility {
+    override val description: String = if (minCount == 1) {
+        "can't be blocked as long as defending player controls ${permanentFilter.description}"
+    } else {
+        "can't be blocked as long as defending player controls $minCount or more ${permanentFilter.description}"
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MyrAdapter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MyrAdapter.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Myr Adapter — Mirrodin #210
+ * {3} · Artifact Creature — Myr · 1/1
+ *
+ * This creature gets +1/+1 for each Equipment attached to it.
+ *
+ * The Champion of the Flame / Winter Soldier shape, restricted to Equipment: a
+ * [GrantDynamicStatsEffect] over [GroupFilter.source] whose bonus is
+ * [DynamicAmounts.equipmentAttachedToSelf] — the *Equipment-only* attachment count, so Auras
+ * hung on the Adapter (Inertia Bubble, Relic Bane) don't feed it. The count is read from
+ * projected subtypes and recomputed continuously, so the bonus tracks Equipment being attached,
+ * unattached, or ceasing to be an Equipment mid-turn.
+ *
+ * Bonus, not base-setting: it stacks additively with anything the Equipment itself grants
+ * (Bonesplitter's +2/+0 makes the Adapter a 4/2, not a 3/3), and applies in layer 7c alongside
+ * every other +N/+N.
+ */
+val MyrAdapter = card("Myr Adapter") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Myr"
+    power = 1
+    toughness = 1
+    oracleText = "This creature gets +1/+1 for each Equipment attached to it."
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.equipmentAttachedToSelf(),
+            toughnessBonus = DynamicAmounts.equipmentAttachedToSelf()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Ben Thompson"
+        flavorText = "\"The simplest way to plan ahead is merely to be ready for everything.\"\n" +
+            "—Pontifex, elder researcher"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d6ddde9-4427-4a0f-b05c-9cfd886aad2d.jpg?1783944512"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MyrEnforcer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MyrEnforcer.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Myr Enforcer — Mirrodin #211
+ * {7} · Artifact Creature — Myr · 4/4
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ *
+ * The top of the affinity curve alongside [Frogmite] — the whole cost is generic, so seven
+ * artifacts make a 4/4 free. Nothing but the stock [KeywordAbility.Affinity] over
+ * [CardType.ARTIFACT]; affinity only shaves generic mana and there is nothing else here to shave.
+ *
+ * Affinity is a cost reduction, not an alternative cost: the mana value stays 7 in every zone no
+ * matter how cheaply it was cast, and the artifact count is taken as the total cost is locked in
+ * while casting.
+ */
+val MyrEnforcer = card("Myr Enforcer") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Myr"
+    power = 4
+    toughness = 4
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)"
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "211"
+        artist = "Greg Staples"
+        flavorText = "Most myr monitor other species. Some myr monitor other myr."
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eeeef899-a8b5-4416-a208-3bd5a0c7177b.jpg?1783944512"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NeurokSpy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NeurokSpy.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedIfDefenderControls
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Neurok Spy — Mirrodin #44
+ * {2}{U} · Creature — Human Rogue · 2/2
+ *
+ * This creature can't be blocked as long as defending player controls an artifact.
+ *
+ * "Artifactwalk" — the landwalk shape with an artifact instead of a land type, and on Mirrodin that
+ * makes a 2/2 for three essentially unblockable. Modelled with
+ * [CantBeBlockedIfDefenderControls] over the unscoped [GameObjectFilter.Artifact]: the evasion rule
+ * counts artifacts on the *defending player's* battlefield, so the filter needs no controller
+ * predicate, and in a multiplayer pod attacking an artifact-less player leaves the Spy blockable
+ * even while another opponent is drowning in Myr.
+ *
+ * Deliberately not `Conditions.OpponentControls(Artifact)` wrapped around `CantBeBlocked`: that
+ * reads "any opponent", which is the same thing only in a two-player game.
+ *
+ * The check is made as blockers are declared and uses projected state, so a permanent that merely
+ * *became* an artifact (Ensoul Artifact, March of the Machines) turns the evasion on, and an
+ * artifact that leaves after blockers are declared doesn't retroactively undo a legal block.
+ */
+val NeurokSpy = card("Neurok Spy") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "This creature can't be blocked as long as defending player controls an artifact."
+
+    staticAbility {
+        ability = CantBeBlockedIfDefenderControls(GameObjectFilter.Artifact)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Daren Bader"
+        flavorText = "From the murk of Mephidross to the heart of Kuldotha, the vedalken send " +
+            "their servants forth to gather knowledge from every inch of Mirrodin."
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/47b86a02-d40a-4615-8402-bd5700cb5101.jpg?1783944553"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NuisanceEngine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NuisanceEngine.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Nuisance Engine — Mirrodin #221
+ * {3} · Artifact · Uncommon
+ *
+ * {2}, {T}: Create a 0/1 colorless Pest artifact creature token.
+ *
+ * A repeatable chump-blocker factory. The whole card is one activated ability —
+ * [Costs.Composite] of [Costs.Mana] "{2}" and [Costs.Tap] with a single [CreateTokenEffect]:
+ * 0 power, 1 toughness, no colors (`colors = emptySet()`, which is what makes the token
+ * *colorless* rather than merely uncolored-looking), `creatureTypes = setOf("Pest")` and
+ * `artifactToken = true` for the artifact card type. The token defaults to the name "Pest Token".
+ *
+ * The tap cost is the throttle — one Pest per turn, and the Engine has to be untapped, so it
+ * can't be used the turn it enters unless it was already on the battlefield.
+ *
+ * No `imageUri`: Mirrodin printed no token cards and Scryfall has no colorless artifact Pest token
+ * in any printing, so the token falls through to the generic `TokenArt.IMAGES["Pest"]` stand-in
+ * (added with this card) inside the client's generated frame, which carries the correct 0/1 and the
+ * artifact-creature type line.
+ */
+val NuisanceEngine = card("Nuisance Engine") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}: Create a 0/1 colorless Pest artifact creature token."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = CreateTokenEffect(
+            power = 0,
+            toughness = 1,
+            colors = emptySet(),
+            creatureTypes = setOf("Pest"),
+            artifactToken = true
+        )
+        description = "{2}, {T}: Create a 0/1 colorless Pest artifact creature token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Stephen Tappin"
+        flavorText = "All Auriok children know the tale, \"Bolgri and the Long Day of Squashing.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/266df8c3-5872-4d83-90bc-8f6f854ac838.jpg?1783944509"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SerumTank.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SerumTank.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Serum Tank — Mirrodin #240
+ * {3} · Artifact · Uncommon
+ *
+ * Whenever this artifact or another artifact enters, put a charge counter on this artifact.
+ * {3}, {T}, Remove a charge counter from this artifact: Draw a card.
+ *
+ * The trigger is deliberately unscoped: the oracle text says "another artifact", not "another
+ * artifact you control", so *every* artifact entering the battlefield charges the Tank — including
+ * an opponent's. Modelled as [Triggers.entersBattlefield] over the plain (uncontrolled)
+ * [GameObjectFilter.Artifact] with [TriggerBinding.ANY], the same read [LeoninElder] and
+ * [Vermiculos] use. ANY rather than OTHER is what covers the "this artifact or" half: the Tank is
+ * already on the battlefield when its own `ZoneChangeEvent` is emitted, so it sees itself enter and
+ * arrives with one counter already on it.
+ *
+ * The draw is [Costs.Composite] of mana, [Costs.Tap] and [Costs.RemoveCounterFromSelf] — three
+ * separate throttles, so the Tank converts at most one counter per turn cycle and only while it has
+ * a counter to remove. Removing the counter is part of the *cost*, so an unpaid or illegal
+ * activation never draws, and countering the ability on the stack does not refund the counter.
+ */
+val SerumTank = card("Serum Tank") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever this artifact or another artifact enters, put a charge counter on this artifact.\n" +
+        "{3}, {T}, Remove a charge counter from this artifact: Draw a card."
+
+    // Whenever this artifact or another artifact enters, put a charge counter on this artifact.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact,
+            binding = TriggerBinding.ANY
+        )
+        effect = AddCountersEffect(Counters.CHARGE, 1, EffectTarget.Self)
+    }
+
+    // {3}, {T}, Remove a charge counter from this artifact: Draw a card.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}"),
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.CHARGE, 1)
+        )
+        effect = Effects.DrawCards(1)
+        description = "{3}, {T}, Remove a charge counter from this artifact: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "240"
+        artist = "Corey D. Macourek"
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/126ec055-1a7d-426b-a87f-c85c60aa7fc3.jpg?1783944505"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -2684,6 +2684,80 @@
     ]
 }
 
+// Myr Adapter
+{
+    "name": "Myr Adapter",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Myr",
+    "oracleText": "This creature gets +1/+1 for each Equipment attached to it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": {
+                        "type": "AttachmentCount",
+                        "kind": "EQUIPMENT"
+                    }
+                },
+                "toughnessBonus": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": {
+                        "type": "AttachmentCount",
+                        "kind": "EQUIPMENT"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Ben Thompson",
+        "flavorText": "\"The simplest way to plan ahead is merely to be ready for everything.\"\n—Pontifex, elder researcher",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d6ddde9-4427-4a0f-b05c-9cfd886aad2d.jpg?1783944512"
+    },
+    "colorIdentityOverride": []
+}
+
+// Myr Enforcer
+{
+    "name": "Myr Enforcer",
+    "manaCost": "{7}",
+    "typeLine": "Artifact Creature — Myr",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "211",
+        "artist": "Greg Staples",
+        "flavorText": "Most myr monitor other species. Some myr monitor other myr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eeeef899-a8b5-4416-a208-3bd5a0c7177b.jpg?1783944512"
+    },
+    "colorIdentityOverride": []
+}
+
 // Myr Mindservant
 {
     "name": "Myr Mindservant",
@@ -3004,6 +3078,39 @@
     "colorIdentityOverride": []
 }
 
+// Neurok Spy
+{
+    "name": "Neurok Spy",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "This creature can't be blocked as long as defending player controls an artifact.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedIfDefenderControls",
+                "permanentFilter": {
+                    "cardPredicates": [
+                        "IsArtifact"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Daren Bader",
+        "flavorText": "From the murk of Mephidross to the heart of Kuldotha, the vedalken send their servants forth to gather knowledge from every inch of Mirrodin.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/47b86a02-d40a-4615-8402-bd5700cb5101.jpg?1783944553"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Nim Lasher
 {
     "name": "Nim Lasher",
@@ -3212,6 +3319,53 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Nuisance Engine
+{
+    "name": "Nuisance Engine",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}: Create a 0/1 colorless Pest artifact creature token.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Pest"
+                    ],
+                    "artifactToken": true
+                },
+                "descriptionOverride": "{2}, {T}: Create a 0/1 colorless Pest artifact creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "UNCOMMON",
+        "artist": "Stephen Tappin",
+        "flavorText": "All Auriok children know the tale, \"Bolgri and the Long Day of Squashing.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/266df8c3-5872-4d83-90bc-8f6f854ac838.jpg?1783944509"
+    },
+    "colorIdentityOverride": []
 }
 
 // Ogre Leadfoot
@@ -3718,6 +3872,74 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Serum Tank
+{
+    "name": "Serum Tank",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever this artifact or another artifact enters, put a charge counter on this artifact.\n{3}, {T}, Remove a charge counter from this artifact: Draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "charge",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{3}, {T}, Remove a charge counter from this artifact: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "UNCOMMON",
+        "artist": "Corey D. Macourek",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/126ec055-1a7d-426b-a87f-c85c60aa7fc3.jpg?1783944505"
+    },
+    "colorIdentityOverride": []
 }
 
 // Shrapnel Blast

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenArt.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenArt.kt
@@ -92,6 +92,7 @@ object TokenArt {
             "Ooze" to "https://cards.scryfall.io/art_crop/front/c/2/c2fc764f-d5fe-452a-8474-5ad380048faf.jpg?1771590231",
             "Otter" to "https://cards.scryfall.io/art_crop/front/e/6/e6b2c465-c446-4dee-9101-763105dcf813.jpg?1783909764",
             "Pegasus" to "https://cards.scryfall.io/art_crop/front/b/c/bc944579-b6d8-40f7-8c46-146513960d61.jpg?1761614913",
+            "Pest" to "https://cards.scryfall.io/art_crop/front/d/0/d0ddbe3e-4a66-494d-9304-7471232549bf.jpg?1783927190",
             "Pirate" to "https://cards.scryfall.io/art_crop/front/4/6/46bf5e2b-869f-480e-ac37-1bdb40a92f8c.jpg?1665776397",
             "Rabbit" to "https://cards.scryfall.io/art_crop/front/8/1/81de52ef-7515-4958-abea-fb8ebdcef93c.jpg?1721431122",
             "Raccoon" to "https://cards.scryfall.io/art_crop/front/a/f/af257e8b-9bed-4c6b-9510-11fe950fa80e.jpg?1783909752",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.CantBeBlockedBy
 import com.wingedsheep.sdk.scripting.CantBeBlockedExceptBy
 import com.wingedsheep.sdk.scripting.CantBeBlockedIfCastSpellType
+import com.wingedsheep.sdk.scripting.CantBeBlockedIfDefenderControls
 import com.wingedsheep.sdk.scripting.CantBeBlockedUnlessDefenderSharesCreatureType
 import com.wingedsheep.sdk.scripting.CantBeBlockedWhilePropertyAtMost
 import com.wingedsheep.sdk.scripting.GameObjectFilter
@@ -360,6 +361,57 @@ class CantBeBlockedUnlessDefenderSharesCreatureTypeRule : BlockEvasionRule {
 }
 
 /**
+ * CantBeBlockedIfDefenderControls: Attacker can't be blocked while the **defending player**
+ * controls at least N permanents matching a filter — the landwalk shape generalized past land
+ * types (Neurok Spy: "can't be blocked as long as defending player controls an artifact").
+ *
+ * Counts against [BlockCheckContext.blockingPlayer], which is the defending player for this
+ * declaration, so a multiplayer attack at a player with no matching permanent stays blockable even
+ * when another opponent has one. The candidate set comes from projected state
+ * ([ProjectedState.getBattlefieldControlledBy]) and each candidate is matched with the projection in
+ * hand, so a permanent that only *became* an artifact (Ensoul Artifact, March of the Machines) counts
+ * and control-changing effects are honored. The filter is evaluated with the defender bound as
+ * "you", so an unscoped filter such as `GameObjectFilter.Artifact` reads "an artifact the defending
+ * player controls" without the card having to spell out a controller predicate.
+ */
+class CantBeBlockedIfDefenderControlsRule(
+    private val predicateEvaluator: PredicateEvaluator
+) : BlockEvasionRule {
+    override fun check(ctx: BlockCheckContext): String? {
+        // Face-down creatures have no abilities — the evasion doesn't apply.
+        if (ctx.state.getEntity(ctx.attackerId)?.has<FaceDownComponent>() == true) return null
+        val attackerCard = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>() ?: return null
+        val cardDef = ctx.cardRegistry.getCard(attackerCard.cardDefinitionId)
+        val printed = cardDef?.staticAbilities
+            ?.filterIsInstance<CantBeBlockedIfDefenderControls>()
+            ?.filter { it.filter.scope is Scope.Self }
+            .orEmpty()
+        val granted = ctx.state.grantedStaticAbilities
+            .filter { it.entityId == ctx.attackerId }
+            .map { it.ability }
+            .filterIsInstance<CantBeBlockedIfDefenderControls>()
+        val abilities = printed + granted
+        if (abilities.isEmpty()) return null
+
+        val predicateContext = PredicateContext(
+            controllerId = ctx.blockingPlayer,
+            sourceId = ctx.attackerId
+        )
+        for (ability in abilities) {
+            val matches = ctx.projected.getBattlefieldControlledBy(ctx.blockingPlayer).count { entityId ->
+                predicateEvaluator.matches(
+                    ctx.state, ctx.projected, entityId, ability.permanentFilter, predicateContext
+                )
+            }
+            if (matches >= ability.minCount) {
+                return "${attackerCard.name} ${ability.description}"
+            }
+        }
+        return null
+    }
+}
+
+/**
  * Protection from color: Attacker can't be blocked by creatures of a color it has protection from.
  */
 class ProtectionFromColorRule : BlockEvasionRule {
@@ -635,6 +687,7 @@ fun defaultBlockEvasionRules(
     CantBeBlockedByColorRule(),
     CantBeBlockedExceptByRule(predicateEvaluator),
     CantBeBlockedUnlessDefenderSharesCreatureTypeRule(),
+    CantBeBlockedIfDefenderControlsRule(predicateEvaluator),
     CantBeBlockedWhilePropertyAtMostRule(),
     CantBeBlockedIfCastSpellTypeRule(predicateEvaluator),
     ProtectionFromColorRule(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -101,6 +101,7 @@ import com.wingedsheep.sdk.scripting.CantBeBlockedBy
 import com.wingedsheep.sdk.scripting.CantBeBlockedByCreaturesWithLessPower
 import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
 import com.wingedsheep.sdk.scripting.CantBeBlockedIfCastSpellType
+import com.wingedsheep.sdk.scripting.CantBeBlockedIfDefenderControls
 import com.wingedsheep.sdk.scripting.CantBeBlockedUnlessDefenderSharesCreatureType
 import com.wingedsheep.sdk.scripting.CantBlockCreaturesWithGreaterPower
 import com.wingedsheep.sdk.scripting.CantBlockUnless
@@ -922,6 +923,7 @@ class StaticAbilityHandler(
             is CantBeBlockedByMoreThan,
             is com.wingedsheep.sdk.scripting.CantBeBlockedByFewerThan,
             is CantBeBlockedIfCastSpellType,
+            is CantBeBlockedIfDefenderControls,
             is CantBeBlockedUnlessDefenderSharesCreatureType,
             is CantBlockCreaturesWithGreaterPower,
             is CantBlockUnless,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MyrAdapterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MyrAdapterScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Myr Adapter (MRD #210) — 1/1 for {3}, "gets +1/+1 for each Equipment attached to it."
+ *
+ * Guards the two ways the bonus is easy to get wrong: it must count Equipment *only* (an Aura hung
+ * on the Adapter must not feed it), and it must stack additively with whatever the Equipment itself
+ * grants rather than replacing it.
+ */
+class MyrAdapterScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Myr Adapter") {
+
+            test("bare, it is a 1/1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Myr Adapter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val adapter = game.findPermanent("Myr Adapter")!!
+                val projected = projector.project(game.state)
+                projected.getPower(adapter) shouldBe 1
+                projected.getToughness(adapter) shouldBe 1
+            }
+
+            test("one Equipment gives +1/+1 on top of the Equipment's own bonus") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Myr Adapter")
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withCardAttachedTo(1, "Bonesplitter", "Myr Adapter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val adapter = game.findPermanent("Myr Adapter")!!
+                val projected = projector.project(game.state)
+                withClue("1/1 base, +2/+0 from Bonesplitter, +1/+1 from the Adapter's own ability") {
+                    projected.getPower(adapter) shouldBe 4
+                    projected.getToughness(adapter) shouldBe 2
+                }
+            }
+
+            test("two Equipment give +2/+2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Myr Adapter")
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withCardOnBattlefield(1, "Vulshok Battlegear")
+                    .withCardAttachedTo(1, "Bonesplitter", "Myr Adapter")
+                    .withCardAttachedTo(1, "Vulshok Battlegear", "Myr Adapter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val adapter = game.findPermanent("Myr Adapter")!!
+                val projected = projector.project(game.state)
+                withClue("1/1 base, +2/+0 and +3/+3 from the Equipment, +2/+2 for the two of them") {
+                    projected.getPower(adapter) shouldBe 8
+                    projected.getToughness(adapter) shouldBe 6
+                }
+            }
+
+            test("an Aura attached to it does not count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Myr Adapter")
+                    .withCardOnBattlefield(1, "Arrest")
+                    .withCardAttachedTo(1, "Arrest", "Myr Adapter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val adapter = game.findPermanent("Myr Adapter")!!
+                val projected = projector.project(game.state)
+                withClue("the ability counts Equipment, not every attachment") {
+                    projected.getPower(adapter) shouldBe 1
+                    projected.getToughness(adapter) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeurokSpyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeurokSpyScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Neurok Spy (MRD #44) — 2/2 for {2}{U}, "can't be blocked as long as defending player controls an
+ * artifact."
+ *
+ * Covers the `CantBeBlockedIfDefenderControls` static this card introduced. The load-bearing cases
+ * are the ones a naive "any opponent controls an artifact" wiring would get wrong:
+ *
+ *  - the evasion is off when the defender has no artifact (the block must be *legal*),
+ *  - it is off when the *attacking* player is the one holding the artifacts,
+ *  - and it is on when the defender's artifact is an artifact *creature*, which is the same card
+ *    type and so counts.
+ */
+class NeurokSpyScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature("Test Blocker", ManaCost.parse("{2}"), emptySet(), power = 2, toughness = 2)
+        )
+
+        context("Neurok Spy") {
+
+            test("can't be blocked while the defending player controls an artifact") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Neurok Spy", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Test Blocker")
+                    .withCardOnBattlefield(2, "Bonesplitter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Neurok Spy" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Test Blocker" to listOf("Neurok Spy")))
+                withClue("the defender controls Bonesplitter — the block is illegal") {
+                    block.error shouldNotBe null
+                }
+            }
+
+            test("CAN be blocked when the defending player controls no artifact") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Neurok Spy", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Test Blocker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Neurok Spy" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Test Blocker" to listOf("Neurok Spy")))
+                withClue("no artifact on the defender's side — the block is legal: ${block.error}") {
+                    block.error shouldBe null
+                }
+            }
+
+            test("the Spy's controller holding the artifacts does not switch the evasion on") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Neurok Spy", summoningSickness = false)
+                    // Two artifacts, both on the *attacking* side. "Defending player controls" is
+                    // defender-relative, so these must not count.
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withCardOnBattlefield(1, "Fireshrieker")
+                    .withCardOnBattlefield(2, "Test Blocker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Neurok Spy" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Test Blocker" to listOf("Neurok Spy")))
+                withClue("the artifacts are the attacker's — the block is legal: ${block.error}") {
+                    block.error shouldBe null
+                }
+            }
+
+            test("an artifact creature the defender controls counts as an artifact") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Neurok Spy", summoningSickness = false)
+                    // Steel Wall is an Artifact Creature — Wall: it is both the blocker and the
+                    // artifact that turns the evasion on, so it can never legally block the Spy.
+                    .withCardOnBattlefield(2, "Steel Wall")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Neurok Spy" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Steel Wall" to listOf("Neurok Spy")))
+                withClue("an artifact creature is still an artifact — the block is illegal") {
+                    block.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SerumTankScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SerumTankScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.SerumTank
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Serum Tank (MRD #240) — "Whenever this artifact or another artifact enters, put a charge counter
+ * on this artifact." / "{3}, {T}, Remove a charge counter from this artifact: Draw a card."
+ *
+ * The two things worth proving are the halves of the trigger's scope, both of which a narrower
+ * wiring would silently drop: `TriggerBinding.ANY` is what makes the Tank see *itself* enter (the
+ * "this artifact or" clause), and the unscoped artifact filter is what makes an *opponent's*
+ * artifact charge it too — the oracle text says "another artifact", not "another artifact you
+ * control".
+ */
+class SerumTankScenarioTest : ScenarioTestBase() {
+
+    private fun chargeCounters(state: com.wingedsheep.engine.state.GameState, id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.CHARGE) ?: 0
+
+    init {
+        context("Serum Tank") {
+
+            test("it sees itself enter and arrives with one charge counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Serum Tank")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Serum Tank").error shouldBe null
+                game.resolveStack()
+
+                val tank = game.findPermanent("Serum Tank")!!
+                withClue("'this artifact or another artifact' includes the Tank's own entry") {
+                    chargeCounters(game.state, tank) shouldBe 1
+                }
+            }
+
+            test("another artifact you control entering adds a counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Serum Tank")
+                    .withCardInHand(1, "Bonesplitter")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tank = game.findPermanent("Serum Tank")!!
+                withClue("the Tank was placed directly, so it starts empty") {
+                    chargeCounters(game.state, tank) shouldBe 0
+                }
+
+                game.castSpell(1, "Bonesplitter").error shouldBe null
+                game.resolveStack()
+
+                chargeCounters(game.state, tank) shouldBe 1
+            }
+
+            test("an opponent's artifact charges it too — the filter is not 'you control'") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Serum Tank")
+                    .withCardInHand(2, "Bonesplitter")
+                    .withLandsOnBattlefield(2, "Island", 3)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tank = game.findPermanent("Serum Tank")!!
+                game.castSpell(2, "Bonesplitter").error shouldBe null
+                game.resolveStack()
+
+                withClue("the oracle text says 'another artifact', with no controller restriction") {
+                    chargeCounters(game.state, tank) shouldBe 1
+                }
+            }
+
+            test("{3}, {T}, remove a charge counter: draw a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Serum Tank")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast it so its own entry trigger supplies the counter the draw needs.
+                game.castSpell(1, "Serum Tank").error shouldBe null
+                game.resolveStack()
+
+                val tank = game.findPermanent("Serum Tank")!!
+                chargeCounters(game.state, tank) shouldBe 1
+                val handBefore = game.handSize(1)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tank,
+                        abilityId = SerumTank.activatedAbilities[0].id,
+                    )
+                )
+                withClue("activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                game.handSize(1) shouldBe handBefore + 1
+                withClue("removing the counter is part of the cost, so it is gone") {
+                    chargeCounters(game.state, tank) shouldBe 0
+                }
+            }
+
+            test("with no charge counter the ability can't be activated") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Serum Tank")
+                    .withLandsOnBattlefield(1, "Island", 6)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val tank = game.findPermanent("Serum Tank")!!
+                chargeCounters(game.state, tank) shouldBe 0
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tank,
+                        abilityId = SerumTank.activatedAbilities[0].id,
+                    )
+                )
+                withClue("the counter-removal cost is unpayable with zero counters") {
+                    (result.error != null) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five Mirrodin cards. MRD goes **143/291 → 148/291**.

| Card | | |
|---|---|---|
| **Myr Enforcer** | `{7}` Artifact Creature — Myr 4/4 | Affinity for artifacts |
| **Myr Adapter** | `{3}` Artifact Creature — Myr 1/1 | +1/+1 for each Equipment attached to it |
| **Neurok Spy** | `{2}{U}` Creature — Human Rogue 2/2 | Can't be blocked while defending player controls an artifact |
| **Nuisance Engine** | `{3}` Artifact | `{2}`, `{T}`: create a 0/1 colorless Pest artifact creature token |
| **Serum Tank** | `{3}` Artifact | Charges on any artifact entering; `{3}`, `{T}`, remove a charge counter: draw |

## New SDK vocabulary

Four of the five are pure composition. Neurok Spy needed one new primitive:

`CantBeBlockedIfDefenderControls(permanentFilter, minCount = 1, filter = source())` — the landwalk shape generalized past land types. Enforced by `CantBeBlockedIfDefenderControlsRule` at block declaration, the same read site as the landwalk and Graxiplon restrictions.

The load-bearing detail is that it counts the **defending player's** projected battlefield, not "any opponent". `Conditions.OpponentControls(Artifact)` wrapped around `CantBeBlocked` would be existential across opponents — identical in a two-player game, wrong in a pod, and this repo is actively building multiplayer. Candidates are matched with the projection in hand, so a permanent that only *became* an artifact (Ensoul Artifact, March of the Machines) counts and control changes are honored.

The basic landwalk keywords keep their own keyword-driven `LandwalkRule` fast path rather than desugaring to this — that refactor is out of scope here.

Wired at every layer that could drop it: `@Serializable` with a `@SerialName` (proved by the card snapshot), registered in `defaultBlockEvasionRules`, and added to `StaticAbilityHandler`'s consumed-elsewhere list so it isn't mistaken for a continuous effect. No new `GameEvent`, decision, or keyword, so no server-DTO or client work. Documented in `docs/card-sdk-language-reference.md`.

## The other four

- **Myr Enforcer** — stock `KeywordAbility.Affinity(CardType.ARTIFACT)`, the Frogmite shape at the top of the curve.
- **Myr Adapter** — `GrantDynamicStatsEffect` over `DynamicAmounts.equipmentAttachedToSelf()`, so Auras hung on it don't feed the bonus and it stacks additively with what the Equipment itself grants.
- **Nuisance Engine** — one `CreateTokenEffect`. Scryfall has no colorless artifact Pest token in any printing (Mirrodin printed no token cards), so a generic `Pest` entry was added to `TokenArt.IMAGES`; without it `TokenArtCoverageTest` fails and the client would name-guess the art off Scryfall.
- **Serum Tank** — `TriggerBinding.ANY` over the *unscoped* `GameObjectFilter.Artifact`: ANY is what covers the "this artifact **or** another" half (the Tank is on the battlefield when its own `ZoneChangeEvent` fires, so it arrives with one counter), and the unscoped filter is what makes an opponent's artifacts charge it — the oracle text says "another artifact", not "another artifact you control".

## Verification

- `just build` — green (10346 tests).
- `NeurokSpyScenarioTest` (4), `SerumTankScenarioTest` (5), `MyrAdapterScenarioTest` (4) — all pass. Myr Enforcer and Nuisance Engine are covered by the snapshot and lint nets.
- `just check-card-printing` clean for all five (MRD is the earliest real printing of each).
- MRD card snapshot re-blessed; the diff contains only the five new cards.
- All five image URIs and the new token art URI verified HTTP 200.
- `just check-backlog` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)