### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/EmpyrialPlate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/EmpyrialPlate.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Empyrial Plate — Mirrodin #168
+ * {2} · Artifact — Equipment
+ *
+ * Equipped creature gets +1/+1 for each card in your hand.
+ * Equip {2}
+ *
+ * Modelling notes:
+ * - "your hand" is the *Equipment controller's* hand, not the equipped creature's controller's.
+ *   That matters the moment the creature changes controller (Act of Treason, Domineer) while the
+ *   Plate stays put. [DynamicAmounts.cardsInYourHand] resolves `Player.You` against the ability's
+ *   source, which is the Plate, so the printed behaviour falls out for free.
+ * - This is a Layer 7c *bonus* recomputed continuously, so the boost shrinks the instant you cast
+ *   a spell in response — hence [GrantDynamicStatsEffect] rather than a snapshotted amount.
+ * - The Plate itself is never in your hand while it's on the battlefield, so it never counts
+ *   toward its own bonus.
+ */
+val EmpyrialPlate = card("Empyrial Plate") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 for each card in your hand.\nEquip {2}"
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = DynamicAmounts.cardsInYourHand(),
+            toughnessBonus = DynamicAmounts.cardsInYourHand()
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "168"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1735bbb-402e-4657-8ad0-df2c56d5ee01.jpg?1783944522"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithStrider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SlithStrider.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slith Strider — Mirrodin #50
+ * {1}{U}{U} · Creature — Slith · 1/1
+ *
+ * Whenever this creature becomes blocked, draw a card.
+ * Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+ *
+ * The blue member of the Slith cycle. Its two triggers pull in opposite directions: getting
+ * blocked replaces the growth with a card, so it always trades up.
+ *
+ * Modelling notes:
+ * - The unfiltered [Triggers.BecomesBlocked] is right here — the printed text has no blocker
+ *   restriction, so a gang block still yields exactly one trigger and exactly one card
+ *   (contrast Ogre Leadfoot in this set, which needs the per-blocker filtered form).
+ * - [Triggers.DealsCombatDamageToPlayer] is *combat* damage only, matching the rest of the
+ *   cycle: a burn spell or a damage-redirection effect never grows it. The counter goes on the
+ *   Slith itself ([EffectTarget.Self]), not on a chosen creature.
+ */
+val SlithStrider = card("Slith Strider") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Slith"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature becomes blocked, draw a card.\n" +
+        "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        effect = Effects.DrawCards(1)
+        description = "Whenever this creature becomes blocked, draw a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Justin Sweet"
+        flavorText = "A slith's form and function are determined by the color of the sun under " +
+            "which it's born."
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85866351-a721-4b3c-9b6f-4d291daab657.jpg?1783944553"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TowerOfMurmurs.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TowerOfMurmurs.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tower of Murmurs — Mirrodin #268
+ * {4} · Artifact
+ *
+ * {8}, {T}: Target player mills eight cards.
+ *
+ * Modelling notes:
+ * - Printed as "Target player puts the top eight cards of their library into their graveyard";
+ *   the modern Oracle wording is the mill keyword action (CR 701.13), which is what
+ *   [Patterns.Library.mill] models. It is *not* a cost and not optional.
+ * - Any player is a legal target, including its controller — self-mill is a real (if grim) use.
+ * - A library with fewer than eight cards simply mills what it has; the player doesn't lose
+ *   until they next try to draw from an empty library (CR 104.3c).
+ */
+val TowerOfMurmurs = card("Tower of Murmurs") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{8}, {T}: Target player mills eight cards."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{8}"), Costs.Tap)
+        val player = target("target player", Targets.Player)
+        effect = Patterns.Library.mill(8, player)
+        description = "{8}, {T}: Target player mills eight cards."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "268"
+        artist = "Glen Angus"
+        flavorText = "Etched on its surface are warnings from a long-lost race of ur-golems " +
+            "pushed to the brink of extinction."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76be1ca8-b68e-436d-86b6-2a2a07da1be9.jpg?1783944497"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TrollsOfTelJilad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TrollsOfTelJilad.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Trolls of Tel-Jilad — Mirrodin #136
+ * {5}{G}{G} · Creature — Troll Shaman · 5/6
+ *
+ * {1}{G}: Regenerate target green creature.
+ *
+ * Modelling notes:
+ * - The ability targets *any* green creature, not just this one and not just creatures you
+ *   control, so the filter is a bare colour filter ([TargetFilter.Creature] narrowed with
+ *   [Color.GREEN]) with no controller restriction. The Trolls are themselves green, so
+ *   "regenerate itself" is just the self-targeting case of the same ability.
+ * - Colour is read off projected state, so a creature that has been *made* green by another
+ *   effect is a legal target and one that has lost green is not — the target is re-checked on
+ *   resolution and the ability fizzles if it no longer matches.
+ * - [RegenerateEffect] applies a shield lasting until end of turn (CR 701.15); it is not a
+ *   regeneration ability granted to the creature, so "can't be regenerated" markers still win.
+ */
+val TrollsOfTelJilad = card("Trolls of Tel-Jilad") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Troll Shaman"
+    power = 5
+    toughness = 6
+    oracleText = "{1}{G}: Regenerate target green creature."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{G}")
+        val greenCreature = target(
+            "target green creature",
+            TargetCreature(filter = TargetFilter.Creature.withColor(Color.GREEN))
+        )
+        effect = RegenerateEffect(greenCreature)
+        description = "{1}{G}: Regenerate target green creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "Marcelo Vignali"
+        flavorText = "\"The secret of this world weighs upon us, and we have been shaped by " +
+            "time and duty to bear it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/6535f2ad-6cda-4be9-8e4f-6f062b63be31.jpg?1783944530"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Woebearer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Woebearer.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Woebearer — Mirrodin #83
+ * {4}{B} · Creature — Zombie · 2/3
+ *
+ * Fear
+ * Whenever this creature deals combat damage to a player, you may return target creature card
+ * from your graveyard to your hand.
+ *
+ * Modelling notes:
+ * - Fear is a printed evasion keyword ([Keyword.FEAR]) — "can't be blocked except by artifact
+ *   creatures and/or black creatures" — so Woebearer connects often enough for the recursion
+ *   trigger to matter.
+ * - The trigger targets on the way onto the stack but the return is a "may", so `optional = true`
+ *   sits on the ability while the target requirement stays mandatory: a legal creature card in
+ *   your graveyard must be chosen for the trigger to go on the stack at all, and only then can
+ *   the controller decline. If that card leaves the graveyard in response, the trigger fizzles.
+ * - "your graveyard" is the *controller's* graveyard at resolution, which is what
+ *   [TargetFilter.CreatureInYourGraveyard] models — an opponent's graveyard is never a source.
+ */
+val Woebearer = card("Woebearer") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 3
+    oracleText = "Fear (This creature can't be blocked except by artifact creatures and/or " +
+        "black creatures.)\n" +
+        "Whenever this creature deals combat damage to a player, you may return target creature " +
+        "card from your graveyard to your hand."
+
+    keywords(Keyword.FEAR)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        optional = true
+        val creatureCard = target(
+            "target creature card",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard)
+        )
+        effect = Effects.Move(creatureCard, Zone.HAND)
+        description = "Whenever this creature deals combat damage to a player, you may return " +
+            "target creature card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Matt Thompson"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5a6e960-169d-431a-9ebd-c4413aa67377.jpg?1783944543"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -1240,6 +1240,73 @@
     ]
 }
 
+// Empyrial Plate
+{
+    "name": "Empyrial Plate",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1 for each card in your hand.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Hand"
+                },
+                "toughnessBonus": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Hand"
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "168",
+        "rarity": "RARE",
+        "artist": "Paolo Parente",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1735bbb-402e-4657-8ad0-df2c56d5ee01.jpg?1783944522"
+    },
+    "colorIdentityOverride": []
+}
+
 // Fabricate
 {
     "name": "Fabricate",
@@ -4962,6 +5029,59 @@
     ]
 }
 
+// Slith Strider
+{
+    "name": "Slith Strider",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Slith",
+    "oracleText": "Whenever this creature becomes blocked, draw a card.\nWhenever this creature deals combat damage to a player, put a +1/+1 counter on it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever this creature becomes blocked, draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "UNCOMMON",
+        "artist": "Justin Sweet",
+        "flavorText": "A slith's form and function are determined by the color of the sun under which it's born.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85866351-a721-4b3c-9b6f-4d291daab657.jpg?1783944553"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Soldier Replica
 {
     "name": "Soldier Replica",
@@ -6329,6 +6449,82 @@
     "colorIdentityOverride": []
 }
 
+// Tower of Murmurs
+{
+    "name": "Tower of Murmurs",
+    "manaCost": "{4}",
+    "typeLine": "Artifact",
+    "oracleText": "{8}, {T}: Target player mills eight cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{8}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 8
+                                },
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "{8}, {T}: Target player mills eight cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "rarity": "RARE",
+        "artist": "Glen Angus",
+        "flavorText": "Etched on its surface are warnings from a long-lost race of ur-golems pushed to the brink of extinction.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76be1ca8-b68e-436d-86b6-2a2a07da1be9.jpg?1783944497"
+    },
+    "colorIdentityOverride": []
+}
+
 // Trash for Treasure
 {
     "name": "Trash for Treasure",
@@ -6444,6 +6640,59 @@
         "artist": "Puddnhead",
         "flavorText": "It's no coincidence that the oldest trolls are also the angriest.",
         "imageUri": "https://cards.scryfall.io/normal/front/f/0/f01233c2-6df0-4f0e-8668-3855868731ea.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Trolls of Tel-Jilad
+{
+    "name": "Trolls of Tel-Jilad",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Troll Shaman",
+    "oracleText": "{1}{G}: Regenerate target green creature.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target green creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature green"
+                        },
+                        "id": "target green creature"
+                    }
+                ],
+                "descriptionOverride": "{1}{G}: Regenerate target green creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "UNCOMMON",
+        "artist": "Marcelo Vignali",
+        "flavorText": "\"The secret of this world weighs upon us, and we have been shaped by time and duty to bear it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/6535f2ad-6cda-4be9-8e4f-6f062b63be31.jpg?1783944530"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -7107,6 +7356,60 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Woebearer
+{
+    "name": "Woebearer",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Fear (This creature can't be blocked except by artifact creatures and/or black creatures.)\nWhenever this creature deals combat damage to a player, you may return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FEAR"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card"
+                    },
+                    "destination": "Hand"
+                },
+                "optional": true,
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, you may return target creature card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Thompson",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5a6e960-169d-431a-9ebd-c4413aa67377.jpg?1783944543"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmpyrialPlateScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmpyrialPlateScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.EmpyrialPlate
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Empyrial Plate (MRD #168, {2}, Artifact — Equipment).
+ *
+ *   Equipped creature gets +1/+1 for each card in your hand.
+ *   Equip {2}
+ *
+ * The point of interest is that the bonus is a *continuously recomputed* Layer 7c amount, not a
+ * value snapshotted when the Plate is attached — so the second test shrinks the hand mid-turn and
+ * asserts the equipped creature shrinks with it.
+ */
+class EmpyrialPlateScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Empyrial Plate") {
+
+            test("equipping grants +1/+1 for each card in the controller's hand") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Empyrial Plate")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardsInHand(1, "Forest", 3)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val plate = game.findPermanent("Empyrial Plate")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Grizzly Bears is a plain 2/2 before the Plate is attached") {
+                    val before = stateProjector.project(game.state)
+                    before.getPower(bears) shouldBe 2
+                    before.getToughness(bears) shouldBe 2
+                }
+
+                val equip = EmpyrialPlate.activatedAbilities.single { it.isEquipAbility }
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = plate,
+                        abilityId = equip.id,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating equip should succeed: ${result.error}") { result.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("The Plate should be attached to Grizzly Bears") {
+                    game.state.getEntity(plate)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                }
+                withClue("Three cards in hand turns the 2/2 into a 5/5") {
+                    val after = stateProjector.project(game.state)
+                    after.getPower(bears) shouldBe 5
+                    after.getToughness(bears) shouldBe 5
+                }
+            }
+
+            test("the bonus tracks hand size as it changes, and is zero on an empty hand") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Empyrial Plate", "Grizzly Bears")
+                    .withCardInHand(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("One card in hand is +1/+1") {
+                    val before = stateProjector.project(game.state)
+                    before.getPower(bears) shouldBe 3
+                    before.getToughness(bears) shouldBe 3
+                }
+
+                val forest = game.findCardsInHand(1, "Forest").single()
+                val played = game.execute(PlayLand(game.player1Id, forest))
+                withClue("Playing the land should succeed: ${played.error}") { played.error shouldBe null }
+
+                withClue("Emptying the hand drops the bonus back to nothing") {
+                    val after = stateProjector.project(game.state)
+                    after.getPower(bears) shouldBe 2
+                    after.getToughness(bears) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlithStriderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlithStriderScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Slith Strider (MRD #50, {1}{U}{U}, Creature — Slith 1/1).
+ *
+ *   Whenever this creature becomes blocked, draw a card.
+ *   Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
+ *
+ * The two triggers are mutually exclusive in practice — getting blocked stops the damage that would
+ * have grown it — so each test drives exactly one of them.
+ */
+class SlithStriderScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Slith Strider") {
+
+            test("connecting with a player puts a +1/+1 counter on it") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Slith Strider", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val slith = game.findPermanent("Slith Strider")!!
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Slith Strider" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.hasPendingDecision()) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("Bob should have taken 1 combat damage") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("The +1/+1 counter turns the 1/1 into a 2/2") {
+                    val after = stateProjector.project(game.state)
+                    after.getPower(slith) shouldBe 2
+                    after.getToughness(slith) shouldBe 2
+                }
+                withClue("Being unblocked draws nothing") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("becoming blocked draws a card and grows nothing") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Slith Strider", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val slith = game.findPermanent("Slith Strider")!!
+                val handBefore = game.handSize(1)
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Slith Strider" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Grizzly Bears" to listOf("Slith Strider"))).error shouldBe null
+                game.resolveStack()
+
+                withClue("The becomes-blocked trigger draws exactly one card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+                withClue("A blocked Slith is still a 1/1 — no combat damage reached a player") {
+                    val after = stateProjector.project(game.state)
+                    after.getPower(slith) shouldBe 1
+                    after.getToughness(slith) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TowerOfMurmursScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TowerOfMurmursScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.TowerOfMurmurs
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Tower of Murmurs (MRD #268, {4}, Artifact).
+ *
+ *   {8}, {T}: Target player mills eight cards.
+ *
+ * Eight generic and a tap is a steep price, so the two things worth pinning down are that the mill
+ * lands on the *targeted* player and that a library shorter than eight simply empties out rather
+ * than erroring — the loss comes later, on the next draw from an empty library (CR 104.3c).
+ */
+class TowerOfMurmursScenarioTest : ScenarioTestBase() {
+
+    private val abilityId = TowerOfMurmurs.activatedAbilities.single().id
+
+    init {
+        context("Tower of Murmurs") {
+
+            test("mills eight cards from the targeted opponent") {
+                var builder = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Tower of Murmurs")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(10) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val tower = game.findPermanent("Tower of Murmurs")!!
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tower,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("Activating the Tower should succeed: ${result.error}") { result.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Bob's library should be eight cards lighter") {
+                    game.librarySize(2) shouldBe 2
+                }
+                withClue("Those eight cards land in Bob's graveyard") {
+                    game.graveyardSize(2) shouldBe 8
+                }
+                withClue("Alice's own library is untouched") {
+                    game.graveyardSize(1) shouldBe 0
+                }
+            }
+
+            test("a library shorter than eight just empties out") {
+                var builder = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Tower of Murmurs")
+                    .withLandsOnBattlefield(1, "Forest", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(3) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val tower = game.findPermanent("Tower of Murmurs")!!
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = tower,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("All three cards are milled, and nothing errors on the shortfall") {
+                    game.librarySize(2) shouldBe 0
+                    game.graveyardSize(2) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrollsOfTelJiladScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrollsOfTelJiladScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.TrollsOfTelJilad
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Trolls of Tel-Jilad (MRD #136, {5}{G}{G}, Creature — Troll Shaman 5/6).
+ *
+ *   {1}{G}: Regenerate target green creature.
+ *
+ * The interesting part is the colour restriction on the target: any green creature qualifies —
+ * including the Trolls themselves and creatures an opponent controls — while a non-green creature
+ * is never a legal target.
+ */
+class TrollsOfTelJiladScenarioTest : ScenarioTestBase() {
+
+    private val abilityId = TrollsOfTelJilad.activatedAbilities.single().id
+
+    private fun TestGame.hasRegenShield(entityId: EntityId): Boolean =
+        state.floatingEffects.any {
+            it.effect.modification is SerializableModification.RegenerationShield &&
+                entityId in it.effect.affectedEntities
+        }
+
+    init {
+        context("Trolls of Tel-Jilad") {
+
+            test("regenerates a green creature") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Trolls of Tel-Jilad", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val trolls = game.findPermanent("Trolls of Tel-Jilad")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.hasRegenShield(bears) shouldBe false
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = trolls,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating on a green creature should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be carrying a regeneration shield") {
+                    game.hasRegenShield(bears) shouldBe true
+                }
+            }
+
+            test("a non-green creature is not a legal target") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Trolls of Tel-Jilad", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val trolls = game.findPermanent("Trolls of Tel-Jilad")!!
+                val hillGiant = game.findPermanent("Hill Giant")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = trolls,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(hillGiant))
+                    )
+                )
+                withClue("Targeting the red Hill Giant should be rejected") {
+                    result.error shouldNotBe null
+                }
+                withClue("No shield should have been handed out") {
+                    game.hasRegenShield(hillGiant) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoebearerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WoebearerScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Woebearer (MRD #83, {4}{B}, Creature — Zombie 2/3).
+ *
+ *   Fear
+ *   Whenever this creature deals combat damage to a player, you may return target creature card
+ *   from your graveyard to your hand.
+ *
+ * Covers the accept path, the declined "may", and the graveyard-ownership restriction (only *your*
+ * graveyard is a legal source, so an opponent's creature card never becomes a target).
+ */
+class WoebearerScenarioTest : ScenarioTestBase() {
+
+    /** Swing with Woebearer into an empty board and push its combat damage through. */
+    private fun TestGame.connectWithWoebearer() {
+        advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+        withClue("Woebearer should be able to attack") {
+            declareAttackers(mapOf("Woebearer" to 2)).error shouldBe null
+        }
+        passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+        resolveStack()
+        if (hasPendingDecision() && getPendingDecision() !is ChooseTargetsDecision) {
+            submitDefaultCombatDamage()
+            resolveStack()
+        }
+    }
+
+    init {
+        context("Woebearer") {
+
+            test("connecting returns the chosen creature card from your graveyard to your hand") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Woebearer", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.connectWithWoebearer()
+
+                withClue("Bob should have taken 2 combat damage") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+
+                val decision = game.getPendingDecision()
+                withClue("The trigger should ask for a target; got $decision") {
+                    decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+                }
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                withClue("Grizzly Bears in your graveyard should be a legal target") {
+                    (decision as ChooseTargetsDecision).legalTargets[0].orEmpty() shouldContain bears
+                }
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be back in Alice's hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("declining the may leaves the creature card in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Woebearer", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.connectWithWoebearer()
+
+                // A targeted "you may" carries its consent through the target decision itself:
+                // `optional = true` drops minTargets to 0, so choosing nothing *is* the decline.
+                val decision = game.getPendingDecision()
+                withClue("The trigger should ask for a target; got $decision") {
+                    decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+                }
+                withClue("An optional trigger must allow selecting zero targets") {
+                    (decision as ChooseTargetsDecision).targetRequirements.single().minTargets shouldBe 0
+                }
+                game.skipTargets()
+                game.resolveStack()
+
+                withClue("Grizzly Bears should still be in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    game.isInHand(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("an opponent's graveyard is never a legal source") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Woebearer", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.connectWithWoebearer()
+
+                val decision = game.getPendingDecision()
+                withClue("The trigger should ask for a target; got $decision") {
+                    decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+                }
+                val hillGiant = game.findCardsInGraveyard(2, "Hill Giant").single()
+                withClue("Bob's Hill Giant is not a legal target for Alice's Woebearer") {
+                    (decision as ChooseTargetsDecision).legalTargets[0].orEmpty() shouldNotContain hillGiant
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five more Mirrodin cards, each built purely from existing SDK primitives — no new effect, trigger, or static-ability types.

| Card | Text |
|---|---|
| **Trolls of Tel-Jilad** {5}{G}{G} 5/6 | `{1}{G}: Regenerate target green creature.` |
| **Tower of Murmurs** {4} | `{8}, {T}: Target player mills eight cards.` |
| **Empyrial Plate** {2} Equipment | `Equipped creature gets +1/+1 for each card in your hand. Equip {2}` |
| **Slith Strider** {1}{U}{U} 1/1 | becomes blocked → draw a card; combat damage to a player → +1/+1 counter |
| **Woebearer** {4}{B} 2/3 | fear; combat damage to a player → you may return target creature card from your graveyard to your hand |

### Modelling notes

- **Trolls of Tel-Jilad** — a bare colour filter (`TargetFilter.Creature.withColor(GREEN)`) with no controller restriction, so an opponent's green creature and the Trolls themselves are both legal. Colour is read off projected state, so a creature made green mid-turn qualifies and one that loses green makes the ability fizzle.
- **Empyrial Plate** — `GrantDynamicStatsEffect` rather than a snapshotted amount, so the bonus shrinks the moment you cast a spell in response. `Player.You` resolves against the ability's source, which is the Plate — so it reads the *Equipment controller's* hand, which is what the printed card says once the equipped creature changes controller.
- **Woebearer** — the targeted "you may" carries its consent through the target decision (`optional = true` drops `minTargets` to 0); choosing nothing *is* the decline. There is no separate yes/no prompt, and the test pins that down.
- **Tower of Murmurs** — modern Oracle uses the mill keyword action; a library shorter than eight simply empties, with the loss deferred to the next draw (CR 104.3c).

### Verification

- `just build` — green (full rules-engine + mtg-sets suites).
- `MRD.json` card snapshot re-blessed; only the five new cards appear in the diff.
- `just check-card-printing` clean for all five — each is canonical in its earliest real printing (MRD), and the later `psal` / `c16` / `ddi` printings are unscaffolded.
- One scenario test file per card, each covering the happy path plus the edge that matters: the non-green target rejection, a library shorter than the mill, a shrinking hand, blocked vs unblocked, and the declined "may".

No UX work needed — every decision routes to an existing component (battlefield targeting, player targeting, graveyard targeting, the standard equip flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)