### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BenthicCriminologists.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BenthicCriminologists.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.TriggeredAbilityBuilder
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+
+/**
+ * Benthic Criminologists — Murders at Karlov Manor #40
+ * {4}{U} · Creature — Merfolk Wizard · 4/5
+ *
+ * Whenever this creature enters or attacks, you may sacrifice an artifact. If you do, draw a card.
+ *
+ * "Enters or attacks" is two separate triggered abilities sharing one rider — the engine has no
+ * combined trigger, and modelling it as two abilities is also what the rules describe (each
+ * condition puts its own copy of the ability on the stack).
+ *
+ * "You may sacrifice an artifact. If you do, draw a card" is an [OptionalCostEffect], not a
+ * `MayEffect` around a composite: the draw is gated on the sacrifice actually happening, so
+ * declining — or controlling no artifact at all — draws nothing. The Clue tokens this set showers
+ * on a blue deck are the intended fuel, and sacrificing a Clue this way is a sacrifice for *this*
+ * ability's cost, not an activation of the Clue's own draw ability.
+ */
+val BenthicCriminologists = card("Benthic Criminologists") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    oracleText = "Whenever this creature enters or attacks, you may sacrifice an artifact. If you " +
+        "do, draw a card."
+    power = 4
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        sacrificeAnArtifactToDraw()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        sacrificeAnArtifactToDraw()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Johan Grenier"
+        flavorText = "Scientists from the Simic Combine are regularly seconded to various " +
+            "detective agencies in hopes that sharing their expertise will improve the guild's " +
+            "tarnished reputation."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/283b6b5a-acdf-4255-a294-0964d9c62686.jpg?1783912916"
+    }
+}
+
+/** The rider shared by the enters and attacks triggers. */
+private fun TriggeredAbilityBuilder.sacrificeAnArtifactToDraw() {
+    effect = OptionalCostEffect(
+        cost = SacrificeEffect(filter = GameObjectFilter.Artifact),
+        ifPaid = Effects.DrawCards(1)
+    )
+    description = "You may sacrifice an artifact. If you do, draw a card."
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BolracClanBasher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BolracClanBasher.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bolrac-Clan Basher — Murders at Karlov Manor #112
+ * {4}{R}{R} · Creature — Cyclops Warrior · 3/2
+ *
+ * Double strike, trample
+ * Disguise {3}{R}{R}
+ *
+ * A pure rate card: six mana for a 3/2 is unplayable, so the disguise line *is* the card. Down for
+ * {3} on turn three it is an anonymous 2/2 with ward {2} (CR 702.168a) — the double strike and
+ * trample are suppressed with the rest of its abilities (CR 708.2) — and the {3}{R}{R} flip can be
+ * paid mid-combat, after blocks, turning a chump block into six trampling damage.
+ *
+ * Flipping is a special action that doesn't use the stack (CR 701.34a), so there is no window for
+ * the defender to respond once the attack is already committed.
+ */
+val BolracClanBasher = card("Bolrac-Clan Basher") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cyclops Warrior"
+    oracleText = "Double strike, trample\n" +
+        "Disguise {3}{R}{R} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)"
+    power = 3
+    toughness = 2
+    keywords(Keyword.DOUBLE_STRIKE, Keyword.TRAMPLE)
+    disguise = "{3}{R}{R}"
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Warren Mahy"
+        flavorText = "Determining the culprit was not difficult. Getting him to stop committing " +
+            "the crime long enough to be arrested, however, was a massive challenge."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b87683f7-8a61-4e4a-8b8b-3bf812454096.jpg?1783912887"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "Turning a permanent face up or face down doesn't change whether that permanent is " +
+                "tapped or untapped."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DragTheCanal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DragTheCanal.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Drag the Canal — Murders at Karlov Manor #199
+ * {U}{B} · Instant
+ *
+ * Create a 2/2 white and blue Detective creature token. If a creature died this turn, you gain 2
+ * life, surveil 2, then investigate.
+ *
+ * Two mana always buys the Detective; the rest is a morbid rider. "If a creature died this turn"
+ * is a resolution-time check on the whole game's turn history (any creature, any controller —
+ * including one that died to combat damage in the same turn this instant is cast), so this is at
+ * its best cast after blockers trade rather than pre-combat.
+ *
+ * The rider's three clauses are ordered as printed: gain 2, then surveil 2, then investigate. The
+ * ordering matters when the surveil is what turns on something watching the graveyard, and it
+ * means the Clue is created after any cards the surveil bins.
+ *
+ * The token's art comes from the MKM `tokenArt` layer (the 2/2 white-and-blue Detective is one of
+ * the set's printed tokens), so no `imageUri` is baked in here.
+ */
+val DragTheCanal = card("Drag the Canal") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Instant"
+    oracleText = "Create a 2/2 white and blue Detective creature token. If a creature died this " +
+        "turn, you gain 2 life, surveil 2, then investigate. (Create a Clue token. It's an " +
+        "artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.WHITE, Color.BLUE),
+                creatureTypes = setOf("Detective")
+            ),
+            ConditionalEffect(
+                condition = Conditions.CreatureDiedThisTurn,
+                effect = Effects.Composite(
+                    Effects.GainLife(2),
+                    Effects.Surveil(2),
+                    Effects.Investigate()
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "199"
+        artist = "Josh Hass"
+        flavorText = "\"Let's gather what we can before the Golgari tidy up the scene.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/508d7096-2be3-4d4b-a55c-d4dbd3c9019c.jpg?1783912850"
+
+        ruling(
+            "2024-02-02",
+            "Clue is an artifact type. Even though it appears on some cards with other permanent " +
+                "types, it's never a creature type, a land type, or anything but an artifact type."
+        )
+        ruling(
+            "2024-02-02",
+            "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger " +
+                "whenever you sacrifice a Clue for any reason, not just to activate a Clue's " +
+                "activated ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ItDoesntAddUp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ItDoesntAddUp.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * It Doesn't Add Up — Murders at Karlov Manor #89
+ * {3}{B}{B} · Instant
+ *
+ * Return target creature card from your graveyard to the battlefield. Suspect it.
+ *
+ * Instant-speed reanimation, priced with a drawback rather than a mana-value restriction: whatever
+ * comes back is suspected, so it has menace and can't block for as long as it stays on the
+ * battlefield (CR 701.60a). Reanimating at end of turn to get a surprise blocker therefore does
+ * *not* work — the point is to flash in an attacker, or to rebuy a value body.
+ *
+ * "Suspect it" is not a second target; it names the permanent that just arrived. The reanimated
+ * card keeps its entity id across the graveyard → battlefield move, so the same target reference
+ * that chose the card in the graveyard addresses the permanent afterwards (same idiom as Prison
+ * Break's "with an additional +1/+1 counter on it").
+ */
+val ItDoesntAddUp = card("It Doesn't Add Up") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Return target creature card from your graveyard to the battlefield. Suspect it. " +
+        "(It has menace and can't block.)"
+
+    spell {
+        val creatureCard = target(
+            "target creature card from your graveyard",
+            Targets.CreatureCardInYourGraveyard
+        )
+        effect = Effects.Move(creatureCard, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+            .then(Effects.Suspect(creatureCard))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "Etrata had committed dozens of murders, all of which she recalled in " +
+            "perfect, loving detail. But no matter how hard she tried, she couldn't remember " +
+            "killing Zegana."
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa02dbc2-ad01-47fd-b39e-f0a695029f26.jpg?1783912898"
+
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until " +
+                "it leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "If a suspected creature loses all abilities, it will lose menace and \"This creature " +
+                "can't block\", but it won't stop being suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "If a creature is already suspected, suspecting it again won't have any effect."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UndercoverCrocodelf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/UndercoverCrocodelf.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Undercover Crocodelf — Murders at Karlov Manor #239
+ * {4}{G}{U} · Creature — Elf Crocodile Detective · 5/5
+ *
+ * Whenever this creature deals combat damage to a player, investigate.
+ * Disguise {3}{G/U}{G/U}
+ *
+ * Six mana for a 5/5 with a damage trigger is a bad rate; {3} face down on turn three is a fine
+ * one. The trade is that a face-down permanent has no abilities at all (CR 702.168a / 708.2), so
+ * connecting while it's still a 2/2 investigates nothing — the Clue only starts flowing once the
+ * {3}{G/U}{G/U} flip has happened.
+ *
+ * The trigger is SELF-bound and combat-only: burn, fight, or any other non-combat damage to a
+ * player doesn't fire it.
+ */
+val UndercoverCrocodelf = card("Undercover Crocodelf") {
+    manaCost = "{4}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Elf Crocodile Detective"
+    oracleText = "Whenever this creature deals combat damage to a player, investigate. (Create a " +
+        "Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "Disguise {3}{G/U}{G/U} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)"
+    power = 5
+    toughness = 5
+    disguise = "{3}{G/U}{G/U}"
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Investigate()
+        description = "Whenever this creature deals combat damage to a player, investigate."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "239"
+        artist = "Nicholas Gregory"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5bc669c8-6f39-4d52-82d3-a4005d41c8a5.jpg?1783912836"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -250,6 +250,78 @@
     ]
 }
 
+// Benthic Criminologists
+{
+    "name": "Benthic Criminologists",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "Whenever this creature enters or attacks, you may sacrifice an artifact. If you do, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "artifact"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "descriptionOverride": "You may sacrifice an artifact. If you do, draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "artifact"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "descriptionOverride": "You may sacrifice an artifact. If you do, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Johan Grenier",
+        "flavorText": "Scientists from the Simic Combine are regularly seconded to various detective agencies in hopes that sharing their expertise will improve the guild's tarnished reputation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/283b6b5a-acdf-4255-a294-0964d9c62686.jpg?1783912916"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Bite Down on Crime
 {
     "name": "Bite Down on Crime",
@@ -347,6 +419,54 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Bolrac-Clan Basher
+{
+    "name": "Bolrac-Clan Basher",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Cyclops Warrior",
+    "oracleText": "Double strike, trample\nDisguise {3}{R}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "DOUBLE_STRIKE",
+        "TRAMPLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{R}{R}"
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "flavorText": "Determining the culprit was not difficult. Getting him to stop committing the crime long enough to be arrested, however, was a massive challenge.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b87683f7-8a61-4e4a-8b8b-3bf812454096.jpg?1783912887",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Turning a permanent face up or face down doesn't change whether that permanent is tapped or untapped."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1366,6 +1486,81 @@
     "colorIdentityOverride": [
         "RED",
         "WHITE"
+    ]
+}
+
+// Drag the Canal
+{
+    "name": "Drag the Canal",
+    "manaCost": "{U}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Create a 2/2 white and blue Detective creature token. If a creature died this turn, you gain 2 life, surveil 2, then investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE",
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Detective"
+                    ]
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": "CreatureDiedThisTurn"
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "Surveil",
+                                "count": 2
+                            },
+                            {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Clue"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "rarity": "RARE",
+        "artist": "Josh Hass",
+        "flavorText": "\"Let's gather what we can before the Golgari tidy up the scene.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/508d7096-2be3-4d4b-a55c-d4dbd3c9019c.jpg?1783912850",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Clue is an artifact type. Even though it appears on some cards with other permanent types, it's never a creature type, a land type, or anything but an artifact type."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger whenever you sacrifice a Clue for any reason, not just to activate a Clue's activated ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 
@@ -3398,6 +3593,94 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// It Doesn't Add Up
+{
+    "name": "It Doesn't Add Up",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Return target creature card from your graveyard to the battlefield. Suspect it. (It has menace and can't block.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SetSuspected",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card from your graveyard"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card from your graveyard"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card from your graveyard"
+                            },
+                            "duration": "Permanent"
+                        }
+                    ],
+                    "descriptionOverride": "target becomes suspected"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "Etrata had committed dozens of murders, all of which she recalled in perfect, loving detail. But no matter how hard she tried, she couldn't remember killing Zegana.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa02dbc2-ad01-47fd-b39e-f0a695029f26.jpg?1783912898",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a suspected creature loses all abilities, it will lose menace and \"This creature can't block\", but it won't stop being suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature is already suspected, suspecting it again won't have any effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -7345,6 +7628,70 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Undercover Crocodelf
+{
+    "name": "Undercover Crocodelf",
+    "manaCost": "{4}{G}{U}",
+    "typeLine": "Creature — Elf Crocodile Detective",
+    "oracleText": "Whenever this creature deals combat damage to a player, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\nDisguise {3}{G/U}{G/U} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{G/U}{G/U}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, investigate."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "artist": "Nicholas Gregory",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5bc669c8-6f39-4d52-82d3-a4005d41c8a5.jpg?1783912836",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ItDoesntAddUpScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ItDoesntAddUpScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.ItDoesntAddUp
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * It Doesn't Add Up (MKM #89) — {3}{B}{B} Instant.
+ *
+ * "Return target creature card from your graveyard to the battlefield. Suspect it."
+ *
+ * The composition under test is that the suspect lands on the *reanimated permanent*, not on some
+ * stale graveyard-card reference: the card is targeted while it is in the graveyard, moved to the
+ * battlefield, and then the same target reference has to address the permanent that just arrived.
+ * If entity identity were not preserved across the zone move, the reanimation would still look
+ * correct while the suspect silently no-opped — which is exactly the failure mode a "did it come
+ * back?" assertion alone would miss.
+ */
+class ItDoesntAddUpScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ItDoesntAddUp)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("the reanimated creature comes back suspected") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val courser = driver.putCardInGraveyard(player, "Centaur Courser")
+        val spell = driver.putCardInHand(player, "It Doesn't Add Up")
+        driver.giveMana(player, Color.BLACK, 2)
+        driver.giveColorlessMana(player, 3)
+
+        driver.castSpellWithTargets(
+            player,
+            spell,
+            listOf(ChosenTarget.Card(courser, player, Zone.GRAVEYARD))
+        ).error shouldBe null
+        driver.bothPass()
+
+        withClue("the creature card is on the battlefield under its owner's control") {
+            driver.findPermanent(player, "Centaur Courser") shouldBe courser
+        }
+
+        val projected = projector.project(driver.state)
+        withClue("and the same permanent is suspected — menace and can't block (CR 701.60a)") {
+            projected.isSuspected(courser) shouldBe true
+            projected.hasKeyword(courser, Keyword.MENACE) shouldBe true
+            projected.cantBlock(courser) shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
Five MKM cards, all composed from existing SDK vocabulary — no new effect, trigger, or keyword types.

| Card | Cost | Shape |
|---|---|---|
| Bolrac-Clan Basher | `{4}{R}{R}` | 3/2 double strike, trample; disguise `{3}{R}{R}` |
| Undercover Crocodelf | `{4}{G}{U}` | 5/5, combat damage to a player investigates; hybrid disguise `{3}{G/U}{G/U}` |
| Benthic Criminologists | `{4}{U}` | 4/5, enters *or* attacks → may sacrifice an artifact to draw |
| Drag the Canal | `{U}{B}` | Instant: Detective token, plus a morbid rider |
| It Doesn't Add Up | `{3}{B}{B}` | Instant: reanimate a creature card, suspect it |

### Modelling notes

- **Benthic Criminologists** — "enters or attacks" is two triggered abilities sharing one private rider; the engine has no combined trigger, and two abilities is also what the rules describe. "You may sacrifice an artifact. If you do, draw a card" is an `OptionalCostEffect`, not a `MayEffect` around a composite, so declining — or controlling no artifact at all — draws nothing.
- **Drag the Canal** — the Detective token is unconditional; the gain-2 / surveil-2 / investigate rider sits behind `Conditions.CreatureDiedThisTurn` in printed order. The token uses the MKM `tokenArt` layer, so no `imageUri` is baked in.
- **It Doesn't Add Up** — "suspect it" is not a second target. The card is targeted in the graveyard, moved to the battlefield, and the same target reference then addresses the permanent that arrived (same idiom as Prison Break's "with an additional +1/+1 counter on it").
- **Disguise cards** — a face-down permanent has no abilities at all (CR 702.168a / 708.2), so Crocodelf investigates nothing until it's flipped, and the Basher's double strike/trample only come online at flip time.

### Tests

`ItDoesntAddUpScenarioTest` covers the one genuinely non-obvious composition: the suspect must land on the *reanimated permanent*, which relies on entity identity surviving the graveyard → battlefield move. Without that, the reanimation would still look correct while the suspect silently no-opped — a failure a "did it come back?" assertion alone would miss.

The other four are covered by the card snapshot and lint nets.

### Verification

- `just build` — green
- `just test-class ItDoesntAddUpScenarioTest` — passing
- `just rebless-cards` — only the five new card trees moved in `snapshots/cards/MKM.json` (347 insertions, 0 deletions)
- `just check-card-printing` — canonical placement confirmed in MKM for all five
- MKM set status: 125 → 130 of 276

🤖 Generated with [Claude Code](https://claude.com/claude-code)