### PR TITLE
Show "doesn't untap" on permanents

### DIFF
--- a/docs/web-client-architecture.md
+++ b/docs/web-client-architecture.md
@@ -231,6 +231,25 @@ and only options that actually put the card into play count. Cycling, plotting a
 things you do *instead of* playing the card, so folding their costs in would make a {1}{G} creature
 with cycling {W} read as a "{W}-to-{1}{G}" spell — they still get their own ladder row.
 
+## "Won't untap" cue
+
+Three server signals mean one thing to a player reading the board — `DOESNT_UNTAP` and
+`CANT_BECOME_UNTAPPED` in `ClientCard.abilityFlags` (both ride the projected keyword set, the same
+one the untap step gates on) and `ClientCard.isExerted` (CR 701.43a). They collapse into a single
+cue: `components/game/card/untapRestriction.ts` picks the strongest, `GameCard` pins a frost padlock
+badge, and a tapped-and-restricted permanent additionally gets `styles.untapLockedOverlay` — an
+inset rime rim that separates "frozen" from the ordinary darkening every tapped permanent wears.
+
+Two things keep it honest. The restriction shows on *untapped* permanents too, because "tapping this
+is one-way" is the read you need before crewing or attacking with it. And the frost is deliberately
+pale, never `TARGET_COLOR`'s saturated cyan, and inset where targeting glows outward — otherwise a
+locked permanent looks like a legal target. Stun counters stay out of the ladder: their own counter
+badge already carries a count, which says more than a padlock would.
+
+A restriction implemented *outside* the layer system (read directly by a manager, as the block
+restrictions are) would stop the untap while leaving the card visually identical to one that untaps
+normally. `UntapRestrictionVisibilityTest` pins the projected-keyword contract this depends on.
+
 ## Battlefield card grouping (token quantity aggregation)
 
 Identical permanents on one player's board collapse into a single visual **stack**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/UntapRestrictionVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/UntapRestrictionVisibilityTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The client paints a padlock on any permanent that won't untap (`untapRestriction.ts`). That badge
+ * reads three things off [ClientCard]: [AbilityFlag.DOESNT_UNTAP] and
+ * [AbilityFlag.CANT_BECOME_UNTAPPED] in `abilityFlags`, and [ClientCard.isExerted].
+ *
+ * The flags reach the client only because they ride the *projected* keyword set — the same set the
+ * untap step itself gates on via `ProjectedState.doesntUntapDuringUntapStep`. That is what makes
+ * the badge trustworthy and also what makes it fragile: a restriction implemented outside the layer
+ * system (read directly by a manager, as the block restrictions are) would still stop the untap
+ * while leaving the card visually indistinguishable from one that untaps normally. These tests pin
+ * the contract for both the printed and the granted form, and for both viewers — an untap
+ * restriction is public information, and the opponent's read of the board is exactly what it's for.
+ */
+class UntapRestrictionVisibilityTest : FunSpec({
+
+    // Goblin Sharpshooter's shape: the restriction is printed on the creature itself.
+    val printedDoesntUntap = card("Printed Sleeper") {
+        manaCost = "{2}{R}"
+        typeLine = "Creature — Goblin"
+        power = 1
+        toughness = 1
+        flags(AbilityFlag.DOESNT_UNTAP)
+    }
+
+    // Charmed Sleep / Tsabo's Web's shape: another permanent grants the restriction continuously.
+    val grantsDoesntUntap = card("Freezing Engine") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        staticAbility {
+            ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name, GroupFilter.AllCreatures)
+        }
+    }
+
+    // Spider-Woman's shape: the stronger restriction, which blocks untap *effects* too.
+    val grantsCantBecomeUntapped = card("Web Cocoon Engine") {
+        manaCost = "{2}"
+        typeLine = "Artifact"
+        staticAbility {
+            ability = GrantKeyword(AbilityFlag.CANT_BECOME_UNTAPPED.name, GroupFilter.AllCreatures)
+        }
+    }
+
+    val plainBear = card("Plain Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + printedDoesntUntap + grantsDoesntUntap + grantsCantBecomeUntapped + plainBear)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun transformer(d: GameTestDriver): ClientStateTransformer =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
+
+    test("a creature that untaps normally carries no untap-restriction flag") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val bear = d.putCreatureOnBattlefield(player, "Plain Bear")
+
+        val card = transformer(d).transform(d.state, viewingPlayerId = player).cards[bear].shouldNotBeNull()
+        card.abilityFlags shouldNotContain AbilityFlag.DOESNT_UNTAP
+        card.abilityFlags shouldNotContain AbilityFlag.CANT_BECOME_UNTAPPED
+        card.isExerted shouldBe false
+    }
+
+    test("a printed DOESNT_UNTAP reaches abilityFlags for both players") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val opponent = d.getOpponent(player)
+        val sleeper = d.putCreatureOnBattlefield(player, "Printed Sleeper")
+
+        transformer(d).transform(d.state, viewingPlayerId = player)
+            .cards[sleeper].shouldNotBeNull().abilityFlags shouldContain AbilityFlag.DOESNT_UNTAP
+        transformer(d).transform(d.state, viewingPlayerId = opponent)
+            .cards[sleeper].shouldNotBeNull().abilityFlags shouldContain AbilityFlag.DOESNT_UNTAP
+    }
+
+    test("a granted DOESNT_UNTAP reaches abilityFlags, and disappears with its source") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val bear = d.putCreatureOnBattlefield(player, "Plain Bear")
+        val engine = d.putPermanentOnBattlefield(player, "Freezing Engine")
+
+        transformer(d).transform(d.state, viewingPlayerId = player)
+            .cards[bear].shouldNotBeNull().abilityFlags shouldContain AbilityFlag.DOESNT_UNTAP
+
+        // The restriction is a continuous effect, so the badge has to vanish when the grant does —
+        // a stale lock on a freed permanent is worse than no lock at all.
+        d.moveToGraveyard(engine)
+        transformer(d).transform(d.state, viewingPlayerId = player)
+            .cards[bear].shouldNotBeNull().abilityFlags shouldNotContain AbilityFlag.DOESNT_UNTAP
+    }
+
+    test("a granted CANT_BECOME_UNTAPPED reaches abilityFlags on an opponent's creature") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val opponent = d.getOpponent(player)
+        val victim = d.putCreatureOnBattlefield(opponent, "Plain Bear")
+        d.putPermanentOnBattlefield(player, "Web Cocoon Engine")
+
+        // Both seats see it: the badge is how the victim's controller learns their creature is
+        // stuck, and how the locking player confirms the lock landed.
+        transformer(d).transform(d.state, viewingPlayerId = player)
+            .cards[victim].shouldNotBeNull().abilityFlags shouldContain AbilityFlag.CANT_BECOME_UNTAPPED
+        transformer(d).transform(d.state, viewingPlayerId = opponent)
+            .cards[victim].shouldNotBeNull().abilityFlags shouldContain AbilityFlag.CANT_BECOME_UNTAPPED
+    }
+
+    test("a tapped, restricted permanent reports both isTapped and the flag") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val sleeper = d.putCreatureOnBattlefield(player, "Printed Sleeper")
+        d.tapPermanent(sleeper)
+
+        // The pair is what the frost overlay keys on — tapped *and* restricted means "stays this
+        // way", which is a different board read from an ordinary tapped creature.
+        val card = transformer(d).transform(d.state, viewingPlayerId = player).cards[sleeper].shouldNotBeNull()
+        card.isTapped shouldBe true
+        card.abilityFlags shouldContain AbilityFlag.DOESNT_UNTAP
+    }
+})

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1,6 +1,15 @@
 import React from 'react'
 import { TARGET_COLOR, TARGET_COLOR_BRIGHT } from '../../../styles/targetingColors'
 
+/**
+ * Frost palette for the "won't untap" cue — shared by the rime overlay on a locked-tapped
+ * permanent (`styles.untapLockedOverlay`) and by the padlock badge GameCard pins to the corner, so
+ * the two halves of one signal can't drift apart. Deliberately pale rather than the saturated cyan
+ * of `TARGET_COLOR`, which means "legal target" a few pixels away on the same card.
+ */
+export const UNTAP_FROST_RIM = 'rgba(206, 236, 255, 0.62)'
+export const UNTAP_FROST_FILL = 'rgba(188, 226, 250, 0.32)'
+
 export const styles: Record<string, React.CSSProperties> = {
   container: {
     position: 'absolute',
@@ -869,6 +878,28 @@ export const styles: Record<string, React.CSSProperties> = {
     backgroundColor: 'rgba(0, 0, 0, 0.3)',
     pointerEvents: 'none',
   },
+  /**
+   * A tapped permanent that won't untap (DOESNT_UNTAP / CANT_BECOME_UNTAPPED / exerted). Sits on
+   * top of `tappedOverlay`, so it only has to add the *cold* — a frost wash plus an inner rime
+   * ring — that distinguishes "frozen" from the plain darkening every tapped permanent gets.
+   */
+  untapLockedOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderRadius: 8,
+    // Rime creeping in from the edges, not a flat film over the whole card: an even wash reads as
+    // "faded", which collides with the phased-out treatment (opacity + grayscale) and says the
+    // wrong thing anyway — the permanent isn't less relevant, it's frozen in place. Leaving the
+    // centre clear also keeps the art and the P/T box readable.
+    // Frost-white rather than the saturated cyan of TARGET_COLOR: both are blue, and the ice must
+    // not read as "this is a legal target". The rime is inset, targeting glows outward.
+    background: `radial-gradient(ellipse at 50% 50%, rgba(120, 190, 235, 0.04) 35%, ${UNTAP_FROST_FILL} 100%)`,
+    boxShadow: `inset 0 0 0 2px ${UNTAP_FROST_RIM}, inset 0 0 14px 3px rgba(170, 220, 245, 0.4)`,
+    pointerEvents: 'none',
+  } as React.CSSProperties,
   summoningSicknessOverlay: {
     position: 'absolute',
     top: 0,

--- a/web-client/src/components/game/card/CardPreview.tsx
+++ b/web-client/src/components/game/card/CardPreview.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { useGameStore } from '@/store/gameStore.ts'
 import { selectGameState, selectViewingPlayerId, useCardLegalActions } from '@/store/selectors.ts'
-import { ZoneType, zoneIdEquals } from '@/types'
+import { AbilityFlagDisplayNames, ZoneType, zoneIdEquals } from '@/types'
 import { getCardImageUrl } from '@/utils/cardImages.ts'
 import { useResponsiveContext, handleImageError, getCounterStatModifier, hasStatCounters, getTokenFrameGradient, getTokenFrameTextColor, getPTColor } from '../board/shared'
 import { styles } from '../board/styles'
@@ -378,9 +378,12 @@ export function CardPreview() {
               <span style={styles.cardPreviewKeywordName}>{keyword}</span>
             </div>
           ))}
+          {/* Ability flags are engine enum names, not printed keywords — a raw "DOESNT_UNTAP" chip
+              is the one place the preview shouts an identifier at the player. Prefer the written
+              rules text, falling back to the enum name for a flag the client hasn't named yet. */}
           {card.abilityFlags?.map((flag) => (
             <div key={flag} style={styles.cardPreviewKeyword}>
-              <span style={styles.cardPreviewKeywordName}>{flag}</span>
+              <span style={styles.cardPreviewKeywordName}>{AbilityFlagDisplayNames[flag] ?? flag}</span>
             </div>
           ))}
         </div>

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -52,12 +52,13 @@ import {
   getCounterCount,
   PASSIVE_COUNTER_TYPES,
 } from '../board/shared'
-import { styles, bandColorFor, passiveCounterBadgeStyle } from '../board/styles'
+import { styles, bandColorFor, passiveCounterBadgeStyle, UNTAP_FROST_RIM, UNTAP_FROST_FILL } from '../board/styles'
 import {
   TARGET_COLOR, TARGET_COLOR_BRIGHT, TARGET_GLOW, TARGET_GLOW_BRIGHT, TARGET_GLOW_OUTER, TARGET_SHADOW,
   SELECTED_COLOR, SELECTED_GLOW, SELECTED_SHADOW,
 } from '@/styles/targetingColors.ts'
 import { KeywordIcons, ActiveEffectBadges } from './CardOverlays'
+import { untapRestrictionOf } from './untapRestriction'
 import { counterManaClass, counterSvgIcon } from '@/assets/icons/keywords'
 import { SvgGlyph } from '@/assets/icons/SvgGlyph'
 import { RenderProfiler } from '@/utils/renderProfiler'
@@ -346,6 +347,10 @@ function GameCardImpl({
 
   const isTapped = suppressTapRotation ? false : (card.isTapped || forceTapped)
   const isPhasedOut = card.isPhasedOut === true
+  // "Won't untap" — DOESNT_UNTAP / CANT_BECOME_UNTAPPED / exerted, collapsed to the strongest one.
+  // Battlefield-only: the restrictions are continuous effects on a permanent, so the same card seen
+  // in a graveyard or hand pile must not wear the lock.
+  const untapRestriction = battlefield ? untapRestrictionOf(card) : null
   // Sideways-printed cards — Rooms (CR 709.5), other split layouts, battles (CR 310) — are rotated
   // +90° on the battlefield so the image reads landscape (the source orientation matches "tilt head
   // right"). Tap state stacks an additional +90° on top (= 180° upside-down portrait), preserving
@@ -1450,23 +1455,48 @@ function GameCardImpl({
         </div>
       )}
 
-      {/* Exerted indicator (CR 701.43a) — won't untap during its controller's next untap step. */}
-      {battlefield && card.isExerted && (
+      {/* "Won't untap" — DOESNT_UNTAP, CANT_BECOME_UNTAPPED, or exerted (CR 701.43a), whichever is
+          strongest (see untapRestrictionOf). One padlock covers all three because they read the same
+          from across the table; the tooltip says which. The chip counter-rotates so the lock stays
+          upright on a tapped (rotated) permanent — which is exactly when it matters most. */}
+      {untapRestriction && (
         <div
-          aria-label="Exerted — won't untap next turn"
-          title="Exerted — won't untap next turn"
+          aria-label={untapRestriction.label}
+          title={untapRestriction.label}
           style={{
             position: 'absolute',
             top: 3,
             right: 3,
-            fontSize: responsive.badges.sicknessIconSize,
-            opacity: 0.85,
+            width: responsive.badges.ptFontSize * 1.7,
+            height: responsive.badges.ptFontSize * 1.7,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '50%',
+            transform: totalRotateDeg ? `rotate(${-totalRotateDeg}deg)` : undefined,
+            background: 'radial-gradient(circle at 35% 30%, #123246 0%, #06121c 80%)',
+            // A permanent lock gets the full frost ring; the one-shot exert marker is muted so the
+            // two are distinguishable at a glance without reading the tooltip.
+            border: `1px solid ${untapRestriction.permanent ? UNTAP_FROST_RIM : UNTAP_FROST_FILL}`,
+            boxShadow: untapRestriction.permanent
+              ? `0 0 6px 1px ${UNTAP_FROST_FILL}, inset 0 1px 1px rgba(0, 0, 0, 0.5)`
+              : 'inset 0 1px 1px rgba(0, 0, 0, 0.5)',
+            fontSize: responsive.badges.ptFontSize * 0.95,
+            lineHeight: 1,
+            opacity: untapRestriction.permanent ? 1 : 0.8,
             zIndex: 7,
             pointerEvents: 'none',
           }}
         >
           🔒
         </div>
+      )}
+
+      {/* A tapped permanent that won't untap is frozen, not merely tapped — the two look identical
+          without this. A cold wash over the whole card separates "will be back next turn" from
+          "stays like this", which is the read that changes how you attack into the board. */}
+      {untapRestriction && isTapped && (
+        <div style={styles.untapLockedOverlay} />
       )}
 
       {/* Ring-bearer badge (CR 701.54) — a prominent golden Ring marker pinned to the top-left of

--- a/web-client/src/components/game/card/untapRestriction.test.ts
+++ b/web-client/src/components/game/card/untapRestriction.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { untapRestrictionOf } from './untapRestriction'
+import type { ClientCard } from '@/types'
+import { AbilityFlag, entityId } from '@/types'
+
+/** Minimal battlefield permanent; override only the axis under test. */
+function permanent(over: Record<string, unknown> = {}): ClientCard {
+  return {
+    id: entityId('p1'),
+    name: 'Goblin Sharpshooter',
+    abilityFlags: [],
+    keywords: [],
+    counters: {},
+    isTapped: false,
+    isExerted: false,
+    ...over,
+  } as unknown as ClientCard
+}
+
+describe('untapRestrictionOf', () => {
+  it('reports nothing for a permanent that untaps normally', () => {
+    expect(untapRestrictionOf(permanent())).toBeNull()
+  })
+
+  it('tolerates a card whose abilityFlags the server omitted', () => {
+    expect(untapRestrictionOf(permanent({ abilityFlags: undefined }))).toBeNull()
+  })
+
+  it("reports DOESNT_UNTAP (Goblin Sharpshooter, Charmed Sleep)", () => {
+    const restriction = untapRestrictionOf(permanent({ abilityFlags: [AbilityFlag.DOESNT_UNTAP] }))
+    expect(restriction?.kind).toBe('DOESNT_UNTAP')
+    expect(restriction?.permanent).toBe(true)
+  })
+
+  it('reports CANT_BECOME_UNTAPPED (Spider-Woman, Blossombind)', () => {
+    const restriction = untapRestrictionOf(
+      permanent({ abilityFlags: [AbilityFlag.CANT_BECOME_UNTAPPED] }),
+    )
+    expect(restriction?.kind).toBe('CANT_BECOME_UNTAPPED')
+    expect(restriction?.permanent).toBe(true)
+  })
+
+  it('reports exert (CR 701.43a) as the weakest, expiring restriction', () => {
+    const restriction = untapRestrictionOf(permanent({ isExerted: true }))
+    expect(restriction?.kind).toBe('EXERTED')
+    expect(restriction?.permanent).toBe(false)
+  })
+
+  it('shows only the strongest restriction when several apply', () => {
+    // A Spider-Woman-locked creature that was also exerted this turn is not usefully
+    // described as "won't untap next turn" — it never untaps at all.
+    expect(
+      untapRestrictionOf(
+        permanent({
+          abilityFlags: [AbilityFlag.DOESNT_UNTAP, AbilityFlag.CANT_BECOME_UNTAPPED],
+          isExerted: true,
+        }),
+      )?.kind,
+    ).toBe('CANT_BECOME_UNTAPPED')
+
+    expect(
+      untapRestrictionOf(permanent({ abilityFlags: [AbilityFlag.DOESNT_UNTAP], isExerted: true }))
+        ?.kind,
+    ).toBe('DOESNT_UNTAP')
+  })
+
+  it('ignores unrelated ability flags', () => {
+    expect(
+      untapRestrictionOf(
+        permanent({ abilityFlags: [AbilityFlag.CANT_BE_BLOCKED, AbilityFlag.CANT_RECEIVE_COUNTERS] }),
+      ),
+    ).toBeNull()
+  })
+
+  it('does not treat MAY_NOT_UNTAP as a restriction — it is the controller\'s option', () => {
+    // Everglove Courier: the player *may* choose not to untap it. That is a decision the
+    // server raises at the untap step, not a state that keeps the permanent tapped.
+    expect(untapRestrictionOf(permanent({ abilityFlags: [AbilityFlag.MAY_NOT_UNTAP] }))).toBeNull()
+  })
+
+  it('reports the restriction on an untapped permanent too — tapping it is one-way', () => {
+    const restriction = untapRestrictionOf(
+      permanent({ isTapped: false, abilityFlags: [AbilityFlag.DOESNT_UNTAP] }),
+    )
+    expect(restriction?.kind).toBe('DOESNT_UNTAP')
+  })
+})

--- a/web-client/src/components/game/card/untapRestriction.ts
+++ b/web-client/src/components/game/card/untapRestriction.ts
@@ -1,0 +1,69 @@
+import type { ClientCard } from '@/types/gameState'
+import { AbilityFlag } from '@/types/enums'
+
+/**
+ * "This permanent won't untap" — the one status the battlefield never showed.
+ *
+ * Three different server signals mean the same thing to a player looking at the board, and until
+ * now only the third had any visual at all:
+ *
+ *  - `CANT_BECOME_UNTAPPED` (Spider-Woman, Blossombind) — no untap source works on it, not even an
+ *    "untap target permanent" effect.
+ *  - `DOESNT_UNTAP` (Goblin Sharpshooter, Charmed Sleep, Crippling Chill, Tsabo's Web) — CR 502.3:
+ *    it is skipped by its controller's untap step, but an untap *effect* still works.
+ *  - Exerted (CR 701.43a) — the same skip, once, at its controller's next untap step.
+ *
+ * They form a strict ladder, so a permanent carrying several shows only the strongest: a creature
+ * that can't become untapped at all is not usefully described as also "exerted". Stun counters are
+ * deliberately not in the ladder — they already render as their own counter badge with a count,
+ * which says more than a lock would (how many untaps are still owed).
+ *
+ * This is a pure read of state the server already sends on `ClientCard`; nothing here decides
+ * rules. The engine's own gate is `ProjectedState.doesntUntapDuringUntapStep`.
+ */
+export type UntapRestrictionKind = 'CANT_BECOME_UNTAPPED' | 'DOESNT_UNTAP' | 'EXERTED'
+
+export interface UntapRestriction {
+  readonly kind: UntapRestrictionKind
+  /** Tooltip / aria text, written about the permanent rather than addressed to its controller. */
+  readonly label: string
+  /**
+   * True for the permanent-until-removed restrictions, false for the one-shot exert marker.
+   * Drives the badge's emphasis: a lock that expires next untap step should not shout as loudly
+   * as one that never will.
+   */
+  readonly permanent: boolean
+}
+
+const RESTRICTIONS: Record<UntapRestrictionKind, UntapRestriction> = {
+  CANT_BECOME_UNTAPPED: {
+    kind: 'CANT_BECOME_UNTAPPED',
+    label: "Can't become untapped — no untap step or untap effect will untap it",
+    permanent: true,
+  },
+  DOESNT_UNTAP: {
+    kind: 'DOESNT_UNTAP',
+    label: "Doesn't untap during its controller's untap step",
+    permanent: true,
+  },
+  EXERTED: {
+    kind: 'EXERTED',
+    label: "Exerted — won't untap during its controller's next untap step",
+    permanent: false,
+  },
+}
+
+/**
+ * The strongest untap restriction currently on [card], or null when it untaps normally.
+ *
+ * Reports the restriction regardless of whether the permanent is tapped right now: on an untapped
+ * permanent it is a warning that tapping it is one-way, which is exactly the read a player needs
+ * *before* they crew, convoke, or attack with it.
+ */
+export function untapRestrictionOf(card: ClientCard): UntapRestriction | null {
+  const flags = card.abilityFlags ?? []
+  if (flags.includes(AbilityFlag.CANT_BECOME_UNTAPPED)) return RESTRICTIONS.CANT_BECOME_UNTAPPED
+  if (flags.includes(AbilityFlag.DOESNT_UNTAP)) return RESTRICTIONS.DOESNT_UNTAP
+  if (card.isExerted === true) return RESTRICTIONS.EXERTED
+  return null
+}


### PR DESCRIPTION
A permanent that won't untap looked exactly like one that will. Charmed Sleep, Frozen in Ice, Tsabo's Web, Goblin Sharpshooter, Spider-Woman's lock — every one of them produced a tapped card indistinguishable from an ordinary tapped creature, so the single most decision-relevant fact about the board was invisible.

## Before / after

Same scenario, same server, both seats' boards. Bob's Hill Giant is under **Charmed Sleep**; Alice has a tapped **Goblin Sharpshooter** (printed "doesn't untap"), an untapped one, and plain **Grizzly Bears** tapped and untapped as the control.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/doesnt-untap-badge-screenshots/before.png) | ![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/doesnt-untap-badge-screenshots/after.png) |

In *before*, the enchanted Hill Giant and the locked Sharpshooter are visually identical to the tapped Grizzly Bears next to them. In *after* they wear a rime rim and a padlock; the ordinary tapped Bears is untouched.

(`doesnt-untap-badge-screenshots` is a throwaway image branch, not part of this PR — delete it after merge.)

## What it does

Three server signals mean the same thing to a player, and only the third had any visual at all (a bare 🔒 emoji): `DOESNT_UNTAP` and `CANT_BECOME_UNTAPPED` in `ClientCard.abilityFlags`, and `isExerted` (CR 701.43a). They collapse into one cue.

- **`untapRestriction.ts`** — pure, unit-tested. Picks the strongest of the three: a creature that can't become untapped at all isn't usefully also described as "exerted". `MAY_NOT_UNTAP` is deliberately *not* a restriction — it's the controller's option, raised as a decision at the untap step.
- **Padlock badge** (`GameCard`) — counter-rotated so it stays upright on a tapped card, which is when it matters most. Permanent restrictions get the full frost ring; the one-shot exert marker is muted, so the two are distinguishable without reading the tooltip.
- **Rime overlay** (`styles.untapLockedOverlay`) — only when the permanent is *also* tapped. Separates "frozen" from the plain darkening every tapped permanent already wears.
- **`CardPreview`** now renders `AbilityFlagDisplayNames` instead of shouting `DOESNT_UNTAP` at the player.

Three deliberate calls:

- The badge shows on **untapped** permanents too. "Tapping this is one-way" is exactly the read you need *before* crewing, convoking or attacking with it.
- The frost is pale and **inset**, never `TARGET_COLOR`'s saturated outward cyan — ice must not read as "legal target" a few pixels from a real targeting glow.
- **Stun counters stay out of the ladder.** Their counter badge already carries a count, which says more than a padlock would.

## Server side

No change needed — both flags already ride the projected keyword set, the same one the untap step gates on via `ProjectedState.doesntUntapDuringUntapStep`. That's what makes the badge trustworthy, and it's also the fragile part: a restriction implemented outside the layer system (read directly by a manager, as the block restrictions are) would stop the untap while leaving the card visually identical to one that untaps normally.

`UntapRestrictionVisibilityTest` pins that contract — printed and granted forms, both viewers (an untap restriction is public information, and the opponent's read of the board is the point), and the grant disappearing with its source, since a stale lock is worse than none.

## Verification

- `just test-class UntapRestrictionVisibilityTest` — 5/5 pass
- `npx vitest run` (web-client) — 38 files, 525 tests pass, including the 9 new `untapRestriction` cases
- `npm run typecheck` — clean
- Screenshots above are the running app against a `POST /api/dev/scenarios` board

🤖 Generated with [Claude Code](https://claude.com/claude-code)
