### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/MaskOfMemoryReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/MaskOfMemoryReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mask of Memory reprint in Commander 2014. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Mirrodin; this file contributes only
+ * presentation data.
+ */
+val MaskOfMemoryReprint = Printing(
+    oracleId = "d6b2c998-a226-426c-a40d-6e6007041bfe",
+    name = "Mask of Memory",
+    setCode = "C14",
+    collectorNumber = "249",
+    scryfallId = "56193a7e-013d-41d3-ac3b-5151e7457768",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/5/6/56193a7e-013d-41d3-ac3b-5151e7457768.jpg?1783938820",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DrossHarvesterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/clb/cards/DrossHarvesterReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.clb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dross Harvester reprint in Commander Legends: Battle for Baldur's Gate. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Mirrodin; this file contributes only
+ * presentation data.
+ */
+val DrossHarvesterReprint = Printing(
+    oracleId = "5520ada0-f173-4b5e-a0b8-a5938a1c0a4b",
+    name = "Dross Harvester",
+    setCode = "CLB",
+    collectorNumber = "750",
+    scryfallId = "35f77a00-1880-416c-813b-c6a870dd5f58",
+    artist = "Michael Sutfin",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35f77a00-1880-416c-813b-c6a870dd5f58.jpg?1783922451",
+    releaseDate = "2022-06-10",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/MaskOfMemoryReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/MaskOfMemoryReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mask of Memory reprint in Commander Legends. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Mirrodin; this file contributes only
+ * presentation data.
+ */
+val MaskOfMemoryReprint = Printing(
+    oracleId = "d6b2c998-a226-426c-a40d-6e6007041bfe",
+    name = "Mask of Memory",
+    setCode = "CMR",
+    collectorNumber = "324",
+    scryfallId = "ba275c02-8581-46a0-9c7c-8baa0fdb4982",
+    artist = "Alan Pollack",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba275c02-8581-46a0-9c7c-8baa0fdb4982.jpg?1783928754",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/DrossHarvester.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/DrossHarvester.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dross Harvester — Mirrodin #63
+ * {1}{B}{B} · Creature — Horror · 4/4
+ *
+ * Protection from white
+ * At the beginning of your end step, you lose 4 life.
+ * Whenever a creature dies, you gain 2 life.
+ *
+ * A 4/4 for three that bleeds you out unless the board keeps dying. The life-gain trigger is
+ * [Triggers.AnyCreatureDies] — *any* creature, either player's, including Dross Harvester itself, so
+ * the trigger has to be a battlefield-wide one rather than a self or you-control death trigger. Note
+ * [Effects.LoseLife] defaults to targeting an opponent; the upkeep drain is explicitly
+ * [EffectTarget.Controller].
+ */
+val DrossHarvester = card("Dross Harvester") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 4
+    toughness = 4
+    oracleText = "Protection from white\n" +
+        "At the beginning of your end step, you lose 4 life.\n" +
+        "Whenever a creature dies, you gain 2 life."
+
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.Color(Color.WHITE)))
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.LoseLife(4, EffectTarget.Controller)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.AnyCreatureDies
+        effect = Effects.GainLife(2)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "63"
+        artist = "Michael Sutfin"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b088832c-6119-4460-98b7-ae25cf70b2c5.jpg?1783944548"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MaskOfMemory.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MaskOfMemory.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Mask of Memory — Mirrodin #203
+ * {2} · Artifact — Equipment
+ *
+ * Whenever equipped creature deals combat damage to a player, you may draw two cards. If you do,
+ * discard a card.
+ * Equip {1}
+ *
+ * The "if you do" isn't a second choice — declining the draw is the only out, so the whole
+ * draw-then-discard package sits inside one [MayEffect]. Accepting always costs the discard, which
+ * is what makes this a filtering Equipment rather than raw card advantage.
+ */
+val MaskOfMemory = card("Mask of Memory") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Whenever equipped creature deals combat damage to a player, you may draw two cards. " +
+        "If you do, discard a card.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED,
+        )
+        effect = MayEffect(
+            Effects.Composite(
+                listOf(
+                    Effects.DrawCards(2),
+                    Effects.Discard(1),
+                )
+            )
+        )
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Alan Pollack"
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/512f8021-aaf3-4b1c-b08c-fe667ce2d8e1.jpg?1783944513"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Needlebug.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Needlebug.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Needlebug — Mirrodin #217
+ * {4} · Artifact Creature — Insect · 2/2
+ *
+ * Flash
+ * Protection from artifacts
+ *
+ * An artifact that hoses artifacts: flashed in as a surprise blocker it can't be blocked by, damaged
+ * by, targeted by, or enchanted/equipped by anything artifact — including itself being blocked by
+ * artifact creatures. Same [ProtectionScope.CardType] scope as Tel-Jilad Chosen, so all four
+ * protection consequences fall out of the projection without per-card wiring.
+ */
+val Needlebug = card("Needlebug") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Insect"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\nProtection from artifacts"
+
+    keywords(Keyword.FLASH)
+    keywordAbility(KeywordAbility.Protection(ProtectionScope.CardType("Artifact")))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Paolo Parente"
+        flavorText =
+            "Near Tel-Jilad, the Tangle is almost silent, save for the trolls' chants and the skittering of needlebugs."
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d54fbd8a-1e2a-450e-98f2-26bbc9e9ac79.jpg?1783944510"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NeurokFamiliar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NeurokFamiliar.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Neurok Familiar — Mirrodin #43
+ * {1}{U} · Creature — Bird · 1/1
+ *
+ * Flying
+ * When this creature enters, reveal the top card of your library. If it's an artifact card, put it
+ * into your hand. Otherwise, put it into your graveyard.
+ *
+ * Gather → Select → Move, the same shape as Skirk Drill Sergeant: the top card is gathered *revealed*
+ * so both players see it either way, then partitioned by [GameObjectFilter.Artifact]. Whichever side
+ * of the partition is empty simply moves nothing, so an empty library resolves as a no-op rather than
+ * failing.
+ */
+val NeurokFamiliar = card("Neurok Familiar") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\n" +
+        "When this creature enters, reveal the top card of your library. If it's an artifact card, " +
+        "put it into your hand. Otherwise, put it into your graveyard."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "revealed",
+                    revealed = true
+                ),
+                SelectFromCollectionEffect(
+                    from = "revealed",
+                    selection = SelectionMode.All,
+                    filter = GameObjectFilter.Artifact,
+                    storeSelected = "artifact",
+                    storeRemainder = "nonArtifact"
+                ),
+                MoveCollectionEffect(
+                    from = "artifact",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                ),
+                MoveCollectionEffect(
+                    from = "nonArtifact",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Edward P. Beard, Jr."
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52fd15b0-4ada-41c7-81e0-4f8956798685.jpg?1783944553"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SkyhunterCub.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SkyhunterCub.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Skyhunter Cub — Mirrodin #21
+ * {2}{W} · Creature — Cat Knight · 2/2
+ *
+ * As long as this creature is equipped, it gets +1/+1 and has flying.
+ *
+ * Two self-scoped statics behind the same "is equipped" gate ([Conditions.SourceMatches] over
+ * `GameObjectFilter.Any.equipped()`, as on Merry, Esquire of Rohan). They land in different layers —
+ * the keyword grant in layer 6, the stat bump in layer 7c — so they're modelled separately rather
+ * than as one bundled ability; the condition is re-read each time state is projected, so unattaching
+ * the Equipment drops both halves at once.
+ */
+val SkyhunterCub = card("Skyhunter Cub") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Knight"
+    power = 2
+    toughness = 2
+    oracleText = "As long as this creature is equipped, it gets +1/+1 and has flying."
+
+    staticAbility {
+        ability = GrantKeyword(keyword = Keyword.FLYING.name, filter = GroupFilter.source())
+        condition = Conditions.SourceMatches(GameObjectFilter.Any.equipped())
+    }
+
+    staticAbility {
+        ability = ModifyStats(powerBonus = 1, toughnessBonus = 1, filter = GroupFilter.source())
+        condition = Conditions.SourceMatches(GameObjectFilter.Any.equipped())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Pete Venters"
+        flavorText = "Every young leonin wishes to become a skyhunter, for they soar closest to the suns."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd46bfba-0685-4dcb-9b63-f90da8fb0ce7.jpg?1783944559"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -858,6 +858,73 @@
     ]
 }
 
+// Dross Harvester
+{
+    "name": "Dross Harvester",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "Protection from white\nAt the beginning of your end step, you lose 4 life.\nWhenever a creature dies, you gain 2 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.Color",
+                "color": "WHITE"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": "Controller"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "RARE",
+        "artist": "Michael Sutfin",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b088832c-6119-4460-98b7-ae25cf70b2c5.jpg?1783944548"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dross Prowler
 {
     "name": "Dross Prowler",
@@ -2427,6 +2494,116 @@
     ]
 }
 
+// Mask of Memory
+{
+    "name": "Mask of Memory",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Whenever equipped creature deals combat damage to a player, you may draw two cards. If you do, discard a card.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "Alan Pollack",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/512f8021-aaf3-4b1c-b08c-fe667ce2d8e1.jpg?1783944513"
+    },
+    "colorIdentityOverride": []
+}
+
 // Mass Hysteria
 {
     "name": "Mass Hysteria",
@@ -3022,6 +3199,113 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Needlebug
+{
+    "name": "Needlebug",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Insect",
+    "oracleText": "Flash\nProtection from artifacts",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Protection",
+            "scope": {
+                "type": "ProtectionScope.CardType",
+                "cardType": "Artifact"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Paolo Parente",
+        "flavorText": "Near Tel-Jilad, the Tangle is almost silent, save for the trolls' chants and the skittering of needlebugs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d54fbd8a-1e2a-450e-98f2-26bbc9e9ac79.jpg?1783944510"
+    },
+    "colorIdentityOverride": []
+}
+
+// Neurok Familiar
+{
+    "name": "Neurok Familiar",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhen this creature enters, reveal the top card of your library. If it's an artifact card, put it into your hand. Otherwise, put it into your graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "revealed",
+                            "revealed": true
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "revealed",
+                            "selection": "SelectAll",
+                            "filter": "artifact",
+                            "storeSelected": "artifact",
+                            "storeRemainder": "nonArtifact"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "artifact",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "nonArtifact",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Edward P. Beard, Jr.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52fd15b0-4ada-41c7-81e0-4f8956798685.jpg?1783944553"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -4020,6 +4304,72 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Skyhunter Cub
+{
+    "name": "Skyhunter Cub",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Cat Knight",
+    "oracleText": "As long as this creature is equipped, it gets +1/+1 and has flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsEquipped"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsEquipped"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Pete Venters",
+        "flavorText": "Every young leonin wishes to become a skyhunter, for they soar closest to the suns.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd46bfba-0685-4dcb-9b63-f90da8fb0ce7.jpg?1783944559"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DrossHarvesterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DrossHarvesterScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dross Harvester (MRD) — protection from white; "At the beginning of your end step, you lose 4
+ * life"; "Whenever a creature dies, you gain 2 life."
+ *
+ * The death trigger is deliberately battlefield-wide ([com.wingedsheep.sdk.dsl.Triggers.AnyCreatureDies]):
+ * *any* creature, either player's, and the Harvester itself. That last case is the one a self- or
+ * you-control-scoped trigger would silently drop, so it gets its own test.
+ */
+class DrossHarvesterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dross Harvester") {
+            test("your end step drains you for 4") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dross Harvester")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("the upkeep-style drain is a straight 4 off the controller") {
+                    game.getLifeTotal(1) shouldBe 16
+                }
+            }
+
+            test("an opponent's creature dying gains you 2 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dross Harvester")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(1, "Stonesplitter Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+                game.castXSpell(1, "Stonesplitter Bolt", xValue = 2, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the trigger is 'a creature', not 'a creature you control'") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+
+            test("the Harvester's own death still gains you 2 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dross Harvester")
+                    .withCardInHand(1, "Stonesplitter Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val harvester = game.findPermanent("Dross Harvester").shouldNotBeNull()
+
+                game.castXSpell(1, "Stonesplitter Bolt", xValue = 4, targetId = harvester).error shouldBe null
+                game.resolveStack()
+
+                withClue("its own death is a creature dying — the trigger fires off last-known info") {
+                    game.isOnBattlefield("Dross Harvester") shouldBe false
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaskOfMemoryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaskOfMemoryScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mask of Memory (MRD) — "Whenever equipped creature deals combat damage to a player, you may draw
+ * two cards. If you do, discard a card." Equip {1}.
+ *
+ * The "if you do" is not a second decision: the discard is the price of the draw, so both sit inside
+ * one may. These tests pin that accepting costs exactly one card from hand and that declining costs
+ * nothing — the failure mode being a discard that fires even when the draw was declined.
+ */
+class MaskOfMemoryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Mask of Memory — draw two, discard one, on combat damage") {
+            test("accepting draws two and then discards one") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Mask of Memory", "Grizzly Bears")
+                    .withCardsInHand(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libBefore = game.state.getLibrary(game.player1Id).size
+                val handBefore = game.state.getHand(game.player1Id).size
+                val gyBefore = game.state.getGraveyard(game.player1Id).size
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.passPriority()
+                game.resolveStack()
+
+                game.answerYesNo(true).error shouldBe null
+
+                val discard = game.getPendingDecision()
+                withClue("the accepted branch always reaches the discard") {
+                    (discard is SelectCardsDecision) shouldBe true
+                }
+                game.selectCards(listOf((discard as SelectCardsDecision).options.first()))
+                    .error shouldBe null
+                game.resolveStack()
+
+                withClue("two drawn off the top") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libBefore - 2
+                }
+                withClue("net +1 in hand: drew two, discarded one") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore + 1
+                }
+                withClue("the discarded card is in the graveyard") {
+                    game.state.getGraveyard(game.player1Id).size shouldBe gyBefore + 1
+                }
+            }
+
+            test("declining draws nothing and discards nothing") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Mask of Memory", "Grizzly Bears")
+                    .withCardsInHand(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libBefore = game.state.getLibrary(game.player1Id).size
+                val handBefore = game.state.getHand(game.player1Id).size
+                val gyBefore = game.state.getGraveyard(game.player1Id).size
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.passPriority()
+                game.resolveStack()
+
+                game.answerYesNo(false).error shouldBe null
+                game.resolveStack()
+
+                withClue("declining the draw also skips the 'if you do' discard") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libBefore
+                    game.state.getHand(game.player1Id).size shouldBe handBefore
+                    game.state.getGraveyard(game.player1Id).size shouldBe gyBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeurokFamiliarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NeurokFamiliarScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Neurok Familiar (MRD) — "When this creature enters, reveal the top card of your library. If it's
+ * an artifact card, put it into your hand. Otherwise, put it into your graveyard."
+ *
+ * Gather → Select → Move: the top card is gathered revealed, partitioned on `Artifact`, and each
+ * side moved to its zone. There is no "may" anywhere, so the trigger must resolve without pausing —
+ * that, and the partition landing the card in exactly one zone, is what these tests pin.
+ */
+class NeurokFamiliarScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    /** Cast the Familiar from hand for {1}{U} and let the enters trigger resolve. */
+    fun GameTestDriver.castFamiliar(you: EntityId) {
+        val familiar = putCardInHand(you, "Neurok Familiar")
+        giveMana(you, Color.BLUE, 2)
+        castSpell(you, familiar).isSuccess shouldBe true
+        while (!isPaused && state.stack.isNotEmpty()) bothPass()
+    }
+
+    test("an artifact card on top goes to your hand") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val top = d.putCardOnTopOfLibrary(you, "Frogmite") // Artifact Creature — Myr
+
+        d.castFamiliar(you)
+
+        d.isPaused shouldBe false // nothing to choose — the partition is mechanical
+        d.getHand(you) shouldContain top
+        d.getGraveyard(you) shouldNotContain top
+    }
+
+    test("a nonartifact card on top goes to your graveyard") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val top = d.putCardOnTopOfLibrary(you, "Grizzly Bears") // green creature, no artifact type
+
+        d.castFamiliar(you)
+
+        d.isPaused shouldBe false
+        d.getGraveyard(you) shouldContain top
+        d.getHand(you) shouldNotContain top
+    }
+
+    test("only the single top card is looked at — the card beneath it stays in the library") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val second = d.putCardOnTopOfLibrary(you, "Frogmite")
+        val top = d.putCardOnTopOfLibrary(you, "Grizzly Bears")
+
+        d.castFamiliar(you)
+
+        d.getGraveyard(you) shouldContain top
+        d.getHand(you) shouldNotContain second
+        d.getGraveyard(you) shouldNotContain second
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkyhunterCubScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkyhunterCubScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Skyhunter Cub (MRD) — "As long as this creature is equipped, it gets +1/+1 and has flying."
+ *
+ * Both halves hang off one `IsEquipped` gate but land in different layers (keyword in 6, stats in
+ * 7c), so they're two conditional statics. These tests pin that the gate reads *this* creature's
+ * attachments — not "an Equipment exists" and not "something is attached to anything".
+ */
+class SkyhunterCubScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Skyhunter Cub — equipped-gated flying and +1/+1") {
+            test("unequipped, it is a plain 2/2 without flying") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Skyhunter Cub")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cub = game.findPermanent("Skyhunter Cub").shouldNotBeNull()
+                val projected = game.state.projectedState
+
+                withClue("no Equipment attached, so neither static applies") {
+                    projected.getPower(cub) shouldBe 2
+                    projected.getToughness(cub) shouldBe 2
+                    projected.hasKeyword(cub, Keyword.FLYING) shouldBe false
+                }
+            }
+
+            test("equipped, it is a 3/3 flier") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Skyhunter Cub")
+                    .withCardAttachedTo(1, "Whispersilk Cloak", "Skyhunter Cub")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cub = game.findPermanent("Skyhunter Cub").shouldNotBeNull()
+                val projected = game.state.projectedState
+
+                withClue("Whispersilk Cloak changes no stats itself, so 3/3 is the Cub's own bonus") {
+                    projected.getPower(cub) shouldBe 3
+                    projected.getToughness(cub) shouldBe 3
+                    projected.hasKeyword(cub, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("an Equipment on another creature does not switch the Cub on") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Skyhunter Cub")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Whispersilk Cloak", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cub = game.findPermanent("Skyhunter Cub").shouldNotBeNull()
+                val projected = game.state.projectedState
+
+                withClue("the gate is 'this creature is equipped', not 'you control an Equipment'") {
+                    projected.getPower(cub) shouldBe 2
+                    projected.getToughness(cub) shouldBe 2
+                    projected.hasKeyword(cub, Keyword.FLYING) shouldBe false
+                }
+            }
+
+            test("an Aura is not Equipment — enchanting the Cub leaves it a 2/2 ground creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Skyhunter Cub")
+                    .withCardAttachedTo(1, "Pacifism", "Skyhunter Cub")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cub = game.findPermanent("Skyhunter Cub").shouldNotBeNull()
+                val projected = game.state.projectedState
+
+                withClue("IsEquipped must not degrade into a generic 'is attached to' check") {
+                    projected.getPower(cub) shouldBe 2
+                    projected.getToughness(cub) shouldBe 2
+                    projected.hasKeyword(cub, Keyword.FLYING) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements five Mirrodin cards, all canonical in MRD and all built from existing SDK primitives — no new effect, trigger, condition, or keyword types.

## Cards

| Card | Text | Notes |
|---|---|---|
| **Needlebug** `{4}` 2/2 | Flash, protection from artifacts | `ProtectionScope.CardType("Artifact")`, the same scope Tel-Jilad Chosen already uses |
| **Skyhunter Cub** `{2}{W}` 2/2 | As long as this creature is equipped, it gets +1/+1 and has flying | Two conditional statics behind one `IsEquipped` gate — the keyword grant lands in layer 6, the stat bump in 7c, so they're modelled separately rather than bundled |
| **Dross Harvester** `{1}{B}{B}` 4/4 | Protection from white; end-step drain of 4; gain 2 whenever a creature dies | The death trigger is `Triggers.AnyCreatureDies` — *any* creature, either player's, including the Harvester itself |
| **Mask of Memory** `{2}` Equipment | Combat damage to a player → you may draw two, then discard one. Equip `{1}` | The "if you do" isn't a second decision: draw and discard sit inside one `MayEffect`, so declining skips both |
| **Neurok Familiar** `{1}{U}` 1/1 | Flying; ETB reveal top card, artifact → hand, otherwise → graveyard | Gather → Select → Move, partitioned on `Artifact`; an empty library resolves as a no-op |

## Reprint rows

`just check-card-printing` flagged later printings in already-scaffolded sets, so those got `Printing` rows: Dross Harvester (CLB), Mask of Memory (C14, CMR). All five canonical definitions verified as the card's earliest real expansion printing.

## Tests

One scenario test file per card for the four whose behaviour is a composition:

- `SkyhunterCubScenarioTest` — unequipped 2/2 no flying; equipped 3/3 flier; an Equipment on *another* creature doesn't switch it on; an Aura is not Equipment.
- `NeurokFamiliarScenarioTest` — artifact to hand, nonartifact to graveyard, resolves without pausing, and only the single top card is touched.
- `MaskOfMemoryScenarioTest` — accepting is net +1 card and +1 in the graveyard; declining costs nothing.
- `DrossHarvesterScenarioTest` — end-step drain; an opponent's creature dying pays out; its own death pays out too.

Needlebug is two plain keywords over an already-proven protection scope, so it rides the snapshot net.

## Verification

- `just build` green (compile + `mtg-sets` snapshot + full `rules-engine` suite).
- `MRD.json` golden re-blessed; the diff is 350 added lines and nothing else moved.
- `just check-card-printing` clean for all five.
- All seven Scryfall image URIs verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
