### PR TITLE
Add five Murders at Karlov Manor cards, with Ward—Collect evidence support

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/DecisionResponder.kt
@@ -201,6 +201,24 @@ class DecisionResponder(
             return CardsSelectedResponse(decision.id, options)
         }
 
+        // A `minTotalManaValue` floor (collect evidence N, CR 701.59a) is a *sum* gate, so none of
+        // the count-based branches below can satisfy it — taking `min` cheap cards submits an
+        // illegal selection the validator rejects, and taking zero silently declines an optional
+        // one (a ward cost) every time. Pay it with the fewest cards, highest mana values first,
+        // which is the same choice `CollectEvidenceResolver.autoSelect` makes; submit nothing when
+        // the pool can't reach the floor, which CR 701.59b makes the only legal answer anyway.
+        decision.minTotalManaValue?.let { floor ->
+            val byValueDesc = options.sortedByDescending { manaValueOf(state, it) }
+            val payment = mutableListOf<EntityId>()
+            var total = 0
+            for (cardId in byValueDesc) {
+                if (total >= floor || payment.size >= max) break
+                payment.add(cardId)
+                total += manaValueOf(state, cardId)
+            }
+            return CardsSelectedResponse(decision.id, if (total >= floor) payment else emptyList())
+        }
+
         // Context-aware ranking
         val prompt = decision.prompt.lowercase()
         val isDiscard = prompt.contains("discard")
@@ -238,6 +256,14 @@ class DecisionResponder(
             }
         }
     }
+
+    /**
+     * Mana value of a card in a non-battlefield zone — intrinsic to the card (CR 202.3), so the
+     * base [CardComponent] is the correct read. Unreadable entities count 0, which keeps a
+     * mana-value floor failing closed.
+     */
+    private fun manaValueOf(state: GameState, cardId: EntityId): Int =
+        state.getEntity(cardId)?.get<CardComponent>()?.manaValue ?: 0
 
     /** Prefer the smallest legal selection, honoring reductions such as “discard two unless one is a creature.” */
     private fun minimumLegalSelection(

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/rollout/FastDecisionResponder.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/rollout/FastDecisionResponder.kt
@@ -41,6 +41,7 @@ import com.wingedsheep.engine.core.TargetsResponse
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
 
 /**
@@ -88,11 +89,18 @@ class FastDecisionResponder(private val intents: IntentCatalog = IntentCatalog.N
 
             // Take the minimum a selection demands. Selections are overwhelmingly costs (discard,
             // sacrifice) rather than benefits, and a playout that over-pays every cost biases every
-            // line that contains one.
-            is SelectCardsDecision -> CardsSelectedResponse(
-                decision.id,
-                decision.options.take(decision.minSelections.coerceAtMost(decision.options.size))
-            )
+            // line that contains one. The exception is a `minTotalManaValue` floor (collect
+            // evidence N, CR 701.59a): that gate is a *sum*, so "the minimum count" is an illegal
+            // submission the validator rejects — pay it with the fewest cards instead.
+            is SelectCardsDecision ->
+                if (decision.minTotalManaValue != null) {
+                    CardsSelectedResponse(decision.id, manaFloorSelection(state, decision))
+                } else {
+                    CardsSelectedResponse(
+                        decision.id,
+                        decision.options.take(decision.minSelections.coerceAtMost(decision.options.size))
+                    )
+                }
 
             // A search is a benefit, so take as much as it offers.
             is SearchLibraryDecision -> CardsSelectedResponse(
@@ -197,6 +205,28 @@ class FastDecisionResponder(private val intents: IntentCatalog = IntentCatalog.N
         decision.cards.forEachIndexed { index, card -> piles[index % piles.size].add(card) }
         return piles
     }
+
+    /**
+     * Satisfy a `minTotalManaValue` floor with the fewest cards — highest mana values first, the
+     * same choice `CollectEvidenceResolver.autoSelect` makes. Returns nothing when the pool can't
+     * reach the floor, which CR 701.59b makes the only legal answer anyway (and which the engine's
+     * validator exempts from the floor, so an optional collection reads as a decline).
+     */
+    private fun manaFloorSelection(state: GameState, decision: SelectCardsDecision): List<EntityId> {
+        val floor = decision.minTotalManaValue ?: return emptyList()
+        val selected = mutableListOf<EntityId>()
+        var total = 0
+        val byValueDesc = decision.options.sortedByDescending { manaValueOf(state, it) }
+        for (cardId in byValueDesc) {
+            if (total >= floor || selected.size >= decision.maxSelections) break
+            selected.add(cardId)
+            total += manaValueOf(state, cardId)
+        }
+        return if (total >= floor) selected else emptyList()
+    }
+
+    private fun manaValueOf(state: GameState, cardId: EntityId): Int =
+        state.getEntity(cardId)?.get<CardComponent>()?.manaValue ?: 0
 
     /** Greedy cheapest-first spend of a pawprint budget, free modes taken exactly once. */
     private fun budgetModes(decision: BudgetModalDecision): List<Int> {

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1456,6 +1456,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CreateClue(count?, controller?)` / `Investigate(count?, controller?)` — Clue tokens (artifact with
   "{2}, Sacrifice this token: Draw a card."). `Investigate` is the keyword-action spelling (CR 701.36) so
   card text "investigate" maps directly; both create the same predefined `Clue` token — Malcolm, the Eyes.
+  Both also take a `DynamicAmount` in place of the `Int` for "investigate once for each …" wording
+  whose repetition count is only known at resolution (Wojek Investigator:
+  `Investigate(DynamicAmount.CountPlayersWith(EachOpponent, …))`). A count of zero investigates not at
+  all, which is what the wording means when nothing qualifies.
 - `CreateShard(count?, controller?)` — Shard tokens (the Clue token's enchantment cousin: colorless
   "Enchantment — Shard" with "{2}, Sacrifice this enchantment: Scry 1, then draw a card."). Niko, Light of Hope.
 - `CreateLander(count?, controller?)` — Lander land tokens.
@@ -2773,6 +2777,16 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   creature]'s owner shuffles it into their library and draws three cards"* (Gandalf, Wandering
   Wizard). Distinct from `Player.You` precisely when ownership and control diverge — a stolen
   permanent's ability still acts on its owner. Reach for `Player.You` whenever the text says "you".
+- `Player.ControllerOfSource` — "you", but read off the **source permanent** rather than off the
+  resolution context's `controllerId`. Normally identical to `Player.You`, and `Player.You` stays the
+  right reference; this one exists for the case where the context's controller has been **rebound to
+  another player**, which is what the per-player loops do. `DynamicAmount.CountPlayersWith` and
+  `ForEach`-over-players evaluate their inner condition once per candidate with `controllerId` set to
+  that candidate, so `Player.You` inside the loop means "the player being tested" and the ability's own
+  controller is otherwise unreachable. That is the shape of "for each opponent who has more cards in
+  hand **than you**" (Wojek Investigator): `CountPlayersWith(EachOpponent, CompareAmounts(Count(You,
+  HAND), GT, Count(ControllerOfSource, HAND)))`. Pairs with `Player.OwnerOfSource`, which follows
+  *ownership* instead of control.
 - `Player.OwnersOfLinkedExile` — the **distinct owners** of the cards still in the effect source's
   linked-exile pile (`LinkedExileComponent`, populated by `Effects.ExileUntilLeaves`). A *list*
   reference: reach it only through `Effects.ForEachPlayer(Player.OwnersOfLinkedExile, …)`, typically
@@ -6284,9 +6298,10 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 > permanent the spell becomes. Because the rail carries a `ChoiceSlot` rather than a boolean, the
 > three facts never read as each other: a spell cast with evidence collected doesn't satisfy
 > `Conditions.WasKicked` or `Conditions.WasBargained`, and neither of those satisfies
-> `Conditions.WasEvidenceCollected`. Every *unlinked* collect-evidence cost (all the activated
-> abilities, Axebane Ferox's ward) uses `Costs.CollectEvidence(n)` and stamps nothing, because nothing
-> on those cards asks the question.
+> `Conditions.WasEvidenceCollected`. Every *unlinked* collect-evidence cost stamps nothing, because
+> nothing on those cards asks the question: the activated abilities use `Costs.CollectEvidence(n)`,
+> and a **ward** cost uses `KeywordAbility.wardCollectEvidence(n)` → `WardCost.CollectEvidence(n)`
+> (Axebane Ferox — see § Keywords → Ward for the prompt shape and the fail-closed behaviour).
 >
 > The payoff shapes the printed cards use:
 > - **Enters trigger** — `triggerCondition = Conditions.WasEvidenceCollected` (Vitu-Ghazi Inspector).
@@ -6480,7 +6495,8 @@ composite abilities).
   **own printed** ward; granting ward to *other* permanents is the `GrantWard` static ability instead
   (see *Composite static abilities*). Non-mana costs use
   `KeywordAbility.Ward(WardCost.X)`: `WardCost.Mana`, `WardCost.Life(n)`, `WardCost.DynamicLife(amount)`,
-  `WardCost.Discard(n, random, filter)`,
+  `WardCost.Discard(n, random, filter)`, `WardCost.CollectEvidence(n)` ("Ward—Collect evidence 4",
+  Axebane Ferox),
   and `WardCost.Sacrifice(filter, count = 1)` ("Ward—Sacrifice a Food", Ygra; "Ward—Sacrifice three
   nonland permanents" with `count = 3`, Valgavoth, Terror Eater, via `KeywordAbility.wardSacrifice(filter, count)`).
   For sacrifice ward, the opponent chooses which `count` matching permanent(s) they control to sacrifice
@@ -6503,6 +6519,19 @@ composite abilities).
   last-known power if the source has left the battlefield (CR 112.7a, via `EntityReference.Source`'s
   last-known-information policy). It resolves down to a fixed `WardCost.Life` in the executor, so it
   composes inside `WardCost.Composite` and uses the same pay-or-counter prompt.
+  `WardCost.CollectEvidence(n)` (built via `KeywordAbility.wardCollectEvidence(n)`) is
+  **Ward—Collect evidence N** (CR 701.59 — Axebane Ferox's "Ward—Collect evidence 4"): the targeting
+  opponent must exile any number of cards from their own graveyard with **total mana value** N or
+  greater. It is the one ward cost whose constraint is a *sum* rather than a count, so the prompt is a
+  variable-size `SelectCardsDecision` (min 0 — the empty selection is how declining is expressed — up
+  to the whole graveyard) carrying `minTotalManaValue = n`; `DecisionValidators` enforces that floor on
+  any non-empty submission, so the resumer only ever sees a decline or a legal collection. CR 701.59b
+  fails closed exactly as in every other collect-evidence context: a graveyard that can't reach N means
+  the controller *can't choose to collect evidence*, and the spell is countered with **no prompt at
+  all**. The reachability gate, the legality re-check and the exile all run through the shared
+  `CollectEvidenceResolver`, so the `EvidenceCollectedEvent` a ward payment emits fires "whenever you
+  collect evidence" payoffs (Surveillance Monitor) like any other. It is an **unlinked** cost — it
+  stamps no `ChoiceSlot`, so it satisfies no `Conditions.WasEvidenceCollected` (§ Collect evidence N).
   **Ward—Waterbend `{N}`** (Avatar: The Last Airbender — The Unagi of Kyoshi Island's
   "Ward—Waterbend {4}") is `KeywordAbility.wardWaterbend("{4}")` → `WardCost.Mana("{4}", waterbend = true)`.
   It is an ordinary mana ward, but while paying the `{N}` the controller may tap their untapped

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2564,6 +2564,10 @@ object Effects {
     fun CreateClue(count: Int = 1, controller: EffectTarget? = null): Effect =
         CreatePredefinedTokenEffect("Clue", count, controller)
 
+    /** Create a dynamic number of Clue tokens — the count is evaluated at resolution time. */
+    fun CreateClue(count: DynamicAmount, controller: EffectTarget? = null): Effect =
+        CreatePredefinedTokenEffect("Clue", controller = controller, dynamicCount = count)
+
     /**
      * Investigate (keyword action, CR 701.36): create [count] Clue tokens. Synonymous with
      * [CreateClue]; named after the keyword action so card text "investigate" maps directly.
@@ -2573,6 +2577,14 @@ object Effects {
      */
     fun Investigate(count: Int = 1, controller: EffectTarget? = null): Effect =
         CreatePredefinedTokenEffect("Clue", count, controller)
+
+    /**
+     * Investigate a dynamic number of times — "investigate once for each …" (Wojek Investigator),
+     * where the repetition count is only known at resolution. A count of zero investigates not at
+     * all, which is what the wording means when nothing qualifies.
+     */
+    fun Investigate(count: DynamicAmount, controller: EffectTarget? = null): Effect =
+        CreatePredefinedTokenEffect("Clue", controller = controller, dynamicCount = count)
 
     /**
      * Create Lander artifact tokens.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -77,6 +77,7 @@ sealed interface KeywordAbility {
      * - `Ward(WardCost.Life(2))`             — "Ward—Pay 2 life"
      * - `Ward(WardCost.Discard())`           — "Ward—Discard a card"
      * - `Ward(WardCost.Sacrifice(filter))`   — "Ward—Sacrifice a Food"
+     * - `Ward(WardCost.CollectEvidence(4))`  — "Ward—Collect evidence 4"
      */
     @SerialName("Ward")
     @Serializable
@@ -89,6 +90,9 @@ sealed interface KeywordAbility {
             is WardCost.DynamicLife -> "Ward—Pay life equal to ${cost.amount.description}"
             is WardCost.Discard -> "Ward—Discard ${cost.description}"
             is WardCost.Sacrifice -> "Ward—Sacrifice ${cost.description}"
+            // Capitalized: "Collect evidence N" is a keyword action, and the printed line reads
+            // "Ward—Collect evidence 4."
+            is WardCost.CollectEvidence -> "Ward—Collect evidence ${cost.amount}"
             is WardCost.Composite -> "Ward—${cost.description}"
         }
     }
@@ -1117,6 +1121,14 @@ sealed interface KeywordAbility {
          */
         fun wardSacrifice(filter: GameObjectFilter, count: Int = 1): KeywordAbility =
             Ward(WardCost.Sacrifice(filter, count))
+
+        /**
+         * Create Ward—Collect evidence N (CR 701.59) — "Ward—Collect evidence 4" (Axebane Ferox).
+         * The targeting opponent must exile cards with total mana value [amount] or greater from
+         * their own graveyard, or the spell/ability is countered.
+         */
+        fun wardCollectEvidence(amount: Int): KeywordAbility =
+            Ward(WardCost.CollectEvidence(amount))
 
         /**
          * Create Ward with a composite cost — all components must be paid. E.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordStaticAbilities.kt
@@ -85,6 +85,8 @@ data class GrantWard(
         is WardCost.DynamicLife -> "${filter.description} have \"Ward—Pay life equal to ${cost.amount.description}.\""
         is WardCost.Discard -> "${filter.description} have \"Ward—Discard ${cost.description}.\""
         is WardCost.Sacrifice -> "${filter.description} have \"Ward—Sacrifice ${cost.description}.\""
+        is WardCost.CollectEvidence ->
+            "${filter.description} have \"Ward—Collect evidence ${cost.amount}.\""
         is WardCost.Composite -> "${filter.description} have \"Ward—${cost.description}.\""
     }
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
@@ -491,6 +491,30 @@ sealed interface WardCost {
     }
 
     /**
+     * Ward—Collect evidence N (CR 701.59) — e.g. Axebane Ferox's "Ward—Collect evidence 4."
+     *
+     * The payment is the ordinary keyword action: exile any number of cards from your graveyard
+     * with total mana value [amount] or greater. Because the constraint is a **sum** and not a
+     * count, this is not expressible as a [Sacrifice]-style counted selection; the engine routes it
+     * through the same `CollectEvidenceResolver` every other collect-evidence context uses, so the
+     * reachability gate, the legal-selection rule and the exile can't drift from the activated-cost
+     * and cast-cost forms.
+     *
+     * CR 701.59b fails closed here as everywhere else: a controller whose graveyard cannot reach
+     * [amount] *can't choose to collect evidence*, so the spell or ability is countered without a
+     * prompt rather than offering a payment they'd have to refuse.
+     *
+     * This is an **unlinked** cost — nothing on the card asks "was evidence collected", so it
+     * stamps no `ChoiceSlot` (the linkage of CR 701.59c belongs only to the optional cast-cost
+     * shape, `card { collectEvidence(n) }`).
+     */
+    @SerialName("WardCost.CollectEvidence")
+    @Serializable
+    data class CollectEvidence(val amount: Int) : WardCost {
+        override val description: String = "collect evidence $amount"
+    }
+
+    /**
      * A ward cost made of two or more component costs that must *all* be paid — e.g.
      * "Ward—{2}, Pay 2 life." (Gisa, the Hellraiser). The components are paid one at a time
      * in order; declining or being unable to pay any one component counters the spell or
@@ -531,6 +555,9 @@ data class WardCounterEffect(
         is WardCost.DynamicLife -> "Counter it unless its controller pays life equal to ${cost.amount.description}"
         is WardCost.Discard -> "Counter it unless its controller discards ${cost.description}"
         is WardCost.Sacrifice -> "Counter it unless its controller sacrifices ${cost.description}"
+        is WardCost.CollectEvidence ->
+            "Counter it unless its controller exiles cards with total mana value " +
+                "${cost.amount} or greater from their graveyard"
         is WardCost.Composite -> "Counter it unless its controller pays ${cost.description}"
     }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -201,6 +201,32 @@ sealed interface Player {
     }
 
     /**
+     * The controller of the effect's **source** — read off the source permanent rather than off
+     * the resolution context's `controllerId`.
+     *
+     * Ordinarily that is the same player [You] names, and [You] stays the right reference. This
+     * one exists for the case where the context's controller has been **rebound to some other
+     * player**, which is exactly what the per-player loops do:
+     * [com.wingedsheep.sdk.scripting.values.DynamicAmount.CountPlayersWith] and
+     * `ForEach`-over-players evaluate their inner condition once per candidate with
+     * `controllerId` set to that candidate, so `You` inside the loop means "the player being
+     * tested". A comparison against the ability's *own* controller then has no reference left to
+     * reach for — the shape of "for each opponent who has more cards in hand **than you**"
+     * (Wojek Investigator), which is `CountPlayersWith(EachOpponent, Compare(Count(You, HAND),
+     * GT, Count(ControllerOfSource, HAND)))`.
+     *
+     * Outside such a loop, prefer [You]. Note the pairing with [OwnerOfSource]: that one reads the
+     * source's *owner* (right when control and ownership diverge and the card says "its owner");
+     * this one follows control, so a stolen permanent's ability compares against whoever controls
+     * it now, as "you" always does.
+     */
+    @SerialName("ControllerOfSource")
+    @Serializable
+    data object ControllerOfSource : Player {
+        override val description: String = "you"
+    }
+
+    /**
      * The distinct owners of the cards currently in the effect source's *linked-exile pile*
      * (the source's [com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent],
      * populated by [com.wingedsheep.sdk.dsl.Effects.ExileUntilLeaves]). Resolves to one entry
@@ -243,6 +269,8 @@ sealed interface Player {
             is ControllerOf -> "its controller's"
             is OwnerOf -> "its owner's"
             OwnerOfSource -> "its owner's"
+            // Names the same player [You] does; the difference is only where it reads from.
+            ControllerOfSource -> "your"
             OwnersOfLinkedExile -> "the exiled card's owner's"
         }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AxebaneFerox.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AxebaneFerox.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Axebane Ferox — Murders at Karlov Manor #153
+ * {2}{G}{G} · Creature — Beast · 4/4 · Rare
+ *
+ * Deathtouch, haste
+ * Ward—Collect evidence 4.
+ *
+ * A hasty 4/4 deathtoucher that also taxes removal — but in cards rather than mana, and out of the
+ * *opponent's* graveyard. Early on that is nearly a hard protection: an empty graveyard cannot reach
+ * 4 at all, and CR 701.59b says a player who can't reach the total **can't choose to collect
+ * evidence**, so the removal spell is countered with no prompt. Late, with a stocked graveyard, it
+ * costs a real chunk of the opponent's recursion instead.
+ *
+ * The ward cost is [KeywordAbility.wardCollectEvidence], which this card introduces — the fourth of
+ * the four collect-evidence contexts and the only one that is a *ward* cost. It exiles any number
+ * of cards from the paying player's graveyard with total mana value 4 or greater; the constraint is
+ * a **sum**, not a count, so a graveyard of five lands is never enough and over-paying (exiling a
+ * 6-drop) is legal. It is an **unlinked** cost: nothing on this card asks whether evidence was
+ * collected, so it stamps no `ChoiceSlot` and satisfies no `WasEvidenceCollected` condition.
+ */
+val AxebaneFerox = card("Axebane Ferox") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 4
+    oracleText = "Deathtouch, haste\n" +
+        "Ward—Collect evidence 4. (Whenever this creature becomes the target of a spell or " +
+        "ability an opponent controls, counter it unless that player exiles cards with total mana " +
+        "value 4 or greater from their graveyard.)"
+
+    keywords(Keyword.DEATHTOUCH, Keyword.HASTE)
+    keywordAbility(KeywordAbility.wardCollectEvidence(4))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "153"
+        artist = "Maxime Minard"
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/610a0de4-a4f7-446b-8477-00c917cb4789.jpg?1783912873"
+
+        ruling(
+            "2024-02-02",
+            "If you can't exile enough cards to meet or exceed the required mana value, you can't " +
+                "choose to collect evidence at all."
+        )
+        ruling(
+            "2024-02-02",
+            "Once you've announced that you're casting a spell, players can't take actions until " +
+                "you've finished doing so. Notably, opponents can't try to remove cards from your " +
+                "graveyard to stop you from collecting evidence."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ChalkOutline.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ChalkOutline.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Chalk Outline — Murders at Karlov Manor #157
+ * {3}{G} · Enchantment · Uncommon
+ *
+ * Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective
+ * creature token, then investigate.
+ *
+ * "One or more … leave" is CR 603.2c batch wording, so [Triggers.CardsLeaveYourGraveyard] is the
+ * right shape rather than a per-card trigger: a mass reanimation, a flashback cast, and a
+ * graveyard-exiling sweep each fire this exactly once no matter how many creature cards moved or
+ * where they went (the printed ruling says so in as many words). The filter is
+ * [GameObjectFilter.Creature] — matched against the *card*, so a creature card cast from the
+ * graveyard counts on its way to the stack.
+ *
+ * The payoff is a plain [Effects.Composite]: the Detective token first, then the Clue. Order is
+ * printed order and observable — a "whenever you create a token" watcher sees the Detective before
+ * the Clue. Both take their art from the MKM `tokenArt` layer, so no `imageUri` is baked in here.
+ */
+val ChalkOutline = card("Chalk Outline") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Whenever one or more creature cards leave your graveyard, create a 2/2 white and " +
+        "blue Detective creature token, then investigate. (Create a Clue token. It's an artifact " +
+        "with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard(GameObjectFilter.Creature)
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.WHITE, Color.BLUE),
+                creatureTypes = setOf("Detective")
+            ),
+            Effects.Investigate()
+        )
+        description = "Whenever one or more creature cards leave your graveyard, create a 2/2 " +
+            "white and blue Detective creature token, then investigate."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "157"
+        artist = "Julia Griffin"
+        flavorText = "\"In your search for a suspect, never forget that the most important person " +
+            "is the victim.\"\n—Ezrim, Agency chief"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3ff56c1-4153-4e15-9ac6-06d93fa2ae50.jpg?1783912868"
+
+        ruling(
+            "2024-02-02",
+            "If multiple creature cards leave your graveyard at the same time, Chalk Outline's " +
+                "ability will trigger only once."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/InnocentBystander.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/InnocentBystander.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Innocent Bystander — Murders at Karlov Manor #133
+ * {1}{R} · Creature — Goblin Citizen · 2/1
+ *
+ * Whenever this creature is dealt 3 or more damage, investigate.
+ *
+ * A 2/1 that turns overkill into a card: anything that bothers to point a real burn spell or a
+ * big blocker at it hands you a Clue on the way out.
+ *
+ * The "3 or more" gate is measured **per damage event**, not cumulatively over the turn — the
+ * engine models damage as one `DamageDealtEvent` per source/recipient pair, so being blocked by
+ * two 2/2s deals two separate 2-damage instances and this never fires, exactly as the printed
+ * card behaves. [Triggers.TakesDamage] is the SELF "whenever this is dealt damage" event and the
+ * threshold rides on it as a `triggerCondition` comparing that event's damage
+ * ([ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT]) against 3 with [ComparisonOperator.GTE] — the same
+ * idiom Spinneret and Spiderling uses on the outgoing side.
+ *
+ * Lethal damage doesn't suppress the trigger: state-based actions kill the Bystander before the
+ * ability resolves, but the trigger was already detected off the damage event (CR 603.10), and
+ * `DamageTriggerDetector.detectDamageReceivedTriggers` deliberately looks the creature up after
+ * it has left the battlefield for exactly this case. Dying to a Lightning Bolt still investigates.
+ */
+val InnocentBystander = card("Innocent Bystander") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Citizen"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever this creature is dealt 3 or more damage, investigate. (Create a Clue " +
+        "token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(3),
+        )
+        effect = Effects.Investigate()
+        description = "Whenever this creature is dealt 3 or more damage, investigate."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "133"
+        artist = "Warren Mahy"
+        flavorText = "\"Whoops, this isn't my street! Don't mind me! I'll just be on my way while " +
+            "you enjoy your . . . very sharp knives.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/085f4595-4ae5-428e-a934-e918774df6fd.jpg?1783912882"
+
+        ruling(
+            "2024-02-02",
+            "Innocent Bystander's ability triggers only if it's dealt 3 or more damage all at " +
+                "once. It doesn't trigger if damage that adds up to 3 or more is dealt to it at " +
+                "different times."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SuddenSetback.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SuddenSetback.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpellOrPermanent
+
+/**
+ * Sudden Setback — Murders at Karlov Manor #72
+ * {2}{U}{U} · Instant · Uncommon
+ *
+ * The owner of target spell or nonland permanent puts it on their choice of the top or bottom of
+ * their library.
+ *
+ * A counterspell and a removal spell in one card, and neither half is a counter: a spell answered
+ * this way is *removed from the stack* rather than countered, so "can't be countered" doesn't save
+ * it. [TargetSpellOrPermanent] is the union target that already models "target spell or nonland
+ * permanent" (Press the Enemy), with `permanentFilter = NonlandPermanent` — unrestricted by
+ * controller, so it can also rescue your own creature from removal by tucking it.
+ *
+ * The library placement is [Effects.PutOnTopOrBottomOfLibrary], whose executor dispatches on what
+ * the target resolves to (stack object vs. battlefield permanent) and pauses for a
+ * ChooseOptionDecision. Two details of that decision match the printed card and are easy to get
+ * wrong: the choice belongs to the **owner**, not to Sudden Setback's controller, and it is made on
+ * resolution rather than on cast.
+ */
+val SuddenSetback = card("Sudden Setback") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "The owner of target spell or nonland permanent puts it on their choice of the " +
+        "top or bottom of their library."
+
+    spell {
+        val t = target(
+            "target spell or nonland permanent",
+            TargetSpellOrPermanent(permanentFilter = GameObjectFilter.NonlandPermanent)
+        )
+        effect = Effects.PutOnTopOrBottomOfLibrary(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "72"
+        artist = "Olivier Bernard"
+        flavorText = "\"Look, buddy, you're not in trouble. I just wanna ask you a questio—\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b9e5fd6-a5ea-4ae5-83f5-89ed6a658dd3.jpg?1783912904"
+
+        ruling(
+            "2024-02-02",
+            "The spell or permanent's owner chooses whether to put it on the top or bottom of " +
+                "their library. If multiple cards are put into the library this way (such as when " +
+                "the spell targets a melded permanent), that spell or permanent's owner puts all " +
+                "the cards on top or all the cards on the bottom. They put them in whatever order " +
+                "they wish, and they do not need to reveal the order."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/WojekInvestigator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/WojekInvestigator.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Wojek Investigator — Murders at Karlov Manor #36
+ * {2}{W} · Creature — Angel Detective · 2/4 · Rare
+ *
+ * Flying, vigilance
+ * At the beginning of your upkeep, investigate once for each opponent who has more cards in hand
+ * than you.
+ *
+ * A catch-up engine: it pays you only while you are behind on cards, and it pays *per* opponent,
+ * so in a pod it can hand you several Clues in one upkeep. Strictly "more than", so an opponent
+ * tied with you contributes nothing.
+ *
+ * The count is [DynamicAmount.CountPlayersWith] over [Player.EachOpponent], and the comparison
+ * inside it is where the subtlety lives. That loop re-evaluates its condition once per candidate
+ * with the context's controller **rebound to that candidate**, so `Player.You` inside means "the
+ * opponent being tested" — which is what we want on the left of the comparison, but leaves the
+ * ability's own controller unreachable on the right. [Player.ControllerOfSource] is that missing
+ * reference: it reads control off the Investigator itself rather than off the rebound context, so
+ * the comparison stays "that opponent's hand > *your* hand" for every candidate.
+ *
+ * Hand sizes are read when the ability **resolves**, not when it triggers — an opponent who
+ * discards in response drops out of the count, and one who draws in response joins it.
+ */
+val WojekInvestigator = card("Wojek Investigator") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel Detective"
+    power = 2
+    toughness = 4
+    oracleText = "Flying, vigilance\n" +
+        "At the beginning of your upkeep, investigate once for each opponent who has more cards " +
+        "in hand than you. (To investigate, create a Clue token. It's an artifact with \"{2}, " +
+        "Sacrifice this token: Draw a card.\")"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Investigate(
+            DynamicAmount.CountPlayersWith(
+                scope = Player.EachOpponent,
+                condition = Conditions.CompareAmounts(
+                    left = DynamicAmount.Count(Player.You, Zone.HAND),
+                    operator = ComparisonOperator.GT,
+                    right = DynamicAmount.Count(Player.ControllerOfSource, Zone.HAND),
+                ),
+            )
+        )
+        description = "At the beginning of your upkeep, investigate once for each opponent who " +
+            "has more cards in hand than you."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "36"
+        artist = "Ben Hill"
+        flavorText = "\"Well, this clearly didn't come from anyone I know...\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/296574c6-3933-4ab3-b591-72514b244da9.jpg?1783912917"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -131,6 +131,51 @@
     ]
 }
 
+// Axebane Ferox
+{
+    "name": "Axebane Ferox",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Deathtouch, haste\nWard—Collect evidence 4. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player exiles cards with total mana value 4 or greater from their graveyard.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "DEATHTOUCH",
+        "HASTE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.CollectEvidence",
+                "amount": 4
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "153",
+        "rarity": "RARE",
+        "artist": "Maxime Minard",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/610a0de4-a4f7-446b-8477-00c917cb4789.jpg?1783912873",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Once you've announced that you're casting a spell, players can't take actions until you've finished doing so. Notably, opponents can't try to remove cards from your graveyard to stop you from collecting evidence."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Basilica Stalker
 {
     "name": "Basilica Stalker",
@@ -532,6 +577,64 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Chalk Outline
+{
+    "name": "Chalk Outline",
+    "manaCost": "{3}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective creature token, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CardsLeftYourGraveyardEvent",
+                    "filter": "creature"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "WHITE",
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Detective"
+                            ]
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Clue"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective creature token, then investigate."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "UNCOMMON",
+        "artist": "Julia Griffin",
+        "flavorText": "\"In your search for a suspect, never forget that the most important person is the victim.\"\n—Ezrim, Agency chief",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3ff56c1-4153-4e15-9ac6-06d93fa2ae50.jpg?1783912868",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If multiple creature cards leave your graveyard at the same time, Chalk Outline's ability will trigger only once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -2909,6 +3012,58 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Innocent Bystander
+{
+    "name": "Innocent Bystander",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Citizen",
+    "oracleText": "Whenever this creature is dealt 3 or more damage, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "Whenever this creature is dealt 3 or more damage, investigate."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "artist": "Warren Mahy",
+        "flavorText": "\"Whoops, this isn't my street! Don't mind me! I'll just be on my way while you enjoy your . . . very sharp knives.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/085f4595-4ae5-428e-a934-e918774df6fd.jpg?1783912882",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Innocent Bystander's ability triggers only if it's dealt 3 or more damage all at once. It doesn't trigger if damage that adds up to 3 or more is dealt to it at different times."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -6197,6 +6352,51 @@
     ]
 }
 
+// Sudden Setback
+{
+    "name": "Sudden Setback",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "The owner of target spell or nonland permanent puts it on their choice of the top or bottom of their library.",
+    "script": {
+        "spellEffect": {
+            "type": "PutOnLibraryPositionOfChoice",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target spell or nonland permanent"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetSpellOrPermanent",
+                "id": "target spell or nonland permanent",
+                "permanentFilter": {
+                    "cardPredicates": [
+                        "IsNonland",
+                        "IsPermanent"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "rarity": "UNCOMMON",
+        "artist": "Olivier Bernard",
+        "flavorText": "\"Look, buddy, you're not in trouble. I just wanna ask you a questio—\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b9e5fd6-a5ea-4ae5-83f5-89ed6a658dd3.jpg?1783912904",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "The spell or permanent's owner chooses whether to put it on the top or bottom of their library. If multiple cards are put into the library this way (such as when the spell targets a melded permanent), that spell or permanent's owner puts all the cards on top or all the cards on the bottom. They put them in whatever order they wish, and they do not need to reveal the order."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Surveillance Monitor
 {
     "name": "Surveillance Monitor",
@@ -7255,6 +7455,67 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Wojek Investigator
+{
+    "name": "Wojek Investigator",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Angel Detective",
+    "oracleText": "Flying, vigilance\nAt the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue",
+                    "dynamicCount": {
+                        "type": "CountPlayersWith",
+                        "scope": "EachOpponent",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Hand"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "Count",
+                                "player": "ControllerOfSource",
+                                "zone": "Hand"
+                            }
+                        }
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "RARE",
+        "artist": "Ben Hill",
+        "flavorText": "\"Well, this clearly didn't come from anyone I know...\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/296574c6-3933-4ab3-b591-72514b244da9.jpg?1783912917"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ManaContinuations.kt
@@ -296,6 +296,39 @@ data class CounterUnlessSacrificeContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the controller chooses which graveyard cards to exile to collect evidence
+ * [amount] and so prevent their spell/ability from being countered
+ * (Ward—Collect evidence N, CR 701.59 / 702.21 — Axebane Ferox).
+ *
+ * The decision is a variable-size selection gated on a **sum**, not a count: the player may exile
+ * any number of cards as long as their total mana value reaches [amount] (over-paying is legal).
+ * A selection that falls short — including the empty selection, which is how declining is
+ * expressed — counters the spell. The payment itself runs through `CollectEvidenceResolver`, the
+ * single source of truth every collect-evidence context shares, so the legality rule and the exile
+ * are identical to the activated-ability and cast-cost forms.
+ *
+ * The graveyard is re-read at resume time, so cards that left it between the prompt and the
+ * response no longer count toward the total.
+ *
+ * @property payingPlayerId The spell's controller who must decide whether to pay
+ * @property spellEntityId The spell/ability that will be countered if they don't pay
+ * @property amount The total mana value the exiled cards must reach
+ */
+@Serializable
+data class CounterUnlessCollectEvidenceContinuation(
+    override val decisionId: String,
+    val payingPlayerId: EntityId,
+    val spellEntityId: EntityId,
+    val amount: Int,
+    val exileOnCounter: Boolean = false,
+    val controllerId: EntityId? = null,
+    /** See [CounterUnlessPaysManaSelectionContinuation.remainingWardParts]. */
+    val remainingWardParts: List<WardCost> = emptyList(),
+    /** See [CounterUnlessPaysManaSelectionContinuation.wardSourceId]. */
+    val wardSourceId: EntityId? = null
+) : ContinuationFrame
+
+/**
  * Information about a mana source available for manual selection.
  *
  * @property requiresSacrifice Selecting this source also sacrifices the permanent

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -246,6 +246,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CounterUnlessPaysLifeContinuation::class)
         subclass(CounterUnlessDiscardContinuation::class)
         subclass(CounterUnlessSacrificeContinuation::class)
+        subclass(CounterUnlessCollectEvidenceContinuation::class)
         subclass(ModalContinuation::class)
         subclass(ChooseDoorContinuation::class)
         subclass(ModalTargetContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -1049,7 +1049,8 @@ class DynamicAmountEvaluator(
             // resolver (parity with resolvePlayerRef), so aggregates like "creatures that target's
             // controller controls" work (Skulking Killer's "if that opponent controls no other
             // creatures" = AggregateBattlefield(ControllerOf("target"), Creature) == 1).
-            is Player.ControllerOf, is Player.OwnerOf, is Player.OwnerOfSource -> listOfNotNull(
+            is Player.ControllerOf, is Player.OwnerOf, is Player.OwnerOfSource,
+            is Player.ControllerOfSource -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
             is Player.TriggeringPlayer -> {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ManaPaymentContinuationResumer.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.handlers.continuations
 import com.wingedsheep.sdk.dsl.Patterns
 
 import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.handlers.effects.life.LifePaymentService
@@ -30,6 +31,7 @@ class ManaPaymentContinuationResumer(
         resumer(CounterUnlessPaysLifeContinuation::class, ::resumeCounterUnlessPaysLife),
         resumer(CounterUnlessDiscardContinuation::class, ::resumeCounterUnlessDiscard),
         resumer(CounterUnlessSacrificeContinuation::class, ::resumeCounterUnlessSacrifice),
+        resumer(CounterUnlessCollectEvidenceContinuation::class, ::resumeCounterUnlessCollectEvidence),
         resumer(CounterUnlessPaysManaSelectionContinuation::class, ::resumeCounterUnlessPaysManaSelection),
         resumer(WardTapPermanentsSubCostContinuation::class, ::resumeWardTapPermanentsSubCost),
         resumer(ChangeSpellTargetContinuation::class, ::resumeChangeSpellTarget),
@@ -386,6 +388,72 @@ class ManaPaymentContinuationResumer(
             checkForMore
         )?.let { return it }
         return checkForMore(newState, events)
+    }
+
+    /**
+     * Resume after the controller picks which graveyard cards to exile for a Ward—Collect
+     * evidence N trigger (CR 701.59 / 702.21 — Axebane Ferox).
+     *
+     * A legal collection (cards still in their graveyard whose mana values total at least
+     * `amount`) pays the cost and the spell resolves; anything short of that — including the empty
+     * selection, which is how the prompt expresses declining — counters it.
+     *
+     * The legality re-check and the exile both go through [CollectEvidenceResolver], so this path
+     * cannot drift from the activated-ability / cast-cost / effect forms, and the
+     * `EvidenceCollectedEvent` it emits fires "whenever you collect evidence" payoffs
+     * (Surveillance Monitor) off a ward payment exactly as off any other.
+     */
+    fun resumeCounterUnlessCollectEvidence(
+        state: GameState,
+        continuation: CounterUnlessCollectEvidenceContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is CardsSelectedResponse) {
+            return ExecutionResult.error(
+                state, "Expected card selection response for counter unless collect evidence"
+            )
+        }
+
+        // Declined, or the graveyard shifted under the selection between prompt and response →
+        // counter. `isLegalSelection` re-reads the graveyard, so a card that left it no longer pays.
+        val legal = CollectEvidenceResolver.isLegalSelection(
+            state, continuation.payingPlayerId, continuation.amount, response.selectedCards
+        )
+        if (!legal) {
+            val counterResult = if (continuation.exileOnCounter) {
+                services.stackResolver.counterSpellToExile(
+                    state, continuation.spellEntityId,
+                    grantFreeCast = false,
+                    controllerId = continuation.controllerId ?: continuation.payingPlayerId
+                )
+            } else {
+                services.stackResolver.counterSpellOrAbility(state, continuation.spellEntityId)
+            }
+            return checkForMore(counterResult.newState, counterResult.events)
+        }
+
+        val collected = CollectEvidenceResolver.collect(
+            state,
+            continuation.payingPlayerId,
+            continuation.amount,
+            response.selectedCards,
+            sourceName = "Ward",
+        )
+        // Unreachable: isLegalSelection above already proved the collection legal.
+        if (collected !is CollectEvidenceResolver.Result.Success) {
+            return ExecutionResult.error(
+                state, "Ward—Collect evidence: ${(collected as CollectEvidenceResolver.Result.Failure).reason}"
+            )
+        }
+
+        chargeNextWardPartOrNull(
+            collected.state, collected.events,
+            continuation.remainingWardParts, continuation.spellEntityId,
+            continuation.payingPlayerId, continuation.wardSourceId, continuation.controllerId,
+            checkForMore
+        )?.let { return it }
+        return checkForMore(collected.state, collected.events)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -166,6 +166,13 @@ object TargetResolutionUtils {
             // still acts on the owner (Gandalf, Wandering Wizard).
             Player.OwnerOfSource -> context.sourceId
                 ?.let { state.getEntity(it)?.get<CardComponent>()?.ownerId }
+            // "You", read off the source instead of the context — the one reference that survives
+            // a per-player rebind of controllerId (CountPlayersWith / ForEach-over-players).
+            // Falls back to the context controller for sources that aren't on the battlefield
+            // (a resolving spell), where the two always agree anyway.
+            Player.ControllerOfSource -> context.sourceId
+                ?.let { controllerOf(state, it) }
+                ?: context.controllerId
             is Player.ControllerOf -> context.targets.firstOrNull()?.toEntityId()
                 ?.let { controllerOf(state, it) }
             // Multi-player / list-only references have no single resolution here.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.handlers.effects.stack
 
+import com.wingedsheep.engine.core.CounterUnlessCollectEvidenceContinuation
 import com.wingedsheep.engine.core.CounterUnlessDiscardContinuation
 import com.wingedsheep.engine.core.CounterUnlessPaysLifeContinuation
 import com.wingedsheep.engine.core.CounterUnlessPaysManaSelectionContinuation
@@ -17,6 +18,7 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.handlers.costs.CollectEvidenceResolver
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.mechanics.SacrificeImmunity
@@ -51,6 +53,8 @@ import kotlin.reflect.KClass
  *      standard discard pipeline (random or player's choice).
  *    - WardCost.Sacrifice → SelectCardsDecision over the controller's matching permanents
  *      (min 0, max N); selecting N pays and the spell resolves, declining counters it.
+ *    - WardCost.CollectEvidence → SelectCardsDecision over the controller's graveyard with a
+ *      `minTotalManaValue` floor (CR 701.59's sum gate); an empty selection declines.
  *    - WardCost.Composite → pay each component cost in order (CR 702.21a; "Ward—{2}, Pay 2
  *      life"). Each component reuses the per-component flow above and carries the remaining
  *      components so the resumer charges the next one after a successful payment. Declining or
@@ -163,6 +167,10 @@ class WardCounterEffectExecutor(
                     state, cardRegistry, spellEntityId, container, payingPlayerId,
                     cost.filter, cost.count, remainingParts, wardSourceId, controllerId
                 )
+                is WardCost.CollectEvidence -> handleCollectEvidenceCost(
+                    state, cardRegistry, spellEntityId, payingPlayerId,
+                    cost.amount, remainingParts, wardSourceId, controllerId
+                )
                 is WardCost.Composite -> {
                     require(cost.parts.isNotEmpty()) { "WardCost.Composite must have at least one part" }
                     chargeWardCost(
@@ -253,6 +261,73 @@ class WardCounterEffectExecutor(
 
             return EffectResult.paused(
                 stateWithContinuation,
+                decisionResult.pendingDecision,
+                decisionResult.events
+            )
+        }
+
+        /**
+         * Ward—Collect evidence N (CR 701.59 — Axebane Ferox's "Ward—Collect evidence 4").
+         *
+         * Two things separate this from every other ward cost:
+         *
+         * 1. **The constraint is a sum, not a count.** The player exiles *any number* of cards from
+         *    their graveyard whose mana values total at least [amount], and over-paying is legal, so
+         *    the prompt is a variable-size selection (min 0 — declining — up to the whole graveyard)
+         *    carrying `minTotalManaValue`. `DecisionValidators` enforces that floor on any non-empty
+         *    submission, so the resumer only ever sees a decline or a legal collection.
+         * 2. **CR 701.59b fails closed.** A graveyard that can't reach [amount] means the controller
+         *    *can't choose to collect evidence* at all, so the spell is countered with no prompt
+         *    rather than offering a payment they would have to refuse.
+         *    [CollectEvidenceResolver.canCollect] is that gate, shared with every other context.
+         *
+         * When the graveyard totals exactly [amount] there is nothing to choose (every card must go),
+         * but the *decision* still matters — declining is a real option for a ward cost, unlike the
+         * mandatory [com.wingedsheep.engine.handlers.effects.player.CollectEvidenceExecutor] — so the
+         * prompt is raised regardless.
+         */
+        private fun handleCollectEvidenceCost(
+            state: GameState,
+            cardRegistry: CardRegistry,
+            spellEntityId: EntityId,
+            payingPlayerId: EntityId,
+            amount: Int,
+            remainingParts: List<WardCost>,
+            wardSourceId: EntityId?,
+            controllerId: EntityId?
+        ): EffectResult {
+            val candidates = CollectEvidenceResolver.candidates(state, payingPlayerId)
+            if (!candidates.canReach(amount)) {
+                return counterSpellOrAbility(state, cardRegistry, spellEntityId)
+            }
+
+            val decisionResult = DecisionHandler().createCardSelectionDecision(
+                state = state,
+                playerId = payingPlayerId,
+                sourceId = wardSourceId,
+                sourceName = "Ward",
+                prompt = "Collect evidence $amount (exile cards with total mana value $amount or " +
+                    "greater from your graveyard) or your spell will be countered",
+                options = candidates.cards,
+                minSelections = 0,
+                maxSelections = candidates.cards.size,
+                ordered = false,
+                phase = DecisionPhase.RESOLUTION,
+                minTotalManaValue = amount
+            )
+
+            val continuation = CounterUnlessCollectEvidenceContinuation(
+                decisionId = decisionResult.pendingDecision!!.id,
+                payingPlayerId = payingPlayerId,
+                spellEntityId = spellEntityId,
+                amount = amount,
+                controllerId = controllerId,
+                remainingWardParts = remainingParts,
+                wardSourceId = wardSourceId
+            )
+
+            return EffectResult.paused(
+                decisionResult.state.pushContinuation(continuation),
                 decisionResult.pendingDecision,
                 decisionResult.events
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AxebaneFeroxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AxebaneFeroxScenarioTest.kt
@@ -1,0 +1,144 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.AxebaneFerox
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Axebane Ferox — "Ward—Collect evidence 4." (CR 702.21 + CR 701.59).
+ *
+ * The fourth collect-evidence context and the only one that is a *ward* cost. What these tests pin
+ * is that it behaves like collect evidence everywhere else it appears, not like a counted sacrifice:
+ *
+ * - the constraint is a **mana-value sum**, so a graveyard of zero-cost lands is not payment however
+ *   many cards it holds, and over-paying (two mana value 3 cards for a threshold of 4) is legal;
+ * - **CR 701.59b fails closed** — an opponent who can't reach 4 *can't choose to collect evidence*,
+ *   so the spell is countered with no prompt at all rather than a payment offered and refused;
+ * - declining, which the prompt expresses as an empty selection, counters the spell.
+ *
+ * Centaur Courser ({2}{G}, mana value 3) is the fodder: one is never enough, two over-pay.
+ */
+class AxebaneFeroxScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AxebaneFerox)
+        return driver
+    }
+
+    test("collecting evidence 4 from the graveyard lets the targeting spell resolve") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ferox = driver.putCreatureOnBattlefield(opponent, "Axebane Ferox")
+
+        val courserA = driver.putCardInGraveyard(activePlayer, "Centaur Courser")
+        val courserB = driver.putCardInGraveyard(activePlayer, "Centaur Courser")
+
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(ferox)))
+
+        driver.bothPass()
+        val decision = driver.pendingDecision
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        // The sum gate, not a count: any number of cards, total mana value >= 4.
+        decision.minTotalManaValue shouldBe 4
+        decision.minSelections shouldBe 0
+
+        // Two mana value 3 cards total 6 — over-paying is the player's right (CR 701.59a).
+        driver.submitCardSelection(activePlayer, listOf(courserA, courserB))
+
+        repeat(3) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        // Paid → Bolt resolved (3 damage to a 4/4, so the Ferox lives) and the evidence is exiled.
+        driver.getExileCardNames(activePlayer) shouldBe listOf("Centaur Courser", "Centaur Courser")
+        driver.getGraveyardCardNames(activePlayer) shouldContain "Lightning Bolt"
+        driver.findPermanent(opponent, "Axebane Ferox").shouldNotBeNull()
+    }
+
+    test("declining the collection counters the spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ferox = driver.putCreatureOnBattlefield(opponent, "Axebane Ferox")
+        driver.putCardInGraveyard(activePlayer, "Centaur Courser")
+        driver.putCardInGraveyard(activePlayer, "Centaur Courser")
+
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(ferox)))
+
+        driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(activePlayer, emptyList())
+
+        repeat(2) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        // Countered — nothing exiled, the Bolt in the graveyard, the Ferox untouched.
+        driver.getExileCardNames(activePlayer) shouldBe emptyList()
+        driver.getGraveyardCardNames(activePlayer) shouldContain "Lightning Bolt"
+        driver.findPermanent(opponent, "Axebane Ferox").shouldNotBeNull()
+    }
+
+    test("CR 701.59b: a graveyard that can't reach 4 is countered with no prompt at all") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ferox = driver.putCreatureOnBattlefield(opponent, "Axebane Ferox")
+        // Mana value 3 — one short. The option must be absent, not offered and refused.
+        driver.putCardInGraveyard(activePlayer, "Centaur Courser")
+
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(ferox)))
+
+        driver.bothPass()
+        driver.pendingDecision shouldBe null
+        driver.getExileCardNames(activePlayer) shouldBe emptyList()
+        driver.findPermanent(opponent, "Axebane Ferox").shouldNotBeNull()
+    }
+
+    test("the threshold is a mana-value sum: five lands in the graveyard are not evidence 4") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ferox = driver.putCreatureOnBattlefield(opponent, "Axebane Ferox")
+
+        // Lands have no mana cost (CR 202.3b) — mana value 0, so five of them total 0.
+        repeat(5) { driver.putCardInGraveyard(activePlayer, "Mountain") }
+
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(ferox)))
+
+        driver.bothPass()
+        driver.pendingDecision shouldBe null
+        driver.getExileCardNames(activePlayer) shouldBe emptyList()
+        driver.findPermanent(opponent, "Axebane Ferox").shouldNotBeNull()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChalkOutlineScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChalkOutlineScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.ChalkOutline
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Chalk Outline (MKM #157) — {3}{G} Enchantment.
+ *
+ * "Whenever one or more creature cards leave your graveyard, create a 2/2 white and blue Detective
+ *  creature token, then investigate."
+ *
+ * Both halves of the payoff and the batch semantics of the trigger. The printed ruling — "if
+ * multiple creature cards leave your graveyard at the same time, Chalk Outline's ability will
+ * trigger only once" — is the one that a per-card trigger would get wrong, so it gets its own test;
+ * the filter (creature cards, not any card) gets the other.
+ */
+class ChalkOutlineScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(ChalkOutline)
+
+        context("Chalk Outline") {
+
+            test("a creature card leaving your graveyard makes a Detective and a Clue") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Chalk Outline")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(1, "Raise Dead")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .build()
+
+                withClue("nothing has left the graveyard yet") {
+                    game.findPermanents("Detective Token").size shouldBe 0
+                    game.findPermanents("Clue").size shouldBe 0
+                }
+
+                game.castSpellTargetingGraveyardCard(1, "Raise Dead", 1, "Grizzly Bears")
+                    .error shouldBe null
+                game.resolveStack()
+
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+                withClue("one Detective token, then one Clue") {
+                    game.findPermanents("Detective Token").size shouldBe 1
+                    game.findPermanents("Clue").size shouldBe 1
+                }
+            }
+
+            test("a noncreature card leaving your graveyard triggers nothing") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Chalk Outline")
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withCardInHand(1, "Regrowth")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Regrowth", 1, "Lightning Bolt")
+                    .error shouldBe null
+                game.resolveStack()
+
+                game.isInHand(1, "Lightning Bolt") shouldBe true
+                withClue("the filter is creature cards, so an instant leaving pays nothing") {
+                    game.findPermanents("Detective Token").size shouldBe 0
+                    game.findPermanents("Clue").size shouldBe 0
+                }
+            }
+
+            test("a creature card leaving an opponent's graveyard triggers nothing") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Chalk Outline")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInHand(2, "Raise Dead")
+                    .withLandsOnBattlefield(2, "Swamp", 2)
+                    .withActivePlayer(2)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(2, "Raise Dead", 2, "Grizzly Bears")
+                    .error shouldBe null
+                game.resolveStack()
+
+                withClue("\"leave **your** graveyard\" is scoped to the controller's own graveyard") {
+                    game.findPermanents("Detective Token").size shouldBe 0
+                    game.findPermanents("Clue").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InnocentBystanderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InnocentBystanderScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.InnocentBystander
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Innocent Bystander (MKM) — "Whenever this creature is dealt 3 or more damage, investigate."
+ *
+ * The threshold is measured **per damage event** (the printed ruling: "all at once … not if damage
+ * that adds up to 3 or more is dealt to it at different times"), so these cover both sides of that
+ * line: one instance of 3 fires it, two instances of 2 do not, and — because the Bystander is a 2/1
+ * — a lethal instance still fires, since the trigger is detected off the damage event before the
+ * state-based action that kills it has any say (CR 603.10).
+ */
+class InnocentBystanderScenarioTest : ScenarioTestBase() {
+
+    /** Free burn spells so the only variable is the size of a single damage instance. */
+    private val ping = card("Ping Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Ping Test deals 2 damage to target creature."
+        spell {
+            val t = target("target creature", TargetCreature())
+            effect = Effects.DealDamage(2, t)
+        }
+    }
+
+    private val bolt = card("Bolt Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Bolt Test deals 3 damage to target creature."
+        spell {
+            val t = target("target creature", TargetCreature())
+            effect = Effects.DealDamage(3, t)
+        }
+    }
+
+    /** Toughness so the 2/1 survives to be pinged twice — the "adds up" case needs a live target. */
+    private val fortify = card("Fortify Test") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "Target creature gets +0/+8 until end of turn."
+        spell {
+            val t = target("target creature", TargetCreature())
+            effect = Effects.ModifyStats(0, 8, t)
+        }
+    }
+
+    private fun game(vararg spells: String): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Innocent Bystander", summoningSickness = false)
+            .withCardInLibrary(1, "Mountain")
+            .withCardInLibrary(2, "Mountain")
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        spells.forEach { builder.withCardInHand(1, it) }
+        return builder.build()
+    }
+
+    init {
+        cardRegistry.register(InnocentBystander)
+        cardRegistry.register(ping)
+        cardRegistry.register(bolt)
+        cardRegistry.register(fortify)
+
+        context("Innocent Bystander") {
+
+            test("a single 3-damage instance investigates") {
+                val game = game("Bolt Test")
+                val bystander = game.findPermanent("Innocent Bystander")!!
+                game.findPermanents("Clue").size shouldBe 0
+
+                game.castSpell(1, "Bolt Test", targetId = bystander).error shouldBe null
+                game.resolveStack()
+
+                withClue("3 >= 3 — the trigger fires even though the 2/1 dies to the same damage") {
+                    game.findPermanents("Clue").size shouldBe 1
+                }
+                withClue("lethal damage still killed it; the Clue survives it") {
+                    game.isOnBattlefield("Innocent Bystander") shouldBe false
+                }
+            }
+
+            test("two separate 2-damage instances never investigate, even though they total 4") {
+                // The Bystander is propped up to a 2/9 first so it survives both pings; without
+                // that the second instance would never land on a live creature.
+                val game = game("Fortify Test", "Ping Test", "Ping Test")
+                val bystander = game.findPermanent("Innocent Bystander")!!
+                game.castSpell(1, "Fortify Test", targetId = bystander).error shouldBe null
+                game.resolveStack()
+
+                game.castSpell(1, "Ping Test", targetId = bystander).error shouldBe null
+                game.resolveStack()
+                game.castSpell(1, "Ping Test", targetId = bystander).error shouldBe null
+                game.resolveStack()
+
+                withClue("4 total damage, but no single instance reached 3 — the ruling's case") {
+                    game.isOnBattlefield("Innocent Bystander") shouldBe true
+                    game.findPermanents("Clue").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SuddenSetbackScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SuddenSetbackScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.SuddenSetback
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sudden Setback (MKM #72) — {2}{U}{U} Instant.
+ *
+ * "The owner of target spell or nonland permanent puts it on their choice of the top or bottom of
+ *  their library."
+ *
+ * A tuck that works on both halves of its union target, so both are exercised. Two details the
+ * printed ruling pins down, and that a naive wiring would get backwards, get their own assertions:
+ * the top-or-bottom choice belongs to the **owner** rather than to Sudden Setback's controller, and
+ * a *spell* answered this way is removed from the stack without resolving — it is not a counter, so
+ * the tucked spell never has its effect.
+ */
+class SuddenSetbackScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(SuddenSetback)
+
+        context("Sudden Setback") {
+
+            test("a nonland permanent goes to its owner's chosen top of library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sudden Setback")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                game.castSpell(1, "Sudden Setback", targetId = courser).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val choice = game.getPendingDecision()
+                withClue("resolution raises a top/bottom choice") {
+                    (choice is ChooseOptionDecision) shouldBe true
+                }
+                val topBottom = choice as ChooseOptionDecision
+                withClue("the choice belongs to the permanent's owner, not the caster") {
+                    topBottom.playerId shouldBe game.player2Id
+                }
+                game.submitDecision(OptionChosenResponse(topBottom.id, 0)).error shouldBe null
+                game.resolveStack()
+
+                game.findPermanent("Centaur Courser") shouldBe null
+                game.cardNameAtTop(2) shouldBe "Centaur Courser"
+            }
+
+            test("the owner may instead choose the bottom of their library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sudden Setback")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                game.castSpell(1, "Sudden Setback", targetId = courser).error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val topBottom = game.getPendingDecision() as ChooseOptionDecision
+                game.submitDecision(OptionChosenResponse(topBottom.id, 1)).error shouldBe null
+                game.resolveStack()
+
+                game.findPermanent("Centaur Courser") shouldBe null
+                withClue("Forest was the only library card, so it is on top and the Courser below") {
+                    game.cardNameAtTop(2) shouldBe "Forest"
+                    game.findCardsInLibrary(2, "Centaur Courser").isNotEmpty() shouldBe true
+                }
+            }
+
+            test("a spell on the stack is tucked without resolving — not countered, but never resolves") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sudden Setback")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                // The caster keeps priority after casting; pass so player 1 can respond.
+                game.passPriority()
+
+                game.castSpellTargetingStackSpell(1, "Sudden Setback", "Grizzly Bears")
+                    .error shouldBe null
+                if (game.getPendingDecision() is SelectManaSourcesDecision) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val topBottom = game.getPendingDecision() as ChooseOptionDecision
+                withClue("the spell's owner chooses, and it is player 2's spell") {
+                    topBottom.playerId shouldBe game.player2Id
+                }
+                game.submitDecision(OptionChosenResponse(topBottom.id, 0)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the creature spell never resolved — no Bears on the battlefield") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("and it is not in the graveyard either; it went to the library") {
+                    game.cardNameAtTop(2) shouldBe "Grizzly Bears"
+                }
+            }
+        }
+    }
+
+    private fun TestGame.cardNameAtTop(playerNumber: Int): String? =
+        state.getEntity(
+            state.getLibrary(if (playerNumber == 1) player1Id else player2Id).first()
+        )?.get<CardComponent>()?.name
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WojekInvestigatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WojekInvestigatorScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.WojekInvestigator
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wojek Investigator (MKM) — "At the beginning of your upkeep, investigate once for each opponent
+ * who has more cards in hand than you."
+ *
+ * Two things are under test and both live in the count rather than in the trigger:
+ *
+ * 1. **The comparison is strict and controller-relative.** `DynamicAmount.CountPlayersWith` rebinds
+ *    the resolution context's controller to each candidate opponent, so `Player.You` inside the
+ *    condition is *that opponent*; the ability's own controller is reached with
+ *    [com.wingedsheep.sdk.scripting.references.Player.ControllerOfSource], which reads control off
+ *    the Investigator itself and so survives the rebind. Get that wrong and the comparison collapses
+ *    to "opponent vs. opponent" — always false — or to "you vs. you".
+ * 2. **Zero is a legal count.** No qualifying opponent means no Clue at all, not one.
+ *
+ * The board starts on the Investigator's controller's UNTAP and advances into their UPKEEP, so the
+ * hands are exactly what each test sets — no draw step or cleanup discard has run yet.
+ */
+class WojekInvestigatorScenarioTest : ScenarioTestBase() {
+
+    /**
+     * Player 1 controls Wojek Investigator and it is player 1's turn. Deals [myHand] cards to
+     * player 1 and [theirHand] to player 2, then walks into player 1's upkeep and resolves.
+     */
+    private fun runUpkeep(myHand: Int, theirHand: Int): TestGame {
+        val builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Wojek Investigator", summoningSickness = false)
+            .withActivePlayer(1)
+            .inPhase(Phase.BEGINNING, Step.UNTAP)
+        repeat(myHand) { builder.withCardInHand(1, "Mountain") }
+        repeat(theirHand) { builder.withCardInHand(2, "Mountain") }
+        builder.withCardInLibrary(1, "Mountain")
+        builder.withCardInLibrary(2, "Mountain")
+        val game = builder.build()
+
+        game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+        game.resolveStack()
+        return game
+    }
+
+    init {
+        cardRegistry.register(WojekInvestigator)
+
+        context("Wojek Investigator") {
+
+            test("an opponent with more cards in hand than you yields one Clue") {
+                val game = runUpkeep(myHand = 1, theirHand = 3)
+                withClue("3 > 1 — the one opponent qualifies, so investigate once") {
+                    game.findPermanents("Clue").size shouldBe 1
+                }
+            }
+
+            test("an opponent with an equal hand yields nothing — the comparison is strict") {
+                val game = runUpkeep(myHand = 3, theirHand = 3)
+                withClue("\"more cards in hand than you\" is > , not >=") {
+                    game.findPermanents("Clue").size shouldBe 0
+                }
+            }
+
+            test("an opponent with a smaller hand yields nothing") {
+                val game = runUpkeep(myHand = 4, theirHand = 1)
+                game.findPermanents("Clue").size shouldBe 0
+            }
+
+            test("the comparison reads the controller's hand, not the candidate's own") {
+                // Both hands are empty except the opponent's single card. If the inner comparison
+                // had collapsed to "candidate vs. candidate" it would be 1 > 1 = false and no Clue
+                // would appear; the correct reading is 1 > 0 = true.
+                val game = runUpkeep(myHand = 0, theirHand = 1)
+                game.findPermanents("Clue").size shouldBe 1
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five MKM cards. Three are pure composition over existing primitives; two needed new SDK vocabulary.

| Card | | |
|---|---|---|
| **Innocent Bystander** | `{1}{R}` 2/1 | Whenever this creature is dealt 3 or more damage, investigate. |
| **Wojek Investigator** | `{2}{W}` 2/4 | Flying, vigilance. At the beginning of your upkeep, investigate once for each opponent who has more cards in hand than you. |
| **Chalk Outline** | `{3}{G}` | Whenever one or more creature cards leave your graveyard, create a 2/2 W/U Detective token, then investigate. |
| **Axebane Ferox** | `{2}{G}{G}` 4/4 | Deathtouch, haste, Ward—Collect evidence 4. |
| **Sudden Setback** | `{2}{U}{U}` | The owner of target spell or nonland permanent puts it on their choice of the top or bottom of their library. |

## New SDK vocabulary

### `WardCost.CollectEvidence(n)` — Ward—Collect evidence N (CR 702.21 + CR 701.59)

The fourth collect-evidence context, and the only one that is a *ward* cost — so the only ward cost whose constraint is a mana-value **sum** rather than a count. It raises a variable-size `SelectCardsDecision` over the paying player's graveyard carrying `minTotalManaValue`, min 0 (the empty selection is how declining is expressed) up to the whole graveyard.

**CR 701.59b fails closed**, as in every other collect-evidence context: a graveyard that can't reach N means the controller *can't choose to collect evidence*, so the spell is countered with **no prompt at all** rather than offering a payment they'd have to refuse.

Reachability, the legality re-check and the exile all route through the existing shared `CollectEvidenceResolver`, so a ward payment emits the same `EvidenceCollectedEvent` (firing "whenever you collect evidence" payoffs) and can't drift from the activated-ability, cast-cost, or effect forms. It is an **unlinked** cost — it stamps no `ChoiceSlot`, so it satisfies no `Conditions.WasEvidenceCollected`.

Wiring: a new `CounterUnlessCollectEvidenceContinuation` + resumer alongside the other ward-cost branches. The client's existing `CardSelectionDecisionUI` already handles the mana floor and the "Select None" decline (its comment even anticipates "a ward cost you may decline"), so **no frontend change was needed**.

### `Player.ControllerOfSource`

"You", read off the source permanent rather than off the resolution context's `controllerId`. `DynamicAmount.CountPlayersWith` rebinds the controller to each candidate player, so `Player.You` inside the loop means "the opponent being tested" and the ability's own controller is otherwise unreachable — which is exactly what Wojek Investigator's "more cards in hand **than you**" needs. Pairs with the existing `Player.OwnerOfSource`, which follows ownership instead of control.

`Effects.Investigate` / `CreateClue` also gain a `DynamicAmount` overload for the same card's "investigate once for each …" count (zero investigates not at all).

## AI

Both decision responders now understand `minTotalManaValue`. The count-based branches can't satisfy a sum gate, so previously they either submitted an illegal under-total selection (mandatory collect evidence) or silently declined every optional one. They now pay the floor with the fewest cards, highest mana values first — the same choice `CollectEvidenceResolver.autoSelect` makes — and submit nothing when the pool can't reach it.

## Verification

- `just build` — green (card snapshot reblessed; only the five new cards moved in `MKM.json`, additions only)
- `./gradlew :ai:test :rules-engine:test :mtg-sets:test --rerun-tasks` — green
- `just check` — green
- `just check-card-printing` — all five canonical in MKM (their only real printing), no drift
- Image URIs verified HTTP 200 against the exact `image_uris.normal` from Scryfall
- One scenario test per card (5 new files, 16 tests). Axebane Ferox's cover the paid path, the decline, the unreachable-threshold no-prompt case, and that five mana-value-0 lands are not evidence 4.
- `docs/card-sdk-language-reference.md` updated for the new ward cost, the player reference, and the dynamic `Investigate` overload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)