### PR TITLE
Add four The Hobbit cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1554,7 +1554,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ### Ability granting
 
-- `GrantTriggeredAbilityEffect(ability)` — permanently grant a triggered ability.
+- `GrantTriggeredAbilityEffect(ability, target, duration = Duration.EndOfTurn)` — grant a triggered ability to a battlefield permanent for a duration; `Duration.Permanent` for "gains … " with no end (Carnage, Crimson Chaos). **Target-general — not creature-only.** Nothing in the rules restricts "gains '<triggered ability>'" to creatures, and the printed wording routinely names a noncreature permanent: Down in the Valley's chapter II is "*This Saga* gains 'Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token'", authored as `GrantTriggeredAbilityEffect(ability, EffectTarget.Self, Duration.Permanent)`. Whether a noncreature is a *legal* pick is the `TargetRequirement`'s job; the executor only requires the target to be on the battlefield. Recorded in `GameState.grantedTriggeredAbilities` and merged into the entity's abilities by `TriggerAbilityResolver`, so a granted trigger is detected exactly like a printed one and dies with the permanent.
 - `CreateGlobalTriggeredAbility(ability, duration = Duration.Permanent, descriptionOverride? = null)` — engine-wide triggered ability with no source permanent. `duration` is a plain parameter, so the one method covers every lifetime: `Duration.EndOfTurn` (False Cure, Death Frenzy), `Duration.UntilYourNextTurn` (Season of the Bold), `Duration.EndOfCombat`, `Duration.Permanent` (Dimensional Breach, planeswalker emblems), etc. `descriptionOverride` sets emblem display text.
 - `GrantSpellKeywordEffect` — grant a keyword to a spell on the stack.
 - `GrantSpellsCantBeCountered(target, filter, duration)` — target's matching spells become uncounterable (Domri shape).
@@ -5917,6 +5917,22 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
     (the same shape as the existing wither-on-spell check, which reads `SpellGrantedKeywordsComponent`). One-shot
     per-spell grants (`GrantKeywordToSpellEffect` → `SpellGrantedKeywordsComponent`, e.g. a copy that gains lifelink)
     feed the same check.
+- `GrantFlashToSpellType(filter, controllerOnly = false, nthOfTypePerTurn = null)` — a battlefield
+  static letting matching spells be cast as though they had flash (CR 702.8). `controllerOnly = true`
+  is the "**You** may cast …" wording (Raff Capashen, Valley Floodcaller); the default covers "**Any
+  player** may cast …" (Quick Sliver). `nthOfTypePerTurn = N` narrows the grant to the Nth matching
+  spell a player casts each turn (1-indexed, counting the spell being cast) — **Radagast of
+  Rhosgobel**'s "the first creature spell you cast each turn … can be cast as though it had flash" is
+  `GrantFlashToSpellType(GameObjectFilter.Creature, controllerOnly = true, nthOfTypePerTurn = 1)`.
+  This is the *timing* twin of [`CostGating.NthOfTypePerTurn`](#9-static-abilities) and counts
+  identically — off `GameState.spellsCastThisTurnByPlayer`, which does not yet contain the spell
+  being cast — so a card printing both halves of "costs {2} less **and** can be cast as though it had
+  flash" can never disagree about which spell is the first. A matching spell already cast this turn
+  closes the window even if it was countered ("you cast" keys on the cast, not the resolution). Both
+  flash read sites — `CastPermissionUtils.hasGrantedFlash` (legal-action enumeration, also consulted
+  by the suspend paths) and `CastZoneResolver.hasGrantedFlash` (the authoritative cast-time check) —
+  route the gate through the shared `FlashTypeGrants.nthGateAllows`. Sibling of the durational
+  `Effects.GrantFlashToSpells`; use the static for "as long as this is on the battlefield" wording.
 - `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false, spellFilter = Any, oncePerTurn = false, fromExileOnly = false)` — a
   battlefield permission to cast a spell without paying its mana cost (CR 118.9). Composable
   gates: `controllerOnly = true` restricts the benefit to the source's controller ("you" wording);

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -21,18 +21,60 @@ import kotlinx.serialization.Serializable
  *
  * @property filter The filter that spells must match to gain flash
  * @property controllerOnly If true, only the permanent's controller benefits (default: false = any player)
+ * @property nthOfTypePerTurn When set, only the Nth matching spell a player casts each turn gains
+ *   flash (1-indexed; counts the spell being cast). `1` is "the **first** [type] spell you cast each
+ *   turn … can be cast as though it had flash" (Radagast of Rhosgobel). The timing half of the same
+ *   "first spell each turn" gate that [CostGating.NthOfTypePerTurn] applies to cost, and it counts
+ *   the same way — off the caster's spells-cast-this-turn record, so a matching spell already cast
+ *   this turn closes the window even if it was countered. `null` (default) grants flash to every
+ *   matching spell, the Quick Sliver / Raff Capashen shape.
  */
 @SerialName("GrantFlashToSpellType")
 @Serializable
 data class GrantFlashToSpellType(
     val filter: GameObjectFilter,
-    val controllerOnly: Boolean = false
+    val controllerOnly: Boolean = false,
+    val nthOfTypePerTurn: Int? = null
 ) : StaticAbility {
-    override val description: String = if (controllerOnly) {
-        "You may cast ${filter.description} spells as though they had flash"
-    } else {
-        "Any player may cast ${filter.description} spells as though they had flash"
+    init {
+        require(nthOfTypePerTurn == null || nthOfTypePerTurn >= 1) {
+            "nthOfTypePerTurn must be at least 1, was $nthOfTypePerTurn"
+        }
     }
+
+    override val description: String = buildDescription()
+
+    private fun buildDescription(): String {
+        val subject = if (controllerOnly) "you cast" else "any player casts"
+        return if (nthOfTypePerTurn != null) {
+            // The gate names a single spell, so the whole clause goes singular.
+            "The ${ordinal(nthOfTypePerTurn)} ${filter.description} spell $subject each turn " +
+                "can be cast as though it had flash"
+        } else if (controllerOnly) {
+            "You may cast ${filter.description} spells as though they had flash"
+        } else {
+            "Any player may cast ${filter.description} spells as though they had flash"
+        }
+    }
+
+    private fun ordinal(n: Int): String = when (n) {
+        1 -> "first"
+        2 -> "second"
+        3 -> "third"
+        4 -> "fourth"
+        5 -> "fifth"
+        else -> {
+            val suffix = when {
+                n % 100 in 11..13 -> "th"
+                n % 10 == 1 -> "st"
+                n % 10 == 2 -> "nd"
+                n % 10 == 3 -> "rd"
+                else -> "th"
+            }
+            "$n$suffix"
+        }
+    }
+
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DainIronfoot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DainIronfoot.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dáin Ironfoot
+ * {2}{R}
+ * Legendary Creature — Dwarf Warrior
+ * 1/4
+ * When Dáin enters, create a colorless Equipment artifact token named Axe with "Equipped creature
+ * gets +1/+0" and equip {2}. When you do, attach it to target creature you control.
+ * Whenever Dáin attacks, each equipped attacking creature gains double strike until end of turn.
+ *
+ *  - The Axe is the named Equipment token already registered in `PredefinedTokens.kt` (shared with
+ *    Iron Hills Blacksmith), minted by [CreatePredefinedTokenEffect] so its static bonus and equip
+ *    ability are real printed abilities rather than an ad-hoc grant.
+ *  - "When you do" is a genuine **reflexive trigger** (CR 603.12), not a second clause of the same
+ *    ability: the attach goes on the stack separately and picks its target then, so opponents get a
+ *    priority window between the token appearing and it being attached. [ReflexiveTriggerEffect]
+ *    with `optional = false` — creating the token isn't a "may", so the reflexive half always fires.
+ *    The freshly minted token is addressed through the [CREATED_TOKENS] pipeline collection, which
+ *    the reflexive trigger carries over from its action half.
+ *  - The attach is not an equip activation: no cost is paid and it happens at instant speed.
+ *  - "Each **equipped attacking** creature" is deliberately not controller-scoped — the printed text
+ *    says neither "you control" nor "attacking creature you control". In practice only the attacking
+ *    player has attackers, but the filter mirrors the wording rather than the common case. Dáin
+ *    itself is included when it is carrying an Equipment.
+ */
+val DainIronfoot = card("Dáin Ironfoot") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dwarf Warrior"
+    power = 1
+    toughness = 4
+    oracleText = "When Dáin enters, create a colorless Equipment artifact token named Axe with " +
+        "\"Equipped creature gets +1/+0\" and equip {2}. When you do, attach it to target creature " +
+        "you control.\n" +
+        "Whenever Dáin attacks, each equipped attacking creature gains double strike until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = CreatePredefinedTokenEffect("Axe"),
+            optional = false,
+            reflexiveEffect = Effects.AttachTargetEquipmentToCreature(
+                equipmentTarget = EffectTarget.PipelineTarget(CREATED_TOKENS, 0),
+                creatureTarget = EffectTarget.ContextTarget(0),
+            ),
+            reflexiveTargetRequirements = listOf(Targets.CreatureYouControl),
+            descriptionOverride = "Create a colorless Equipment artifact token named Axe with " +
+                "\"Equipped creature gets +1/+0\" and equip {2}. When you do, attach it to target " +
+                "creature you control.",
+        )
+        description = "When Dáin enters, create a colorless Equipment artifact token named Axe " +
+            "with \"Equipped creature gets +1/+0\" and equip {2}. When you do, attach it to " +
+            "target creature you control."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Group.grantKeywordToAll(
+            Keyword.DOUBLE_STRIKE,
+            GroupFilter(GameObjectFilter.Creature.attacking().equipped())
+        )
+        description = "Whenever Dáin attacks, each equipped attacking creature gains double " +
+            "strike until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "91"
+        artist = "Tomas Duchek"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/7112e460-9160-4535-ad94-93f1f4ac04cf.jpg?1785236701"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DownInTheValley.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DownInTheValley.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/** "Elves you control" — the group chapters III and IV pump. */
+private val elvesYouControl = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.ELF).youControl())
+
+/**
+ * Down in the Valley
+ * {2}{G}
+ * Enchantment — Saga
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+ * I — Search your library for a basic land card, reveal it, put it into your hand, then shuffle.
+ * II — This Saga gains "Landfall — Whenever a land you control enters, create a 1/1 green Elf
+ * creature token."
+ * III, IV — Elves you control get +1/+0 and gain vigilance until end of turn.
+ *
+ *  - **Chapter II grants the ability to the Saga itself**, not to a group: the wording is "*This
+ *    Saga* gains …", so it is a [GrantTriggeredAbilityEffect] over [EffectTarget.Self] with
+ *    [Duration.Permanent]. The grant outlives chapter III but not the Saga — sacrificing after IV
+ *    (CR 714.4) takes the granted landfall trigger with it, which is why the token payoff only
+ *    covers the two turns between chapter II and the sacrifice.
+ *  - **Chapters III and IV are the same ability**, declared once in [valleyRally] and wired to
+ *    both, exactly like the four identical chapters of The Misty Mountains Cold.
+ *  - The pump filter is "Elves you control", not "Elf creatures you control" — but the printed
+ *    "get +1/+0" only means anything on a creature, and a noncreature Elf permanent can't gain
+ *    vigilance meaningfully either, so [Creature][GameObjectFilter.Creature] is the honest scope.
+ */
+val DownInTheValley = card("Down in the Valley") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\n" +
+        "I — Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n" +
+        "II — This Saga gains \"Landfall — Whenever a land you control enters, create a 1/1 green " +
+        "Elf creature token.\"\n" +
+        "III, IV — Elves you control get +1/+0 and gain vigilance until end of turn."
+
+    sagaChapter(1) {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.HAND,
+            reveal = true
+        )
+    }
+
+    sagaChapter(2) {
+        effect = GrantTriggeredAbilityEffect(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.LandYouControlEnters.event,
+                binding = Triggers.LandYouControlEnters.binding,
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.GREEN),
+                    creatureTypes = setOf("Elf"),
+                    imageUri = "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812",
+                ),
+                descriptionOverride = "Landfall — Whenever a land you control enters, create a 1/1 " +
+                    "green Elf creature token."
+            ),
+            target = EffectTarget.Self,
+            duration = Duration.Permanent
+        )
+    }
+
+    sagaChapter(3) { effect = valleyRally() }
+    sagaChapter(4) { effect = valleyRally() }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "124"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c8aa5179-475b-4cc8-b21e-205b475eb4cf.jpg?1784895042"
+    }
+}
+
+/** The one chapter ability shared by III and IV. */
+private fun valleyRally() =
+    Patterns.Group.modifyStatsForAll(1, 0, elvesYouControl) then
+        Patterns.Group.grantKeywordToAll(Keyword.VIGILANCE, elvesYouControl)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RadagastOfRhosgobel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RadagastOfRhosgobel.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Radagast of Rhosgobel
+ * {2}{G}{G}
+ * Legendary Creature — Avatar Wizard
+ * 2/5
+ * The first creature spell you cast each turn costs {2} less to cast and can be cast as though it
+ * had flash.
+ *
+ *  - One printed sentence, two engine-level statics: cost reduction (CR 601.2f) and a timing
+ *    permission (CR 702.8) are read at different points of the cast, and neither can express the
+ *    other. Both carry the *same* "first creature spell you cast each turn" gate so they can never
+ *    disagree about which spell is the discounted one.
+ *  - The gate counts off the caster's spells-cast-this-turn record, which the cost side already used
+ *    ([CostGating.NthOfTypePerTurn]); [GrantFlashToSpellType.nthOfTypePerTurn] is the timing twin
+ *    added for this card. The spell being cast is not yet in that record, so both gates are open
+ *    exactly while zero creature spells have been cast this turn — and a creature spell that was
+ *    countered still closes the window, because the wording keys on casting, not resolving.
+ *  - Only generic mana is reduced (CR 601.2f), so a `{G}{G}` creature spell gets no discount.
+ *  - The discount and the flash are not tied together: casting a creature spell at instant speed on
+ *    an opponent's turn is itself the turn's first creature spell, and gets both.
+ */
+val RadagastOfRhosgobel = card("Radagast of Rhosgobel") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 2
+    toughness = 5
+    oracleText = "The first creature spell you cast each turn costs {2} less to cast and can be " +
+        "cast as though it had flash."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature),
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.NthOfTypePerTurn(1),
+        )
+    }
+
+    staticAbility {
+        ability = GrantFlashToSpellType(
+            filter = GameObjectFilter.Creature,
+            controllerOnly = true,
+            nthOfTypePerTurn = 1,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "136"
+        artist = "Anna Podedworna"
+        flavorText = "\"Perhaps you have heard of my good cousin Radagast who lives near the " +
+            "southern borders of Mirkwood?\" Gandalf asked.\n" +
+            "\"Yes,\" said Beorn, \"not a bad fellow as Wizards go, I believe.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/5741bbad-a6e4-45e0-b827-73f48c9975bf.jpg?1785496313"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SilvanReveler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SilvanReveler.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Silvan Reveler
+ * {2}{G}{U}
+ * Creature — Elf Citizen
+ * 3/2
+ * When this creature enters, draw a card, then discard a card. If you discard a land card this way,
+ * put it from your graveyard onto the battlefield tapped.
+ * Landfall — Whenever a land you control enters, you may pay {1}{G}{U}. If you do, return this card
+ * from your graveyard to your hand.
+ *
+ *  - **The discard is a real discard** ([MoveType.Discard]), not a plain move to the graveyard, so
+ *    discard triggers and madness see it. Madness is exactly why the land branch re-checks the zone:
+ *    a discarded land with madness is exiled instead of hitting the graveyard, and "put it **from
+ *    your graveyard**" then has nothing to put. The [CollectionFilter.InZone] step keeps that case
+ *    a no-op rather than dragging the card back out of exile.
+ *  - Putting the land onto the battlefield is not playing a land (CR 305.1), so it neither uses nor
+ *    needs a land drop.
+ *  - **The landfall ability functions from the graveyard** (`triggerZone = Zone.GRAVEYARD`,
+ *    CR 113.6b) — that is the only zone it does anything in. "You" is the card's owner there, so
+ *    `Land.youControl()` correctly watches the owner's lands.
+ */
+val SilvanReveler = card("Silvan Reveler") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Elf Citizen"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, draw a card, then discard a card. If you discard a " +
+        "land card this way, put it from your graveyard onto the battlefield tapped.\n" +
+        "Landfall — Whenever a land you control enters, you may pay {1}{G}{U}. If you do, return " +
+        "this card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Pipeline {
+            // "draw a card, then discard a card"
+            run(Effects.DrawCards(1))
+            val hand = gather(CardSource.FromZone(Zone.HAND, Player.You))
+            val discarded = chooseExactly(
+                1,
+                from = hand,
+                prompt = "Choose a card to discard",
+                selectedLabel = "Discard"
+            )
+            move(discarded, CardDestination.ToZone(Zone.GRAVEYARD), moveType = MoveType.Discard)
+            // "If you discard a land card this way, put it from your graveyard onto the
+            // battlefield tapped."
+            val discardedLand = filter(discarded, GameObjectFilter.Land)
+            val landInGraveyard = filter(discardedLand, CollectionFilter.InZone(Zone.GRAVEYARD))
+            move(
+                landInGraveyard,
+                CardDestination.ToZone(Zone.BATTLEFIELD, Player.You, ZonePlacement.Tapped)
+            )
+        }
+        description = "When this creature enters, draw a card, then discard a card. If you " +
+            "discard a land card this way, put it from your graveyard onto the battlefield tapped."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        triggerZone = Zone.GRAVEYARD
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}{G}{U}"),
+            effect = Effects.Move(EffectTarget.Self, Zone.HAND)
+        )
+        description = "Landfall — Whenever a land you control enters, you may pay {1}{G}{U}. If " +
+            "you do, return this card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Bokun An"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c71b74fb-fb0c-4953-b536-7a3f283c6918.jpg?1784382379"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1593,6 +1593,183 @@
     ]
 }
 
+// Down in the Valley
+{
+    "name": "Down in the Valley",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nII — This Saga gains \"Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token.\"\nIII, IV — Elves you control get +1/+0 and gain vigilance until end of turn.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "GrantTriggeredAbility",
+                    "ability": {
+                        "id": "ability_1",
+                        "trigger": {
+                            "type": "ZoneChangeEvent",
+                            "filter": "land ctrl:you",
+                            "to": "Battlefield"
+                        },
+                        "binding": "OTHER",
+                        "effect": {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "GREEN"
+                            ],
+                            "creatureTypes": [
+                                "Elf"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812"
+                        },
+                        "descriptionOverride": "Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token."
+                    },
+                    "target": "Self",
+                    "duration": "Permanent"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Elf ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Elf ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "VIGILANCE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 4,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Elf ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature Elf ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "VIGILANCE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "RARE",
+        "artist": "Rovina Cai",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c8aa5179-475b-4cc8-b21e-205b475eb4cf.jpg?1784895042"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Down, Down to Goblin-town
 {
     "name": "Down, Down to Goblin-town",
@@ -2099,6 +2276,94 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Dáin Ironfoot
+{
+    "name": "Dáin Ironfoot",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Dwarf Warrior",
+    "oracleText": "When Dáin enters, create a colorless Equipment artifact token named Axe with \"Equipped creature gets +1/+0\" and equip {2}. When you do, attach it to target creature you control.\nWhenever Dáin attacks, each equipped attacking creature gains double strike until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Axe"
+                    },
+                    "optional": false,
+                    "reflexiveEffect": {
+                        "type": "AttachTargetEquipmentToCreature",
+                        "equipmentTarget": {
+                            "type": "PipelineTarget",
+                            "collectionName": "createdTokens"
+                        },
+                        "creatureTarget": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "Create a colorless Equipment artifact token named Axe with \"Equipped creature gets +1/+0\" and equip {2}. When you do, attach it to target creature you control."
+                },
+                "descriptionOverride": "When Dáin enters, create a colorless Equipment artifact token named Axe with \"Equipped creature gets +1/+0\" and equip {2}. When you do, attach it to target creature you control."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "IsAttacking",
+                                    "IsEquipped"
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "DOUBLE_STRIKE",
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever Dáin attacks, each equipped attacking creature gains double strike until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "rarity": "RARE",
+        "artist": "Tomas Duchek",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/7112e460-9160-4535-ad94-93f1f4ac04cf.jpg?1785236701"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -6190,6 +6455,53 @@
     ]
 }
 
+// Radagast of Rhosgobel
+{
+    "name": "Radagast of Rhosgobel",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Creature — Avatar Wizard",
+    "oracleText": "The first creature spell you cast each turn costs {2} less to cast and can be cast as though it had flash.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "creature"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "NthOfTypePerTurn",
+                    "n": 1
+                }
+            },
+            {
+                "type": "GrantFlashToSpellType",
+                "filter": "creature",
+                "controllerOnly": true,
+                "nthOfTypePerTurn": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "RARE",
+        "artist": "Anna Podedworna",
+        "flavorText": "\"Perhaps you have heard of my good cousin Radagast who lives near the southern borders of Mirkwood?\" Gandalf asked.\n\"Yes,\" said Beorn, \"not a bad fellow as Wizards go, I believe.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/5741bbad-a6e4-45e0-b827-73f48c9975bf.jpg?1785496313"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Rage into the Valley
 {
     "name": "Rage into the Valley",
@@ -6801,6 +7113,138 @@
         "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2e4099e-86bd-461f-87fa-7f7850ae7eec.jpg?1785152396"
     },
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Silvan Reveler
+{
+    "name": "Silvan Reveler",
+    "manaCost": "{2}{G}{U}",
+    "typeLine": "Creature — Elf Citizen",
+    "oracleText": "When this creature enters, draw a card, then discard a card. If you discard a land card this way, put it from your graveyard onto the battlefield tapped.\nLandfall — Whenever a land you control enters, you may pay {1}{G}{U}. If you do, return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "gathered1"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered1",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected2",
+                            "prompt": "Choose a card to discard",
+                            "selectedLabel": "Discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected2",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "selected2",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "land"
+                            },
+                            "storeMatching": "matching4"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "matching4",
+                            "filter": {
+                                "type": "InZone",
+                                "zone": "Graveyard"
+                            },
+                            "storeMatching": "matching5"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "matching5",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, draw a card, then discard a card. If you discard a land card this way, put it from your graveyard onto the battlefield tapped."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}{G}{U}"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand"
+                    }
+                },
+                "activeZones": [
+                    "Graveyard"
+                ],
+                "descriptionOverride": "Landfall — Whenever a land you control enters, you may pay {1}{G}{U}. If you do, return this card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Bokun An",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c71b74fb-fb0c-4953-b536-7a3f283c6918.jpg?1784382379"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
         "BLUE"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.GraveyardCastRiderSelection
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.mechanics.DisturbCasts
+import com.wingedsheep.engine.mechanics.FlashTypeGrants
 import com.wingedsheep.engine.mechanics.FlashbackGrants
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.mechanics.ModalDfcCasts
@@ -620,6 +621,9 @@ class CastZoneResolver(
                     if (ability is GrantFlashToSpellType) {
                         // If controllerOnly, only the permanent's controller benefits
                         if (ability.controllerOnly && playerId != spellOwner) continue
+                        // "The first [type] spell you cast each turn" — the grant covers only one
+                        // spell per turn (Radagast of Rhosgobel).
+                        if (!FlashTypeGrants.nthGateAllows(state, spellOwner, ability, predicateEvaluator)) continue
                         if (predicateEvaluator.matches(state, state.projectedState, spellCardId, ability.filter, context)) {
                             return true
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/abilities/GrantTriggeredAbilityExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/abilities/GrantTriggeredAbilityExecutor.kt
@@ -37,11 +37,13 @@ class GrantTriggeredAbilityExecutor : EffectExecutor<GrantTriggeredAbilityEffect
         if (!state.getBattlefield().contains(targetId)) {
             return EffectResult.error(state, "Target is not on the battlefield")
         }
-        // Read projected state so type-changing floating effects earlier in the same
-        // composite (e.g., AnimateLand on a land becoming a creature) are visible here.
-        if (!state.projectedState.isCreature(targetId)) {
-            return EffectResult.error(state, "Target is not a creature")
-        }
+        // Deliberately *not* gated on the target being a creature. Nothing in the rules restricts
+        // "gains '<triggered ability>'" to creatures, and the printed wording routinely names a
+        // noncreature permanent — Down in the Valley's chapter II is "**This Saga** gains 'Landfall
+        // — Whenever a land you control enters, create a 1/1 green Elf creature token.'" A
+        // creature-only guard turned that into a silent no-op (the grant errored, the chapter
+        // resolved, and no trigger ever fired). Whether a given effect may legally pick a
+        // noncreature is the TargetRequirement's job, not this executor's.
 
         val grant = GrantedTriggeredAbility(
             entityId = targetId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -43,6 +43,7 @@ import com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.PlotFromTopOfLibrary
 import com.wingedsheep.engine.mechanics.ExhaustActivationWaiver
+import com.wingedsheep.engine.mechanics.FlashTypeGrants
 import com.wingedsheep.sdk.scripting.IgnoreExhaustActivationLimit
 import com.wingedsheep.sdk.scripting.PlayersCantActivateAbilities
 import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
@@ -528,6 +529,7 @@ class CastPermissionUtils(
                 for (ability in cardDef.script.staticAbilities) {
                     if (ability is GrantFlashToSpellType) {
                         if (ability.controllerOnly && playerId != spellOwner) continue
+                        if (!FlashTypeGrants.nthGateAllows(state, spellOwner, ability, predicateEvaluator)) continue
                         if (predicateEvaluator.matches(state, state.projectedState, spellCardId, ability.filter, context)) {
                             return true
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/FlashTypeGrants.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/FlashTypeGrants.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
+
+/**
+ * Shared gate for [GrantFlashToSpellType.nthOfTypePerTurn].
+ *
+ * "The first creature spell you cast each turn … can be cast as though it had flash" (Radagast of
+ * Rhosgobel) is a *timing* grant that only covers one spell per turn, so both flash read sites —
+ * `CastPermissionUtils.canCastAtInstantSpeed` (which enumerates legal actions) and
+ * `CastZoneResolver.hasGrantedFlash` (which authoritatively re-checks at cast time) — have to apply
+ * the same count. They live in different packages and neither can see the other's private helpers,
+ * so the count lives here rather than being written twice and drifting.
+ *
+ * The count comes off `GameState.spellsCastThisTurnByPlayer`, the same record
+ * `CostGating.NthOfTypePerTurn` uses in `CostCalculator`, and with the same convention: the spell
+ * being cast is **not** yet in the list, so the gate is open exactly while the caster has already
+ * cast `n - 1` matching spells this turn. That means a matching spell already cast this turn closes
+ * the window even if it was countered or fizzled — matching the "you cast" wording, which cares
+ * about the cast and not the resolution.
+ */
+object FlashTypeGrants {
+
+    /**
+     * Whether [ability]'s per-turn gate (if any) currently lets [casterId] cast a matching spell at
+     * instant speed. Always true for an ungated grant (Quick Sliver, Raff Capashen).
+     */
+    fun nthGateAllows(
+        state: GameState,
+        casterId: EntityId,
+        ability: GrantFlashToSpellType,
+        predicateEvaluator: PredicateEvaluator,
+    ): Boolean {
+        val n = ability.nthOfTypePerTurn ?: return true
+        val castThisTurn = state.spellsCastThisTurnByPlayer[casterId] ?: emptyList()
+        return castThisTurn.count { predicateEvaluator.matchesFilter(it, ability.filter) } == n - 1
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DainIronfootScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DainIronfootScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dáin Ironfoot — ETB mints the Axe and a reflexive trigger attaches it to a targeted creature;
+ * his attack trigger hands double strike to every equipped attacking creature.
+ *
+ * The reflexive half is the interesting wiring: the attach goes on the stack as its own ability
+ * (CR 603.12) and has to still be able to name the token the *action* half created, which it does
+ * through the carried `CREATED_TOKENS` pipeline collection.
+ */
+class DainIronfootScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dáin Ironfoot") {
+
+            test("the ETB creates an Axe and the reflexive trigger attaches it to the chosen creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dáin Ironfoot")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Dáin Ironfoot").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                if (game.hasPendingDecision()) game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                val axe = game.findPermanent("Axe")
+                withClue("the Axe token was created") { (axe != null) shouldBe true }
+                withClue("and the reflexive trigger attached it to the targeted creature") {
+                    game.state.getEntity(axe!!)!!.get<AttachedToComponent>()?.targetId shouldBe bears
+                }
+                withClue("so the Bears is a 3/2") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+            }
+
+            test("attacking gives double strike to equipped attackers but not to unequipped ones") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dáin Ironfoot", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    // Bonesplitter is a plain static-only Equipment, so nothing but the attach
+                    // matters here.
+                    .withCardAttachedTo(1, "Bonesplitter", "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Dáin Ironfoot" to 2, "Grizzly Bears" to 2, "Hill Giant" to 2))
+                game.resolveStack()
+
+                withClue("the equipped attacker gained double strike") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.DOUBLE_STRIKE) shouldBe true
+                }
+                withClue("the unequipped attacker did not") {
+                    game.state.projectedState.hasKeyword(giant, Keyword.DOUBLE_STRIKE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DownInTheValleyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DownInTheValleyScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Down in the Valley — the Saga's three distinct chapter shapes.
+ *
+ * Chapter II is the one worth a test: "This Saga gains …" grants a triggered ability to a
+ * *noncreature permanent* — the Saga itself — for the rest of its life, so the payoff has to keep
+ * firing on later turns and has to die with the Saga at chapter IV.
+ */
+class DownInTheValleyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Down in the Valley") {
+
+            /** Advance to the start of the given player-turn's precombat main. */
+            fun TestGame.advanceToTurn(turnNumber: Int) {
+                var guard = 0
+                while (state.turnNumber < turnNumber && guard < 20) {
+                    passUntilPhase(Phase.ENDING, Step.END)
+                    resolveStack()
+                    passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    resolveStack()
+                    guard++
+                }
+            }
+
+            fun board() = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Down in the Valley")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            test("chapter I searches a basic land into hand") {
+                val game = board()
+
+                game.castSpell(1, "Down in the Valley").error shouldBe null
+                game.resolveStack()
+
+                withClue("chapter I raised a library search") {
+                    (game.getPendingDecision() is SelectCardsDecision) shouldBe true
+                }
+                val forest = game.findCardsInLibrary(1, "Forest").single()
+                game.selectCards(listOf(forest))
+                game.resolveStack()
+
+                withClue("the chosen basic land went to hand, not the battlefield") {
+                    game.isInHand(1, "Forest") shouldBe true
+                    game.findCardsInLibrary(1, "Forest").size shouldBe 0
+                }
+            }
+
+            test("chapter II grants the Saga a landfall trigger that mints Elf tokens") {
+                val game = board()
+
+                game.castSpell(1, "Down in the Valley").error shouldBe null
+                game.resolveStack()
+                game.findCardsInLibrary(1, "Forest").firstOrNull()
+                    ?.let { game.selectCards(listOf(it)) }
+                game.resolveStack()
+
+                withClue("no landfall payoff before chapter II") {
+                    game.findAllPermanents("Elf Token").size shouldBe 0
+                }
+
+                // Player 1's next turn: chapter II resolves after the draw step.
+                game.advanceToTurn(3)
+
+                val landInHand = game.findCardsInHand(1, "Forest").firstOrNull()
+                withClue("a land to play so the granted landfall trigger can fire") {
+                    (landInHand != null) shouldBe true
+                }
+                game.execute(PlayLand(game.player1Id, landInHand!!)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Saga's granted landfall trigger created a 1/1 Elf") {
+                    game.findAllPermanents("Elf Token").size shouldBe 1
+                }
+            }
+
+            test("chapter III pumps Elves and gives them vigilance") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Down in the Valley")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardOnBattlefield(1, "Llanowar Elves", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Down in the Valley").error shouldBe null
+                game.resolveStack()
+                game.findCardsInLibrary(1, "Forest").firstOrNull()
+                    ?.let { game.selectCards(listOf(it)) }
+                game.resolveStack()
+
+                val elves = game.findPermanent("Llanowar Elves")!!
+                withClue("no pump before chapter III") {
+                    game.state.projectedState.getPower(elves) shouldBe 1
+                }
+
+                game.advanceToTurn(5) // chapter II on turn 3, chapter III on turn 5
+                game.resolveStack()
+
+                withClue("Elves you control get +1/+0 and gain vigilance") {
+                    game.state.projectedState.getPower(elves) shouldBe 2
+                    game.state.projectedState.getToughness(elves) shouldBe 1
+                    game.state.projectedState.hasKeyword(elves, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RadagastOfRhosgobelScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RadagastOfRhosgobelScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Radagast of Rhosgobel — "The first creature spell you cast each turn costs {2} less to cast and
+ * can be cast as though it had flash."
+ *
+ * The cost half rides `CostGating.NthOfTypePerTurn(1)`, which already existed. The timing half is
+ * the new `GrantFlashToSpellType.nthOfTypePerTurn`, so these tests pin both halves *and* that they
+ * agree on which spell is "the first" — the failure mode worth guarding is a discount that applies
+ * without the flash, or a flash window that never closes.
+ *
+ * Grizzly Bears is {1}{G}: with the discount it costs {G} (only generic is reducible, CR 601.2f),
+ * so "one Forest is enough" and "two Forests are not enough for the second one" are direct,
+ * behavioural proofs of the gate rather than assertions about a displayed number.
+ */
+class RadagastOfRhosgobelScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Radagast of Rhosgobel — first creature spell each turn: {2} off and flash") {
+
+            test("the turn's first creature spell costs {2} less") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Radagast of Rhosgobel", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("{1}{G} reduced to {G} is payable with the single Forest") {
+                    game.castSpell(1, "Grizzly Bears").error shouldBe null
+                }
+                game.resolveStack()
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+            }
+
+            test("the second creature spell that turn pays full price") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Radagast of Rhosgobel", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardsInHand(1, "Grizzly Bears", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("the second Bears costs the full {1}{G}, and only one Forest is left") {
+                    game.castSpell(1, "Grizzly Bears").error shouldNotBe null
+                }
+            }
+
+            test("the turn's first creature spell can be cast at instant speed, and only that one") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Radagast of Rhosgobel", summoningSickness = false)
+                    // Four Forests so affordability is never what stops the second cast — only the
+                    // closed flash window is.
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardsInHand(1, "Grizzly Bears", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    // The end step is sorcery-speed-illegal, so any offered creature cast is flash.
+                    .inPhase(Phase.ENDING, Step.END)
+                    .build()
+
+                fun bearsCastOffered() = game.getLegalActions(1).any { info ->
+                    (info.action as? CastSpell)?.let { cast ->
+                        game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } == true
+                }
+
+                withClue("no creature spell cast yet this turn, so the flash grant is live") {
+                    bearsCastOffered() shouldBe true
+                }
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("the grant covered only the first creature spell this turn") {
+                    bearsCastOffered() shouldBe false
+                }
+            }
+
+            test("without Radagast the same board can't cast a creature in the end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.ENDING, Step.END)
+                    .build()
+
+                val offered = game.getLegalActions(1).any { info ->
+                    (info.action as? CastSpell)?.let { cast ->
+                        game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == "Grizzly Bears"
+                    } == true
+                }
+                withClue("control: the flash in the previous test came from Radagast") {
+                    offered shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SilvanRevelerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SilvanRevelerScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Silvan Reveler — ETB loot whose land branch reanimates the discarded land, plus a landfall
+ * ability that only functions from the graveyard.
+ *
+ * The three things worth pinning:
+ *  1. Discarding a **land** puts it onto the battlefield **tapped** and out of the graveyard.
+ *  2. Discarding a **nonland** leaves it in the graveyard — the branch really is filtered.
+ *  3. The landfall ability fires from the **graveyard**, and only returns the card when the
+ *     optional {1}{G}{U} is actually paid.
+ */
+class SilvanRevelerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Silvan Reveler") {
+
+            test("discarding a land to the ETB puts it onto the battlefield tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Silvan Reveler")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    // The only card to draw, so it is also the only card that can be discarded.
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Silvan Reveler").error shouldBe null
+                game.resolveStack()
+
+                withClue("the discarded Mountain came back onto the battlefield") {
+                    game.isOnBattlefield("Mountain") shouldBe true
+                    game.isInGraveyard(1, "Mountain") shouldBe false
+                }
+                withClue("it entered tapped") {
+                    val mountain = game.findPermanent("Mountain")!!
+                    game.state.getEntity(mountain)!!.has<TappedComponent>() shouldBe true
+                }
+                withClue("the loot still drew and discarded — hand is empty again") {
+                    game.handSize(1) shouldBe 0
+                }
+            }
+
+            test("discarding a nonland leaves it in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Silvan Reveler")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Silvan Reveler").error shouldBe null
+                game.resolveStack()
+
+                withClue("a nonland discard stays discarded") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                    game.isOnBattlefield("Lightning Bolt") shouldBe false
+                }
+            }
+
+            test("landfall from the graveyard returns it to hand when the cost is paid") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Silvan Reveler")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(1, "Mountain")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    PlayLand(game.player1Id, game.findCardsInHand(1, "Mountain").single())
+                ).error shouldBe null
+
+                game.resolveStack()
+                game.answerYesNo(true)
+                game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("paying {1}{G}{U} returned the Reveler from the graveyard to hand") {
+                    game.isInHand(1, "Silvan Reveler") shouldBe true
+                    game.isInGraveyard(1, "Silvan Reveler") shouldBe false
+                }
+            }
+
+            test("declining the landfall cost leaves it in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Silvan Reveler")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInHand(1, "Mountain")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    PlayLand(game.player1Id, game.findCardsInHand(1, "Mountain").single())
+                ).error shouldBe null
+
+                game.resolveStack()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("declining is free and changes nothing") {
+                    game.isInGraveyard(1, "Silvan Reveler") shouldBe true
+                    game.isInHand(1, "Silvan Reveler") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Four more HOB cards. The set's remaining ~50 gaps are dominated by the unimplemented **recruit**, **storied** and **hone** keywords (all `add-feature` work), so these are the clean remainder:

| Card | Text |
|---|---|
| **Down in the Valley** {2}{G} | Saga — I tutors a basic land to hand; II grants the Saga a landfall Elf-token trigger; III/IV pump Elves |
| **Silvan Reveler** {2}{G}{U} | ETB loot that reanimates a discarded land; graveyard landfall pays {1}{G}{U} to return itself |
| **Dáin Ironfoot** {2}{R} | ETB mints the Axe + reflexive attach; attack trigger gives equipped attackers double strike |
| **Radagast of Rhosgobel** {2}{G}{G} | First creature spell each turn costs {2} less and can be cast as though it had flash |

## Engine changes

**`GrantTriggeredAbilityEffect` was creature-only.** Nothing in the rules restricts "gains '&lt;triggered ability&gt;'" to creatures, and Down in the Valley chapter II is "*This Saga* gains 'Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token.'" The guard made that a **silent no-op** — the grant returned an error, the chapter resolved anyway, and no trigger ever fired. Whether a noncreature is a legal pick is the `TargetRequirement`'s job; the executor now only requires the target to be on the battlefield.

**`GrantFlashToSpellType` gained `nthOfTypePerTurn`.** Radagast prints both halves of one gate — "the first creature spell you cast each turn costs {2} less **and** can be cast as though it had flash". The cost half already had `CostGating.NthOfTypePerTurn`; this is its timing twin, counting off the same `spellsCastThisTurnByPlayer` record with the same convention (the spell being cast is not yet in it), so the two can never disagree about which spell is the first. The count lives in a shared `FlashTypeGrants` because the two flash read sites — `CastPermissionUtils.hasGrantedFlash` (enumeration, also feeding the suspend paths) and `CastZoneResolver.hasGrantedFlash` (authoritative cast-time check) — sit in different packages.

## Modelling notes

- **Silvan Reveler** discards through `MoveType.Discard`, so discard triggers and madness see it, and the land branch re-checks `InZone(GRAVEYARD)` — a madness discard that lands in exile is then a no-op instead of dragging the card back out. Its landfall ability is `triggerZone = Zone.GRAVEYARD` (CR 113.6b), the only zone it does anything in.
- **Dáin**'s "When you do" is a genuine reflexive trigger (CR 603.12), not a second clause: the attach goes on the stack separately so opponents get a priority window, and it names the freshly minted Axe through the `CREATED_TOKENS` collection the reflexive half carries over. "Each equipped attacking creature" is left uncontroller-scoped, matching the printed wording.
- **Down in the Valley** chapter II grants with `Duration.Permanent`, so the landfall payoff dies with the Saga at chapter IV rather than outliving it.

## Verification

- `just build` and `just test` pass in full.
- One scenario test file per card (13 tests), including negative controls: no Radagast → no end-step creature cast; declining Silvan Reveler's landfall cost; unequipped attackers don't get double strike.
- `just check-card-printing` clean for all four; every mechanical field and image URI re-diffed against Scryfall (all HTTP 200).
- HOB snapshot re-blessed — diff is 444 added lines and nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)