### PR TITLE
Add three The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GandalfGoblinsBane.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GandalfGoblinsBane.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gandalf, Goblins' Bane // Flameshape — The Hobbit #96
+ * {2}{R} · Legendary Creature — Avatar Wizard · Mythic
+ * 2/3
+ *
+ * Whenever you cast a noncreature spell, Gandalf gets +1/+1 until end of turn and deals 1 damage
+ * to each opponent.
+ *
+ * Adventure: Flameshape — {1}{R}, Sorcery — Adventure
+ * Look at the top two cards of your library and exile them face down. For as long as they remain
+ * exiled, you may play them if you control a Wizard.
+ *
+ * Modeling notes:
+ *  - The cast trigger is one ability with two effects, so both halves happen (or neither) on a
+ *    single resolution. The pump is [EffectTarget.Self]-scoped and end-of-turn bounded; the damage
+ *    is a non-targeted hit on `Player.EachOpponent`, so it ignores hexproof and works in a pod.
+ *  - Flameshape is the impulse pipeline with two riders the plain `impulse()` recipe can't express:
+ *    the exiled cards are face down ([FaceDownMode.HIDDEN], so opponents never learn them), and the
+ *    play permission never expires ([MayPlayExpiry.Permanent] — "for as long as they remain
+ *    exiled") but is *gated* on controlling a Wizard. The gate is a `condition` on the grant, which
+ *    the engine re-checks on every legal-action query, so losing your last Wizard suspends the
+ *    permission and getting one back restores it — matching "you may play them **if** you control a
+ *    Wizard" rather than a one-shot check on resolution.
+ *  - The gather keeps the default controller-facing look overlay, which *is* the "look at the top
+ *    two cards of your library" clause.
+ *  - Note Gandalf himself is a Wizard, so casting the creature face later turns the permission on.
+ *  - (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ *    caster cast it as the creature spell while it remains in exile.)
+ */
+val GandalfGoblinsBane = card("Gandalf, Goblins' Bane") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever you cast a noncreature spell, Gandalf gets +1/+1 until end of turn and " +
+        "deals 1 damage to each opponent."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.Composite(
+            Effects.ModifyStats(power = 1, toughness = 1, target = EffectTarget.Self),
+            Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        )
+    }
+
+    adventure("Flameshape") {
+        manaCost = "{1}{R}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Look at the top two cards of your library and exile them face down. For as " +
+            "long as they remain exiled, you may play them if you control a Wizard. (Then exile " +
+            "this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.Composite(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(2)),
+                    storeAs = "flameshapeExiled"
+                ),
+                MoveCollectionEffect(
+                    from = "flameshapeExiled",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN
+                ),
+                Effects.GrantMayPlayFromExile(
+                    from = "flameshapeExiled",
+                    expiry = MayPlayExpiry.Permanent,
+                    condition = Conditions.YouControl(GameObjectFilter.Creature.withSubtype("Wizard"))
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "96"
+        artist = "Francisco Miyara"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b0d29a1-7da9-4fb3-8536-8ff8d8acae0b.jpg?1784376993"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GloinTheMighty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GloinTheMighty.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Glóin the Mighty // Easy Pickings — The Hobbit #99
+ * {3}{R} · Legendary Creature — Dwarf Warrior · Uncommon
+ * 4/3
+ *
+ * At the beginning of your first main phase, add {R}{R}.
+ *
+ * Adventure: Easy Pickings — {2}{R}, Sorcery — Adventure
+ * Easy Pickings deals 1 damage to each creature your opponents control.
+ *
+ * The mana trigger is *not* a mana ability (CR 605.1b) — it triggers off a step beginning rather
+ * than off a mana ability resolving, so it uses the stack like any other triggered ability. Modeled
+ * as [Triggers.FirstMainPhase], which is the precombat main phase of the controller's turn; the
+ * mana lands in the pool once the trigger resolves and empties at the end of that phase.
+ *
+ * Easy Pickings is a group effect, not a targeted one — [GroupFilter.AllCreaturesOpponentsControl]
+ * snapshots the affected set before iterating, and [EffectTarget.Self] inside the body binds to the
+ * creature currently being damaged. Hexproof and shroud don't apply; protection from red does, and
+ * the engine's damage handling covers that.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast it as the creature spell while it remains in exile.)
+ */
+val GloinTheMighty = card("Glóin the Mighty") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dwarf Warrior"
+    power = 4
+    toughness = 3
+    oracleText = "At the beginning of your first main phase, add {R}{R}."
+
+    triggeredAbility {
+        trigger = Triggers.FirstMainPhase
+        effect = Effects.AddMana(Color.RED, 2)
+    }
+
+    adventure("Easy Pickings") {
+        manaCost = "{2}{R}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Easy Pickings deals 1 damage to each creature your opponents control. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            effect = Effects.ForEachInGroup(
+                filter = GroupFilter.AllCreaturesOpponentsControl,
+                effect = Effects.DealDamage(1, EffectTarget.Self)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Colin Boyer"
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/5793b8eb-2fc5-454d-8fa2-20346fef167a.jpg?1785324545"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SmaugWickedWorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SmaugWickedWorm.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Smaug, Wicked Worm — The Hobbit #164
+ * {3}{B}{R} · Legendary Creature — Dragon · Rare
+ * 5/5
+ *
+ * Flying
+ * When Smaug enters, create X tapped Treasure tokens, where X is the number of artifacts your
+ * opponents control.
+ * Whenever you cast a spell, if mana from a Treasure was spent to cast it, you draw a card and
+ * lose 1 life.
+ *
+ * Modeling notes:
+ *  - X counts *opponents'* artifacts, so it reads `Player.EachOpponent` (the same aggregation
+ *    Gaea's Avenger uses). It's evaluated on resolution, and X = 0 simply creates nothing.
+ *  - "if mana from a Treasure was spent to cast it" is a property of the payment that already
+ *    happened, so it rides the trigger itself as
+ *    [SpellCastPredicate.PaidWithManaFromSubtype]`(Subtype.TREASURE)` rather than an intervening-if
+ *    re-checked on resolution. The engine records the spent-mana provenance on the `SpellCastEvent`
+ *    and the cast record, so the check is stable whether or not the spell is still on the stack —
+ *    and the ability still triggers for a spell that gets countered.
+ *  - The draw and the life loss are a single effect ("you draw a card **and** lose 1 life"), so
+ *    they are not independently replaceable and both are mandatory. The life loss targets
+ *    `Player.You` explicitly — Smaug's controller, not the spell's.
+ */
+val SmaugWickedWorm = card("Smaug, Wicked Worm") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Dragon"
+    power = 5
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When Smaug enters, create X tapped Treasure tokens, where X is the number of artifacts " +
+        "your opponents control.\n" +
+        "Whenever you cast a spell, if mana from a Treasure was spent to cast it, you draw a card " +
+        "and lose 1 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateTreasure(
+            count = DynamicAmounts.battlefield(Player.EachOpponent, GameObjectFilter.Artifact).count(),
+            tapped = true
+        )
+        description = "Create X tapped Treasure tokens, where X is the number of artifacts your " +
+            "opponents control."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            requires = setOf(SpellCastPredicate.PaidWithManaFromSubtype(Subtype.TREASURE))
+        )
+        effect = Effects.DrawCards(1)
+            .then(Effects.LoseLife(1, EffectTarget.PlayerRef(Player.You)))
+        description = "You draw a card and lose 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "164"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19cc91f0-e724-41ac-b6d8-9a293bd63b42.jpg?1785323313"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -3142,6 +3142,118 @@
     ]
 }
 
+// Gandalf, Goblins' Bane
+{
+    "name": "Gandalf, Goblins' Bane",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Avatar Wizard",
+    "oracleText": "Whenever you cast a noncreature spell, Gandalf gets +1/+1 until end of turn and deals 1 damage to each opponent.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "rarity": "MYTHIC",
+        "artist": "Francisco Miyara",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b0d29a1-7da9-4fb3-8536-8ff8d8acae0b.jpg?1784376993"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Flameshape",
+            "manaCost": "{1}{R}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Look at the top two cards of your library and exile them face down. For as long as they remain exiled, you may play them if you control a Wizard. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "flameshapeExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "flameshapeExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "flameshapeExiled",
+                            "expiry": "Permanent",
+                            "condition": {
+                                "type": "Exists",
+                                "player": "You",
+                                "zone": "Battlefield",
+                                "filter": "creature Wizard"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
 // Gandalf, Spark Starter
 {
     "name": "Gandalf, Spark Starter",
@@ -3584,6 +3696,75 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Glóin the Mighty
+{
+    "name": "Glóin the Mighty",
+    "manaCost": "{3}{R}",
+    "typeLine": "Legendary Creature — Dwarf Warrior",
+    "oracleText": "At the beginning of your first main phase, add {R}{R}.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "PRECOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Colin Boyer",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/5793b8eb-2fc5-454d-8fa2-20346fef167a.jpg?1785324545"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Easy Pickings",
+            "manaCost": "{2}{R}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Easy Pickings deals 1 damage to each creature your opponents control. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        }
     ]
 }
 
@@ -7370,6 +7551,90 @@
         "imageUri": "https://cards.scryfall.io/normal/front/a/1/a16f203a-785e-4c78-9410-fb9f8a0ffa01.jpg"
     },
     "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Smaug, Wicked Worm
+{
+    "name": "Smaug, Wicked Worm",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Legendary Creature — Dragon",
+    "oracleText": "Flying\nWhen Smaug enters, create X tapped Treasure tokens, where X is the number of artifacts your opponents control.\nWhenever you cast a spell, if mana from a Treasure was spent to cast it, you draw a card and lose 1 life.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure",
+                    "tapped": true,
+                    "dynamicCount": {
+                        "type": "AggregateBattlefield",
+                        "player": "EachOpponent",
+                        "filter": "artifact"
+                    }
+                },
+                "descriptionOverride": "Create X tapped Treasure tokens, where X is the number of artifacts your opponents control."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        {
+                            "type": "SpellPaidWithManaFromSubtype",
+                            "subtype": "Treasure"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "You draw a card and lose 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "RARE",
+        "artist": "Antonio José Manzanedo",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19cc91f0-e724-41ac-b6d8-9a293bd63b42.jpg?1785323313"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
         "RED"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfGoblinsBaneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfGoblinsBaneScenarioTest.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gandalf, Goblins' Bane // Flameshape (HOB #96) — {2}{R} Legendary Creature — Avatar Wizard 2/3.
+ *
+ *   Whenever you cast a noncreature spell, Gandalf gets +1/+1 until end of turn and deals 1 damage
+ *   to each opponent.
+ *
+ *   Adventure — Flameshape {1}{R}, Sorcery:
+ *   Look at the top two cards of your library and exile them face down. For as long as they remain
+ *   exiled, you may play them if you control a Wizard.
+ *
+ * The interesting claim is Flameshape's gate. "You may play them **if** you control a Wizard" is a
+ * standing condition on a never-expiring permission, not a one-shot check at resolution — so the
+ * permission has to be re-evaluated whenever the cards are queried. The cast trigger's own claim is
+ * that both halves fire off a single *noncreature* cast, and neither fires off a creature spell.
+ */
+class GandalfGoblinsBaneScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass()
+            safety++
+        }
+    }
+
+    /** Can [player] currently cast [card] — from anywhere the enumerator will offer it? */
+    fun castableNow(driver: GameTestDriver, player: EntityId, card: EntityId): Boolean =
+        driver.legalActions(player).any { (it.action as? CastSpell)?.cardId == card }
+
+    test("casting a noncreature spell pumps Gandalf and pings each opponent; a creature spell does neither") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        val gandalf = driver.putPermanentOnBattlefield(me, "Gandalf, Goblins' Bane")
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        // Control: a creature spell must not trigger the ability.
+        val creature = driver.putCardInHand(me, "Goblin Guide")
+        driver.giveMana(me, Color.RED, 1)
+        driver.submitSuccess(
+            CastSpell(playerId = me, cardId = creature, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        resolveStack(driver)
+        withClue("a creature spell is not a noncreature spell") {
+            driver.getLifeTotal(opponent) shouldBe 20
+            driver.state.projectedState.getPower(gandalf) shouldBe 2
+        }
+
+        // The real case: an instant.
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.submitSuccess(
+            CastSpell(
+                playerId = me,
+                cardId = bolt,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        resolveStack(driver)
+
+        withClue("the cast trigger pumps Gandalf to 3/4 until end of turn") {
+            driver.state.projectedState.getPower(gandalf) shouldBe 3
+            driver.state.projectedState.getToughness(gandalf) shouldBe 4
+        }
+        withClue("...and deals 1 damage to each opponent (the Bolt itself hit the creature, not the player)") {
+            driver.getLifeTotal(opponent) shouldBe 19
+            driver.getLifeTotal(me) shouldBe 20
+        }
+    }
+
+    test("Flameshape exiles the top two face down and gates the play permission on controlling a Wizard") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        val second = driver.putCardOnTopOfLibrary(me, "Goblin Guide")
+        val first = driver.putCardOnTopOfLibrary(me, "Lightning Bolt")
+
+        val card = driver.putCardInHand(me, "Gandalf, Goblins' Bane")
+        driver.giveMana(me, Color.RED, 2)
+
+        // faceIndex 0 is the Adventure face (Flameshape), not the creature.
+        driver.submitSuccess(
+            CastSpell(
+                playerId = me,
+                cardId = card,
+                faceIndex = 0,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        resolveStack(driver)
+
+        withClue("both cards are exiled, face down") {
+            driver.getExile(me) shouldContain first
+            driver.getExile(me) shouldContain second
+            driver.state.getEntity(first)?.get<FaceDownComponent>().shouldNotBeNull()
+            driver.state.getEntity(second)?.get<FaceDownComponent>().shouldNotBeNull()
+        }
+
+        val permission = driver.state.mayPlayPermissions.single { first in it.cardIds }
+        withClue("'for as long as they remain exiled' is a permanent grant to the caster, covering both cards") {
+            permission.permanent shouldBe true
+            permission.controllerId shouldBe me
+            permission.cardIds shouldContain second
+        }
+        withClue("the Wizard requirement rides the permission as a re-checked condition") {
+            (permission.condition != null) shouldBe true
+        }
+
+        // Plenty of mana in both branches, so the only variable is the Wizard.
+        driver.giveMana(me, Color.RED, 6)
+        withClue("no Wizard on the battlefield → the permission is suspended") {
+            castableNow(driver, me, first) shouldBe false
+            castableNow(driver, me, second) shouldBe false
+        }
+
+        // Gandalf is himself an Avatar Wizard, so resolving the creature face turns the gate on.
+        driver.putPermanentOnBattlefield(me, "Gandalf, Goblins' Bane")
+        withClue("with a Wizard on the battlefield the exiled cards become playable") {
+            castableNow(driver, me, first) shouldBe true
+            castableNow(driver, me, second) shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GloinTheMightyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GloinTheMightyScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Glóin the Mighty // Easy Pickings (HOB #99) — {3}{R} Legendary Creature — Dwarf Warrior 4/3.
+ *
+ *   At the beginning of your first main phase, add {R}{R}.
+ *
+ *   Adventure — Easy Pickings {2}{R}, Sorcery:
+ *   Easy Pickings deals 1 damage to each creature your opponents control.
+ *
+ * Two claims worth pinning: the mana trigger fires on the controller's *precombat* main (and puts
+ * two red mana in the pool, not one or a generic two), and the Adventure is one-sided — it must
+ * leave the caster's own creatures untouched.
+ */
+class GloinTheMightyScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        return driver
+    }
+
+    fun pool(driver: GameTestDriver, player: EntityId): ManaPoolComponent =
+        driver.state.getEntity(player)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+
+    fun resolveStack(driver: GameTestDriver) {
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass()
+            safety++
+        }
+    }
+
+    test("the beginning-of-first-main trigger adds {R}{R} to its controller's pool") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        // Onto the battlefield during the upkeep, so the precombat main trigger still has a chance
+        // to fire this turn.
+        driver.putPermanentOnBattlefield(me, "Glóin the Mighty")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        resolveStack(driver)
+
+        val mana = pool(driver, me)
+        withClue("two red, and nothing else — {R}{R} is not {2} and not one mana") {
+            mana.red shouldBe 2
+            mana.colorless shouldBe 0
+            mana.green shouldBe 0
+        }
+        withClue("the mana goes to Glóin's controller, not their opponent") {
+            pool(driver, driver.player2).red shouldBe 0
+        }
+    }
+
+    test("Easy Pickings damages every creature opponents control and none of your own") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val myElf = driver.putCreatureOnBattlefield(me, "Llanowar Elves")        // 1/1 — would die
+        val theirElf = driver.putCreatureOnBattlefield(opponent, "Llanowar Elves") // 1/1 — dies
+        val theirCourser = driver.putCreatureOnBattlefield(opponent, "Centaur Courser") // 3/3 — lives
+
+        val gloin = driver.putCardInHand(me, "Glóin the Mighty")
+        driver.giveMana(me, Color.RED, 3)
+
+        // faceIndex 0 is the Adventure face (Easy Pickings), not the creature.
+        driver.submitSuccess(
+            CastSpell(
+                playerId = me,
+                cardId = gloin,
+                faceIndex = 0,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        resolveStack(driver)
+
+        withClue("your opponent's 1/1 dies") {
+            driver.getPermanents(opponent).contains(theirElf) shouldBe false
+        }
+        withClue("your opponent's 3/3 survives 1 damage") {
+            driver.getPermanents(opponent) shouldContain theirCourser
+        }
+        withClue("'creatures your opponents control' must not include your own 1/1") {
+            driver.getPermanents(me) shouldContain myElf
+        }
+        withClue("CR 715: the Adventure exiles itself on resolution, castable later as the creature") {
+            driver.getExile(me) shouldContain gloin
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmaugWickedWormScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SmaugWickedWormScenarioTest.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Smaug, Wicked Worm (HOB #164) — {3}{B}{R} Legendary Creature — Dragon 5/5, flying.
+ *
+ *   When Smaug enters, create X tapped Treasure tokens, where X is the number of artifacts your
+ *   opponents control.
+ *   Whenever you cast a spell, if mana from a Treasure was spent to cast it, you draw a card and
+ *   lose 1 life.
+ *
+ * Both abilities are easy to get subtly wrong in the same direction: X must count *opponents'*
+ * artifacts (not yours, and not everyone's), and the cast trigger must read the spent-mana
+ * provenance rather than firing on every spell while you happen to control a Treasure.
+ */
+class SmaugWickedWormScenarioTest : FunSpec({
+
+    val treasureManaAbilityId = PredefinedTokens.Treasure.activatedAbilities.single().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(PredefinedTokens.Treasure)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass()
+            safety++
+        }
+    }
+
+    fun treasures(driver: GameTestDriver, player: EntityId): List<EntityId> =
+        driver.getPermanents(player).filter { driver.getCardName(it) == "Treasure" }
+
+    test("the enter trigger creates one tapped Treasure per artifact your opponents control") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        // Two artifacts on their side; one on mine, which must not be counted.
+        driver.putCreatureOnBattlefield(opponent, "Frogmite")
+        driver.putCreatureOnBattlefield(opponent, "Frogmite")
+        driver.putCreatureOnBattlefield(me, "Frogmite")
+
+        val smaug = driver.putCardInHand(me, "Smaug, Wicked Worm")
+        driver.giveMana(me, Color.BLACK, 3)
+        driver.giveMana(me, Color.RED, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = me, cardId = smaug, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        resolveStack(driver)
+
+        val created = treasures(driver, me)
+        withClue("X = 2 (their artifacts), not 3 (everyone's) and not 1 (mine)") {
+            created.size shouldBe 2
+        }
+        withClue("the tokens enter tapped") {
+            created.all { driver.isTapped(it) } shouldBe true
+        }
+        withClue("the Treasures belong to Smaug's controller") {
+            treasures(driver, opponent).size shouldBe 0
+        }
+    }
+
+    test("no opponent artifacts means no Treasures — X = 0 creates nothing") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        val smaug = driver.putCardInHand(me, "Smaug, Wicked Worm")
+        driver.giveMana(me, Color.BLACK, 3)
+        driver.giveMana(me, Color.RED, 2)
+        driver.submitSuccess(
+            CastSpell(playerId = me, cardId = smaug, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        resolveStack(driver)
+
+        treasures(driver, me).size shouldBe 0
+    }
+
+    test("a spell paid with Treasure mana draws a card and loses 1 life; the same spell paid from a land does not") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        driver.putPermanentOnBattlefield(me, "Smaug, Wicked Worm")
+        resolveStack(driver)
+
+        // Control: a Bolt paid with ordinary mana, while a Treasure sits untouched on the
+        // battlefield. Controlling a Treasure is not the same as spending its mana.
+        driver.putPermanentOnBattlefield(me, "Treasure")
+        val lifeBefore = driver.getLifeTotal(me)
+        val handBefore = driver.getHandSize(me)
+
+        val plainBolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.submitSuccess(
+            CastSpell(
+                playerId = me,
+                cardId = plainBolt,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        resolveStack(driver)
+
+        withClue("no Treasure mana was spent → no life loss and no extra card") {
+            driver.getLifeTotal(me) shouldBe lifeBefore
+            // +1 for the Bolt arriving in hand, -1 for casting it: back where we started.
+            driver.getHandSize(me) shouldBe handBefore
+        }
+
+        // The real case: tap and sacrifice the Treasure for {R}, then spend exactly that.
+        val treasure = treasures(driver, me).single()
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = treasure,
+                abilityId = treasureManaAbilityId,
+                manaColorChoice = Color.RED,
+            )
+        )
+        resolveStack(driver)
+
+        val lifeBeforeTreasureBolt = driver.getLifeTotal(me)
+        val handBeforeTreasureBolt = driver.getHandSize(me)
+
+        val treasureBolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.submitSuccess(
+            CastSpell(
+                playerId = me,
+                cardId = treasureBolt,
+                targets = listOf(ChosenTarget.Player(opponent)),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        resolveStack(driver)
+
+        withClue("Treasure mana was spent → you draw a card and lose 1 life") {
+            driver.getLifeTotal(me) shouldBe lifeBeforeTreasureBolt - 1
+            // +1 for the Bolt going into hand, -1 for casting it, +1 for the trigger's draw.
+            driver.getHandSize(me) shouldBe handBeforeTreasureBolt + 1 - 1 + 1
+        }
+    }
+})


### PR DESCRIPTION
Three HOB cards, each built entirely from existing SDK primitives — no new effects, triggers, or conditions.

## Cards

**Glóin the Mighty // Easy Pickings** (#99) — {3}{R} Legendary Creature — Dwarf Warrior 4/3
- *At the beginning of your first main phase, add {R}{R}* → `Triggers.FirstMainPhase` + `Effects.AddMana(RED, 2)`. Not a mana ability (CR 605.1b): it triggers off a step, so it uses the stack.
- Adventure *Easy Pickings* {2}{R} → `ForEachInGroup(AllCreaturesOpponentsControl, DealDamage(1, Self))` — a group effect, so hexproof/shroud don't apply.

**Gandalf, Goblins' Bane // Flameshape** (#96) — {2}{R} Legendary Creature — Avatar Wizard 2/3
- Cast trigger is one ability with two effects, so the pump and the ping are atomic.
- Adventure *Flameshape* {1}{R} → the impulse pipeline with two riders `ExilePatterns.impulse()` can't express: `FaceDownMode.HIDDEN` (opponents never learn the cards) and a `MayPlayExpiry.Permanent` grant *gated* by a `condition`. The Wizard clause is a standing condition re-checked on every legal-action query, not a one-shot test at resolution — losing your last Wizard suspends the permission and regaining one restores it.

**Smaug, Wicked Worm** (#164) — {3}{B}{R} Legendary Creature — Dragon 5/5, flying
- X counts *opponents'* artifacts (`Player.EachOpponent` aggregation), evaluated at resolution; X=0 creates nothing.
- *"if mana from a Treasure was spent"* rides the trigger as `SpellCastPredicate.PaidWithManaFromSubtype(TREASURE)` rather than an intervening-if. The payment fact is immutable, so it reads the same either way, and the trigger stays correct for a spell that gets countered.

## Tests

One scenario test per card, each covering the payoff **and** its negative case:
- Glóin: {R}{R} lands in the controller's pool (not the opponent's); Easy Pickings kills their 1/1, spares their 3/3, and never touches your own.
- Gandalf: a creature spell does *not* trigger; an instant pumps to 3/4 and pings for 1. Flameshape's exiles are face down, and the two cards flip from uncastable to castable purely by putting a Wizard on the battlefield.
- Smaug: X = 2 with two opposing artifacts and one of your own (not 3, not 1); tokens enter tapped; X=0 creates nothing. A Bolt paid from a land while you control an untapped Treasure does *not* trigger; the same Bolt paid by sacrificing that Treasure draws and loses 1.

## Deliberately excluded

**My Precious // Allure of Power** was implemented and then pulled: the Adventure's *"As an additional cost to cast this spell, sacrifice a creature"* silently does nothing. `CardFaceBuilder.additionalCost()` stores the cost on `CardFace.script.additionalCosts`, but nothing in the engine ever reads it — `CastSpellHandler` and `CastSpellEnumerator` both go through `cardDef.script.additionalCosts`, which is the *main* face. Confirmed by test: the spell casts with no creature on the battlefield, and a supplied sacrifice payment is ignored.

My Precious is the only card in the repo that would use a face-level additional cost, so this gap has never been exercised. Making the cast pipeline face-aware for additional costs is `add-feature` work on a hot path, not something to bolt onto a card PR — so the card is left unimplemented rather than shipped resolving wrongly.

HOB: 146 → 149 of 193.

## Verification

- `just build` — green (full test suite).
- `just rebless-cards` — only the three new cards moved in the HOB golden.
- `just check-card-printing` — canonical placement OK for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
