### PR TITLE
Add four The Hobbit cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2983,6 +2983,16 @@ Every `TargetRequirement` carries count semantics (defaults shown):
   the battlefield — can never share, so the set is rejected. A no-op for single-target requirements and for
   non-permanent targets. E.g. `TargetCreature(count = 2, filter = TargetFilter.CreatureYouControl,
   sameCreatureType = true)` (Secret Tunnel).
+- `sameCardType = false` — on `TargetObject` / `TargetPermanent(...)`; the **card-type** sibling of
+  `sameCreatureType`. When `true` and the requirement picks more than one target, the chosen **permanent**
+  targets must all share at least one *card type* per CR 205.2a — artifact, creature, enchantment,
+  planeswalker, … ("**two target nonland permanents that share a card type**"). Enforced cross-target by
+  `TargetValidator` as the non-empty intersection of every target's *projected* types with supertypes
+  sieved out, so an animated land counts as a creature but two legendary permanents do **not** qualify by
+  both being legendary. A target off the battlefield contributes nothing and rejects the set. A no-op for
+  single-target requirements and non-permanent targets. E.g. `TargetPermanent(count = 2, filter =
+  TargetFilter.NonlandPermanent, sameCardType = true)` (Burglar's Plot, the Adventure half of
+  Bilbo, Luckwearer).
 - `totalManaValueAtMost = null` — on `TargetObject`; when set to a `DynamicAmount`, the **combined
   mana value** of the chosen **card** targets may not exceed the resolved amount ("**any number of
   target creature cards with total mana value X or less**"). The amount is resolved once the ability
@@ -3193,6 +3203,15 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   creature you control") with `filter = GameObjectFilter.Creature.legendary()`. Colorless candidates
   never match. Evaluated for real in targeting/search/count contexts; inert (false) in
   static-projection / trigger-gating, permissive (true) in cost-calculation.
+- `.sharingNameWithPermanentYouControl(filter)` — `CardPredicate.SharesNameWithPermanentYouControl`:
+  has the **same name** as at least one permanent the evaluating player controls matching `filter`. The
+  name sibling of `.sharingColorWithPermanentYouControl`; names compare exactly, read off the permanent's
+  card component (copy effects already rewrite it), and a nameless object never matches. Used by Key to
+  the Side-Door ("Discard a legendary card with the same name as a legendary permanent you control") as a
+  `Costs.Discard(...)` filter — the cost enumerators supply a `PredicateContext` whose `controllerId` is
+  the activating player, so the battlefield side is scoped to "you control". Evaluated for real in
+  targeting/search/cost contexts; inert (false) in static-projection / trigger-gating, permissive (true)
+  in cost-calculation.
 - `.notSharingCreatureTypeWithPermanentYouControl(filter)` —
   `CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl`: shares **no** (projected) creature
   type with any permanent the evaluating player controls matching `filter`. Negative analogue of

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -657,6 +657,15 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must have the same name as at least one permanent the evaluating player controls matching
+     * [filter] (Key to the Side-Door: "a legendary card with the same name as a legendary permanent
+     * you control").
+     */
+    fun sharingNameWithPermanentYouControl(filter: GameObjectFilter) = copy(
+        cardPredicates = cardPredicates + CardPredicate.SharesNameWithPermanentYouControl(filter)
+    )
+
+    /**
      * Must share **no** creature type with any permanent the evaluating player controls matching
      * [filter] (Radagast the Brown: "a creature card that doesn't share a creature type with a
      * creature you control").

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -904,6 +904,28 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     }
 
     /**
+     * Matches objects whose name equals that of at least one permanent the evaluating player
+     * controls matching [filter]. Used by Key to the Side-Door ("Discard a legendary card with the
+     * same name as a legendary permanent you control") with
+     * `filter = GameObjectFilter.Permanent.legendary()`. The name-sharing sibling of
+     * [SharesColorWithPermanentYouControl].
+     *
+     * Names are compared exactly, and read from the permanent's card definition rather than
+     * projected state — copy effects already rewrite the card component's name, and nothing in the
+     * layer system renames a permanent without doing so. A nameless object (a token with no name)
+     * never matches.
+     */
+    @SerialName("SharesNameWithPermanentYouControl")
+    @Serializable
+    data class SharesNameWithPermanentYouControl(val filter: GameObjectFilter) : CardPredicate {
+        override val description: String = "with the same name as ${filter.description} you control"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /**
      * Matches creature cards that share **no** creature type with any permanent the evaluating
      * player controls matching [filter]. Used by Radagast the Brown ("a creature card that doesn't
      * share a creature type with a creature you control") with `filter = GameObjectFilter.Creature`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -189,14 +189,16 @@ fun TargetPermanent(
     unlimited: Boolean = false,
     filter: TargetFilter = TargetFilter.Permanent,
     id: String? = null,
-    dynamicMaxCount: DynamicAmount? = null
+    dynamicMaxCount: DynamicAmount? = null,
+    sameCardType: Boolean = false
 ): TargetObject = TargetObject(
     count = count,
     optional = optional,
     unlimited = unlimited,
     filter = filter,
     id = id,
-    dynamicMaxCount = dynamicMaxCount
+    dynamicMaxCount = dynamicMaxCount,
+    sameCardType = sameCardType
 )
 
 // =============================================================================
@@ -385,6 +387,17 @@ data class TargetObject(
      */
     val sameCreatureType: Boolean = false,
     /**
+     * When true and more than one target is chosen for this requirement, the chosen permanent
+     * targets must all share at least one **card type** (CR 205.2a — artifact, creature,
+     * enchantment, planeswalker, …) with one another — "two target nonland permanents that share a
+     * card type" (Burglar's Plot). The card-type sibling of [sameCreatureType]: enforced
+     * cross-target by `TargetValidator` using each permanent's *projected* types (so an animated
+     * land counts as a creature) with supertypes sieved out (two legendary permanents don't share
+     * a card type by being legendary). A no-op for single-target requirements and for non-permanent
+     * targets. Defaults to false.
+     */
+    val sameCardType: Boolean = false,
+    /**
      * When non-null, the chosen card targets for this requirement must have a **combined mana
      * value no greater than this amount** — "any number of target creature cards with total mana
      * value X or less" (Fire Lord Sozin). The [DynamicAmount] is resolved once the ability is
@@ -437,6 +450,7 @@ data class TargetObject(
             sameController -> "$base controlled by the same player"
             sameOwner -> "$base from a single graveyard"
             sameCreatureType -> "$base that share a creature type"
+            sameCardType -> "$base that share a card type"
             else -> base
         }
         if (totalManaValueAtMost != null) {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BilboLuckwearer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BilboLuckwearer.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlocked
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Bilbo, Luckwearer // Burglar's Plot — The Hobbit #32
+ * {1}{U} · Legendary Creature — Halfling Rogue · Uncommon
+ * 1/1
+ *
+ * Bilbo can't be blocked.
+ * Whenever Bilbo deals combat damage to a player, draw a card, then discard a card.
+ *
+ * Adventure: Burglar's Plot — {4}{U}, Sorcery — Adventure
+ * Exchange control of two target nonland permanents that share a card type.
+ *
+ * Modeling notes:
+ *  - "Draw a card, then discard a card" is the loot composition, not two loose effects — the
+ *    ordering matters (the drawn card is a legal discard), and [Patterns.Hand.loot] encodes it.
+ *  - The Adventure's "two target nonland permanents that share a card type" is a *single*
+ *    two-target requirement carrying [TargetObject.sameCardType], the card-type sibling of Secret
+ *    Tunnel's `sameCreatureType`. Declaring two separate requirements would make the two halves
+ *    independent instances of the word "target" and lose the cross-target constraint entirely;
+ *    `TargetValidator` enforces the shared card type over the projected types of the chosen pair.
+ *  - Neither target is restricted by controller: the printed text says only "two target nonland
+ *    permanents", so exchanging two permanents you already control (a legal, pointless play) and
+ *    swapping between two *opponents* in a multiplayer game are both allowed.
+ *  - (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets its
+ *    caster cast the creature later from exile.)
+ */
+val BilboLuckwearer = card("Bilbo, Luckwearer") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Halfling Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "Bilbo can't be blocked.\n" +
+        "Whenever Bilbo deals combat damage to a player, draw a card, then discard a card."
+
+    staticAbility {
+        ability = CantBeBlocked()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Patterns.Hand.loot(draw = 1, discard = 1)
+        description = "Draw a card, then discard a card."
+    }
+
+    adventure("Burglar's Plot") {
+        manaCost = "{4}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Exchange control of two target nonland permanents that share a card type. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+
+        spell {
+            target(
+                "two target nonland permanents that share a card type",
+                TargetPermanent(
+                    count = 2,
+                    filter = TargetFilter.NonlandPermanent,
+                    sameCardType = true
+                )
+            )
+            effect = Effects.ExchangeControl()
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "32"
+        artist = "Anna Steinbauer"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bff0aa6-16d9-4c83-b598-ef00a3b33d2c.jpg?1783902786"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BilbosGambit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BilbosGambit.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bilbo's Gambit — The Hobbit #5
+ * {1}{W} · Instant · Rare
+ *
+ * Gift a Treasure (You may promise an opponent a gift as you cast this spell. If you do, they
+ * create a Treasure token before its other effects. It's an artifact with "{T}, Sacrifice this
+ * token: Add one mana of any color.")
+ * Return target spell to its owner's hand. If the gift was promised, players can't cast spells
+ * this turn.
+ *
+ * Modeling notes:
+ *  - Gift on an instant has no permanent to trigger off, so it is the two-mode
+ *    [Patterns.Mechanic.giftSpell] shape rather than the `gift(GiftKind)` keyword — `CardValidator`
+ *    rejects the keyword on a non-permanent for exactly that reason. Mode 0 is "don't promise",
+ *    mode 1 promises and picks the recipient (CR 702.174a).
+ *  - Both modes target a spell, so the bounce happens either way; only the lockout rides on the
+ *    promise. The Treasure lands *before* the bounce, matching "they create a Treasure token
+ *    before its other effects" (CR 702.174d).
+ *  - "Players can't cast spells this turn" is every player, including you — the gambit shuts the
+ *    turn down after the bounce, so the returned spell can't simply be recast. [Player.Each]
+ *    covers all of them; the restriction is [Duration.EndOfTurn] by default.
+ *  - The bounce resolving *before* the lockout matters: were the order reversed the spell would
+ *    still return, but the intervening state would be identical. Ordering follows the printed text.
+ */
+val BilbosGambit = card("Bilbo's Gambit") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Gift a Treasure (You may promise an opponent a gift as you cast this spell. " +
+        "If you do, they create a Treasure token before its other effects. It's an artifact with " +
+        "\"{T}, Sacrifice this token: Add one mana of any color.\")\n" +
+        "Return target spell to its owner's hand. If the gift was promised, players can't cast " +
+        "spells this turn."
+
+    spell {
+        effect = Patterns.Mechanic.giftSpell(
+            noGiftMode = Mode.withTarget(
+                Effects.ReturnSpellToOwnersHand(),
+                Targets.Spell,
+                "Don't promise a gift — return target spell to its owner's hand"
+            ),
+            giftMode = Mode.withTarget(
+                Effects.CreateTreasure(
+                    count = 1,
+                    controller = EffectTarget.PlayerRef(Player.ChosenOpponent)
+                )
+                    .then(Effects.ReturnSpellToOwnersHand())
+                    .then(Effects.CantCastSpells(EffectTarget.PlayerRef(Player.Each)))
+                    .then(Effects.GiftGiven()),
+                Targets.Spell,
+                "Promise a gift — that opponent creates a Treasure, then return target spell to " +
+                    "its owner's hand and players can't cast spells this turn"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "5"
+        artist = "Randy Gallegos"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45ad01f0-cda8-4931-82bb-cb4949e56ae9.jpg?1784894818"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/KeyToTheSideDoor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/KeyToTheSideDoor.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+
+/**
+ * Key to the Side-Door — The Hobbit #175
+ * {1} · Artifact · Uncommon
+ *
+ * {2}, {T}: Target creature can't be blocked this turn.
+ * {1}, {T}, Discard a legendary card with the same name as a legendary permanent you control:
+ *   Draw two cards.
+ *
+ * Modeling notes:
+ *  - "Can't be blocked this turn" is a duration-bounded [AbilityFlag.CANT_BE_BLOCKED] grant on the
+ *    target (the Rogue's Passage idiom), not the permanent [CantBeBlocked] static — the latter would
+ *    outlive the turn.
+ *  - The second ability's discard cost is the interesting half: the discarded card must be legendary
+ *    *and* name-match a legendary permanent already on your battlefield. That cross-zone comparison
+ *    is [CardPredicate.SharesNameWithPermanentYouControl], the name sibling of the existing
+ *    `SharesColorWithPermanentYouControl` — the cost enumerators hand it a `PredicateContext` with
+ *    the activating player as `controllerId`, so the battlefield side is correctly scoped to "you
+ *    control". Without a matching pair in hand and play the ability simply isn't offered.
+ *  - The legendary-permanent side reads projected state, so a permanent that only became legendary
+ *    through a continuous effect still counts.
+ */
+val KeyToTheSideDoor = card("Key to the Side-Door") {
+    manaCost = "{1}"
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}: Target creature can't be blocked this turn.\n" +
+        "{1}, {T}, Discard a legendary card with the same name as a legendary permanent you " +
+        "control: Draw two cards."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val creature = target("target creature", Targets.Creature)
+        effect = GrantKeywordEffect(AbilityFlag.CANT_BE_BLOCKED.name, creature)
+        description = "Target creature can't be blocked this turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap,
+            Costs.Discard(
+                GameObjectFilter.Any
+                    .legendary()
+                    .sharingNameWithPermanentYouControl(GameObjectFilter.Permanent.legendary())
+            )
+        )
+        effect = Effects.DrawCards(2)
+        description = "Draw two cards."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "Nathaniel Himawan"
+        flavorText = "\"I forgot to mention that with the map went a key, a small and curious " +
+            "key.\"\n—Gandalf, to Thorin"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/898c14a2-d897-4341-83ed-eee666df9648.jpg?1785412757"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/WizardsStaff.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/WizardsStaff.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Wizard's Staff — The Hobbit #59
+ * {1}{U} · Artifact — Equipment · Rare
+ *
+ * Equipped creature has prowess.
+ * If an ability of equipped creature triggers, that ability triggers an additional time.
+ * Equip Wizard {1}
+ * Equip {3}
+ *
+ * Modeling notes:
+ *  - The doubling is [AdditionalSourceTriggers] scoped by `attachedToBySource()` — "the permanent
+ *    this Equipment is attached to". That's the mirror of Cloud, Midgar Mercenary, which scopes the
+ *    same primitive with `attachedToSource()` (the Equipment attached to *it*). `excludeSelf` is
+ *    irrelevant here since the Staff can never be attached to itself, but it stays at its default
+ *    so the Staff's own future triggers aren't caught by the filter.
+ *  - Only *triggered* abilities trigger, so the printed "an ability" is exactly what
+ *    [AdditionalSourceTriggers] covers; per its rulings this is one extra firing, not a copy, so
+ *    modes and targets are chosen independently for each instance.
+ *  - Two equip costs are two separate equip-flagged activated abilities — the Bilbo's Ring shape.
+ *    `equipAbility(...)` handles the generic "Equip {3}"; the Wizard-restricted one is hand-rolled
+ *    because the facade has no target-filter parameter.
+ */
+val WizardsStaff = card("Wizard's Staff") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has prowess. (Whenever its controller casts a noncreature " +
+        "spell, that creature gets +1/+1 until end of turn.)\n" +
+        "If an ability of equipped creature triggers, that ability triggers an additional time.\n" +
+        "Equip Wizard {1} ({1}: Attach to target Wizard you control. Equip only as a sorcery.)\n" +
+        "Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.PROWESS, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = AdditionalSourceTriggers(
+            sourceFilter = GameObjectFilter.Permanent.attachedToBySource(),
+            description = "If an ability of equipped creature triggers, that ability triggers " +
+                "an additional time"
+        )
+    }
+
+    // Equip Wizard {1}: Attach to target Wizard you control. Equip only as a sorcery.
+    activatedAbility {
+        isEquipAbility = true
+        cost = Costs.Mana("{1}")
+        timing = TimingRule.SorcerySpeed
+        val wizard = target(
+            "target Wizard you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.WIZARD))
+        )
+        effect = Effects.AttachEquipment(wizard)
+        description = "Equip Wizard {1}"
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "59"
+        artist = "Gaboleps"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0de529a7-bdc5-4581-a169-1ad123bc099a.jpg?1785152406"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -657,6 +657,194 @@
     ]
 }
 
+// Bilbo's Gambit
+{
+    "name": "Bilbo's Gambit",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Gift a Treasure (You may promise an opponent a gift as you cast this spell. If you do, they create a Treasure token before its other effects. It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\nReturn target spell to its owner's hand. If the gift was promised, players can't cast spells this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "ReturnSpellToOwnersHand",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            }
+                        }
+                    ],
+                    "description": "Don't promise a gift — return target spell to its owner's hand"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreatePredefinedToken",
+                                        "tokenType": "Treasure",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    "ReturnSpellToOwnersHand",
+                                    {
+                                        "type": "CantCastSpells",
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "Each"
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            }
+                        }
+                    ],
+                    "description": "Promise a gift — that opponent creates a Treasure, then return target spell to its owner's hand and players can't cast spells this turn"
+                }
+            ],
+            "countsAsModalSpell": false
+        }
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "RARE",
+        "artist": "Randy Gallegos",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45ad01f0-cda8-4931-82bb-cb4949e56ae9.jpg?1784894818"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Bilbo, Luckwearer
+{
+    "name": "Bilbo, Luckwearer",
+    "manaCost": "{1}{U}",
+    "typeLine": "Legendary Creature — Halfling Rogue",
+    "oracleText": "Bilbo can't be blocked.\nWhenever Bilbo deals combat damage to a player, draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "Draw a card, then discard a card."
+            }
+        ],
+        "staticAbilities": [
+            "CantBeBlocked"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Steinbauer",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bff0aa6-16d9-4c83-b598-ef00a3b33d2c.jpg?1783902786"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Burglar's Plot",
+            "manaCost": "{4}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Exchange control of two target nonland permanents that share a card type. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": "ExchangeControl",
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        },
+                        "id": "two target nonland permanents that share a card type",
+                        "sameCardType": true
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Bofur, Reliable Guardian
 {
     "name": "Bofur, Reliable Guardian",
@@ -4986,6 +5174,103 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Key to the Side-Door
+{
+    "name": "Key to the Side-Door",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}: Target creature can't be blocked this turn.\n{1}, {T}, Discard a legendary card with the same name as a legendary permanent you control: Draw two cards.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "Target creature can't be blocked this turn."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsLegendary",
+                                        {
+                                            "type": "SharesNameWithPermanentYouControl",
+                                            "filter": {
+                                                "cardPredicates": [
+                                                    "IsPermanent",
+                                                    "IsLegendary"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "Draw two cards."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "UNCOMMON",
+        "artist": "Nathaniel Himawan",
+        "flavorText": "\"I forgot to mention that with the map went a key, a small and curious key.\"\n—Gandalf, to Thorin",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/898c14a2-d897-4341-83ed-eee666df9648.jpg?1785412757"
+    }
 }
 
 // Lake-town
@@ -10580,6 +10865,103 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Wizard's Staff
+{
+    "name": "Wizard's Staff",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has prowess. (Whenever its controller casts a noncreature spell, that creature gets +1/+1 until end of turn.)\nIf an ability of equipped creature triggers, that ability triggers an additional time.\nEquip Wizard {1} ({1}: Attach to target Wizard you control. Equip only as a sorcery.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Wizard you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Wizard ctrl:you"
+                        },
+                        "id": "target Wizard you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true,
+                "descriptionOverride": "Equip Wizard {1}"
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "PROWESS"
+            },
+            {
+                "type": "AdditionalSourceTriggers",
+                "sourceFilter": {
+                    "cardPredicates": [
+                        "IsPermanent"
+                    ],
+                    "statePredicates": [
+                        "IsAttachedToBySource"
+                    ]
+                },
+                "description": "If an ability of equipped creature triggers, that ability triggers an additional time"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "RARE",
+        "artist": "Gaboleps",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0de529a7-bdc5-4581-a169-1ad123bc099a.jpg?1785152406"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -654,6 +654,17 @@ class PredicateEvaluator {
                 }
             }
 
+            is CardPredicate.SharesNameWithPermanentYouControl -> {
+                val name = card.name
+                if (name.isBlank()) return false
+                val controllerId = context?.controllerId ?: return false
+                state.getBattlefield().any { otherId ->
+                    projected.getController(otherId) == controllerId &&
+                        state.getEntity(otherId)?.get<CardComponent>()?.name == name &&
+                        matches(state, projected, otherId, predicate.filter, context)
+                }
+            }
+
             is CardPredicate.SharesColorWith -> {
                 val referenceId = resolveEntityReference(predicate.entity, context) ?: return false
                 val referenceColors = projected.getColors(referenceId).ifEmpty {
@@ -1584,6 +1595,7 @@ class PredicateEvaluator {
             is CardPredicate.SharesCreatureTypeWith,
             is CardPredicate.SharesColorWith,
             is CardPredicate.SharesColorWithPermanentYouControl,
+            is CardPredicate.SharesNameWithPermanentYouControl,
             is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl,
             is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl -> false
             is CardPredicate.HasSubtypeFromVariable, is CardPredicate.HasSubtypeInStoredList,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -1032,6 +1032,7 @@ class CastZoneResolver(
                 is CardPredicate.SharesColorWith,
                 is CardPredicate.SharesColorWithRecipient,
                 is CardPredicate.SharesColorWithPermanentYouControl,
+                is CardPredicate.SharesNameWithPermanentYouControl,
                 is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl,
                 is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl,
                 is CardPredicate.TargetsMatching,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -795,6 +795,7 @@ internal class AffectsFilterResolver {
         is CardPredicate.SharesCreatureTypeWith,
         is CardPredicate.SharesColorWith,
         is CardPredicate.SharesColorWithPermanentYouControl,
+        is CardPredicate.SharesNameWithPermanentYouControl,
         is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl,
         is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl,
         is CardPredicate.HasSubtypeFromVariable,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1177,6 +1177,7 @@ class CostCalculator(
             is CardPredicate.SharesCreatureTypeWith -> true
             is CardPredicate.SharesColorWith -> true
             is CardPredicate.SharesColorWithPermanentYouControl -> true
+            is CardPredicate.SharesNameWithPermanentYouControl -> true
             is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl -> true
             is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl -> true
             CardPredicate.SharesColorWithRecipient -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -26,6 +26,13 @@ import com.wingedsheep.sdk.scripting.targets.*
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
+ * The card-type names (CR 205.2a). `ProjectedState.getTypes` folds supertypes (LEGENDARY, BASIC,
+ * SNOW, …) in beside them, so a "share a card type" comparison has to sieve through this — else two
+ * legendary permanents would qualify by both being legendary.
+ */
+private val CARD_TYPE_NAMES: Set<String> = CardType.entries.mapTo(mutableSetOf()) { it.name }
+
+/**
  * Validates that chosen targets match their target requirements.
  *
  * This class checks if a target:
@@ -193,6 +200,25 @@ class TargetValidator {
                 val shared = subtypeSets.reduce { acc, next -> acc intersect next }
                 if (shared.isEmpty()) {
                     return "Targets must share a creature type"
+                }
+            }
+
+            // "... that share a card type" — every chosen permanent target must hold at least one
+            // *card type* (CR 205.2a) in common with all the others (Burglar's Plot). Projected
+            // types, so an animated land counts as a creature; supertypes are sieved out, so two
+            // legendary permanents don't qualify by both being legendary. No-op for single-target
+            // requirements; a target off the battlefield contributes nothing and rejects the set.
+            if (requirement is TargetObject && requirement.sameCardType && targetsForReq.size > 1) {
+                val projected = state.projectedState
+                val typeSets = targetsForReq.map { target ->
+                    (target as? ChosenTarget.Permanent)
+                        ?.takeIf { it.entityId in state.getBattlefield() }
+                        ?.let { perm -> projected.getTypes(perm.entityId).filterTo(mutableSetOf()) { it in CARD_TYPE_NAMES } }
+                        ?: emptySet()
+                }
+                val shared = typeSets.reduce { acc, next -> acc intersect next }
+                if (shared.isEmpty()) {
+                    return "Targets must share a card type"
                 }
             }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BilboLuckwearerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BilboLuckwearerScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.BilboLuckwearer
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bilbo, Luckwearer // Burglar's Plot (HOB #32) — Adventure (CR 715).
+ *
+ * Creature face: {1}{U} 1/1 legendary Halfling Rogue — "Bilbo can't be blocked" plus a
+ * combat-damage loot trigger.
+ * Adventure face: Burglar's Plot {4}{U}, Sorcery — Adventure —
+ *   "Exchange control of two target nonland permanents that share a card type."
+ *
+ * The interesting half is the new cross-target [TargetObject.sameCardType] constraint, so the two
+ * exchange tests are the point of this file: two creatures share CREATURE and swap; a creature and
+ * a noncreature artifact share no card type and the cast is rejected outright.
+ */
+class BilboLuckwearerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BilboLuckwearer)
+        return driver
+    }
+
+    fun startAtMain(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40, "Grizzly Bears" to 20), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return player
+    }
+
+    test("the creature face can't be blocked") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val bilbo = driver.putCreatureOnBattlefield(player, "Bilbo, Luckwearer")
+
+        driver.state.projectedState.hasKeyword(bilbo, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+    }
+
+    test("Burglar's Plot exchanges control of two creatures — they share the creature card type") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+        val opponent = driver.getOpponent(player)
+
+        val mine = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val card = driver.putCardInHand(player, "Bilbo, Luckwearer")
+        driver.giveMana(player, Color.BLUE, 5) // {4}{U}
+
+        // faceIndex 0 is the Adventure face (Burglar's Plot).
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                faceIndex = 0,
+                targets = listOf(ChosenTarget.Permanent(mine), ChosenTarget.Permanent(theirs)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // ExchangeControlEffect installs a continuous control-change effect, so the swap shows up
+        // in projected state rather than on the base ControllerComponent.
+        driver.state.projectedState.getController(mine) shouldBe opponent
+        driver.state.projectedState.getController(theirs) shouldBe player
+    }
+
+    test("Burglar's Plot can't target a creature and a noncreature artifact — no card type in common") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+        val opponent = driver.getOpponent(player)
+
+        val creature = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val artifact = driver.putPermanentOnBattlefield(opponent, "Sol Ring")
+
+        val card = driver.putCardInHand(player, "Bilbo, Luckwearer")
+        driver.giveMana(player, Color.BLUE, 5)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                faceIndex = 0,
+                targets = listOf(ChosenTarget.Permanent(creature), ChosenTarget.Permanent(artifact)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe false
+        // Rejected specifically by the cross-target constraint, not by some unrelated legality check.
+        result.error?.contains("share a card type") shouldBe true
+
+        // Nothing changed hands.
+        driver.state.projectedState.getController(creature) shouldBe player
+        driver.state.projectedState.getController(artifact) shouldBe opponent
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BilbosGambitScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BilbosGambitScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.BilbosGambit
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bilbo's Gambit (HOB #5) — {1}{W} Instant.
+ *
+ *   Gift a Treasure
+ *   Return target spell to its owner's hand. If the gift was promised, players can't cast spells
+ *   this turn.
+ *
+ * Mode 0 (no gift): bounce only.
+ * Mode 1 (gift): the promised opponent gets a Treasure *before* the other effects, the spell is
+ * bounced, and then **every** player — the caster included — is locked out of casting for the turn.
+ */
+class BilbosGambitScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(PredefinedTokens.allTokens)
+        driver.registerCard(BilbosGambit)
+        return driver
+    }
+
+    test("mode 0 (no gift): the spell is bounced and nobody is locked out") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // The caster's own creature spell is the thing being bounced — targeting a spell only needs
+        // one on the stack, and using the caster's keeps priority in the right place.
+        val bears = driver.putCardInHand(caster, "Grizzly Bears")
+        driver.giveMana(caster, Color.GREEN, 2)
+        driver.submit(CastSpell(playerId = caster, cardId = bears)).isSuccess shouldBe true
+
+        val gambit = driver.putCardInHand(caster, "Bilbo's Gambit")
+        driver.giveMana(caster, Color.WHITE, 2)
+        driver.submit(
+            CastSpell(
+                playerId = caster,
+                cardId = gambit,
+                targets = listOf(ChosenTarget.Spell(bears)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Spell(bears)))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        (bears in driver.getHand(caster)) shouldBe true
+        driver.findPermanent(opponent, "Treasure").shouldBeNull()
+        driver.state.getEntity(caster)?.get<CantCastSpellsComponent>().shouldBeNull()
+        driver.state.getEntity(opponent)?.get<CantCastSpellsComponent>().shouldBeNull()
+    }
+
+    test("mode 1 (gift): the opponent gets the Treasure and EVERY player is locked out this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val caster = driver.activePlayer!!
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCardInHand(caster, "Grizzly Bears")
+        driver.giveMana(caster, Color.GREEN, 2)
+        driver.submit(CastSpell(playerId = caster, cardId = bears)).isSuccess shouldBe true
+
+        val gambit = driver.putCardInHand(caster, "Bilbo's Gambit")
+        driver.giveMana(caster, Color.WHITE, 2)
+        driver.submit(
+            CastSpell(
+                playerId = caster,
+                cardId = gambit,
+                targets = listOf(ChosenTarget.Spell(bears)),
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Spell(bears)))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        (bears in driver.getHand(caster)) shouldBe true
+
+        // The gift goes to the promised opponent, never the caster.
+        driver.findPermanent(opponent, "Treasure").shouldNotBeNull()
+        driver.findPermanent(caster, "Treasure").shouldBeNull()
+
+        // "Players" is everyone — the caster is shut off too.
+        driver.state.getEntity(caster)?.get<CantCastSpellsComponent>().shouldNotBeNull()
+        driver.state.getEntity(opponent)?.get<CantCastSpellsComponent>().shouldNotBeNull()
+
+        // And it bites: the just-bounced Bears can't be recast this turn.
+        driver.giveMana(caster, Color.GREEN, 2)
+        driver.submit(CastSpell(playerId = caster, cardId = bears)).isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KeyToTheSideDoorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KeyToTheSideDoorScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.KeyToTheSideDoor
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Key to the Side-Door (HOB #175) — {1} Artifact.
+ *
+ *   {2}, {T}: Target creature can't be blocked this turn.
+ *   {1}, {T}, Discard a legendary card with the same name as a legendary permanent you control:
+ *     Draw two cards.
+ *
+ * The second ability carries the new `SharesNameWithPermanentYouControl` cost filter, so these
+ * tests pin down what the discard cost will and won't accept: a hand card whose name matches a
+ * legendary permanent you control pays it; a legendary card with a *different* name doesn't; and
+ * neither does a name match against a permanent an opponent controls.
+ */
+class KeyToTheSideDoorScenarioTest : FunSpec({
+
+    val drawAbilityId = KeyToTheSideDoor.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun startAtMain(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40, "Grizzly Bears" to 20), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return player
+    }
+
+    test("discarding a legendary card that names a legendary permanent you control draws two") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val key = driver.putPermanentOnBattlefield(player, "Key to the Side-Door")
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.putCreatureOnBattlefield(player, "Bilbo, Luckwearer")
+
+        val handSizeBefore = driver.getHand(player).size
+        val duplicate = driver.putCardInHand(player, "Bilbo, Luckwearer")
+
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = key,
+                abilityId = drawAbilityId,
+                costPayment = AdditionalCostPayment(discardedCards = listOf(duplicate))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // +1 duplicate put in hand, -1 discarded as the cost, +2 drawn on resolution.
+        driver.getHand(player).size shouldBe handSizeBefore + 2
+        driver.getGraveyardCardNames(player).contains("Bilbo, Luckwearer") shouldBe true
+    }
+
+    test("a legendary card with a different name can't pay the discard cost") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val key = driver.putPermanentOnBattlefield(player, "Key to the Side-Door")
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.putCreatureOnBattlefield(player, "Bilbo, Luckwearer")
+
+        val other = driver.putCardInHand(player, "Bilbo Baggins, Burglar")
+
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = key,
+                abilityId = drawAbilityId,
+                costPayment = AdditionalCostPayment(discardedCards = listOf(other))
+            )
+        ).isSuccess shouldBe false
+    }
+
+    test("a name match on a permanent an OPPONENT controls doesn't pay the cost") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+        val opponent = driver.getOpponent(player)
+
+        val key = driver.putPermanentOnBattlefield(player, "Key to the Side-Door")
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.putCreatureOnBattlefield(opponent, "Bilbo, Luckwearer")
+
+        val duplicate = driver.putCardInHand(player, "Bilbo, Luckwearer")
+
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = key,
+                abilityId = drawAbilityId,
+                costPayment = AdditionalCostPayment(discardedCards = listOf(duplicate))
+            )
+        ).isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WizardsStaffScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WizardsStaffScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.WizardsStaff
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wizard's Staff (HOB #59) — {1}{U} Artifact — Equipment.
+ *
+ *   Equipped creature has prowess.
+ *   If an ability of equipped creature triggers, that ability triggers an additional time.
+ *   Equip Wizard {1}
+ *   Equip {3}
+ *
+ * The doubling is [AdditionalSourceTriggers] scoped by `attachedToBySource()` — the *host*
+ * direction of the primitive, where Cloud, Midgar Mercenary uses the attachment direction. The
+ * attack test proves the scoping actually fires: Ravenous Skirge's "whenever this creature attacks,
+ * it gets +2/+0" resolves twice, so a 1/1 attacks as a 5/1 rather than a 3/1.
+ */
+class WizardsStaffScenarioTest : FunSpec({
+
+    val equipWizardId = WizardsStaff.activatedAbilities[0].id
+    val equipGenericId = WizardsStaff.activatedAbilities[1].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(WizardsStaff)
+        return driver
+    }
+
+    fun startAtMain(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40, "Grizzly Bears" to 20), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return player
+    }
+
+    test("Equip {3} grants the equipped creature prowess") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val staff = driver.putPermanentOnBattlefield(player, "Wizard's Staff")
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.giveMana(player, Color.BLUE, 3)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = staff,
+                abilityId = equipGenericId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.state.projectedState.hasKeyword(bear, Keyword.PROWESS) shouldBe true
+    }
+
+    test("Equip Wizard {1} only attaches to a Wizard") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val staff = driver.putPermanentOnBattlefield(player, "Wizard's Staff")
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.giveMana(player, Color.BLUE, 1)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = staff,
+                abilityId = equipWizardId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        ).isSuccess shouldBe false
+
+        driver.state.projectedState.hasKeyword(bear, Keyword.PROWESS) shouldBe false
+    }
+
+    test("the equipped creature's attack trigger fires an additional time") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+        val opponent = driver.getOpponent(player)
+
+        val staff = driver.putPermanentOnBattlefield(player, "Wizard's Staff")
+        val skirge = driver.putCreatureOnBattlefield(player, "Ravenous Skirge")
+        driver.removeSummoningSickness(skirge)
+        driver.giveMana(player, Color.BLUE, 3)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = staff,
+                abilityId = equipGenericId,
+                targets = listOf(ChosenTarget.Permanent(skirge))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(skirge), opponent).isSuccess shouldBe true
+
+        // Resolve both copies of "whenever this creature attacks, it gets +2/+0".
+        repeat(4) { if (driver.stackSize > 0) driver.bothPass() }
+
+        // Base 1/1, doubled +2/+0 → 5/1. Without the Staff it would be 3/1.
+        driver.state.projectedState.getPower(skirge) shouldBe 5
+    }
+})


### PR DESCRIPTION
Adds four cards from The Hobbit (HOB), taking the set from **151/193 → 155/193**.

| Card | Shape |
|---|---|
| **Bilbo's Gambit** — {1}{W} Instant | Gift a Treasure; return target spell to its owner's hand; if the gift was promised, players can't cast spells this turn |
| **Bilbo, Luckwearer // Burglar's Plot** — {1}{U} 1/1 Adventure | Unblockable + combat-damage loot; the Adventure exchanges control of two target nonland permanents that share a card type |
| **Key to the Side-Door** — {1} Artifact | {2},{T}: target creature can't be blocked; {1},{T}, discard a legendary card naming a legendary permanent you control: draw two |
| **Wizard's Staff** — {1}{U} Equipment | Equipped creature has prowess; its triggered abilities trigger an additional time; Equip Wizard {1} / Equip {3} |

## New SDK vocabulary

Two cards needed new vocabulary. Both are siblings of an existing primitive rather than a new shape.

**`TargetObject.sameCardType`** — the card-type sibling of the existing `sameCreatureType` (Secret Tunnel), for *"two target nonland permanents that share a card type"*. `TargetValidator` enforces it as a non-empty intersection of the chosen permanents' **projected** types with supertypes sieved out — so an animated land counts as a creature, while two legendary permanents do **not** qualify by both being legendary. Declaring the two halves as separate requirements would make them independent instances of the word "target" and lose the constraint entirely, so it rides one two-target requirement.

**`CardPredicate.SharesNameWithPermanentYouControl`** — the name sibling of `SharesColorWithPermanentYouControl` (Ringsight), used as a `Costs.Discard(...)` filter. The cost enumerators hand it a `PredicateContext` whose `controllerId` is the activating player, so the battlefield side is correctly scoped to "you control"; without a matching pair in hand and play the ability simply isn't offered.

The other two cards compose existing primitives — Bilbo's Gambit is the `Patterns.Mechanic.giftSpell` two-mode shape plus `CantCastSpells` over `Player.Each`, and Wizard's Staff scopes `AdditionalSourceTriggers` with `attachedToBySource()`, the *host* direction of the primitive Cloud, Midgar Mercenary uses in the attachment direction.

## Tests

One scenario test file per card (four files), covering the happy path plus the interesting rejections:

- `BilboLuckwearerScenarioTest` — two creatures swap; a creature and a noncreature artifact are rejected, asserting on the *"share a card type"* error so it can't pass for an unrelated reason.
- `KeyToTheSideDoorScenarioTest` — a name-matching discard pays and draws two; a differently-named legendary card doesn't; a name match against an **opponent's** permanent doesn't.
- `BilbosGambitScenarioTest` — mode 0 bounces with no lockout; mode 1 gives the Treasure to the promised opponent, bounces, and locks out *every* player including the caster (proven by failing to recast the bounced spell).
- `WizardsStaffScenarioTest` — prowess grant, the Wizard-restricted equip refusing a non-Wizard, and Ravenous Skirge's attack trigger resolving twice (1/1 attacks as a 5/1, not a 3/1).

`docs/card-sdk-language-reference.md` is updated for both additions in the same change.

## Verification

`just build` passes clean (full check across all modules). `HOB.json` re-blessed — only HOB moved, additions only.

## Notes

- **Dropped from this batch: My Precious // Allure of Power.** Its Adventure face declares *"As an additional cost to cast this spell, sacrifice a creature"*, and face-level additional costs are not wired through the cast path — `CastSpellHandler` reads `cardDef.script.additionalCosts` (never the face's) and `CastSpellEnumerator.enumerateAdventureFace` never reads them at all. That's a documented gap (see the comment on that method), so the card would have shipped with its sacrifice cost silently unenforced. It's `add-feature` work, not a card change.
- `sameCardType`, like the existing `sameCreatureType`, is enforced in `TargetValidator` only — the legal-action target enumerator doesn't pre-filter the second pick, so an illegal pair is rejected at submit rather than being ungrabbable. Same behaviour as Secret Tunnel today; flagging it rather than diverging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
