### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonBloodReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Blood reprint in J22. Canonical CardDefinition lives in Urza's Saga (USG),
+ * its earliest real-expansion printing.
+ */
+val DragonBloodReprint = Printing(
+    oracleId = "b751c1c6-195d-4023-9d0b-3c91d6b834d4",
+    name = "Dragon Blood",
+    setCode = "J22",
+    collectorNumber = "762",
+    scryfallId = "2aed32a2-01db-4416-bd27-666f3abe04a1",
+    artist = "Ron Spencer",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2aed32a2-01db-4416-bd27-666f3abe04a1.jpg?1783918816",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ClockworkBeetle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ClockworkBeetle.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Clockwork Beetle — Mirrodin #153
+ * {1} · Artifact Creature — Insect · 0/0
+ *
+ * This creature enters with two +1/+1 counters on it.
+ * Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat.
+ *
+ * Modelling notes:
+ * - Base P/T is the printed 0/0; the two +1/+1 counters (CR 613.4c, layer 7d) make it a 2/2 on
+ *   the battlefield. It dies as a state-based action once the last counter is shed.
+ * - The printed ability is a trigger that *sets up a delayed trigger* ("…remove a counter from
+ *   it at end of combat"). It is modelled the way its Antiquities ancestor Clockwork Avian
+ *   already is in this codebase: an [Triggers.EachEndOfCombat] trigger with the intervening-if
+ *   [Conditions.SourceAttackedOrBlockedThisCombat]. That is observationally identical — one
+ *   counter shed per combat the Beetle fought in, on any player's turn — because the delayed
+ *   trigger and the tracker are keyed to the same object and both go away when it leaves the
+ *   battlefield.
+ */
+val ClockworkBeetle = card("Clockwork Beetle") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Insect"
+    power = 0
+    toughness = 0
+    oracleText = "This creature enters with two +1/+1 counters on it.\n" +
+        "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 2,
+            selfOnly = true
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EachEndOfCombat
+        triggerCondition = Conditions.SourceAttackedOrBlockedThisCombat
+        effect = Effects.RemoveCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc3c8db7-cf58-4571-b4ad-2b68d73495b2.jpg?1783944525"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/DragonBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/DragonBloodReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Blood reprint in MRD. Canonical CardDefinition lives in Urza's Saga (USG),
+ * its earliest real-expansion printing.
+ */
+val DragonBloodReprint = Printing(
+    oracleId = "b751c1c6-195d-4023-9d0b-3c91d6b834d4",
+    name = "Dragon Blood",
+    setCode = "MRD",
+    collectorNumber = "163",
+    scryfallId = "5fdfc372-c5f9-4f98-9a15-0ea4a33017b1",
+    artist = "Ron Spencer",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5fdfc372-c5f9-4f98-9a15-0ea4a33017b1.jpg?1783944523",
+    releaseDate = "2003-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Duskworker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Duskworker.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Duskworker — Mirrodin #166
+ * {4} · Artifact Creature — Construct · 2/2
+ *
+ * Whenever this creature becomes blocked, regenerate it.
+ * {3}: This creature gets +1/+0 until end of turn.
+ *
+ * Modelling notes:
+ * - The *unfiltered* [Triggers.BecomesBlocked] is the right shape here: the printed text has no
+ *   blocker restriction, so a gang block still yields exactly one trigger and one regeneration
+ *   shield (contrast Ogre Leadfoot in this set, which needs the per-blocker filtered form).
+ * - The shield is applied at resolution and lasts until end of turn, so it survives the whole
+ *   combat-damage step and can still save the Duskworker from a later removal spell that turn.
+ */
+val Duskworker = card("Duskworker") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature becomes blocked, regenerate it.\n" +
+        "{3}: This creature gets +1/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = RegenerateEffect(EffectTarget.Self)
+        description = "Whenever this creature becomes blocked, regenerate it."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "{3}: This creature gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "166"
+        artist = "Greg Staples"
+        flavorText = "At the setting of each sun, it emerges to clean Mirrodin's floor of the day's carrion."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d18dd3b-980b-4833-93fd-79dc3a260da4.jpg?1783944523"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GoblinWarWagon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GoblinWarWagon.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Goblin War Wagon — Mirrodin #179
+ * {4} · Artifact Creature — Juggernaut · 3/3
+ *
+ * This creature doesn't untap during your untap step.
+ * At the beginning of your upkeep, you may pay {2}. If you do, untap this creature.
+ *
+ * Modelling notes:
+ * - The untap restriction is the narrow [AbilityFlag.DOESNT_UNTAP] ("doesn't untap during its
+ *   controller's untap step"), *not* [AbilityFlag.CANT_BECOME_UNTAPPED] — an "untap target
+ *   permanent" effect from elsewhere still untaps the Wagon, and so does the ability below.
+ *   It is scoped to [GroupFilter.source] so the static only ever affects this permanent.
+ * - The upkeep trigger is a plain "you may pay {2}. If you do, …" gate ([MayPayManaEffect]),
+ *   which is the CR 601-style optional-cost payment window, not an additional cost or a
+ *   cumulative upkeep. Declining simply leaves the Wagon tapped.
+ */
+val GoblinWarWagon = card("Goblin War Wagon") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Juggernaut"
+    power = 3
+    toughness = 3
+    oracleText = "This creature doesn't untap during your untap step.\n" +
+        "At the beginning of your upkeep, you may pay {2}. If you do, untap this creature."
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name, GroupFilter.source())
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}"),
+            effect = Effects.Untap(EffectTarget.Self)
+        )
+        description = "At the beginning of your upkeep, you may pay {2}. If you do, untap this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "179"
+        artist = "Doug Chaffee"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/229e8124-54ed-4c29-8c44-4962bd60f145.jpg?1783944519"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LifesparkSpellbomb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LifesparkSpellbomb.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+/**
+ * Lifespark Spellbomb — Mirrodin #197
+ * {1} · Artifact
+ *
+ * {G}, Sacrifice this artifact: Until end of turn, target land becomes a 3/3 creature that's
+ *   still a land.
+ * {1}, Sacrifice this artifact: Draw a card.
+ *
+ * Modelling notes:
+ * - [Effects.AnimateLand] is exactly the "becomes an X/Y creature; it's still a land" shape —
+ *   it adds the Creature type in layer 4 and *sets* base P/T in layer 7b without touching the
+ *   land's types or abilities, so the target keeps its mana ability and any subtypes.
+ * - Both abilities sacrifice the Spellbomb as a cost, so the artifact is already in the
+ *   graveyard when the ability resolves; the animate effect is independent of its source and
+ *   still resolves normally.
+ * - The animate ability targets **any** land, not just one you control — matching the printed
+ *   text — which is occasionally relevant as a way to make an opponent's land die to a sweeper.
+ */
+val LifesparkSpellbomb = card("Lifespark Spellbomb") {
+    manaCost = "{1}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "{G}, Sacrifice this artifact: Until end of turn, target land becomes a 3/3 creature " +
+        "that's still a land.\n" +
+        "{1}, Sacrifice this artifact: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.SacrificeSelf)
+        val land = target("target land", Targets.Land)
+        effect = Effects.AnimateLand(land, power = 3, toughness = 3)
+        description = "{G}, Sacrifice this artifact: Until end of turn, target land becomes a 3/3 creature that's still a land."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        effect = DrawCardsEffect(1)
+        description = "{1}, Sacrifice this artifact: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Jim Nelson"
+        flavorText = "\"Awaken that which was never asleep.\"\n—Spellbomb inscription"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0adde668-67af-4a08-a36a-2a49893ab20d.jpg?1783944515"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LoxodonMender.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LoxodonMender.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+
+/**
+ * Loxodon Mender — Mirrodin #12
+ * {5}{W} · Creature — Elephant Cleric · 3/3
+ *
+ * {W}, {T}: Regenerate target artifact.
+ *
+ * Modelling notes:
+ * - Targets *any* artifact, not just artifact creatures — a regeneration shield on a
+ *   noncreature artifact does nothing until something would destroy it, which is exactly
+ *   the printed behaviour (CR 701.15). [Targets.Artifact] is the permanent-scoped filter.
+ * - [RegenerateEffect] drops the shield until end of turn; it is not a regeneration
+ *   *ability* on the artifact, so "can't be regenerated" markers still win.
+ */
+val LoxodonMender = card("Loxodon Mender") {
+    manaCost = "{5}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Cleric"
+    power = 3
+    toughness = 3
+    oracleText = "{W}, {T}: Regenerate target artifact."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val artifact = target("target artifact", Targets.Artifact)
+        effect = RegenerateEffect(artifact)
+        description = "{W}, {T}: Regenerate target artifact."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Heather Hudson"
+        flavorText = "The Auriok believe that in the hands of a loxodon, no weapon can be broken."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c17ac7c1-6d53-40b4-921f-4e23e4026041.jpg?1783944561"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -525,6 +525,74 @@
     ]
 }
 
+// Clockwork Beetle
+{
+    "name": "Clockwork Beetle",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Insect",
+    "oracleText": "This creature enters with two +1/+1 counters on it.\nWhenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END_COMBAT",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "RemoveCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": {
+                                "statePredicates": [
+                                    "AttackedThisCombat"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": {
+                                "statePredicates": [
+                                    "BlockedThisCombat"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Arnie Swekel",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc3c8db7-cf58-4571-b4ad-2b68d73495b2.jpg?1783944525"
+    },
+    "colorIdentityOverride": []
+}
+
 // Cloudpost
 {
     "name": "Cloudpost",
@@ -998,6 +1066,64 @@
         "artist": "Jim Nelson",
         "flavorText": "They skitter out of the mists to consume fresh kill before Mephidross has a chance to corrode it away.",
         "imageUri": "https://cards.scryfall.io/normal/front/2/7/27c5381c-2e79-41fa-b1d7-2cf0c6dc1808.jpg?1783944523"
+    },
+    "colorIdentityOverride": []
+}
+
+// Duskworker
+{
+    "name": "Duskworker",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Whenever this creature becomes blocked, regenerate it.\n{3}: This creature gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "Regenerate",
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever this creature becomes blocked, regenerate it."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "{3}: This creature gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "flavorText": "At the setting of each sun, it emerges to clean Mirrodin's floor of the day's carrion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d18dd3b-980b-4833-93fd-79dc3a260da4.jpg?1783944523"
     },
     "colorIdentityOverride": []
 }
@@ -1516,6 +1642,62 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Goblin War Wagon
+{
+    "name": "Goblin War Wagon",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Juggernaut",
+    "oracleText": "This creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {2}. If you do, untap this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, you may pay {2}. If you do, untap this creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "artist": "Doug Chaffee",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/229e8124-54ed-4c29-8c44-4962bd60f145.jpg?1783944519"
+    },
+    "colorIdentityOverride": []
 }
 
 // Gold Myr
@@ -2157,6 +2339,86 @@
     ]
 }
 
+// Lifespark Spellbomb
+{
+    "name": "Lifespark Spellbomb",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{G}, Sacrifice this artifact: Until end of turn, target land becomes a 3/3 creature that's still a land.\n{1}, Sacrifice this artifact: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "AnimateLand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land"
+                    },
+                    "power": 3,
+                    "toughness": 3
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land"
+                        },
+                        "id": "target land"
+                    }
+                ],
+                "descriptionOverride": "{G}, Sacrifice this artifact: Until end of turn, target land becomes a 3/3 creature that's still a land."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{1}, Sacrifice this artifact: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "artist": "Jim Nelson",
+        "flavorText": "\"Awaken that which was never asleep.\"\n—Spellbomb inscription",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0adde668-67af-4a08-a36a-2a49893ab20d.jpg?1783944515"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Lightning Greaves
 {
     "name": "Lightning Greaves",
@@ -2264,6 +2526,64 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Loxodon Mender
+{
+    "name": "Loxodon Mender",
+    "manaCost": "{5}{W}",
+    "typeLine": "Creature — Elephant Cleric",
+    "oracleText": "{W}, {T}: Regenerate target artifact.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact"
+                        },
+                        "id": "target artifact"
+                    }
+                ],
+                "descriptionOverride": "{W}, {T}: Regenerate target artifact."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Heather Hudson",
+        "flavorText": "The Auriok believe that in the hands of a loxodon, no weapon can be broken.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c17ac7c1-6d53-40b4-921f-4e23e4026041.jpg?1783944561"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClockworkBeetleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClockworkBeetleScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Clockwork Beetle (MRD #153).
+ *
+ * {1} Artifact Creature — Insect 0/0
+ * "This creature enters with two +1/+1 counters on it.
+ *  Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+ *
+ * The printed base P/T is 0/0, so the counters are the only thing keeping it alive — shedding the
+ * last one kills it as a state-based action. That is the edge worth pinning down, alongside the
+ * "attacks *or* blocks" shed itself.
+ */
+class ClockworkBeetleScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        fun plusOnePlusOne(game: TestGame, id: EntityId): Int =
+            game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+        context("Clockwork Beetle") {
+
+            test("enters with two +1/+1 counters and is a 2/2") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Clockwork Beetle")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Clockwork Beetle").error shouldBe null
+                game.resolveStack()
+
+                val beetle = game.findPermanent("Clockwork Beetle")!!
+                withClue("Enters with two +1/+1 counters") {
+                    plusOnePlusOne(game, beetle) shouldBe 2
+                }
+                withClue("Base 0/0 plus two +1/+1 counters projects as a 2/2") {
+                    val projected = stateProjector.project(game.state)
+                    projected.getPower(beetle) shouldBe 2
+                    projected.getToughness(beetle) shouldBe 2
+                }
+            }
+
+            test("sheds a counter at end of combat after attacking, becoming a 1/1") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Clockwork Beetle")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                val beetle = game.findPermanent("Clockwork Beetle")!!
+                game.state = game.state.updateEntity(beetle) { c ->
+                    c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)))
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Clockwork Beetle" to 2)).error shouldBe null
+
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                withClue("One +1/+1 counter shed at end of combat (attacked this combat)") {
+                    plusOnePlusOne(game, beetle) shouldBe 1
+                }
+                withClue("With one +1/+1 counter it is a 1/1") {
+                    val projected = stateProjector.project(game.state)
+                    projected.getPower(beetle) shouldBe 1
+                    projected.getToughness(beetle) shouldBe 1
+                }
+            }
+
+            test("shedding its last counter kills it — a 0/0 dies to state-based actions") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Clockwork Beetle")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                val beetle = game.findPermanent("Clockwork Beetle")!!
+                // Down to its last counter — a 1/1 going into combat.
+                game.state = game.state.updateEntity(beetle) { c ->
+                    c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Clockwork Beetle" to 2)).error shouldBe null
+
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                withClue("The last counter is gone, leaving a 0/0 that dies immediately") {
+                    game.findPermanent("Clockwork Beetle") shouldBe null
+                    game.isInGraveyard(1, "Clockwork Beetle") shouldBe true
+                }
+            }
+
+            test("does not shed a counter if it neither attacked nor blocked") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Clockwork Beetle")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                val beetle = game.findPermanent("Clockwork Beetle")!!
+                game.state = game.state.updateEntity(beetle) { c ->
+                    c.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)))
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                withClue("No combat participation → the intervening-if fails and no counter is removed") {
+                    plusOnePlusOne(game, beetle) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinWarWagonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinWarWagonScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Goblin War Wagon (MRD #179).
+ *
+ * {4} Artifact Creature — Juggernaut 3/3
+ * "This creature doesn't untap during your untap step.
+ *  At the beginning of your upkeep, you may pay {2}. If you do, untap this creature."
+ *
+ * The interesting bit is the *self-scoped* untap restriction: every other user of
+ * `AbilityFlag.DOESNT_UNTAP` in the catalog is an Aura granting it to the enchanted creature,
+ * so this is the first card applying it to itself via `GroupFilter.source()`. These tests prove
+ * the restriction actually survives projection and is read by the untap step, and that the
+ * upkeep may-pay is the only way back.
+ */
+class GoblinWarWagonScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun isTapped(game: TestGame, id: EntityId): Boolean =
+            game.state.getEntity(id)?.get<TappedComponent>() != null
+
+        context("Goblin War Wagon") {
+
+            test("stays tapped through its controller's untap step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Goblin War Wagon", tapped = true)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.ENDING, Step.END)
+                    .build()
+
+                val wagon = game.findPermanent("Goblin War Wagon")!!
+                isTapped(game, wagon) shouldBe true
+
+                // Cross into player 1's turn — the untap step runs on the way.
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                withClue("DOESNT_UNTAP kept the Wagon tapped through the untap step") {
+                    isTapped(game, wagon) shouldBe true
+                }
+            }
+
+            test("paying {2} at upkeep untaps it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Goblin War Wagon", tapped = true)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.ENDING, Step.END)
+                    .build()
+
+                val wagon = game.findPermanent("Goblin War Wagon")!!
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                // The upkeep trigger is on the stack; resolving it surfaces the optional payment.
+                game.resolveStack()
+
+                withClue("Upkeep trigger offers the optional {2} payment") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.getPendingDecision().shouldBeInstanceOf<SelectManaSourcesDecision>()
+                game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Paying {2} untaps the Wagon") {
+                    isTapped(game, wagon) shouldBe false
+                }
+            }
+
+            test("declining the payment leaves it tapped") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Goblin War Wagon", tapped = true)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.ENDING, Step.END)
+                    .build()
+
+                val wagon = game.findPermanent("Goblin War Wagon")!!
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Declining the may-pay leaves the Wagon tapped") {
+                    isTapped(game, wagon) shouldBe true
+                }
+            }
+
+            test("the restriction is scoped to the Wagon — other permanents untap normally") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Goblin War Wagon", tapped = true)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = true)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.ENDING, Step.END)
+                    .build()
+
+                val wagon = game.findPermanent("Goblin War Wagon")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                withClue("GroupFilter.source() confines the flag to the Wagon itself") {
+                    isTapped(game, wagon) shouldBe true
+                    isTapped(game, bears) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LifesparkSpellbombScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LifesparkSpellbombScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.LifesparkSpellbomb
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Lifespark Spellbomb (MRD #197).
+ *
+ * "{G}, Sacrifice this artifact: Until end of turn, target land becomes a 3/3 creature that's
+ *  still a land.
+ *  {1}, Sacrifice this artifact: Draw a card."
+ *
+ * The load-bearing claim is the "*that's still a land*" half: the animate must add the Creature
+ * type and set base P/T without replacing the Land type. It also proves the effect survives its
+ * source being sacrificed as part of the activation cost, and that it wears off at end of turn.
+ */
+class LifesparkSpellbombScenarioTest : FunSpec({
+
+    val animateAbilityId = LifesparkSpellbomb.activatedAbilities[0].id // {G}, Sacrifice: animate a land
+    val drawAbilityId = LifesparkSpellbomb.activatedAbilities[1].id // {1}, Sacrifice: draw a card
+
+    val stateProjector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        return driver
+    }
+
+    test("animates a land into a 3/3 that is still a land, and sacrifices the Spellbomb") {
+        val driver = createDriver()
+        val player = driver.player1
+        val spellbomb = driver.putPermanentOnBattlefield(player, "Lifespark Spellbomb")
+        val forest = driver.putLandOnBattlefield(player, "Forest")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = spellbomb,
+                abilityId = animateAbilityId,
+                targets = listOf(entityIdToChosenTarget(driver.state, forest))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        val projected = stateProjector.project(driver.state)
+        withClue("The land is now a 3/3 creature") {
+            projected.isCreature(forest) shouldBe true
+            projected.getPower(forest) shouldBe 3
+            projected.getToughness(forest) shouldBe 3
+        }
+        withClue("\"It's still a land\" — the Land type is added to, not replaced") {
+            projected.hasType(forest, "LAND") shouldBe true
+        }
+        withClue("The Spellbomb was sacrificed as part of the activation cost") {
+            driver.findPermanent(player, "Lifespark Spellbomb") shouldBe null
+        }
+    }
+
+    test("the animation wears off at end of turn") {
+        val driver = createDriver()
+        val player = driver.player1
+        val spellbomb = driver.putPermanentOnBattlefield(player, "Lifespark Spellbomb")
+        val forest = driver.putLandOnBattlefield(player, "Forest")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = spellbomb,
+                abilityId = animateAbilityId,
+                targets = listOf(entityIdToChosenTarget(driver.state, forest))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        stateProjector.project(driver.state).isCreature(forest) shouldBe true
+
+        // Run out the turn — Duration.EndOfTurn should drop the animate at cleanup.
+        driver.passPriorityUntil(Step.END, maxPasses = 200)
+        driver.bothPass()
+
+        withClue("Until end of turn — the Forest is a plain land again next turn") {
+            stateProjector.project(driver.state).isCreature(forest) shouldBe false
+        }
+    }
+
+    test("the second ability draws a card and sacrifices the Spellbomb") {
+        val driver = createDriver()
+        val player = driver.player1
+        val spellbomb = driver.putPermanentOnBattlefield(player, "Lifespark Spellbomb")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val handBefore = driver.state.getZone(ZoneKey(player, Zone.HAND)).size
+        driver.giveColorlessMana(player, 1)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = spellbomb, abilityId = drawAbilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        withClue("One card drawn") {
+            driver.state.getZone(ZoneKey(player, Zone.HAND)).size shouldBe handBefore + 1
+        }
+        withClue("The Spellbomb was sacrificed as part of the activation cost") {
+            driver.findPermanent(player, "Lifespark Spellbomb") shouldBe null
+        }
+    }
+})


### PR DESCRIPTION
Implements five more Mirrodin cards, all built from existing SDK primitives — no new effects, triggers, or keywords.

| Card | Cost | Text |
|---|---|---|
| **Goblin War Wagon** | `{4}` | Artifact Creature — Juggernaut 3/3. Doesn't untap during your untap step; at the beginning of your upkeep, you may pay `{2}` to untap it. |
| **Loxodon Mender** | `{5}{W}` | Creature — Elephant Cleric 3/3. `{W}`, `{T}`: Regenerate target artifact. |
| **Clockwork Beetle** | `{1}` | Artifact Creature — Insect 0/0. Enters with two +1/+1 counters; sheds one at end of combat if it attacked or blocked. |
| **Duskworker** | `{4}` | Artifact Creature — Construct 2/2. Whenever it becomes blocked, regenerate it. `{3}`: +1/+0 until end of turn. |
| **Lifespark Spellbomb** | `{1}` | Artifact. `{G}`, Sacrifice: target land becomes a 3/3 creature that's still a land. `{1}`, Sacrifice: draw a card. |

Also adds `Printing` rows for **Dragon Blood** in MRD and J22 — its canonical `CardDefinition` already lives in Urza's Saga, and `just check-card-printing "Dragon Blood"` was flagging both as missing.

## Modelling notes

- **Goblin War Wagon** is the first card in the catalog to apply `AbilityFlag.DOESNT_UNTAP` to *itself*, via `GroupFilter.source()`. Every existing user is an Aura granting the flag to the enchanted creature, so this path was previously unexercised. It uses the narrow `DOESNT_UNTAP` rather than `CANT_BECOME_UNTAPPED` — an outside "untap target permanent" effect still works on the Wagon, as it should. The upkeep ability is a plain `MayPayManaEffect` gate, not an additional cost or cumulative upkeep.
- **Clockwork Beetle**'s printed ability sets up a delayed trigger. It's modelled the way its Antiquities ancestor Clockwork Avian already is here — `Triggers.EachEndOfCombat` with the `Conditions.SourceAttackedOrBlockedThisCombat` intervening-if — which is observationally identical, since the delayed trigger and the tracker are keyed to the same object and both vanish when it leaves the battlefield.
- **Duskworker** uses the *unfiltered* `Triggers.BecomesBlocked`: the printed text has no blocker restriction, so a gang block yields one trigger and one shield. (Contrast Ogre Leadfoot in this same set, which needs the per-blocker filtered form.)
- **Lifespark Spellbomb** animates via `Effects.AnimateLand`, which adds the Creature type in layer 4 and sets base P/T in layer 7b without touching the land's types or abilities — the "it's still a land" clause. It targets any land, not only one you control, matching the printed text.

## Tests

Scenario tests cover the two shapes worth pinning down; the other three are covered by the snapshot and lint nets.

- `GoblinWarWagonScenarioTest` — the restriction survives projection and is honored by the untap step, paying `{2}` at upkeep untaps it, declining leaves it tapped, and `GroupFilter.source()` keeps the flag off other permanents.
- `ClockworkBeetleScenarioTest` — enters as a 2/2, sheds to a 1/1 after attacking, **dies as a 0/0 to state-based actions when the last counter goes**, and sheds nothing if it sat out combat.
- `LifesparkSpellbombScenarioTest` — the animated Forest is a 3/3 that still has the Land type, the effect outlives the Spellbomb being sacrificed as a cost, it wears off at cleanup, and the draw mode works.

## Verification

- `just build` — green (includes `CardDefinitionSnapshotTest`; MRD golden re-blessed, only these five cards moved).
- `just check-card-printing` — clean for all five plus Dragon Blood.
- The three new scenario test classes pass.
- `origin/main` merged in and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
