### PR TITLE
Add five Mirrodin cards, with an Equipment-only attachment count on the equipped creature

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -8289,11 +8289,15 @@ For "X = the number of [things] attached to this permanent":
 - `DynamicAmounts.equipmentAttachedToSelf()` — only the Equipment attached to the source (Shagrat,
   Loot Bearer: "amass Orcs X, where X is the number of Equipment attached to Shagrat"). Desugars to
   `EntityProperty(Source, AttachmentCount(AttachmentKind.EQUIPMENT))`.
-- `DynamicAmounts.attachmentsOnEnchantedCreature()` — every Aura/Equipment attached to the
-  *enchanted* creature (the creature the source Aura is attached to), for an Aura that buffs its host
-  by its host's own attachment count (With Great Power…: "enchanted creature gets +2/+2 for each Aura
-  and Equipment attached to it"). Desugars to `EntityProperty(EnchantedCreature, AttachmentCount())`.
-  Distinct from `attachmentsOnSelf()`, which counts attachments on the source itself.
+- `DynamicAmounts.attachmentsOnEnchantedCreature(kind = AttachmentKind.ANY)` — attachments of `kind`
+  on the creature the *source* is attached to (the enchanted creature for an Aura, the equipped
+  creature for an Equipment — both read the same attachment link), for an Aura or Equipment that
+  buffs its host by that host's own attachment count. Desugars to
+  `EntityProperty(EnchantedCreature, AttachmentCount(kind))`. Default `ANY` counts every Aura and
+  Equipment (With Great Power…: "enchanted creature gets +2/+2 for each Aura and Equipment attached
+  to it"); `AttachmentKind.EQUIPMENT` counts only Equipment (Golem-Skin Gauntlets: "equipped creature
+  gets +1/+0 for each Equipment attached to it", which includes the Gauntlets themselves). Distinct
+  from `attachmentsOnSelf()`, which counts attachments on the source itself.
 
 `AttachmentCount(kind)` takes an `AttachmentKind` (`ANY` / `EQUIPMENT` / `AURA`); the evaluator
 counts the source's `attachedIds` whose card type matches the kind.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/DynamicAmounts.kt
@@ -621,13 +621,21 @@ object DynamicAmounts {
         DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.AttachmentCount())
 
     /**
-     * Number of Auras and Equipment attached to the enchanted creature — the creature the source
-     * Aura is attached to (With Great Power…: "enchanted creature gets +2/+2 for each Aura and
-     * Equipment attached to it"). Distinct from [attachmentsOnSelf], which counts attachments on
-     * the source itself.
+     * Number of attachments of [kind] on the creature the source is attached to — the *enchanted*
+     * creature for an Aura, the *equipped* creature for an Equipment; both read the same attachment
+     * link. Defaults to [AttachmentKind.ANY]: every Aura and Equipment (With Great Power…:
+     * "enchanted creature gets +2/+2 for each Aura and Equipment attached to it"). Pass
+     * [AttachmentKind.EQUIPMENT] for the Equipment-only count an Equipment buffing its own host by
+     * that host's Equipment needs (Golem-Skin Gauntlets: "equipped creature gets +1/+0 for each
+     * Equipment attached to it" — which includes the Gauntlets themselves).
+     *
+     * Distinct from [attachmentsOnSelf], which counts attachments on the source itself.
      */
-    fun attachmentsOnEnchantedCreature(): DynamicAmount =
-        DynamicAmount.EntityProperty(EntityReference.EnchantedCreature, EntityNumericProperty.AttachmentCount())
+    fun attachmentsOnEnchantedCreature(kind: AttachmentKind = AttachmentKind.ANY): DynamicAmount =
+        DynamicAmount.EntityProperty(
+            EntityReference.EnchantedCreature,
+            EntityNumericProperty.AttachmentCount(kind)
+        )
 
     /** Number of Equipment attached to the source (Shagrat, Loot Bearer's amass amount). */
     fun equipmentAttachedToSelf(): DynamicAmount =

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ClockworkCondor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ClockworkCondor.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Clockwork Condor — Mirrodin #154
+ * {4} · Artifact Creature — Bird · 0/0
+ *
+ * Flying
+ * This creature enters with three +1/+1 counters on it.
+ * Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat.
+ *
+ * The Mirrodin Clockwork Beetle with one more counter and a pair of wings, so it is modelled the
+ * same way its setmate and its Antiquities ancestor Clockwork Avian already are: the printed 0/0
+ * plus three +1/+1 counters (CR 613.4c, layer 7d) make a 3/3 on the battlefield, and it dies as a
+ * state-based action once the last counter is shed.
+ *
+ * The printed ability is a trigger that *sets up a delayed trigger* ("…remove a counter from it at
+ * end of combat"). [Triggers.EachEndOfCombat] with the intervening-if
+ * [Conditions.SourceAttackedOrBlockedThisCombat] is observationally identical — one counter shed
+ * per combat the Condor fought in, on any player's turn — because the delayed trigger and the
+ * tracker are keyed to the same object and both go away when it leaves the battlefield.
+ */
+val ClockworkCondor = card("Clockwork Condor") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Bird"
+    power = 0
+    toughness = 0
+    oracleText = "Flying\n" +
+        "This creature enters with three +1/+1 counters on it.\n" +
+        "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+
+    keywords(Keyword.FLYING)
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 3,
+            selfOnly = true
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EachEndOfCombat
+        triggerCondition = Conditions.SourceAttackedOrBlockedThisCombat
+        effect = Effects.RemoveCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02a7e1a6-347e-47bc-8a14-e584a45941e1.jpg?1783944525"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GolemSkinGauntlets.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GolemSkinGauntlets.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.values.AttachmentKind
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Golem-Skin Gauntlets — Mirrodin #181
+ * {1} · Artifact — Equipment
+ *
+ * Equipped creature gets +1/+0 for each Equipment attached to it.
+ * Equip {2}
+ *
+ * The bonus counts Equipment on the *equipped creature*, not on the Gauntlets — so it reads through
+ * the source's attachment link with
+ * [DynamicAmounts.attachmentsOnEnchantedCreature]`(AttachmentKind.EQUIPMENT)`. Two consequences
+ * worth spelling out, both of them correct per the card's rulings:
+ *
+ *  - The Gauntlets count themselves, so a lone pair is +1/+0, not +0/+0.
+ *  - Two pairs of Gauntlets on one creature each see *both*, so the total is +4/+0 rather than
+ *    +2/+0 — each is a separate static ability contributing its own recomputed bonus.
+ *
+ * The count is read off *projected* subtypes, so a permanent animated into or out of being an
+ * Equipment is counted correctly, and Auras attached to the same creature never are.
+ */
+val GolemSkinGauntlets = card("Golem-Skin Gauntlets") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+0 for each Equipment attached to it.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = Filters.EquippedCreature,
+            powerBonus = DynamicAmounts.attachmentsOnEnchantedCreature(AttachmentKind.EQUIPMENT),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "181"
+        artist = "Alan Pollack"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9519f2a-e98d-4f84-885c-24a9849a996d.jpg?1783944519"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LoxodonPunisher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LoxodonPunisher.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Loxodon Punisher — Mirrodin #14
+ * {3}{W} · Creature — Elephant Soldier · 2/2
+ *
+ * This creature gets +2/+2 for each Equipment attached to it.
+ *
+ * The Winter Soldier shape: a [GrantDynamicStatsEffect] over [GroupFilter.source] whose bonus is
+ * `Multiply(equipmentAttachedToSelf(), 2)`. The attachment count is read off *projected* subtypes,
+ * so a permanent that becomes — or stops being — an Equipment is counted correctly, Auras and
+ * Fortifications are excluded, and the bonus recomputes continuously as Equipment is attached or
+ * falls off rather than being a snapshot taken at equip time.
+ */
+val LoxodonPunisher = card("Loxodon Punisher") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "This creature gets +2/+2 for each Equipment attached to it."
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.Multiply(DynamicAmounts.equipmentAttachedToSelf(), 2),
+            toughnessBonus = DynamicAmount.Multiply(DynamicAmounts.equipmentAttachedToSelf(), 2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "14"
+        artist = "Terese Nielsen"
+        flavorText = "The loxodons believe punishment comes in two steps: pain and atonement. " +
+            "They carry a weapon for each."
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df2b90b8-8306-4543-b9f4-3cfd033f5ca5.jpg?1783944561"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ScrabblingClaws.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ScrabblingClaws.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Scrabbling Claws — Mirrodin #237
+ * {1} · Artifact
+ *
+ * {T}: Target player exiles a card from their graveyard.
+ * {1}, Sacrifice this artifact: Exile target card from a graveyard. Draw a card.
+ *
+ * The two abilities differ in *who chooses*, and that difference is the whole card:
+ *
+ *  - The tap ability targets a **player**, and that player picks which of their own cards to
+ *    exile. It is the Chimney Imp shape — Gather → Select → Move over the target player's
+ *    graveyard with [Chooser.TargetPlayer]. An empty graveyard gathers nothing, so the selection
+ *    is skipped and the ability resolves as a no-op; a player is a legal target regardless.
+ *  - The sacrifice ability targets a **card in any graveyard**, so the Claws' controller picks,
+ *    and it is a plain [TargetObject] over [TargetFilter.CardInGraveyard].
+ *
+ * The sacrifice is part of the cost, so the Claws are already in the graveyard when the ability
+ * resolves and can themselves be the sacrificed-then-exiled card only via the *other* copy of the
+ * ability — nothing here reads the source's battlefield state. If the targeted card leaves the
+ * graveyard in response the ability is countered on resolution and no card is drawn.
+ */
+val ScrabblingClaws = card("Scrabbling Claws") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Target player exiles a card from their graveyard.\n" +
+        "{1}, Sacrifice this artifact: Exile target card from a graveyard. Draw a card."
+
+    activatedAbility {
+        cost = Costs.Tap
+        target = TargetPlayer()
+        effect = Effects.Pipeline {
+            val graveyard = gather(
+                CardSource.FromZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                name = "clawsGraveyard"
+            )
+            val chosen = chooseExactly(
+                1,
+                from = graveyard,
+                chooser = Chooser.TargetPlayer,
+                prompt = "Exile a card from your graveyard",
+                name = "clawsExiled"
+            )
+            exile(chosen, owner = Player.ContextPlayer(0))
+        }
+        description = "{T}: Target player exiles a card from their graveyard."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.SacrificeSelf)
+        val exiled = target("target card in a graveyard", TargetObject(filter = TargetFilter.CardInGraveyard))
+        effect = Effects.Composite(
+            Effects.Move(exiled, Zone.EXILE),
+            Effects.DrawCards(1)
+        )
+        description = "{1}, Sacrifice this artifact: Exile target card from a graveyard. Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Thomas M. Baxa"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/415027f8-ccef-4b38-ace2-db4e94f066fe.jpg?1783944505"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WrenchMind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/WrenchMind.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Wrench Mind — Mirrodin #84
+ * {B}{B} · Sorcery
+ *
+ * Target player discards two cards unless they discard an artifact card.
+ *
+ * "Unless" here is a *choice made by the discarding player as the spell resolves*, not a cost and
+ * not a condition checked beforehand: they either pitch two cards of their choosing, or a single
+ * artifact card. [Patterns.Hand.discardCardsUnlessMatching] is exactly that shape — a
+ * choose-exactly-two selection over the target player's hand carrying a
+ * `ReducedMinimumIfMatches` restriction that drops the minimum to one as soon as the selection
+ * holds an artifact card.
+ *
+ * `EffectTarget.ContextTarget(0)` scopes both the gathered hand and the chooser to the targeted
+ * player, so they pick from their own cards. A player with fewer than two cards in hand discards
+ * what they have; an empty hand makes it a no-op, and the spell still resolves (a player is a
+ * legal target regardless of hand size).
+ */
+val WrenchMind = card("Wrench Mind") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target player discards two cards unless they discard an artifact card."
+
+    spell {
+        target = TargetPlayer()
+        effect = Patterns.Hand.discardCardsUnlessMatching(
+            count = 2,
+            unlessFilter = GameObjectFilter.Artifact,
+            target = EffectTarget.ContextTarget(0),
+            prompt = "Discard two cards, or a single artifact card"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Pete Venters"
+        flavorText = "What is the sound of one head snapping?"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36ce975b-c3df-4472-a6c1-2546df11b74e.jpg?1783944542"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ScrabblingClawsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ScrabblingClawsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scrabbling Claws reprint in RNA. Canonical CardDefinition lives in its earliest set (Mirrodin).
+ */
+val ScrabblingClawsReprint = Printing(
+    oracleId = "4538ec2c-867e-412b-b6e3-a57f8e29ba84",
+    name = "Scrabbling Claws",
+    setCode = "RNA",
+    collectorNumber = "238",
+    scryfallId = "67b06cb5-5e74-456f-81b1-fced1346cc47",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67b06cb5-5e74-456f-81b1-fced1346cc47.jpg?1783933622",
+    releaseDate = "2019-01-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -593,6 +593,77 @@
     "colorIdentityOverride": []
 }
 
+// Clockwork Condor
+{
+    "name": "Clockwork Condor",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Bird",
+    "oracleText": "Flying\nThis creature enters with three +1/+1 counters on it.\nWhenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END_COMBAT",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "RemoveCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": {
+                                "statePredicates": [
+                                    "AttackedThisCombat"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": {
+                                "statePredicates": [
+                                    "BlockedThisCombat"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Arnie Swekel",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02a7e1a6-347e-47bc-8a14-e584a45941e1.jpg?1783944525"
+    },
+    "colorIdentityOverride": []
+}
+
 // Cloudpost
 {
     "name": "Cloudpost",
@@ -1802,6 +1873,75 @@
     ]
 }
 
+// Golem-Skin Gauntlets
+{
+    "name": "Golem-Skin Gauntlets",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+0 for each Equipment attached to it.\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "EntityProperty",
+                    "entity": "EnchantedCreature",
+                    "numericProperty": {
+                        "type": "AttachmentCount",
+                        "kind": "EQUIPMENT"
+                    }
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "UNCOMMON",
+        "artist": "Alan Pollack",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9519f2a-e98d-4f84-885c-24a9849a996d.jpg?1783944519"
+    },
+    "colorIdentityOverride": []
+}
+
 // Great Furnace
 {
     "name": "Great Furnace",
@@ -2648,6 +2788,63 @@
         "artist": "Heather Hudson",
         "flavorText": "The Auriok believe that in the hands of a loxodon, no weapon can be broken.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/1/c17ac7c1-6d53-40b4-921f-4e23e4026041.jpg?1783944561"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Loxodon Punisher
+{
+    "name": "Loxodon Punisher",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Elephant Soldier",
+    "oracleText": "This creature gets +2/+2 for each Equipment attached to it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "AttachmentCount",
+                            "kind": "EQUIPMENT"
+                        }
+                    },
+                    "multiplier": 2
+                },
+                "toughnessBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "AttachmentCount",
+                            "kind": "EQUIPMENT"
+                        }
+                    },
+                    "multiplier": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "RARE",
+        "artist": "Terese Nielsen",
+        "flavorText": "The loxodons believe punishment comes in two steps: pain and atonement. They carry a weapon for each.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df2b90b8-8306-4543-b9f4-3cfd033f5ca5.jpg?1783944561"
     },
     "colorIdentityOverride": [
         "WHITE"
@@ -4483,6 +4680,123 @@
         "artist": "Arnie Swekel",
         "flavorText": "Where herds have passed, the dented ground is lined with piles of rust.",
         "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d23449c-4439-4425-ad53-84168a94b1ce.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
+// Scrabbling Claws
+{
+    "name": "Scrabbling Claws",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Target player exiles a card from their graveyard.\n{1}, Sacrifice this artifact: Exile target card from a graveyard. Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "clawsGraveyard"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "clawsGraveyard",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "clawsExiled",
+                            "prompt": "Exile a card from your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "clawsExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    "TargetPlayer"
+                ],
+                "descriptionOverride": "{T}: Target player exiles a card from their graveyard."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target card in a graveyard"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card in a graveyard"
+                    }
+                ],
+                "descriptionOverride": "{1}, Sacrifice this artifact: Exile target card from a graveyard. Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Thomas M. Baxa",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/415027f8-ccef-4b38-ace2-db4e94f066fe.jpg?1783944505"
     },
     "colorIdentityOverride": []
 }
@@ -7407,6 +7721,79 @@
         "rarity": "UNCOMMON",
         "artist": "Matt Thompson",
         "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5a6e960-169d-431a-9ebd-c4413aa67377.jpg?1783944543"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wrench Mind
+{
+    "name": "Wrench Mind",
+    "manaCost": "{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player discards two cards unless they discard an artifact card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "hand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "hand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "chooser": "TargetPlayer",
+                    "storeSelected": "discarded",
+                    "prompt": "Discard two cards, or a single artifact card",
+                    "restrictions": [
+                        {
+                            "type": "ReducedMinimumIfMatches",
+                            "reducedMinimum": 1,
+                            "filter": "artifact"
+                        }
+                    ]
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "discarded",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                }
+            ]
+        },
+        "targetRequirements": [
+            "TargetPlayer"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Pete Venters",
+        "flavorText": "What is the sound of one head snapping?",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36ce975b-c3df-4472-a6c1-2546df11b74e.jpg?1783944542"
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GolemSkinGauntletsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GolemSkinGauntletsScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Bonesplitter
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.GolemSkinGauntlets
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Golem-Skin Gauntlets.
+ *
+ * Golem-Skin Gauntlets ({1}): Artifact — Equipment
+ *   "Equipped creature gets +1/+0 for each Equipment attached to it.
+ *    Equip {2}"
+ *
+ * Exercises the Equipment-only attachment count read through the source's attachment link —
+ * `DynamicAmounts.attachmentsOnEnchantedCreature(AttachmentKind.EQUIPMENT)`. The three things that
+ * distinguish it from every existing attachment-count card and are therefore worth pinning:
+ *
+ *  1. The count is taken on the *equipped creature*, not on the Gauntlets, so a lone pair counts
+ *     itself and gives +1/+0.
+ *  2. Two pairs of Gauntlets are two separate static abilities that each see both, so the bonus is
+ *     +4/+0 in total rather than +2/+0.
+ *  3. `AttachmentKind.EQUIPMENT` excludes Auras attached to the same creature.
+ */
+class GolemSkinGauntletsScenarioTest : FunSpec({
+
+    val Bear = CardDefinition.creature(
+        name = "Gauntlet Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    fun GameTestDriver.putEquipmentAttached(
+        playerId: EntityId,
+        cardName: String,
+        targetCreatureId: EntityId
+    ): EntityId {
+        val equipmentId = putPermanentOnBattlefield(playerId, cardName)
+        var newState = state.updateEntity(equipmentId) { c -> c.with(AttachedToComponent(targetCreatureId)) }
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Bear, GolemSkinGauntlets, Bonesplitter))
+        return driver
+    }
+
+    val stateProjector = StateProjector()
+
+    fun setUp(): Pair<GameTestDriver, EntityId> {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to player
+    }
+
+    test("a lone pair of Gauntlets counts itself for +1/+0") {
+        val (driver, player) = setUp()
+        val bear = driver.putCreatureOnBattlefield(player, "Gauntlet Bear")
+        driver.putEquipmentAttached(player, "Golem-Skin Gauntlets", bear)
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(bear) shouldBe 3     // 2 + 1 (the Gauntlets themselves)
+        projected.getToughness(bear) shouldBe 2 // never modified
+    }
+
+    test("a second Equipment on the same creature raises the bonus") {
+        val (driver, player) = setUp()
+        val bear = driver.putCreatureOnBattlefield(player, "Gauntlet Bear")
+        driver.putEquipmentAttached(player, "Golem-Skin Gauntlets", bear)
+        driver.putEquipmentAttached(player, "Bonesplitter", bear)
+
+        val projected = stateProjector.project(driver.state)
+        // 2 base + 2 (Gauntlets: two Equipment attached) + 2 (Bonesplitter's own +2/+0)
+        projected.getPower(bear) shouldBe 6
+        projected.getToughness(bear) shouldBe 2
+    }
+
+    test("two pairs of Gauntlets each see both, for +4/+0") {
+        val (driver, player) = setUp()
+        val bear = driver.putCreatureOnBattlefield(player, "Gauntlet Bear")
+        driver.putEquipmentAttached(player, "Golem-Skin Gauntlets", bear)
+        driver.putEquipmentAttached(player, "Golem-Skin Gauntlets", bear)
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(bear) shouldBe 6     // 2 + 2 + 2
+        projected.getToughness(bear) shouldBe 2
+    }
+
+    test("the bonus recomputes when Equipment falls off") {
+        val (driver, player) = setUp()
+        val bear = driver.putCreatureOnBattlefield(player, "Gauntlet Bear")
+        val gauntlets = driver.putEquipmentAttached(player, "Golem-Skin Gauntlets", bear)
+        val bonesplitter = driver.putEquipmentAttached(player, "Bonesplitter", bear)
+
+        stateProjector.project(driver.state).getPower(bear) shouldBe 6
+
+        // Bonesplitter leaves the battlefield: the Gauntlets now see only themselves.
+        var newState = driver.state.updateEntity(bear) { c ->
+            c.with(AttachmentsComponent(listOf(gauntlets)))
+        }
+        newState = newState.removeEntity(bonesplitter)
+        driver.replaceState(newState)
+
+        stateProjector.project(driver.state).getPower(bear) shouldBe 3 // 2 + 1
+    }
+
+    test("an unequipped creature gets no bonus at all") {
+        val (driver, player) = setUp()
+        val bear = driver.putCreatureOnBattlefield(player, "Gauntlet Bear")
+        val other = driver.putCreatureOnBattlefield(player, "Gauntlet Bear")
+        driver.putEquipmentAttached(player, "Golem-Skin Gauntlets", bear)
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(other) shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LoxodonPunisherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LoxodonPunisherScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Bonesplitter
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.LoxodonPunisher
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Loxodon Punisher.
+ *
+ * Loxodon Punisher ({3}{W}): Creature — Elephant Soldier 2/2
+ *   "This creature gets +2/+2 for each Equipment attached to it."
+ *
+ * The bonus is doubled per Equipment and applies to *both* stats, and it counts Equipment only —
+ * so this pins the multiplier, the toughness half (which the existing power-only cards on this
+ * shape never exercise), and that the Punisher is a plain 2/2 while unequipped.
+ */
+class LoxodonPunisherScenarioTest : FunSpec({
+
+    fun GameTestDriver.putEquipmentAttached(
+        playerId: EntityId,
+        cardName: String,
+        targetCreatureId: EntityId
+    ): EntityId {
+        val equipmentId = putPermanentOnBattlefield(playerId, cardName)
+        var newState = state.updateEntity(equipmentId) { c -> c.with(AttachedToComponent(targetCreatureId)) }
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    val stateProjector = StateProjector()
+
+    fun setUp(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LoxodonPunisher, Bonesplitter))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to player
+    }
+
+    test("unequipped, it is a plain 2/2") {
+        val (driver, player) = setUp()
+        val punisher = driver.putCreatureOnBattlefield(player, "Loxodon Punisher")
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(punisher) shouldBe 2
+        projected.getToughness(punisher) shouldBe 2
+    }
+
+    test("one Equipment is +2/+2, on top of that Equipment's own bonus") {
+        val (driver, player) = setUp()
+        val punisher = driver.putCreatureOnBattlefield(player, "Loxodon Punisher")
+        driver.putEquipmentAttached(player, "Bonesplitter", punisher)
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(punisher) shouldBe 6     // 2 base + 2 (Punisher) + 2 (Bonesplitter)
+        projected.getToughness(punisher) shouldBe 4 // 2 base + 2 (Punisher); Bonesplitter is +2/+0
+    }
+
+    test("two Equipment double the bonus") {
+        val (driver, player) = setUp()
+        val punisher = driver.putCreatureOnBattlefield(player, "Loxodon Punisher")
+        driver.putEquipmentAttached(player, "Bonesplitter", punisher)
+        driver.putEquipmentAttached(player, "Bonesplitter", punisher)
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(punisher) shouldBe 10    // 2 + 4 (Punisher) + 4 (two Bonesplitters)
+        projected.getToughness(punisher) shouldBe 6 // 2 + 4 (Punisher)
+    }
+
+    test("Equipment on another creature does not count") {
+        val (driver, player) = setUp()
+        val punisher = driver.putCreatureOnBattlefield(player, "Loxodon Punisher")
+        val other = driver.putCreatureOnBattlefield(player, "Loxodon Punisher")
+        driver.putEquipmentAttached(player, "Bonesplitter", other)
+
+        val projected = stateProjector.project(driver.state)
+        projected.getPower(punisher) shouldBe 2
+        projected.getToughness(punisher) shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScrabblingClawsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScrabblingClawsScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scrabbling Claws (MRD) — "{T}: Target player exiles a card from their graveyard.
+ * {1}, Sacrifice this artifact: Exile target card from a graveyard. Draw a card."
+ *
+ * The card's whole point is that its two abilities put the choice in *different hands*, so that is
+ * what these tests pin:
+ *
+ *  - The tap ability targets a player, and the decision to pick which card gets exiled must land on
+ *    that **targeted player**, not on the Claws' controller — including when the target is the
+ *    controller themselves.
+ *  - The sacrifice ability targets a card directly, so the **controller** picks, no decision is
+ *    raised, and the draw follows the exile.
+ *
+ * Plus the two boundary cases: an empty graveyard makes the tap ability a legal but inert
+ * activation, and the sacrificed Claws end up in their own controller's graveyard rather than
+ * being exiled by their own ability.
+ */
+class ScrabblingClawsScenarioTest : ScenarioTestBase() {
+
+    /** Activate the ability at [index] of Scrabbling Claws, letting the engine auto-pay. */
+    private fun TestGame.activateClaws(
+        index: Int,
+        targets: List<ChosenTarget> = emptyList(),
+    ) = execute(
+        ActivateAbility(
+            playerId = player1Id,
+            sourceId = findPermanent("Scrabbling Claws") ?: error("Claws are not on the battlefield"),
+            abilityId = cardRegistry.getCard("Scrabbling Claws")!!.activatedAbilities[index].id,
+            targets = targets,
+            paymentStrategy = PaymentStrategy.AutoPay,
+        )
+    )
+
+    private fun TestGame.playerId(playerNumber: Int): EntityId =
+        if (playerNumber == 1) player1Id else player2Id
+
+    init {
+        test("the tap ability lets the targeted opponent choose which of their cards is exiled") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "Scrabbling Claws")
+                .withCardInGraveyard(2, "Grizzly Bears")
+                .withCardInGraveyard(2, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.activateClaws(0, listOf(ChosenTarget.Player(game.playerId(2)))).error shouldBe null
+            game.resolveStack()
+
+            // The opponent — not the Claws' controller — is asked, and picks from their own cards.
+            val decision = game.getPendingDecision().shouldNotBeNull()
+            decision.playerId shouldBe game.playerId(2)
+
+            val courser = game.findCardsInGraveyard(2, "Centaur Courser").single()
+            game.selectCards(listOf(courser))
+
+            game.isInExile(2, "Centaur Courser") shouldBe true
+            game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            game.graveyardSize(2) shouldBe 1
+        }
+
+        test("the tap ability can target its own controller, who then chooses") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "Scrabbling Claws")
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withCardInGraveyard(1, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.activateClaws(0, listOf(ChosenTarget.Player(game.playerId(1)))).error shouldBe null
+            game.resolveStack()
+
+            val decision = game.getPendingDecision().shouldNotBeNull()
+            decision.playerId shouldBe game.playerId(1)
+
+            game.selectCards(listOf(game.findCardsInGraveyard(1, "Grizzly Bears").single()))
+            game.isInExile(1, "Grizzly Bears") shouldBe true
+            game.isInGraveyard(1, "Centaur Courser") shouldBe true
+        }
+
+        test("a sole card in the graveyard is exiled without prompting — the choice is forced") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "Scrabbling Claws")
+                .withCardInGraveyard(2, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.activateClaws(0, listOf(ChosenTarget.Player(game.playerId(2)))).error shouldBe null
+            game.resolveStack()
+
+            game.hasPendingDecision() shouldBe false
+            game.isInExile(2, "Grizzly Bears") shouldBe true
+            game.graveyardSize(2) shouldBe 0
+        }
+
+        test("targeting a player with an empty graveyard resolves as a no-op") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "Scrabbling Claws")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.activateClaws(0, listOf(ChosenTarget.Player(game.playerId(2)))).error shouldBe null
+            game.resolveStack()
+
+            // Nothing to gather, so nobody is asked anything.
+            game.hasPendingDecision() shouldBe false
+            game.graveyardSize(2) shouldBe 0
+        }
+
+        test("the sacrifice ability exiles the controller's chosen card and draws") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "Scrabbling Claws")
+                .withLandsOnBattlefield(1, "Forest", 1)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInGraveyard(2, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val courser = game.findCardsInGraveyard(2, "Centaur Courser").single()
+            val handBefore = game.handSize(1)
+
+            game.activateClaws(
+                1,
+                listOf(ChosenTarget.Card(courser, game.playerId(2), Zone.GRAVEYARD))
+            ).error shouldBe null
+            game.resolveStack()
+
+            // The controller targeted the card directly — no selection decision is raised.
+            game.hasPendingDecision() shouldBe false
+            game.isInExile(2, "Centaur Courser") shouldBe true
+            game.handSize(1) shouldBe handBefore + 1
+        }
+
+        test("the sacrificed Claws land in their controller's graveyard, not in exile") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "Scrabbling Claws")
+                .withLandsOnBattlefield(1, "Forest", 1)
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInGraveyard(2, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val courser = game.findCardsInGraveyard(2, "Centaur Courser").single()
+            game.activateClaws(
+                1,
+                listOf(ChosenTarget.Card(courser, game.playerId(2), Zone.GRAVEYARD))
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Scrabbling Claws") shouldBe false
+            game.isInGraveyard(1, "Scrabbling Claws") shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WrenchMindScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WrenchMindScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wrench Mind (MRD) — "Target player discards two cards unless they discard an artifact card."
+ *
+ * "Unless" is a choice the *discarding* player makes on resolution, and the whole card lives or
+ * dies on the two branches being genuinely available to them: pitch two cards of their choosing, or
+ * a single artifact card. These tests pin both branches, that the decision belongs to the targeted
+ * player rather than the caster, and the small-hand boundary where the choice collapses.
+ */
+class WrenchMindScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("the targeted player may discard a single artifact card instead of two") {
+            val game = scenario()
+                .withPlayers("Caster", "Victim")
+                .withCardInHand(1, "Wrench Mind")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardInHand(2, "Bonesplitter")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInHand(2, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpellTargetingPlayer(1, "Wrench Mind", 2).error shouldBe null
+            game.resolveStack()
+
+            // The victim chooses from their own hand, not the caster.
+            val decision = game.getPendingDecision().shouldNotBeNull()
+            decision.playerId shouldBe game.player2Id
+
+            val bonesplitter = game.findCardsInHand(2, "Bonesplitter").single()
+            game.selectCards(listOf(bonesplitter)).error shouldBe null
+
+            game.isInGraveyard(2, "Bonesplitter") shouldBe true
+            game.handSize(2) shouldBe 2 // only the one artifact left
+        }
+
+        test("without an artifact in the selection, two cards go") {
+            val game = scenario()
+                .withPlayers("Caster", "Victim")
+                .withCardInHand(1, "Wrench Mind")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardInHand(2, "Bonesplitter")
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInHand(2, "Centaur Courser")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpellTargetingPlayer(1, "Wrench Mind", 2).error shouldBe null
+            game.resolveStack()
+            game.getPendingDecision().shouldNotBeNull()
+
+            val bears = game.findCardsInHand(2, "Grizzly Bears").single()
+            val courser = game.findCardsInHand(2, "Centaur Courser").single()
+            game.selectCards(listOf(bears, courser)).error shouldBe null
+
+            game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            game.isInGraveyard(2, "Centaur Courser") shouldBe true
+            game.isInGraveyard(2, "Bonesplitter") shouldBe false
+            game.handSize(2) shouldBe 1
+        }
+
+        test("a hand with no artifact loses two cards") {
+            val game = scenario()
+                .withPlayers("Caster", "Victim")
+                .withCardInHand(1, "Wrench Mind")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withCardInHand(2, "Grizzly Bears")
+                .withCardInHand(2, "Centaur Courser")
+                .withCardInHand(2, "Lightning Bolt")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpellTargetingPlayer(1, "Wrench Mind", 2).error shouldBe null
+            game.resolveStack()
+            game.getPendingDecision().shouldNotBeNull()
+
+            val bears = game.findCardsInHand(2, "Grizzly Bears").single()
+            val bolt = game.findCardsInHand(2, "Lightning Bolt").single()
+            game.selectCards(listOf(bears, bolt)).error shouldBe null
+
+            game.handSize(2) shouldBe 1
+        }
+
+        test("an empty hand makes it a legal but inert cast") {
+            val game = scenario()
+                .withPlayers("Caster", "Victim")
+                .withCardInHand(1, "Wrench Mind")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpellTargetingPlayer(1, "Wrench Mind", 2).error shouldBe null
+            game.resolveStack()
+
+            game.hasPendingDecision() shouldBe false
+            game.handSize(2) shouldBe 0
+            game.isInGraveyard(1, "Wrench Mind") shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
Five Mirrodin cards, all canonical in MRD (their earliest real printing per Scryfall).

## Cards

| Card | Shape |
|---|---|
| **Clockwork Condor** `{4}` 0/0 Artifact Creature — Bird | Flying + `EntersWithCounters(3)` + an `EachEndOfCombat` trigger gated on `Conditions.SourceAttackedOrBlockedThisCombat` — the Clockwork Beetle / Clockwork Avian modelling already in the codebase. |
| **Loxodon Punisher** `{3}{W}` 2/2 | `GrantDynamicStatsEffect` over `GroupFilter.source()` with `Multiply(equipmentAttachedToSelf(), 2)` on both stats. |
| **Golem-Skin Gauntlets** `{1}` Equipment | The same count taken on the **equipped creature** rather than on the source. |
| **Wrench Mind** `{B}{B}` Sorcery | `Patterns.Hand.discardCardsUnlessMatching(2, Artifact)` scoped to the target player, so *they* make the "two cards, or one artifact" choice as it resolves. |
| **Scrabbling Claws** `{1}` Artifact | Two abilities that differ in **who chooses** — see below. |

### Golem-Skin Gauntlets

"Equipped creature gets +1/+0 for each Equipment attached to it" counts Equipment on the *host*, not on the Gauntlets. Two consequences, both correct per the card's rulings and both pinned by tests:

- a lone pair counts itself, so it is +1/+0 rather than +0/+0;
- two pairs on one creature each see both, so the total is **+4/+0**, not +2/+0.

### Scrabbling Claws

The two abilities are the same graveyard hate pointed at different deciders:

- `{T}: Target player exiles a card from their graveyard.` — targets a **player**, and that player picks from their own graveyard (`Chooser.TargetPlayer` over the inline Gather → Select → Move pipeline, the Chimney Imp shape).
- `{1}, Sacrifice this artifact: Exile target card from a graveyard. Draw a card.` — targets a **card**, so the Claws' controller picks and no selection decision is raised.

A `Printing` row was added in RNA, which is scaffolded; the C18 printing's set is not.

## SDK change

`DynamicAmounts.attachmentsOnEnchantedCreature()` now takes an `AttachmentKind` (default `ANY`, so its existing caller is unchanged), letting the Equipment-only count be read through the source's attachment link — the same link an Aura and an Equipment both use. `docs/card-sdk-language-reference.md` is updated in the same change.

## Verification

`just build` green. Scenario tests added for the four cards whose wiring wasn't already proven elsewhere (18 tests); the Condor's trigger shape is covered by the existing `ClockworkBeetleScenarioTest`.

Two things the gates corrected rather than confirmed:

- a forced selection (one card in the graveyard, choose exactly one) resolves without prompting — my first test assumed a prompt and was wrong, not the card;
- `just check-card-printing` caught the missing RNA reprint row for Scrabbling Claws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
