### PR TITLE
Add two The Hobbit cards, fixing pipeline numbers lost across a pause

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/AlongTheCrookedWay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/AlongTheCrookedWay.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Along the Crooked Way — The Hobbit #60
+ * {2}{B} · Enchantment · Rare
+ *
+ * When this enchantment enters, return target creature card from your graveyard to your hand.
+ * Whenever a creature card leaves your graveyard, amass Goblins 1.
+ * {1}{B}: Goblins and Orcs you control gain menace until end of turn.
+ *
+ * Modeling notes:
+ *  - The middle ability is a graveyard-exit trigger, not a battlefield one: the event pattern is
+ *    `ZoneChangeEvent(from = GRAVEYARD)` with no `to`, so *any* destination (hand, exile, library,
+ *    battlefield, stack — a flashback/escape cast counts) fires it. `.youControl()` scopes it to
+ *    "your graveyard"; for a card leaving a non-battlefield zone the matcher has no last-known
+ *    controller and falls back to the card's owner, which is exactly whose graveyard it was in
+ *    (CR 400.3).
+ *  - The enchantment's own enters trigger moves a creature card out of your graveyard, so it
+ *    feeds the amass trigger — the two abilities are deliberately chained on the printed card.
+ *  - "Goblins and Orcs you control" is one OR over subtypes, and it covers the amassed Army:
+ *    an Army that has been amassed with Goblins is itself a Goblin (CR 701.47a).
+ */
+val AlongTheCrookedWay = card("Along the Crooked Way") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, return target creature card from your graveyard " +
+        "to your hand.\n" +
+        "Whenever a creature card leaves your graveyard, amass Goblins 1.\n" +
+        "{1}{B}: Goblins and Orcs you control gain menace until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creatureCard = target("target creature card in your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.Move(creatureCard, Zone.HAND)
+        description = "Return target creature card from your graveyard to your hand."
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(filter = GameObjectFilter.Creature, from = Zone.GRAVEYARD),
+            binding = TriggerBinding.ANY
+        ).youControl()
+        effect = Effects.Amass(1, "Goblin")
+        description = "Amass Goblins 1."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{B}")
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Permanent.youControl().withAnySubtype("Goblin", "Orc")),
+            Effects.GrantKeyword(Keyword.MENACE, EffectTarget.Self)
+        )
+        description = "Goblins and Orcs you control gain menace until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "60"
+        artist = "Bruce Brenneise"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/3696d65c-fffd-4685-bb2d-e8769bf476e3.jpg?1785412571"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BolgOfTheNorth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BolgOfTheNorth.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Bolg of the North — The Hobbit #148
+ * {3}{B}{R} · Legendary Creature — Goblin Soldier · Uncommon
+ * 5/5
+ *
+ * When Bolg enters, you may sacrifice another creature. When you do, Bolg deals damage equal to
+ * that creature's power to another target creature. If excess damage was dealt this way, amass
+ * Goblins X, where X is that excess damage.
+ *
+ * Modeling notes:
+ *  - Killmonger, Scourge of Wakanda's shape: the sacrifice is a resolution-time *choice*
+ *    ([SelectTargetEffect] + [Effects.SacrificeTarget]), not a target, so declining commits to
+ *    nothing. Only an actual sacrifice fires the "When you do" reflexive ability, whose own target
+ *    is chosen as it goes on the stack (CR 603.11).
+ *  - **The power snapshot is taken before the sacrifice, not after.** "That creature's power" is
+ *    last-known information (CR 608.2h), and the reflexive ability resolves from a fresh
+ *    `EffectContext` on the far side of a stack round-trip — the sacrificed creature's LKI
+ *    snapshot does not survive that trip, only the pipeline does. So the action stores the power
+ *    into the pipeline via [Effects.StoreNumber] while the creature is still on the battlefield
+ *    (counters and pumps included), and the reflexive reads it back as a
+ *    [DynamicAmount.VariableReference]. Reading `Power` off the card in the graveyard instead
+ *    would silently drop every +1/+1 counter and Layer 7 bonus it had.
+ *  - The excess-damage amass is the Orbital Plunge / Hell to Pay pair: [ConditionalEffect] gated on
+ *    [Conditions.IfTargetTookExcessDamage] for the "if excess damage was dealt" clause, and
+ *    [EntityNumericProperty.ExcessMarkedDamage] for the amount. Both read the target's post-damage
+ *    marked damage in the same composite, which has no interleaved SBA pass — so the only marked
+ *    damage in scope is what Bolg just dealt (CR 120.4a).
+ *  - "Another target creature" excludes Bolg himself (`.other()`), and the sacrifice pool likewise
+ *    excludes him ("another creature").
+ */
+val BolgOfTheNorth = card("Bolg of the North") {
+    manaCost = "{3}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Goblin Soldier"
+    power = 5
+    toughness = 5
+    oracleText = "When Bolg enters, you may sacrifice another creature. When you do, Bolg deals " +
+        "damage equal to that creature's power to another target creature. If excess damage was " +
+        "dealt this way, amass Goblins X, where X is that excess damage. (Put X +1/+1 counters on " +
+        "an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 " +
+        "black Goblin Army creature token first.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Composite(
+                listOf(
+                    SelectTargetEffect(
+                        requirement = TargetObject(filter = TargetFilter.CreatureYouControl.other()),
+                        storeAs = "bolgSacrifice",
+                    ),
+                    Effects.StoreNumber(
+                        "bolgSacrificedPower",
+                        DynamicAmount.EntityProperty(
+                            EntityReference.FromCostStorage("bolgSacrifice"),
+                            EntityNumericProperty.Power,
+                        ),
+                    ),
+                    Effects.SacrificeTarget(EffectTarget.PipelineTarget("bolgSacrifice")),
+                ),
+            ),
+            optional = true,
+            reflexiveEffect = Effects.Composite(
+                Effects.DealDamage(
+                    DynamicAmount.VariableReference("bolgSacrificedPower"),
+                    EffectTarget.ContextTarget(0),
+                ),
+                ConditionalEffect(
+                    condition = Conditions.IfTargetTookExcessDamage(),
+                    effect = Effects.Amass(
+                        DynamicAmount.EntityProperty(
+                            EntityReference.Target(0),
+                            EntityNumericProperty.ExcessMarkedDamage,
+                        ),
+                        "Goblin",
+                    ),
+                ),
+            ),
+            reflexiveTargetRequirements = listOf(
+                TargetCreature(filter = TargetFilter.Creature.other()),
+            ),
+            descriptionOverride = "You may sacrifice another creature. When you do, Bolg deals " +
+                "damage equal to that creature's power to another target creature. If excess " +
+                "damage was dealt this way, amass Goblins X, where X is that excess damage.",
+        )
+        description = "When Bolg enters, you may sacrifice another creature. When you do, Bolg " +
+            "deals damage equal to that creature's power to another target creature. If excess " +
+            "damage was dealt this way, amass Goblins X, where X is that excess damage."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Miklós Ligeti"
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b2d2a7f-88e0-45a9-8579-a6736bcd66eb.jpg?1784377021"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1,3 +1,89 @@
+// Along the Crooked Way
+{
+    "name": "Along the Crooked Way",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, return target creature card from your graveyard to your hand.\nWhenever a creature card leaves your graveyard, amass Goblins 1.\n{1}{B}: Goblins and Orcs you control gain menace until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card in your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card in your graveyard"
+                },
+                "descriptionOverride": "Return target creature card from your graveyard to your hand."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Amass",
+                    "subtype": "Goblin"
+                },
+                "descriptionOverride": "Amass Goblins 1."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "permanent Goblin|Orc ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "MENACE",
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Goblins and Orcs you control gain menace until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "RARE",
+        "artist": "Bruce Brenneise",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/3696d65c-fffd-4685-bb2d-e8769bf476e3.jpg?1785412571"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // An Unexpected Party
 {
     "name": "An Unexpected Party",
@@ -634,6 +720,120 @@
                 ]
             }
         }
+    ]
+}
+
+// Bolg of the North
+{
+    "name": "Bolg of the North",
+    "manaCost": "{3}{B}{R}",
+    "typeLine": "Legendary Creature — Goblin Soldier",
+    "oracleText": "When Bolg enters, you may sacrifice another creature. When you do, Bolg deals damage equal to that creature's power to another target creature. If excess damage was dealt this way, amass Goblins X, where X is that excess damage. (Put X +1/+1 counters on an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 black Goblin Army creature token first.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SelectTarget",
+                                "requirement": {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you",
+                                        "excludeSelf": true
+                                    }
+                                },
+                                "storeAs": "bolgSacrifice"
+                            },
+                            {
+                                "type": "StoreNumber",
+                                "name": "bolgSacrificedPower",
+                                "amount": {
+                                    "type": "EntityProperty",
+                                    "entity": {
+                                        "type": "FromCostStorage",
+                                        "collectionName": "bolgSacrifice"
+                                    },
+                                    "numericProperty": "Power"
+                                }
+                            },
+                            {
+                                "type": "SacrificeTarget",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "bolgSacrifice"
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "VariableReference",
+                                    "variableName": "bolgSacrificedPower"
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": "TargetMarkedDamageExceedsToughness"
+                                },
+                                "then": {
+                                    "type": "Amass",
+                                    "amount": {
+                                        "type": "EntityProperty",
+                                        "entity": "Target",
+                                        "numericProperty": "ExcessMarkedDamage"
+                                    },
+                                    "subtype": "Goblin"
+                                }
+                            }
+                        ]
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may sacrifice another creature. When you do, Bolg deals damage equal to that creature's power to another target creature. If excess damage was dealt this way, amass Goblins X, where X is that excess damage."
+                },
+                "descriptionOverride": "When Bolg enters, you may sacrifice another creature. When you do, Bolg deals damage equal to that creature's power to another target creature. If excess damage was dealt this way, amass Goblins X, where X is that excess damage."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Miklós Ligeti",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b2d2a7f-88e0-45a9-8579-a6736bcd66eb.jpg?1784377021"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/CoreAutoResumerModule.kt
@@ -114,13 +114,17 @@ class CoreAutoResumerModule(
             if (runResult.isPaused) {
                 return@autoResumer ExecutionResult.paused(runResult.state, runResult.pendingDecision!!, events + runResult.events)
             }
-            // A drained composite hands its pipeline collections to the frame beneath —
-            // e.g. a DoAction gate scoring SuccessCriterion.CollectionNonEmpty. The full
-            // frame map (not just this drain's accumulation) is what propagates: keys
-            // injected into this frame by an earlier select-resume are part of it.
+            // A drained composite hands its pipeline storage to the frame beneath — e.g. a DoAction
+            // gate scoring SuccessCriterion.CollectionNonEmpty, or a reflexive "when you do" reading
+            // a number the action stored (Bolg of the North). The full frame maps (not just this
+            // drain's accumulation) are what propagate: keys injected into this frame by an earlier
+            // select-resume are part of them. Numbers and chosen values ride along with collections
+            // so pausing mid-composite preserves exactly what completing it synchronously would.
             val stateWithCollections = exposeCollectionsToNextFrame(
                 runResult.state,
-                continuation.effectContext.pipeline.storedCollections + runResult.updatedCollections
+                continuation.effectContext.pipeline.storedCollections + runResult.updatedCollections,
+                continuation.effectContext.pipeline.storedNumbers + runResult.updatedStoredNumbers,
+                continuation.effectContext.pipeline.chosenValues + runResult.updatedChosenValues,
             )
             checkForMore(stateWithCollections, events + runResult.events)
         },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -50,13 +50,17 @@ class EffectAndTriggerContinuationResumer(
     ): ExecutionResult {
         val effectResult = effectRunner.executeRemainingEffects(state, continuation.remainingEffects, continuation.effectContext)
         if (effectResult.isPaused) return effectResult.toExecutionResult()
-        // A drained composite hands its pipeline collections to the frame beneath —
-        // e.g. a DoAction gate scoring SuccessCriterion.CollectionNonEmpty. The full
-        // frame map (not just this drain's accumulation) is what propagates: keys
-        // injected into this frame by an earlier select-resume are part of it.
+        // A drained composite hands its pipeline storage to the frame beneath — e.g. a DoAction
+        // gate scoring SuccessCriterion.CollectionNonEmpty, or a reflexive "when you do" reading a
+        // number the action stored. The full frame maps (not just this drain's accumulation) are
+        // what propagate: keys injected into this frame by an earlier select-resume are part of
+        // them. Numbers and chosen values ride along with collections so that pausing mid-composite
+        // preserves exactly what completing it synchronously would have.
         val stateWithCollections = exposeCollectionsToNextFrame(
             effectResult.state,
-            continuation.effectContext.pipeline.storedCollections + effectResult.updatedCollections
+            continuation.effectContext.pipeline.storedCollections + effectResult.updatedCollections,
+            continuation.effectContext.pipeline.storedNumbers + effectResult.updatedStoredNumbers,
+            continuation.effectContext.pipeline.chosenValues + effectResult.updatedChosenValues,
         )
         return checkForMore(stateWithCollections, effectResult.events.toList())
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/PipelineCollectionPropagation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/PipelineCollectionPropagation.kt
@@ -9,8 +9,8 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.model.EntityId
 
 /**
- * Merge pipeline [collections] produced by a resolved continuation into the next frame's
- * effect context, so the consumer beneath sees what the drained step stored.
+ * Merge pipeline [collections], [numbers], and [chosenValues] produced by a resolved continuation
+ * into the next frame's effect context, so the consumer beneath sees what the drained step stored.
  *
  * Pipeline storage lives in [EffectContext], which is frozen into each continuation frame
  * when it is pushed — a frame pushed *before* its action ran (the pre-push pattern) holds a
@@ -34,6 +34,20 @@ import com.wingedsheep.sdk.model.EntityId
  *
  * Unknown frame types are left untouched (they don't read pipeline storage).
  *
+ * [numbers] and [chosenValues] ride the same seam as [collections], because a pipeline step stores
+ * all three the same way and a consumer beneath reads them the same way. Dropping them here is not
+ * a harmless omission: `CompositeEffectExecutor` threads `updatedStoredNumbers` between siblings on
+ * the synchronous path, so a composite that stores a number and then pauses would lose it while an
+ * identical composite that never paused would keep it — the same card working or not depending on
+ * whether a decision happened to be presented. Bolg of the North is the case in hand: it snapshots
+ * the sacrificed creature's power into the pipeline before sacrificing it (the reflexive ability
+ * resolves from a fresh context on the far side of a stack round-trip and cannot read the
+ * sacrifice's LKI), and the sacrifice pauses for target selection as soon as you control two
+ * creatures that could be sacrificed.
+ *
+ * [RepeatWhileContinuation] takes only [collections], into its `bodyCollections` slot — the repeat
+ * condition reads collection outputs, and there is no numeric equivalent for it to read.
+ *
  * The consumer is always the top of the continuation stack here: a deferred
  * [PendingTriggersContinuation] queued by a mid-resolution trigger is inserted *beneath* the
  * frames of the in-flight resolution (see `SubmitDecisionHandler`), so it never sits between a
@@ -41,12 +55,20 @@ import com.wingedsheep.sdk.model.EntityId
  */
 fun exposeCollectionsToNextFrame(
     state: GameState,
-    collections: Map<String, List<EntityId>>
+    collections: Map<String, List<EntityId>>,
+    numbers: Map<String, Int> = emptyMap(),
+    chosenValues: Map<String, String> = emptyMap(),
 ): GameState {
-    if (collections.isEmpty()) return state
+    if (collections.isEmpty() && numbers.isEmpty() && chosenValues.isEmpty()) return state
 
     fun EffectContext.withMergedCollections(): EffectContext =
-        copy(pipeline = pipeline.copy(storedCollections = pipeline.storedCollections + collections))
+        copy(
+            pipeline = pipeline.copy(
+                storedCollections = pipeline.storedCollections + collections,
+                storedNumbers = pipeline.storedNumbers + numbers,
+                chosenValues = pipeline.chosenValues + chosenValues,
+            )
+        )
 
     return when (val next = state.peekContinuation()) {
         is EffectContinuation -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlongTheCrookedWayScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlongTheCrookedWayScenarioTest.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.AlongTheCrookedWay
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Along the Crooked Way (HOB #60) — {2}{B} Enchantment.
+ *
+ * "When this enchantment enters, return target creature card from your graveyard to your hand.
+ *  Whenever a creature card leaves your graveyard, amass Goblins 1.
+ *  {1}{B}: Goblins and Orcs you control gain menace until end of turn."
+ *
+ * The three things a lookalike implementation gets wrong: the graveyard-exit trigger is scoped to
+ * *your* graveyard (an opponent reanimating pays you nothing), it is per-card rather than batched
+ * ("a creature card", not "one or more"), and the menace grant reaches Orcs as well as Goblins —
+ * including the amassed Army, which is a Goblin by CR 701.47a.
+ */
+class AlongTheCrookedWayScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        cardRegistry.register(AlongTheCrookedWay)
+
+        context("Along the Crooked Way") {
+
+            fun TestGame.armies(): List<EntityId> {
+                val projected = stateProjector.project(state)
+                return projected.getBattlefieldControlledBy(player1Id)
+                    .filter { projected.isCreature(it) && projected.hasSubtype(it, "Army") }
+            }
+
+            fun TestGame.plusOneCounters(id: EntityId): Int =
+                state.getEntity(id)?.get<CountersComponent>()
+                    ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+            test("the enters trigger returns a creature card, and that exit amasses Goblins 1") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Along the Crooked Way")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Along the Crooked Way").error shouldBe null
+                game.resolveStack()
+
+                // Enters trigger: target the only creature card in the graveyard.
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("the creature card is back in hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("returning it is itself a creature card leaving your graveyard") {
+                    val armies = game.armies()
+                    armies.size shouldBe 1
+                    game.plusOneCounters(armies.single()) shouldBe 1
+                    stateProjector.project(game.state)
+                        .hasSubtype(armies.single(), "Goblin") shouldBe true
+                }
+            }
+
+            test("a creature card leaving an opponent's graveyard amasses nothing") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Along the Crooked Way")
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withCardInHand(2, "Raise Dead")
+                    .withLandsOnBattlefield(2, "Swamp", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(2, "Raise Dead", 2, "Grizzly Bears")
+                    .error shouldBe null
+                game.resolveStack()
+
+                game.isInHand(2, "Grizzly Bears") shouldBe true
+                withClue("\"your graveyard\" — an opponent's reanimation is not your trigger") {
+                    game.armies().size shouldBe 0
+                }
+            }
+
+            test("a noncreature card leaving your graveyard amasses nothing") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Along the Crooked Way")
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withCardInHand(1, "Regrowth")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Regrowth", 1, "Lightning Bolt")
+                    .error shouldBe null
+                game.resolveStack()
+
+                game.isInHand(1, "Lightning Bolt") shouldBe true
+                withClue("the filter is creature cards") { game.armies().size shouldBe 0 }
+            }
+
+            test("{1}{B} gives menace to Goblins and Orcs you control, but nothing else") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Along the Crooked Way")
+                    // Goblin Piker (Goblin), Orcish Mechanics (Orc), Grizzly Bears (Bear).
+                    .withCardOnBattlefield(1, "Goblin Piker", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Orcish Mechanics", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val goblin = game.findPermanent("Goblin Piker")!!
+                val orc = game.findPermanent("Orcish Mechanics")!!
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                withClue("no menace before activation") {
+                    val before = stateProjector.project(game.state)
+                    before.hasKeyword(goblin, Keyword.MENACE) shouldBe false
+                    before.hasKeyword(orc, Keyword.MENACE) shouldBe false
+                }
+
+                val enchantment = game.findPermanent("Along the Crooked Way")!!
+                val menaceAbility = AlongTheCrookedWay.activatedAbilities.single().id
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = enchantment,
+                        abilityId = menaceAbility,
+                    )
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val after = stateProjector.project(game.state)
+                withClue("both tribes named in the text gain menace") {
+                    after.hasKeyword(goblin, Keyword.MENACE) shouldBe true
+                    after.hasKeyword(orc, Keyword.MENACE) shouldBe true
+                }
+                withClue("a Bear is neither a Goblin nor an Orc") {
+                    after.hasKeyword(bear, Keyword.MENACE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BolgOfTheNorthScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BolgOfTheNorthScenarioTest.kt
@@ -1,0 +1,196 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.BolgOfTheNorth
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Bolg of the North (HOB #148) — {3}{B}{R} 5/5 Legendary Goblin Soldier.
+ *
+ * "When Bolg enters, you may sacrifice another creature. When you do, Bolg deals damage equal to
+ *  that creature's power to another target creature. If excess damage was dealt this way, amass
+ *  Goblins X, where X is that excess damage."
+ *
+ * The load-bearing detail is *when* the sacrificed creature's power is read. The reflexive ability
+ * resolves from a fresh `EffectContext` on the far side of a stack round-trip, which carries the
+ * pipeline but not the sacrifice's last-known-information snapshot — so the card stores the power
+ * into the pipeline while the creature is still on the battlefield. The lord test below is the one
+ * that fails if that snapshot slips to resolution time: the graveyard card would read its printed
+ * power and drop the +2/+0.
+ */
+class BolgOfTheNorthScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // "Other creatures you control get +2/+0" — makes projected power differ from printed power,
+    // so the damage amount proves which one the card actually read.
+    val GoblinWarchanter = card("Goblin Warchanter") {
+        manaCost = "{2}{R}"
+        colorIdentity = "R"
+        typeLine = "Creature — Goblin Warrior"
+        power = 1
+        toughness = 1
+        oracleText = "Other creatures you control get +2/+0."
+        staticAbility {
+            ability = ModifyStats(
+                powerBonus = 2,
+                toughnessBonus = 0,
+                filter = GroupFilter(GameObjectFilter.Creature.youControl(), excludeSelf = true),
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BolgOfTheNorth, GoblinWarchanter))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun castBolg(driver: GameTestDriver, me: EntityId) {
+        driver.giveMana(me, Color.BLACK, 1)
+        driver.giveMana(me, Color.RED, 1)
+        driver.giveColorlessMana(me, 3)
+        val card = driver.putCardInHand(me, "Bolg of the North")
+        driver.castSpell(me, card).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature spell
+        driver.bothPass() // resolve the enters trigger off the stack
+    }
+
+    fun GameTestDriver.armiesControlledBy(player: EntityId): List<EntityId> {
+        val projected = projector.project(state)
+        return projected.getBattlefieldControlledBy(player)
+            .filter { projected.isCreature(it) && projected.hasSubtype(it, "Army") }
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("sacrificing a creature deals its power, and the excess amasses that many Goblins") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Hill Giant is a 3/3; Grizzly Bears a 2/2. 3 damage to a 2/2 is 1 excess.
+        val fodder = driver.putCreatureOnBattlefield(me, "Hill Giant")
+        val victim = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        castBolg(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+        driver.submitTargetSelection(me, listOf(fodder))
+
+        // The "When you do" reflexive trigger goes on the stack; pick the damage target.
+        driver.submitTargetSelection(me, listOf(victim))
+        driver.bothPass()
+
+        driver.getGraveyard(me).contains(fodder) shouldBe true
+        driver.getGraveyard(opp).contains(victim) shouldBe true
+
+        val armies = driver.armiesControlledBy(me)
+        armies.size shouldBe 1
+        driver.plusOneCounters(armies.single()) shouldBe 1
+        projector.project(driver.state).hasSubtype(armies.single(), "Goblin") shouldBe true
+    }
+
+    test("the power is the sacrificed creature's last power on the battlefield, lord bonus included") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // Warchanter makes Grizzly Bears a 4/2 while it lives; its card in the graveyard is a 2/2.
+        driver.putCreatureOnBattlefield(me, "Goblin Warchanter")
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        projector.project(driver.state).getPower(fodder) shouldBe 4
+
+        // Wall of Ice is a 0/7, so it survives and keeps the damage marked on it — the assertion
+        // then reads the exact amount Bolg dealt rather than inferring it from a death.
+        val victim = driver.putCreatureOnBattlefield(opp, "Wall of Ice")
+
+        castBolg(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+        driver.submitTargetSelection(me, listOf(fodder))
+        driver.submitTargetSelection(me, listOf(victim))
+        driver.bothPass()
+
+        withClue(
+            "4 = the Bears' power on the battlefield. The printed 2 would mean the graveyard card " +
+                "was read; null/0 would mean the stored snapshot never crossed the pause."
+        ) {
+            driver.state.getEntity(victim)
+                ?.get<DamageComponent>()
+                ?.amount shouldBe 4
+        }
+    }
+
+    test("damage short of lethal deals no excess, so nothing is amassed") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // 2 power into a 3/3: lethal is never reached, so no excess and no Army.
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val victim = driver.putCreatureOnBattlefield(opp, "Hill Giant")
+
+        castBolg(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+        driver.submitTargetSelection(me, listOf(fodder))
+        driver.submitTargetSelection(me, listOf(victim))
+        driver.bothPass()
+
+        driver.getGraveyard(me).contains(fodder) shouldBe true
+        driver.getPermanents(opp).contains(victim) shouldBe true
+        driver.armiesControlledBy(me).size shouldBe 0
+    }
+
+    test("declining the optional sacrifice deals no damage and amasses nothing") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val victim = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        castBolg(driver, me)
+
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, false)
+
+        driver.getPermanents(me).contains(fodder) shouldBe true
+        driver.getPermanents(opp).contains(victim) shouldBe true
+        driver.armiesControlledBy(me).size shouldBe 0
+    }
+
+    test("with no other creature the sacrifice is infeasible and no decision is offered") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        castBolg(driver, me)
+
+        driver.pendingDecision shouldBe null
+        driver.armiesControlledBy(me).size shouldBe 0
+    }
+})


### PR DESCRIPTION
Two HOB cards, plus an engine bug the second one uncovered.

## Cards

**Along the Crooked Way** (#60) — `{2}{B}` Enchantment
Enters trigger returns a creature card from your graveyard; a per-card graveyard-exit trigger amasses Goblins 1; `{1}{B}` grants menace to Goblins and Orcs.

The middle ability is deliberately *not* `Triggers.CardsLeaveYourGraveyard` — that facade is the batched "one or more cards leave" shape (Chalk Outline). This card reads "**a** creature card leaves", so it's a per-card `ZoneChangeEvent(from = GRAVEYARD)` with no `to`, matching Rakshasa Vizier. The two abilities chain on the printed card: the enters trigger's return is itself a creature card leaving your graveyard.

The menace grant covers the amassed Army, which is a Goblin by CR 701.47a.

**Bolg of the North** (#148) — `{3}{B}{R}` 5/5 Legendary Goblin Soldier
Reflexive sacrifice → damage equal to that creature's power → excess amasses Goblins X.

Killmonger's `ReflexiveTriggerEffect` shape, with one addition. "That creature's power" is last-known information (CR 608.2h), but the reflexive resolves from a fresh `EffectContext` across a stack round-trip, and `ReflexiveAbilityTriggeredEvent` carries `carriedPipeline` — not `sacrificedPermanents`. So the action snapshots the power into the pipeline with `StoreNumber` **before** sacrificing, and the reflexive reads it back. Reading `Power` off the graveyard card instead would silently drop every +1/+1 counter and Layer 7 bonus.

The excess-damage half is the Orbital Plunge / Hell to Pay pair: `IfTargetTookExcessDamage` for the "if excess was dealt" clause, `ExcessMarkedDamage` for the amount.

Both cards are pure compositions — no new SDK vocabulary, so `docs/card-sdk-language-reference.md` needs no change.

## Engine fix

`exposeCollectionsToNextFrame` — the seam handing a drained continuation's pipeline storage to the frame beneath — propagated only `storedCollections`, silently dropping `storedNumbers` and `chosenValues`.

`CompositeEffectExecutor` threads all three between siblings on the **synchronous** path, so the bug was timing-dependent and invisible in the common case: a composite that stored a number and then **paused for a decision** lost it, while the identical composite that never paused kept it. Reads came back as `0` (`VariableReference` → `storedNumbers[name] ?: 0`), so it failed silently rather than erroring.

Both resumers needed it:
- `EffectAndTriggerContinuationResumer.resumeEffect` — the decision-resume path.
- `CoreAutoResumerModule`'s `autoResumer(EffectContinuation::class)` — the auto-resume path, which is what actually drains a composite whose earlier step paused. Patching only the first changed nothing.

This is a latent bug beyond this card: any "store a value, read it after a pause" composition hit it.

## Tests

4 scenario tests for Along the Crooked Way, 5 for Bolg.

The Bolg lord-bonus test is what caught the seam bug, and it needs two things to be able to: printed P/T differing from projected P/T (so a wrong read is observable at all), and **two** sacrificeable creatures — with only one legal target the engine auto-selects, never pauses, and takes the synchronous path that always worked.

`just test` passes across all modules. `just check-card-printing` clean for both; HOB has no backlog file to tick.

## Not included

I picked three cards initially and dropped one. **My Precious // Allure of Power** (#176) needs face-scoped additional costs: its Adventure declares "As an additional cost to cast this spell, sacrifice a creature", but `CastSpellEnumerator.enumerateSecondaryFace` and `CastSpellHandler.resolveAdditionalCostsForMode` both read card-level `script.additionalCosts` only. The enumerator's own doc says the additional-cost UX "is not yet wired for these faces." Shipping it would have handed out a free draw-two. That's `add-feature` work.

For context, the rest of the HOB tail is similarly gated — I checked all 44 missing cards. Roughly 30 need the unimplemented `recruit`, `storied`, or `hone counter` keywords; the remainder need new vocabulary (hand-and-library search, "choose a mode that hasn't been chosen", type-changing returns, a shares-a-card-type targeting relation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)