### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CopperhoofVorrac.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CopperhoofVorrac.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Copperhoof Vorrac — Mirrodin #116
+ * {3}{G}{G} · Creature — Boar Beast · 2/2
+ *
+ * This creature gets +1/+1 for each untapped permanent your opponents control.
+ *
+ * Modelling notes:
+ * - "permanent", not "creature" — lands, artifacts, and enchantments all count, so the filter is
+ *   the unrestricted [GameObjectFilter.Any] narrowed to untapped, counted over the battlefield of
+ *   every opponent.
+ * - [GrantDynamicStatsEffect] is a continuously-recomputed layer 7c bonus, which is what the card
+ *   needs: the Vorrac shrinks the moment an opponent taps out and grows back on their untap step,
+ *   including mid-combat.
+ */
+val CopperhoofVorrac = card("Copperhoof Vorrac") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar Beast"
+    power = 2
+    toughness = 2
+    oracleText = "This creature gets +1/+1 for each untapped permanent your opponents control."
+
+    staticAbility {
+        val untappedOpponentPermanents =
+            DynamicAmounts.battlefield(Player.EachOpponent, GameObjectFilter.Any.untapped()).count()
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = untappedOpponentPermanents,
+            toughnessBonus = untappedOpponentPermanents
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "116"
+        artist = "Matt Cavotta"
+        flavorText = "Like all forest beasts, it lives by one rule: if there's no room to grow, make some."
+        imageUri = "https://cards.scryfall.io/normal/front/8/1/81fff4cc-b2ab-4a41-bede-0d807552ba46.jpg?1783944535"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/HeartwoodShard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/HeartwoodShard.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Heartwood Shard — Mirrodin #184
+ * {3} · Artifact
+ *
+ * {3}, {T} or {G}, {T}: Target creature gains trample until end of turn.
+ *
+ * Modelling notes:
+ * - The printed "{3}, {T} or {G}, {T}" is a single ability with two alternative cost options. The
+ *   engine has no alternative-cost shape for activated abilities, and modelling it as two separate
+ *   activated abilities is functionally identical here: both cost a tap of the Shard, so only one
+ *   can ever be activated per untap cycle, and neither ability references the other. The player
+ *   picks the cost they can afford straight from the action menu.
+ * - The rest of the Shard cycle (Crystal, Granite, Pearl, Skeleton) is the same two-ability shape.
+ */
+val HeartwoodShard = card("Heartwood Shard") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{3}, {T} or {G}, {T}: Target creature gains trample until end of turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        description = "{3}, {T}: Target creature gains trample until end of turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{G}"), Costs.Tap)
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        description = "{G}, {T}: Target creature gains trample until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "184"
+        artist = "Doug Chaffee"
+        flavorText = "Like all other relics, it was left on the Radix by the elves to be destroyed. " +
+            "Unlike all other relics, it persisted."
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b13328a9-fc03-4c1b-b1b7-61cd41766300.jpg?1783944518"
+
+        ruling("2004-10-04", "You can pay either of the two costs (but not both at the same time) to activate the ability.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Irradiate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Irradiate.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Irradiate — Mirrodin #67
+ * {3}{B} · Instant
+ *
+ * Target creature gets -1/-1 until end of turn for each artifact you control.
+ *
+ * Modelling notes:
+ * - [Effects.ModifyStats] with a [DynamicAmount] is the *resolution-time* shape: the artifact count
+ *   is locked in when Irradiate resolves and the -N/-N sticks for the rest of the turn even if the
+ *   artifacts are sacrificed in response to the death trigger. That is the printed behaviour —
+ *   contrast [com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect], which keeps recomputing and
+ *   belongs to permanents like Nim Devourer.
+ * - Irradiate itself is on the stack (not the battlefield) while it resolves, so it never counts
+ *   toward its own bonus; artifact *creatures* you control do count.
+ */
+val Irradiate = card("Irradiate") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -1/-1 until end of turn for each artifact you control."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        val negArtifacts = DynamicAmount.Multiply(
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).count(),
+            -1
+        )
+        effect = Effects.ModifyStats(negArtifacts, negArtifacts, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Dave Dorman"
+        flavorText = "The blast ignores the cage of metal but devours the flesh inside."
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7e0460cf-ff87-4cf8-89b5-a8b9fb7322e0.jpg?1783944547"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RustmouthOgre.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RustmouthOgre.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Rustmouth Ogre — Mirrodin #103
+ * {4}{R}{R} · Creature — Ogre · 5/4
+ *
+ * Whenever this creature deals combat damage to a player, you may destroy target artifact that
+ * player controls.
+ *
+ * Modelling notes:
+ * - "that player controls" is the *damaged* player, not just any opponent — resolved through
+ *   `controlledByTriggeringPlayer()`, which reads projected control so a stolen artifact follows
+ *   its current controller. Same shape as Dreadmaw's Ire's granted rider.
+ * - The target is locked in when the trigger goes on the stack; the "you may" is the resolution-time
+ *   choice, hence [MayEffect] wrapping the destroy rather than an optional trigger.
+ */
+val RustmouthOgre = card("Rustmouth Ogre") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre"
+    power = 5
+    toughness = 4
+    oracleText = "Whenever this creature deals combat damage to a player, you may destroy target " +
+        "artifact that player controls."
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact.controlledByTriggeringPlayer()))
+        )
+        effect = MayEffect(Effects.Destroy(t))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "103"
+        artist = "Brian Snõddy"
+        flavorText = "It has an iron stomach. Literally."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f8bd0c9-6b3a-489e-bf4d-b2062d530b55.jpg?1783944538"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/VulshokGauntlets.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/VulshokGauntlets.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Vulshok Gauntlets — Mirrodin #273
+ * {2} · Artifact — Equipment
+ *
+ * Equipped creature gets +4/+2 and doesn't untap during its controller's untap step.
+ * Equip {3}
+ *
+ * Modelling notes:
+ * - The two halves land in different layers — the +4/+2 in layer 7c, the untap restriction as an
+ *   [AbilityFlag.DOESNT_UNTAP] grant — so they are two static abilities over the same
+ *   [Filters.EquippedCreature] set. Attachment is re-read continuously either way, so unattaching
+ *   the Gauntlets frees the creature to untap on its controller's very next untap step.
+ * - The restriction is permanent while attached, not a one-shot "next untap step" (contrast
+ *   Stitcher's Graft, whose attack rider is duration-bounded).
+ */
+val VulshokGauntlets = card("Vulshok Gauntlets") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +4/+2 and doesn't untap during its controller's untap step.\n" +
+        "Equip {3}"
+
+    staticAbility {
+        ability = ModifyStats(+4, +2, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name, Filters.EquippedCreature)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "273"
+        artist = "Richard Sardinha"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14a04bbd-1d07-4b11-aa54-01790b9dd3a0.jpg?1783944496"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -886,6 +886,49 @@
     ]
 }
 
+// Copperhoof Vorrac
+{
+    "name": "Copperhoof Vorrac",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Boar Beast",
+    "oracleText": "This creature gets +1/+1 for each untapped permanent your opponents control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "EachOpponent",
+                    "filter": "untapped"
+                },
+                "toughnessBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "EachOpponent",
+                    "filter": "untapped"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "flavorText": "Like all forest beasts, it lives by one rule: if there's no room to grow, make some.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/1/81fff4cc-b2ab-4a41-bede-0d807552ba46.jpg?1783944535"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Deconstruct
 {
     "name": "Deconstruct",
@@ -1973,6 +2016,100 @@
     ]
 }
 
+// Heartwood Shard
+{
+    "name": "Heartwood Shard",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T} or {G}, {T}: Target creature gains trample until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{3}, {T}: Target creature gains trample until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "{G}, {T}: Target creature gains trample until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "UNCOMMON",
+        "artist": "Doug Chaffee",
+        "flavorText": "Like all other relics, it was left on the Radix by the elves to be destroyed. Unlike all other relics, it persisted.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b13328a9-fc03-4c1b-b1b7-61cd41766300.jpg?1783944518",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "You can pay either of the two costs (but not both at the same time) to activate the ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Hematite Golem
 {
     "name": "Hematite Golem",
@@ -2052,6 +2189,59 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Irradiate
+{
+    "name": "Irradiate",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -1/-1 until end of turn for each artifact you control.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "artifact"
+                },
+                "multiplier": -1
+            },
+            "toughnessModifier": {
+                "type": "Multiply",
+                "amount": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "artifact"
+                },
+                "multiplier": -1
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "artist": "Dave Dorman",
+        "flavorText": "The blast ignores the cage of metal but devours the flesh inside.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7e0460cf-ff87-4cf8-89b5-a8b9fb7322e0.jpg?1783944547"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -4634,6 +4824,60 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Rustmouth Ogre
+{
+    "name": "Rustmouth Ogre",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Ogre",
+    "oracleText": "Whenever this creature deals combat damage to a player, you may destroy target artifact that player controls.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact ctrl:triggering-player"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Snõddy",
+        "flavorText": "It has an iron stomach. Literally.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f8bd0c9-6b3a-489e-bf4d-b2062d530b55.jpg?1783944538"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -7476,6 +7720,64 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Vulshok Gauntlets
+{
+    "name": "Vulshok Gauntlets",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +4/+2 and doesn't untap during its controller's untap step.\nEquip {3}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 4,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "273",
+        "artist": "Richard Sardinha",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14a04bbd-1d07-4b11-aa54-01790b9dd3a0.jpg?1783944496"
+    },
+    "colorIdentityOverride": []
 }
 
 // Wall of Blood


### PR DESCRIPTION
Adds five Mirrodin cards, chosen for a spread of shapes (instant, static creature, Equipment, combat trigger, artifact with a cost choice). All five compose existing SDK vocabulary — no new effects, triggers, or static abilities — so the only non-card change is the MRD snapshot golden, and that diff is pure additions.

## Cards

| Card | Shape |
|---|---|
| **Irradiate** `{3}{B}` Instant | `Effects.ModifyStats` with a negated `Multiply(count of artifacts you control, -1)`. Resolution-time, so the −N/−N locks in when the spell resolves and survives the artifacts being sacrificed in response — the printed behaviour, in contrast to a `GrantDynamicStatsEffect`. |
| **Copperhoof Vorrac** `{3}{G}{G}` 2/2 | `GrantDynamicStatsEffect` over `GroupFilter.source()`, counting `GameObjectFilter.Any.untapped()` across `Player.EachOpponent`. Continuously recomputed, so it shrinks the instant an opponent taps out and grows back mid-combat. "Permanent", not "creature" — lands and artifacts count. |
| **Vulshok Gauntlets** `{2}` Equipment | Two statics over `Filters.EquippedCreature`: `ModifyStats(+4, +2)` in layer 7c and an `AbilityFlag.DOESNT_UNTAP` grant. Permanent while attached, not a duration-bounded "next untap step" (contrast Stitcher's Graft's attack rider). |
| **Rustmouth Ogre** `{4}{R}{R}` 5/4 | `Triggers.DealsCombatDamageToPlayer` with the target filtered by `controlledByTriggeringPlayer()` — "that player", the damaged one, read from projected control so a stolen artifact follows its current controller. The "you may" is the resolution-time choice, hence `MayEffect` wrapping the destroy rather than an optional trigger. Same shape as Dreadmaw's Ire's granted rider. |
| **Heartwood Shard** `{3}` Artifact | The printed "{3}, {T} or {G}, {T}" is one ability with two alternative costs. Modelled as two activated abilities with explicit descriptions — functionally identical here since both tap the Shard, so only one can ever fire per untap cycle, and it gives the player two clearly-labelled action-menu buttons. The 2004-10-04 ruling ("pay either of the two costs, but not both") is recorded in `metadata`. |

## Verification

- `just build` — green (compile + all module tests, including `FacadeBoundaryTest` and the card linter).
- `just rebless-cards` — MRD golden diff is **302 insertions, 0 deletions**; only the five new cards moved.
- `just check-card-printing` — all five `ok`, canonical in MRD (their earliest real printing). Vulshok Gauntlets' PSAL/2XM reprints aren't scaffolded, so no rows are due.
- Every field re-checked against Scryfall (`&set=mrd`): mana cost, type line, P/T, rarity, collector number, artist, flavour, oracle text. All five `image_uris.normal` return HTTP 200.
- Rulings pulled for all five; only Heartwood Shard has one, and it confirms the two-ability modelling.

No scenario tests: no new SDK vocabulary was added, so the snapshot and lint nets are the coverage per the `add-card` skill. No new decision UI either — targeting, equip, and the may-destroy Yes/No all route to existing components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
