### PR TITLE
Add five Murders at Karlov Manor cards, with disguise face-up replacement support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -113,6 +113,15 @@ section; do not let SDK additions land without a corresponding doc update.
 - `disguise: String?` — disguise mana cost (CR 702.168): cast face down for `{3}` as a 2/2 **with
   ward {2}**, flip for this cost.
 - `disguiseCost: PayCost?` — non-mana disguise cost.
+- `disguiseFaceUpEffect: Effect?` — the disguise-side sibling of `morphFaceUpEffect`, for the
+  "As this creature is turned face up, …" replacement clause (Bubble Smuggler = "put four +1/+1
+  counters on it" → `Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 4, EffectTarget.Self)`). It is
+  applied **as part of the turn-up special action**, so it doesn't use the stack and can't be
+  responded to — that is what separates it from a `Triggers.TurnedFaceUp` ability ("When this
+  creature is turned face up, …", Granite Witness / Exit Specialist), which does use the stack.
+  Like `morphFaceUpEffect` it rides the *turn-up procedure* (CR 702.37b's megamorph treatment), so
+  a card put face down by cloak or manifest and flipped for its mana cost instead of its disguise
+  cost does not get it.
 - `warp: String?` — Warp alt-cost; exiles at end of turn.
 - `dash: String?` — Dash alt-cost (CR 702.109); gains haste and returns to owner's hand at the
   beginning of the next end step.
@@ -9862,7 +9871,9 @@ Card authors rarely reference these directly; they are created/updated by the ma
   common "when this creature is turned face up, …" payoff, or
   `Triggers.or(Triggers.EntersBattlefield, Triggers.TurnedFaceUp)` for the "enters **or** is turned
   face up" wording (Rakish Scoundrel) — one ability with two conditions, which must fire once on
-  either route, not twice.
+  either route, not twice. For the **replacement** wording "As this creature is turned face up, …"
+  (Bubble Smuggler) reach for `disguiseFaceUpEffect` instead: it applies inside the special action,
+  so it can't be responded to, where the `Triggers.TurnedFaceUp` form goes on the stack first.
 - **Cloak** (CR 701.58) — no keyword to author: it is `FaceDownMode.CLOAK` on whichever move puts
   the card onto the battlefield, exactly as manifest is `FaceDownMode.MANIFEST`. For the common
   "look at the top N, cloak M" shape use

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -300,6 +300,13 @@ class CardBuilder(private val name: String) {
     var disguiseCost: PayCost? = null
 
     /**
+     * Effect applied as part of the turn-face-up action for a disguise creature — the "As this
+     * creature is turned face up, …" replacement clause (Bubble Smuggler). Sibling of
+     * [morphFaceUpEffect]; unlike a `Triggers.TurnedFaceUp` ability it doesn't use the stack.
+     */
+    var disguiseFaceUpEffect: Effect? = null
+
+    /**
      * Warp cost as a mana cost string (e.g., "{1}{R}").
      * When set, the card gains the Warp keyword ability.
      * Warp allows casting for an alternative cost; the permanent is exiled at end of turn
@@ -904,8 +911,13 @@ class CardBuilder(private val name: String) {
                 morphCost != null -> add(KeywordAbility.Morph(morphCost!!, morphFaceUpEffect))
             }
             when {
-                disguise != null -> add(KeywordAbility.Disguise(PayCost.Atom(CostAtom.Mana(ManaCost.parse(disguise!!)))))
-                disguiseCost != null -> add(KeywordAbility.Disguise(disguiseCost!!))
+                disguise != null -> add(
+                    KeywordAbility.Disguise(
+                        PayCost.Atom(CostAtom.Mana(ManaCost.parse(disguise!!))),
+                        disguiseFaceUpEffect
+                    )
+                )
+                disguiseCost != null -> add(KeywordAbility.Disguise(disguiseCost!!, disguiseFaceUpEffect))
             }
             if (warp != null) add(KeywordAbility.Warp(ManaCost.parse(warp!!)))
             if (dash != null) add(KeywordAbility.Dash(ManaCost.parse(dash!!)))

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -419,7 +419,14 @@ sealed interface KeywordAbility {
     @SerialName("Disguise")
     @Serializable
     data class Disguise(
-        val disguiseCost: PayCost
+        val disguiseCost: PayCost,
+        /**
+         * Effect applied as part of the turn-face-up action, for the "As this creature is turned
+         * face up, …" replacement clause (Bubble Smuggler: "put four +1/+1 counters on it"). The
+         * exact sibling of [Morph.faceUpEffect] — it does *not* use the stack and can't be
+         * responded to, which is what separates it from a `Triggers.TurnedFaceUp` ability.
+         */
+        val faceUpEffect: com.wingedsheep.sdk.scripting.effects.Effect? = null
     ) : KeywordAbility {
         /** Convenience constructor for mana-based disguise costs. */
         constructor(cost: ManaCost) : this(PayCost.Atom(CostAtom.Mana(cost)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BubbleSmuggler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BubbleSmuggler.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bubble Smuggler — Murders at Karlov Manor #41
+ * {1}{U} · Creature — Octopus Fish · 2/1
+ *
+ * Disguise {5}{U}
+ * As this creature is turned face up, put four +1/+1 counters on it.
+ *
+ * A {3} 2/2 with ward {2} early that later unfolds into a 6/5 for {5}{U}. The counters make it a
+ * genuine 6/5 rather than a pumped 2/1, so they survive the turn and stack with anything else.
+ *
+ * **"As … is turned face up" is a replacement, not a trigger.** It applies as part of the special
+ * action that flips the permanent, so it doesn't use the stack and can't be responded to: an
+ * opponent holding a 4-damage burn spell never gets a window against the 2/1 body. That is the
+ * whole difference between this and the `Triggers.TurnedFaceUp` shape used by [GraniteWitness] and
+ * [ExitSpecialist] — modelling it as a triggered ability would hand the opponent a response window
+ * the card doesn't give them.
+ *
+ * It is carried by `disguiseFaceUpEffect`, the disguise-side sibling of `morphFaceUpEffect`
+ * (Hooded Hydra). Both ride the *turn-up procedure*, matching CR 702.37b's treatment of megamorph.
+ * Known limitation, inherited from the morph model: if this card were put onto the battlefield face
+ * down by cloak or manifest and then turned face up by paying its mana cost instead of its disguise
+ * cost, the counters would not be placed. Flipping it for the disguise cost — the only route MKM
+ * itself offers — is correct.
+ */
+val BubbleSmuggler = card("Bubble Smuggler") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Octopus Fish"
+    oracleText = "Disguise {5}{U} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "As this creature is turned face up, put four +1/+1 counters on it."
+    power = 2
+    toughness = 1
+
+    disguise = "{5}{U}"
+    disguiseFaceUpEffect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 4, EffectTarget.Self)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Leesha Hannigan"
+        flavorText = "By the time they noticed the missing vials, Glovax was three fathoms away."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b863ee0-d9f3-4b1e-993d-5212731d9353.jpg?1783912915"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ExitSpecialist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ExitSpecialist.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Exit Specialist — Murders at Karlov Manor #55
+ * {1}{U} · Creature — Human Detective · 2/1
+ *
+ * This creature can't be blocked by creatures with power 3 or greater.
+ * Disguise {1}{U}
+ * When this creature is turned face up, return another target creature to its owner's hand.
+ *
+ * Two mana down, two mana up: cast it face down for {3}, then flip for {1}{U} at the moment an
+ * attacker or blocker is committed and bounce it. Because turning face up is a special action that
+ * can't be responded to (CR 701.34a), the only window an opponent gets is after the trigger is
+ * already on the stack with its target chosen.
+ *
+ * "Another target creature" is [TargetFilter.OtherCreature] — Exit Specialist can never bounce
+ * itself, and the trigger has no legal target (and so is removed from the stack) if it is the only
+ * creature on the battlefield when the flip happens.
+ *
+ * The evasion clause reads *blocker* power at declare-blockers, not continuously: per the Scryfall
+ * ruling below, pumping a blocker to power 3 after blocks are declared doesn't undo the block. That
+ * falls out of [CantBeBlockedBy] being enforced at block declaration, so nothing extra is needed
+ * here — and equally, flipping Exit Specialist face up after it's already blocked doesn't unblock
+ * it, since the restriction never re-applies mid-combat.
+ */
+val ExitSpecialist = card("Exit Specialist") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Detective"
+    oracleText = "This creature can't be blocked by creatures with power 3 or greater.\n" +
+        "Disguise {1}{U} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, return another target creature to its owner's hand."
+    power = 2
+    toughness = 1
+
+    disguise = "{1}{U}"
+
+    staticAbility {
+        ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtLeast(3))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        val creature = target(
+            "another target creature",
+            TargetCreature(filter = TargetFilter.OtherCreature)
+        )
+        effect = Effects.ReturnToHand(creature)
+        description = "When this creature is turned face up, return another target creature to " +
+            "its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "55"
+        artist = "Mila Pesic"
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/268f142d-9fb1-4673-b804-add1f08dacb9.jpg?1783912910"
+
+        ruling(
+            "2024-02-02",
+            "Once Exit Specialist has been blocked, increasing the blocking creature's power to 3 " +
+                "or greater won't cause Exit Specialist to become unblocked."
+        )
+        ruling(
+            "2024-02-02",
+            "If Exit Specialist becomes blocked while it's face-down, turning it face up won't " +
+                "cause it to become unblocked."
+        )
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GraniteWitness.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GraniteWitness.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+
+/**
+ * Granite Witness — Murders at Karlov Manor #206
+ * {2}{W}{U} · Artifact Creature — Gargoyle Detective · 3/2
+ *
+ * Flying, vigilance
+ * Disguise {W/U}{W/U}
+ * When this creature is turned face up, you may tap or untap target creature.
+ *
+ * The common WU disguise trick: hold up two hybrid mana and flip it mid-combat either to tap a
+ * would-be blocker before blocks, or to untap one of yours after it attacked. Vigilance on the
+ * face-up side makes the second line free.
+ *
+ * "You may tap or untap target creature" is the [SewerVeillanceCam] idiom — a [MayEffect] wrapping
+ * a two-[Mode] [ModalEffect] over the single declared target, with `countsAsModalSpell = false` so
+ * the tap/untap choice isn't mistaken for a modal *spell*. The target is chosen when the trigger
+ * goes on the stack; the tap-or-untap choice is made on resolution, so an opponent who taps the
+ * creature in response doesn't lock you into the now-useless half.
+ *
+ * The trigger is a real triggered ability, not a replacement — it uses the stack and can be
+ * responded to, unlike the flip itself (a special action, CR 701.34a). It fires only on *this*
+ * creature turning face up ([Triggers.TurnedFaceUp] is SELF-bound), and never on the card entering
+ * face up: turning face up is not entering (CR 707.9a).
+ */
+val GraniteWitness = card("Granite Witness") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Artifact Creature — Gargoyle Detective"
+    oracleText = "Flying, vigilance\n" +
+        "Disguise {W/U}{W/U} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, you may tap or untap target creature."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    disguise = "{W/U}{W/U}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        val creature = target("target creature", Targets.Creature)
+        effect = MayEffect(
+            ModalEffect(
+                modes = listOf(
+                    Mode.noTarget(TapUntapEffect(creature, tap = true), "Tap that creature"),
+                    Mode.noTarget(TapUntapEffect(creature, tap = false), "Untap that creature")
+                ),
+                chooseCount = 1,
+                countsAsModalSpell = false
+            )
+        )
+        description = "When this creature is turned face up, you may tap or untap target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "206"
+        artist = "Tuan Duong Chu"
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/daee9d98-f8c6-4980-8f23-c6c636b69430.jpg?1783912849"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "Turning a permanent face up or face down doesn't change whether that permanent is " +
+                "tapped or untapped."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/InsideSource.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/InsideSource.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Inside Source — Murders at Karlov Manor #19
+ * {2}{W} · Creature — Human Citizen · 1/1
+ *
+ * When this creature enters, create a 2/2 white and blue Detective creature token.
+ * {3}, {T}: Target Detective you control gets +2/+0 and gains vigilance until end of turn.
+ * Activate only as a sorcery.
+ *
+ * Two Detectives for three mana, then a mana sink that turns one of them into an attacker who
+ * stays home. The pump targets *a Detective you control* — including the token it just made, and
+ * including Inside Source itself only if something has made it a Detective, since a Human Citizen
+ * isn't one. `TargetFilter.CreatureYouControl.withSubtype(DETECTIVE)` is evaluated against
+ * projected state, so a creature that gained the type from a type-changing effect is a legal
+ * target and one that lost it is not.
+ *
+ * "Activate only as a sorcery" is [TimingRule.SorcerySpeed] — your main phase, empty stack. Note
+ * this bars the usual "pump at end of the opponent's turn to blank a blocker" line; the vigilance
+ * half is the compensation, letting the pumped Detective attack and still block back.
+ *
+ * The token gets no baked-in `imageUri`: a 2/2 white-and-blue Detective is one of MKM's printed
+ * tokens, so the set's `tokenArt` layer supplies the art (same as [MuseumNightwatch]).
+ */
+val InsideSource = card("Inside Source") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "When this creature enters, create a 2/2 white and blue Detective creature token.\n" +
+        "{3}, {T}: Target Detective you control gets +2/+0 and gains vigilance until end of turn. " +
+        "Activate only as a sorcery."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE, Color.BLUE),
+            creatureTypes = setOf("Detective")
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        val detective = target(
+            "target Detective you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.DETECTIVE))
+        )
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, detective),
+            Effects.GrantKeyword(Keyword.VIGILANCE, detective)
+        )
+        description = "Target Detective you control gets +2/+0 and gains vigilance until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "John Stanko"
+        flavorText = "\"I was never here.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/1548d181-3f83-457a-b2d3-eb88cfb2afda.jpg?1783912923"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SumalaSentry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SumalaSentry.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sumala Sentry — Murders at Karlov Manor #233
+ * {G}{W} · Creature — Elf Archer · 1/3
+ *
+ * Reach
+ * Whenever a face-down permanent you control is turned face up, put a +1/+1 counter on it and a
+ * +1/+1 counter on this creature.
+ *
+ * The GW disguise payoff: every flip is two counters, one on the flipped permanent and one here.
+ * Both halves are unconditional and neither is a target, so nothing fizzles if the flipped
+ * permanent leaves in response — the trigger just does as much as it can.
+ *
+ * Oracle says "face-down *permanent*", modelled as [Triggers.CreatureTurnedFaceUp]. That is not a
+ * narrowing: a face-down permanent on the battlefield is always a 2/2 colorless creature with no
+ * name, types, or abilities (CR 708.2), so every face-down permanent you control *is* a face-down
+ * creature you control at the moment the flip happens. The binding is ANY, so Sumala Sentry
+ * triggers on itself being turned face up too (it has no disguise, but manifest and cloak can put
+ * it onto the battlefield face down) — again matching the oracle wording, which doesn't say
+ * "another".
+ *
+ * "Put a +1/+1 counter on it" uses [EffectTarget.TriggeringEntity]: the permanent named by the
+ * event, not a chosen target. Order in the [Effects.Composite] is printed order, which matters
+ * only for watchers counting counter placements.
+ */
+val SumalaSentry = card("Sumala Sentry") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Elf Archer"
+    oracleText = "Reach\n" +
+        "Whenever a face-down permanent you control is turned face up, put a +1/+1 counter on it " +
+        "and a +1/+1 counter on this creature."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.CreatureTurnedFaceUp()
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.TriggeringEntity),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+        description = "Put a +1/+1 counter on that permanent and a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Nicholas Elias"
+        flavorText = "The great meditation garden of Sumala was no place for Ravnica's rising " +
+            "crime wave, and he would keep it that way."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b9d4691-59d1-4e97-9b5d-8017788fbcb3.jpg?1783912836"
+
+        ruling(
+            "2024-02-02",
+            "If the permanent that was turned face up is no longer on the battlefield when Sumala " +
+                "Sentry's triggered ability resolves, you'll still put a +1/+1 counter on Sumala " +
+                "Sentry. Similarly, if Sumala Sentry is no longer on the battlefield, you'll " +
+                "still put a +1/+1 counter on the permanent that turned face up."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -350,6 +350,55 @@
     ]
 }
 
+// Bubble Smuggler
+{
+    "name": "Bubble Smuggler",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Octopus Fish",
+    "oracleText": "Disguise {5}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nAs this creature is turned face up, put four +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{U}"
+                }
+            },
+            "faceUpEffect": {
+                "type": "AddCounters",
+                "counterType": "+1/+1",
+                "count": 4,
+                "target": "Self"
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Leesha Hannigan",
+        "flavorText": "By the time they noticed the missing vials, Glovax was three fathoms away.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b863ee0-d9f3-4b1e-993d-5212731d9353.jpg?1783912915",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Candlestick
 {
     "name": "Candlestick",
@@ -1549,6 +1598,92 @@
     "colorIdentityOverride": []
 }
 
+// Exit Specialist
+{
+    "name": "Exit Specialist",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "This creature can't be blocked by creatures with power 3 or greater.\nDisguise {1}{U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, return another target creature to its owner's hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{U}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target creature"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature",
+                        "excludeSelf": true
+                    },
+                    "id": "another target creature"
+                },
+                "descriptionOverride": "When this creature is turned face up, return another target creature to its owner's hand."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerAtLeast",
+                            "min": 3
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "UNCOMMON",
+        "artist": "Mila Pesic",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/268f142d-9fb1-4673-b804-add1f08dacb9.jpg?1783912910",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Once Exit Specialist has been blocked, increasing the blocking creature's power to 3 or greater won't cause Exit Specialist to become unblocked."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If Exit Specialist becomes blocked while it's face-down, turning it face up won't cause it to become unblocked."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Fae Flight
 {
     "name": "Fae Flight",
@@ -2485,6 +2620,104 @@
     ]
 }
 
+// Granite Witness
+{
+    "name": "Granite Witness",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Artifact Creature — Gargoyle Detective",
+    "oracleText": "Flying, vigilance\nDisguise {W/U}{W/U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, you may tap or untap target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{W/U}{W/U}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature"
+                                    }
+                                },
+                                "description": "Tap that creature"
+                            },
+                            {
+                                "effect": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature"
+                                    },
+                                    "tap": false
+                                },
+                                "description": "Untap that creature"
+                            }
+                        ],
+                        "countsAsModalSpell": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this creature is turned face up, you may tap or untap target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "artist": "Tuan Duong Chu",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/daee9d98-f8c6-4980-8f23-c6c636b69430.jpg?1783912849",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Gravestone Strider
 {
     "name": "Gravestone Strider",
@@ -3064,6 +3297,107 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Inside Source
+{
+    "name": "Inside Source",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "When this creature enters, create a 2/2 white and blue Detective creature token.\n{3}, {T}: Target Detective you control gets +2/+0 and gains vigilance until end of turn. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE",
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Detective"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Detective you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Detective you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Detective ctrl:you"
+                        },
+                        "id": "target Detective you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Target Detective you control gets +2/+0 and gains vigilance until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "John Stanko",
+        "flavorText": "\"I was never here.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/1548d181-3f83-457a-b2d3-eb88cfb2afda.jpg?1783912923"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -6394,6 +6728,65 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Sumala Sentry
+{
+    "name": "Sumala Sentry",
+    "manaCost": "{G}{W}",
+    "typeLine": "Creature — Elf Archer",
+    "oracleText": "Reach\nWhenever a face-down permanent you control is turned face up, put a +1/+1 counter on it and a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "CreatureTurnedFaceUpEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "TriggeringEntity"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Put a +1/+1 counter on that permanent and a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "UNCOMMON",
+        "artist": "Nicholas Elias",
+        "flavorText": "The great meditation garden of Sumala was no place for Ravnica's rising crime wave, and he would keep it that way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b9d4691-59d1-4e97-9b5d-8017788fbcb3.jpg?1783912836",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If the permanent that was turned face up is no longer on the battlefield when Sumala Sentry's triggered ability resolves, you'll still put a +1/+1 counter on Sumala Sentry. Similarly, if Sumala Sentry is no longer on the battlefield, you'll still put a +1/+1 counter on the permanent that turned face up."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceDownTurnUp.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceDownTurnUp.kt
@@ -72,5 +72,5 @@ object FaceDownTurnUp {
 
     private fun disguiseProcedure(cardDef: CardDefinition?): TurnUpProcedure? =
         cardDef?.keywordAbilities?.filterIsInstance<KeywordAbility.Disguise>()?.firstOrNull()
-            ?.let { TurnUpProcedure(it.disguiseCost, FaceDownMode.DISGUISE) }
+            ?.let { TurnUpProcedure(it.disguiseCost, FaceDownMode.DISGUISE, it.faceUpEffect) }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BubbleSmugglerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BubbleSmugglerScenarioTest.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.BubbleSmuggler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bubble Smuggler (MKM #41) — `disguiseFaceUpEffect`, the disguise-side sibling of
+ * `morphFaceUpEffect`.
+ *
+ * Disguise {5}{U}
+ * As this creature is turned face up, put four +1/+1 counters on it.
+ *
+ * The clause is a **replacement**, not a trigger: it applies inside the turn-up special action
+ * (CR 701.34a), which doesn't use the stack and can't be responded to. That's what these tests pin
+ * down — the counters are already there the instant the action resolves, with nothing on the stack
+ * and no pending decision, so an opponent never gets a window against the 2/1 body.
+ *
+ * Covers: the face-down 2/2 carries no counters; the flip places exactly four and yields a 6/5;
+ * the placement uses no stack; and a Bubble Smuggler cast normally for {1}{U} gets nothing.
+ */
+class BubbleSmugglerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BubbleSmuggler))
+        return driver
+    }
+
+    fun counterCount(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Put Bubble Smuggler onto the battlefield face down, deriving turn-up data as a real entry does. */
+    fun GameTestDriver.putFaceDown(playerId: EntityId, mode: FaceDownMode): EntityId {
+        val id = putCreatureOnBattlefield(playerId, "Bubble Smuggler")
+        val cardDef = cardRegistry.requireCard("Bubble Smuggler")
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent).with(FaceDownModeComponent(mode))
+                FaceDownTurnUp.dataFor(cardDef, "Bubble Smuggler", mode)?.let { c = c.with(it) }
+                c
+            }
+        )
+        removeSummoningSickness(id)
+        return id
+    }
+
+    test("the derived disguise turn-up procedure carries the face-up effect") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val smuggler = driver.putFaceDown(player, FaceDownMode.DISGUISE)
+
+        val procedure = driver.state.getEntity(smuggler)
+            ?.get<com.wingedsheep.engine.state.components.identity.MorphDataComponent>()
+            ?.procedures?.single()
+        procedure.shouldNotBeNull()
+        procedure.mechanic shouldBe FaceDownMode.DISGUISE
+        procedure.cost.description shouldBe "{5}{U}"
+        procedure.faceUpEffect.shouldNotBeNull()
+    }
+
+    test("while face down it is a plain 2/2 with no counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val smuggler = driver.putFaceDown(player, FaceDownMode.DISGUISE)
+
+        counterCount(driver, smuggler) shouldBe 0
+        driver.state.projectedState.getPower(smuggler) shouldBe 2
+        driver.state.projectedState.getToughness(smuggler) shouldBe 2
+    }
+
+    test("turning it face up puts four +1/+1 counters on it, making it a 6/5") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val smuggler = driver.putFaceDown(player, FaceDownMode.DISGUISE)
+        driver.giveMana(player, Color.BLUE, 6) // Disguise {5}{U}
+
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = smuggler,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+
+        driver.state.getEntity(smuggler)?.get<FaceDownComponent>() shouldBe null
+        counterCount(driver, smuggler) shouldBe 4
+        // Printed 2/1 plus four counters.
+        driver.state.projectedState.getPower(smuggler) shouldBe 6
+        driver.state.projectedState.getToughness(smuggler) shouldBe 5
+    }
+
+    test("the counters land inside the special action — nothing goes on the stack") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val smuggler = driver.putFaceDown(player, FaceDownMode.DISGUISE)
+        driver.giveMana(player, Color.BLUE, 6)
+
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = smuggler,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+
+        // No trigger to resolve and no decision to answer: a replacement effect, not a trigger.
+        // The opponent never gets priority with a 2/1 Bubble Smuggler on the battlefield.
+        driver.stackSize shouldBe 0
+        driver.pendingDecision shouldBe null
+        counterCount(driver, smuggler) shouldBe 4
+    }
+
+    test("cast face up for its mana cost, it is a plain 2/1 with no counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val card = driver.putCardInHand(player, "Bubble Smuggler")
+        driver.giveMana(player, Color.BLUE, 2) // {1}{U}
+
+        driver.castSpell(player, card).error shouldBe null
+        driver.bothPass()
+
+        val smuggler = driver.findPermanent(player, "Bubble Smuggler")
+        smuggler.shouldNotBeNull()
+        counterCount(driver, smuggler) shouldBe 0
+        driver.state.projectedState.getPower(smuggler) shouldBe 2
+        driver.state.projectedState.getToughness(smuggler) shouldBe 1
+    }
+})


### PR DESCRIPTION
Five MKM cards, taking the set from 120/276 to 125/276. All five are canonical in MKM (`just check-card-printing` clean for each).

## Cards

| Card | Cost | What's interesting |
|---|---|---|
| **Inside Source** | `{2}{W}` | ETB 2/2 W/U Detective token; `{3}, {T}` sorcery-speed pump targeting *a Detective you control* (`TargetFilter.CreatureYouControl.withSubtype(DETECTIVE)`), +2/+0 and vigilance |
| **Sumala Sentry** | `{G}{W}` | Reach; every face-down flip you control puts a +1/+1 counter on the flipped permanent *and* one on the Sentry |
| **Granite Witness** | `{2}{W}{U}` | Flying/vigilance, disguise `{W/U}{W/U}`; on the flip, "you may tap or untap target creature" |
| **Exit Specialist** | `{1}{U}` | `CantBeBlockedBy(power >= 3)`, disguise `{1}{U}`; on the flip, bounce another target creature |
| **Bubble Smuggler** | `{1}{U}` | Disguise `{5}{U}`; "as this creature is turned face up, put four +1/+1 counters on it" |

## SDK addition: `disguiseFaceUpEffect`

Bubble Smuggler's clause is a **replacement, not a trigger**. It applies inside the turn-up special action (CR 701.34a), which doesn't use the stack and can't be responded to — so an opponent never gets a window against the 2/1 body. Modelling it as a `Triggers.TurnedFaceUp` ability (what Granite Witness and Exit Specialist correctly use) would hand them a response window the card doesn't give.

The engine already had this shape for morph (Hooded Hydra's `morphFaceUpEffect`), so this mirrors it rather than inventing anything:

- `KeywordAbility.Disguise` gains `faceUpEffect`, matching `KeywordAbility.Morph`.
- `CardBuilder` surfaces it as `disguiseFaceUpEffect`.
- `FaceDownTurnUp.disguiseProcedure` threads it into the `TurnUpProcedure`.

`TurnFaceUpHandler` needed no change — it was already mechanic-agnostic, reading `procedure.faceUpEffect` for both the mana and non-mana payment paths.

### Known limitation (inherited, documented)

The face-up effect rides the turn-up **procedure**, matching CR 702.37b's treatment of megamorph. So a card put onto the battlefield face down by cloak or manifest and then flipped for its *mana cost* instead of its disguise cost does not get the counters. This is the same limitation the existing morph model has (Hooded Hydra behaves identically), and there is no field in the current model that distinguishes a standalone "as this is turned face up" clause from megamorph's cost-tied counter. Flipping for the disguise cost — the only route MKM itself offers — is correct. Called out in the card's KDoc and in the SDK reference.

## Verification

- `just build` — **BUILD SUCCESSFUL**. The `CardDefinitionSnapshotTest` golden diff is additions only, exactly the five new cards (`git diff` on `MKM.json` shows 393 insertions, 0 deletions).
- `just test-class BubbleSmugglerScenarioTest` — 5/5 pass. Covers the derived turn-up procedure, the face-down 2/2 carrying no counters, the flip placing four counters for a 6/5, that the placement raises no stack entry and no pending decision (the point of it being a replacement), and that a normally-cast copy gets nothing.
- `just test-class DisguiseKeywordScenarioTest` — 16/16 pass, unchanged, guarding the shared turn-up path I touched.
- All five `image_uris` HEAD-checked 200, and every mechanical field re-verified against Scryfall (name, cost, P/T, type line, rarity, collector number, artist, flavor text, oracle text line by line).
- `docs/card-sdk-language-reference.md` updated in the same change, per AGENTS.md.

## Player experience

No new decision types. Inside Source's pump and both flip triggers target permanents in play, so they route to battlefield targeting rather than an overlay; Granite Witness's tap-or-untap reuses the already-shipped Sewer-veillance Cam flow (`ChooseTargets` → `YesNo` → `ChooseOption`). Sumala Sentry and Bubble Smuggler raise no decisions at all. No e2e test needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)