### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AftermathAnalyst.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AftermathAnalyst.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Aftermath Analyst — Murders at Karlov Manor #148
+ * {1}{G} · Creature — Elf Detective · 1/3
+ *
+ * When this creature enters, mill three cards.
+ * {3}{G}, Sacrifice this creature: Return all land cards from your graveyard to the battlefield
+ * tapped.
+ *
+ * The two halves are one engine: the enters trigger stocks the graveyard with lands, and the
+ * activated ability cashes them all in. Because the mill is a *may-less* trigger it happens even
+ * when it hits no lands — the ramp payoff simply reads whatever is in the graveyard at the moment
+ * the ability resolves, including lands that got there long before this Elf arrived.
+ *
+ * The return half is the Lumra, Bellow of the Woods shape: gather every land card in the
+ * controller's graveyard into a named collection, then move that whole collection to the
+ * battlefield tapped. Gathering first is what makes "all land cards" a single snapshot — cards put
+ * into the graveyard while the ability is on the stack are included (the gather happens on
+ * resolution), but nothing is re-scanned mid-move.
+ *
+ * `Costs.SacrificeSelf` pays before resolution (CR 601.2h), so Aftermath Analyst is already in the
+ * graveyard when the ability resolves — it is a creature card, not a land, so it never returns
+ * itself.
+ */
+val AftermathAnalyst = card("Aftermath Analyst") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Detective"
+    oracleText = "When this creature enters, mill three cards. (Put the top three cards of your " +
+        "library into your graveyard.)\n" +
+        "{3}{G}, Sacrifice this creature: Return all land cards from your graveyard to the " +
+        "battlefield tapped."
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(3)
+        description = "When this creature enters, mill three cards."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{G}"), Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.GRAVEYARD, Player.You, GameObjectFilter.Land),
+                storeAs = "graveyard_lands",
+            ),
+            MoveCollectionEffect(
+                from = "graveyard_lands",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped),
+            ),
+        )
+        description = "Return all land cards from your graveyard to the battlefield tapped"
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Danny Schwartz"
+        flavorText = "\"Could someone bring me more evidence markers? Like . . . a lot more?\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c1aa6f8-2d34-4f4b-9184-0eab2e4745f7.jpg?1783912870"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CallASurpriseWitness.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CallASurpriseWitness.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Call a Surprise Witness — Murders at Karlov Manor #6
+ * {1}{W} · Sorcery
+ *
+ * Return target creature card with mana value 3 or less from your graveyard to the battlefield.
+ * Put a flying counter on it. It's a Spirit in addition to its other types.
+ *
+ * Two mana of reanimation with an evasion rider. Resolution is a sequential composite (CR 608.2)
+ * over one stable target reference, the Abuelo's Awakening shape:
+ *  1. [Effects.PutOntoBattlefield] moves the targeted card out of the controller's graveyard. The
+ *     bound target survives the zone change, so the two riders land on the new permanent rather
+ *     than on a stale graveyard object.
+ *  2. A **flying counter** ([Counters.FLYING]) — the keyword counter, not a granted keyword. That
+ *     distinction matters: the counter rides along through copy effects and survives an effect
+ *     that removes all abilities, and it is removed only by removing the counter.
+ *  3. **Spirit** is added with [Effects.AddSubtype] at [Duration.Permanent] — "in addition to its
+ *     other types" means additive, so a returned Human Detective becomes a Human Detective Spirit.
+ *
+ * The mana value check is made on the card in the graveyard as the spell targets it, so a creature
+ * card with {X} in its cost has mana value 0 there and is always a legal target.
+ */
+val CallASurpriseWitness = card("Call a Surprise Witness") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card with mana value 3 or less from your graveyard to " +
+        "the battlefield. Put a flying counter on it. It's a Spirit in addition to its other types."
+
+    spell {
+        val witness = target(
+            "target creature card with mana value 3 or less from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.IsCreature,
+                            CardPredicate.ManaValueAtMost(3),
+                        ),
+                        controllerPredicate = ControllerPredicate.OwnedByYou,
+                    ),
+                    zone = Zone.GRAVEYARD,
+                )
+            )
+        )
+        effect = Effects.PutOntoBattlefield(witness)
+            .then(Effects.AddCounters(Counters.FLYING, 1, witness))
+            .then(Effects.AddSubtype("Spirit", target = witness, duration = Duration.Permanent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Julia Metzger"
+        flavorText = "\"Why would a little thing like death stop me from running the Syndicate? " +
+            "I'm going to be here for a long, long time.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5148def-cf1a-460e-8dfd-856103940892.jpg?1783912928"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DramaticAccusation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/DramaticAccusation.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dramatic Accusation — Murders at Karlov Manor #53
+ * {2}{U} · Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, tap enchanted creature.
+ * Enchanted creature doesn't untap during its controller's untap step.
+ * {U}{U}: Shuffle enchanted creature into its owner's library.
+ *
+ * A Claustrophobia that eventually becomes hard removal. The lock is the classic pair — an enters
+ * trigger taps the creature once, and the static [AbilityFlag.DOESNT_UNTAP] keeps it that way — and
+ * the {U}{U} ability upgrades the lock into exile-grade removal at instant speed once the mana is
+ * spare.
+ *
+ * The tap is a *trigger*, not part of attaching, so it uses the stack and can be responded to; the
+ * static, by contrast, applies continuously from the moment the Aura is attached. Neither targets
+ * ("enchanted creature" is not a target, CR 702.155a), so hexproof on the enchanted creature stops
+ * none of it once the Aura is on.
+ *
+ * The activated ability lives on the Aura, so only the Aura's controller may activate it (per the
+ * ruling below) — enchanting an opponent's creature does not hand them the button. Shuffling the
+ * creature away puts the Aura into its owner's graveyard as a state-based action, since it is no
+ * longer attached to anything.
+ */
+val DramaticAccusation = card("Dramatic Accusation") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, tap enchanted creature.\n" +
+        "Enchanted creature doesn't untap during its controller's untap step.\n" +
+        "{U}{U}: Shuffle enchanted creature into its owner's library."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedCreature)
+        description = "When this Aura enters, tap enchanted creature."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{U}{U}")
+        effect = Effects.ShuffleIntoLibrary(EffectTarget.EnchantedCreature)
+        description = "Shuffle enchanted creature into its owner's library"
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Evyn Fong"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2ca93438-a132-45ca-9fa8-364aeb519594.jpg?1783912912"
+
+        ruling("2024-02-02", "Only the controller of Dramatic Accusation may activate its ability.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EssenceOfAntiquity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EssenceOfAntiquity.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Essence of Antiquity — Murders at Karlov Manor #15
+ * {3}{W}{W} · Artifact Creature — Golem · 1/10
+ *
+ * Disguise {2}{W}
+ * When this creature is turned face up, creatures you control gain hexproof until end of turn.
+ * Untap them.
+ *
+ * A combat trick disguised as a wall. Cast face down for {3}, attack or block with the 2/2, then
+ * flip for {2}{W} — turning face up is a special action that can't be responded to (CR 701.34a),
+ * so the hexproof lands before any removal spell can be cast in response to the flip itself. The
+ * untap is the second half of the ambush: creatures that were tapped attacking are untapped and
+ * can block.
+ *
+ * "Creatures you control … Untap them" is a single affected set captured at resolution
+ * ([Effects.ForEachInGroup] over `Creature.youControl()`), so both halves — the grant and the
+ * untap — apply to exactly the same creatures. The Golem itself is included; it is on the
+ * battlefield the whole time, only its face changes.
+ *
+ * Note the composite order: hexproof is granted before the untap, but neither depends on the other,
+ * and both are one-shot resolution effects rather than statics, so a creature that enters after the
+ * trigger resolves gets nothing.
+ */
+val EssenceOfAntiquity = card("Essence of Antiquity") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Golem"
+    oracleText = "Disguise {2}{W} (You may cast this card face down for {3} as a 2/2 creature " +
+        "with ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, creatures you control gain hexproof until end of " +
+        "turn. Untap them."
+    power = 1
+    toughness = 10
+
+    disguise = "{2}{W}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.GrantKeyword(Keyword.HEXPROOF, EffectTarget.Self),
+                Effects.Untap(EffectTarget.Self),
+            ),
+        )
+        description = "When this creature is turned face up, creatures you control gain hexproof " +
+            "until end of turn. Untap them."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "Caio Monteiro"
+        flavorText = "In a city as old as Ravnica, history takes on a life of its own—even when " +
+            "you least expect it."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aee2945d-bf6d-4328-a482-df24c2973b56.jpg?1783912926"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HuntedBonebrute.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/HuntedBonebrute.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hunted Bonebrute — Murders at Karlov Manor #87
+ * {2}{B} · Creature — Skeleton Beast · 6/2
+ *
+ * Menace
+ * When this creature enters, target opponent creates two 1/1 white Dog creature tokens.
+ * When this creature dies, each opponent loses 3 life.
+ * Disguise {1}{B}
+ *
+ * A six-power three-drop that hands the defender two chump blockers — the Hunted drawback, updated.
+ * Disguise is the way out of the drawback: cast face down for {3} and flip for {1}{B}, and the
+ * enters trigger never fires at all, because turning a permanent face up is not an
+ * enters-the-battlefield event (CR 701.34c / the disguise rulings below). The dies trigger and
+ * menace still apply once it is face up.
+ *
+ * The Dogs enter under the *targeted opponent's* control, which is what
+ * [Effects.CreateToken]'s `controller` parameter expresses — the trigger's controller creates
+ * nothing. If the targeted opponent has become an illegal target by resolution the whole trigger is
+ * removed from the stack and no Dogs appear.
+ *
+ * The death trigger is `Player.EachOpponent`, not "target opponent" — in multiplayer every opponent
+ * loses 3, including ones who never received a Dog.
+ */
+val HuntedBonebrute = card("Hunted Bonebrute") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton Beast"
+    oracleText = "Menace\n" +
+        "When this creature enters, target opponent creates two 1/1 white Dog creature tokens.\n" +
+        "When this creature dies, each opponent loses 3 life.\n" +
+        "Disguise {1}{B} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)"
+    power = 6
+    toughness = 2
+
+    keywords(Keyword.MENACE)
+
+    disguise = "{1}{B}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Dog"),
+            count = 2,
+            controller = opponent,
+        )
+        description = "When this creature enters, target opponent creates two 1/1 white Dog " +
+            "creature tokens."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.LoseLife(3, EffectTarget.PlayerRef(Player.EachOpponent))
+        description = "When this creature dies, each opponent loses 3 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "87"
+        artist = "Maxime Minard"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4ca0e10-8b7c-4ce2-888b-752fc909757a.jpg?1783912897"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1,3 +1,104 @@
+// Aftermath Analyst
+{
+    "name": "Aftermath Analyst",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Detective",
+    "oracleText": "When this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)\n{3}{G}, Sacrifice this creature: Return all land cards from your graveyard to the battlefield tapped.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, mill three cards."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "land"
+                            },
+                            "storeAs": "graveyard_lands"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "graveyard_lands",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Return all land cards from your graveyard to the battlefield tapped"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Danny Schwartz",
+        "flavorText": "\"Could someone bring me more evidence markers? Like . . . a lot more?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c1aa6f8-2d34-4f4b-9184-0eab2e4745f7.jpg?1783912870"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Alley Assailant
 {
     "name": "Alley Assailant",
@@ -516,6 +617,67 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Call a Surprise Witness
+{
+    "name": "Call a Surprise Witness",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card with mana value 3 or less from your graveyard to the battlefield. Put a flying counter on it. It's a Spirit in addition to its other types.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card with mana value 3 or less from your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "flying",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card with mana value 3 or less from your graveyard"
+                    }
+                },
+                {
+                    "type": "AddSubtype",
+                    "subtype": "Spirit",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card with mana value 3 or less from your graveyard"
+                    },
+                    "duration": "Permanent"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature mv<=3 own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card with mana value 3 or less from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Julia Metzger",
+        "flavorText": "\"Why would a little thing like death stop me from running the Syndicate? I'm going to be here for a long, long time.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5148def-cf1a-460e-8dfd-856103940892.jpg?1783912928"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1564,6 +1726,75 @@
     ]
 }
 
+// Dramatic Accusation
+{
+    "name": "Dramatic Accusation",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{U}{U}: Shuffle enchanted creature into its owner's library.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EnchantedCreature"
+                },
+                "descriptionOverride": "When this Aura enters, tap enchanted creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{U}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "EnchantedCreature",
+                    "destination": "Library",
+                    "placement": "Shuffled"
+                },
+                "descriptionOverride": "Shuffle enchanted creature into its owner's library"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Evyn Fong",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2ca93438-a132-45ca-9fa8-364aeb519594.jpg?1783912912",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Only the controller of Dramatic Accusation may activate its ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Due Diligence
 {
     "name": "Due Diligence",
@@ -1791,6 +2022,79 @@
         "imageUri": "https://cards.scryfall.io/normal/front/9/3/93ddde4f-d35e-4128-8f43-d0eadbd715de.jpg?1706242339"
     },
     "colorIdentityOverride": []
+}
+
+// Essence of Antiquity
+{
+    "name": "Essence of Antiquity",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Disguise {2}{W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, creatures you control gain hexproof until end of turn. Untap them.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 10
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{W}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "HEXPROOF",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "TapUntap",
+                                "target": "Self",
+                                "tap": false
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "When this creature is turned face up, creatures you control gain hexproof until end of turn. Untap them."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "UNCOMMON",
+        "artist": "Caio Monteiro",
+        "flavorText": "In a city as old as Ravnica, history takes on a life of its own—even when you least expect it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aee2945d-bf6d-4328-a482-df24c2973b56.jpg?1783912926",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Exit Specialist
@@ -3440,6 +3744,107 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Hunted Bonebrute
+{
+    "name": "Hunted Bonebrute",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Skeleton Beast",
+    "oracleText": "Menace\nWhen this creature enters, target opponent creates two 1/1 white Dog creature tokens.\nWhen this creature dies, each opponent loses 3 life.\nDisguise {1}{B} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{1}{B}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Dog"
+                    ],
+                    "controller": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "When this creature enters, target opponent creates two 1/1 white Dog creature tokens."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, each opponent loses 3 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "RARE",
+        "artist": "Maxime Minard",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4ca0e10-8b7c-4ce2-888b-752fc909757a.jpg?1783912897",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AftermathAnalystScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AftermathAnalystScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.AftermathAnalyst
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Aftermath Analyst (MKM #148) — {1}{G} 1/3 Creature — Elf Detective.
+ *
+ * "When this creature enters, mill three cards."
+ * "{3}{G}, Sacrifice this creature: Return all land cards from your graveyard to the battlefield
+ *  tapped."
+ *
+ * The two halves are tested separately, plus the thing a naive implementation gets wrong: the
+ * return is filtered to *land cards* and enters *tapped*, and the Analyst itself — already in the
+ * graveyard by the time the ability resolves, because sacrifice is a cost — must not come back.
+ */
+class AftermathAnalystScenarioTest : ScenarioTestBase() {
+
+    private val recursionAbility = AftermathAnalyst.activatedAbilities.first().id
+
+    init {
+        context("Aftermath Analyst") {
+
+            test("entering mills three cards") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Aftermath Analyst")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .build()
+
+                game.castSpell(1, "Aftermath Analyst").error shouldBe null
+                game.resolveStack()
+
+                withClue("three cards off the top, one left in the library") {
+                    game.graveyardSize(1) shouldBe 3
+                    game.librarySize(1) shouldBe 1
+                }
+            }
+
+            test("the sacrifice ability returns every land card from the graveyard, tapped") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Aftermath Analyst")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInGraveyard(1, "Mountain")
+                    .withCardInGraveyard(1, "Swamp")
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .build()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Aftermath Analyst")!!,
+                        abilityId = recursionAbility,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("both lands returned, and each one entered tapped") {
+                    val returned = game.findAllPermanents("Mountain") + game.findAllPermanents("Swamp")
+                    returned.size shouldBe 2
+                    returned.all {
+                        game.state.getEntity(it)?.get<TappedComponent>() != null
+                    } shouldBe true
+                }
+                withClue("the filter is land cards — the Bolt stays put") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                }
+                withClue("sacrifice is a cost, so the Elf is in the graveyard and is not a land") {
+                    game.isInGraveyard(1, "Aftermath Analyst") shouldBe true
+                    game.isOnBattlefield("Aftermath Analyst") shouldBe false
+                }
+            }
+
+            test("the ability is happy to return nothing when no lands are in the graveyard") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Aftermath Analyst")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .build()
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Aftermath Analyst")!!,
+                        abilityId = recursionAbility,
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                game.isInGraveyard(1, "Aftermath Analyst") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CallASurpriseWitnessScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CallASurpriseWitnessScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Call a Surprise Witness (MKM #6) — {1}{W} Sorcery.
+ *
+ * "Return target creature card with mana value 3 or less from your graveyard to the battlefield.
+ *  Put a flying counter on it. It's a Spirit in addition to its other types."
+ *
+ * The risk in this shape is the target reference surviving the graveyard → battlefield move: if it
+ * doesn't, the counter and the subtype land on nothing and the card degrades into a plain
+ * reanimation spell. Both riders are therefore asserted on the returned permanent, along with "in
+ * addition to" — the printed creature types must still be there — and the mana-value gate on the
+ * target.
+ */
+class CallASurpriseWitnessScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Call a Surprise Witness") {
+
+            test("returns a cheap creature with a flying counter and the Spirit type added") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Call a Surprise Witness")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Call a Surprise Witness", 1, "Grizzly Bears")
+                    .error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                withClue("the Bears left the graveyard for the battlefield") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+
+                withClue("a flying counter, not a granted keyword") {
+                    game.state.getEntity(bears)?.get<CountersComponent>()
+                        ?.getCount(CounterType.FLYING) shouldBe 1
+                }
+
+                val projected = projector.project(game.state)
+                withClue("the counter grants flying, and Spirit is added to the printed Bear type") {
+                    projected.hasKeyword(bears, Keyword.FLYING) shouldBe true
+                    projected.hasSubtype(bears, "Spirit") shouldBe true
+                    projected.hasSubtype(bears, "Bear") shouldBe true
+                }
+            }
+
+            test("a creature card with mana value 4 or more is not a legal target") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Call a Surprise Witness")
+                    .withCardInGraveyard(1, "Serra Angel")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .build()
+
+                withClue("Serra Angel costs {3}{W}{W} — above the mana value 3 gate") {
+                    game.castSpellTargetingGraveyardCard(1, "Call a Surprise Witness", 1, "Serra Angel")
+                        .error shouldNotBe null
+                }
+                game.isInGraveyard(1, "Serra Angel") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DramaticAccusationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DramaticAccusationScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.DramaticAccusation
+import com.wingedsheep.sdk.core.AbilityFlag
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dramatic Accusation (MKM #53) — {2}{U} Enchantment — Aura.
+ *
+ * "Enchant creature"
+ * "When this Aura enters, tap enchanted creature."
+ * "Enchanted creature doesn't untap during its controller's untap step."
+ * "{U}{U}: Shuffle enchanted creature into its owner's library."
+ *
+ * The lock is two separate pieces — a one-shot enters trigger and a continuous static — so both are
+ * asserted: the creature ends up tapped, and it carries the untap restriction while the Aura is
+ * attached. The activated ability gets its own test because it is the card's actual removal mode,
+ * and because shuffling the host away should take the now-unattached Aura with it.
+ */
+class DramaticAccusationScenarioTest : ScenarioTestBase() {
+
+    private val shuffleAbility = DramaticAccusation.activatedAbilities.first().id
+
+    init {
+        context("Dramatic Accusation") {
+
+            test("entering taps the enchanted creature and keeps it from untapping") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Dramatic Accusation")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Dramatic Accusation", bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the enters trigger taps it") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("and the static keeps it from untapping") {
+                    game.state.projectedState.hasKeyword(bears, AbilityFlag.DOESNT_UNTAP) shouldBe true
+                }
+            }
+
+            test("the activated ability shuffles the enchanted creature into its owner's library") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Dramatic Accusation", "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .build()
+
+                val aura = game.findPermanent("Dramatic Accusation")!!
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = aura, abilityId = shuffleAbility)
+                ).error shouldBe null
+                game.resolveStack()
+                game.checkStateBasedActions()
+
+                withClue("the creature is gone from the battlefield and back in its owner's library") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.findCardsInLibrary(2, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("an Aura attached to nothing is put into its owner's graveyard") {
+                    game.isOnBattlefield("Dramatic Accusation") shouldBe false
+                    game.isInGraveyard(1, "Dramatic Accusation") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EssenceOfAntiquityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EssenceOfAntiquityScenarioTest.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.EssenceOfAntiquity
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Essence of Antiquity (MKM #15) — {3}{W}{W} 1/10 Artifact Creature — Golem with Disguise {2}{W}.
+ *
+ * "When this creature is turned face up, creatures you control gain hexproof until end of turn.
+ *  Untap them."
+ *
+ * The trigger is one affected set doing two things, so both are checked on the same creatures: the
+ * hexproof grant and the untap. The opponent's board is the control — an "each creature" reading of
+ * the group filter would untap their attackers too, which is the failure this catches.
+ */
+class EssenceOfAntiquityScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(EssenceOfAntiquity))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Cast the Golem face down for {3} and return the resulting face-down permanent. */
+    fun castFaceDown(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Essence of Antiquity")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    fun flipFaceUp(driver: GameTestDriver, player: EntityId, golem: EntityId) {
+        driver.giveColorlessMana(player, 2)
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = golem,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        repeat(2) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+    }
+
+    test("flipping it untaps your creatures and gives them hexproof, leaving the opponent's alone") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != player }
+
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val theirBears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.tapPermanent(bears)
+        driver.tapPermanent(theirBears)
+
+        val golem = castFaceDown(driver, player)
+        driver.tapPermanent(golem)
+
+        withClue("nothing has happened yet") {
+            driver.state.projectedState.hasKeyword(bears, Keyword.HEXPROOF) shouldBe false
+            driver.isTapped(bears) shouldBe true
+        }
+
+        flipFaceUp(driver, player, golem)
+
+        withClue("your creatures — including the Golem itself — are untapped and hexproof") {
+            driver.isTapped(bears) shouldBe false
+            driver.isTapped(golem) shouldBe false
+            driver.state.projectedState.hasKeyword(bears, Keyword.HEXPROOF) shouldBe true
+            driver.state.projectedState.hasKeyword(golem, Keyword.HEXPROOF) shouldBe true
+        }
+        withClue("the opponent's creature is untouched by both halves") {
+            driver.isTapped(theirBears) shouldBe true
+            driver.state.projectedState.hasKeyword(theirBears, Keyword.HEXPROOF) shouldBe false
+        }
+    }
+
+    test("face down it is a vanilla 2/2; face up it is the printed 1/10") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val golem = castFaceDown(driver, player)
+
+        driver.state.projectedState.getPower(golem) shouldBe 2
+        driver.state.projectedState.getToughness(golem) shouldBe 2
+
+        flipFaceUp(driver, player, golem)
+
+        driver.state.projectedState.getPower(golem) shouldBe 1
+        driver.state.projectedState.getToughness(golem) shouldBe 10
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedBonebruteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntedBonebruteScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hunted Bonebrute (MKM #87) — {2}{B} 6/2 Creature — Skeleton Beast.
+ *
+ * "Menace"
+ * "When this creature enters, target opponent creates two 1/1 white Dog creature tokens."
+ * "When this creature dies, each opponent loses 3 life."
+ * "Disguise {1}{B}"
+ *
+ * The drawback is the interesting half: the two Dogs must arrive under the *targeted opponent's*
+ * control, not the caster's — a token effect that quietly defaults to the ability's controller
+ * turns a drawback into an upside and nothing else would catch it. The death trigger is checked
+ * separately because it is `each opponent`, not the player who received the Dogs.
+ */
+class HuntedBonebruteScenarioTest : ScenarioTestBase() {
+
+    private fun dogsControlledBy(game: TestGame, playerNumber: Int): Int {
+        val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
+        return game.state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).count { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == "Dog Token"
+        }
+    }
+
+    init {
+        context("Hunted Bonebrute") {
+
+            test("entering gives the targeted opponent two Dogs") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Hunted Bonebrute")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .build()
+
+                game.castSpell(1, "Hunted Bonebrute").error shouldBe null
+                game.resolveStack()
+
+                withClue("the Dogs belong to the opponent, not the Skeleton's controller") {
+                    dogsControlledBy(game, 2) shouldBe 2
+                    dogsControlledBy(game, 1) shouldBe 0
+                }
+                game.isOnBattlefield("Hunted Bonebrute") shouldBe true
+            }
+
+            test("dying drains each opponent for 3") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardOnBattlefield(1, "Hunted Bonebrute")
+                    .withCardInHand(1, "Murder")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .build()
+
+                val brute = game.findPermanent("Hunted Bonebrute")!!
+                game.castSpell(1, "Murder", brute).error shouldBe null
+                game.resolveStack()
+
+                game.isInGraveyard(1, "Hunted Bonebrute") shouldBe true
+                withClue("each opponent — the controller's own life is untouched") {
+                    game.getLifeTotal(2) shouldBe 17
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five more MKM cards, all built from existing SDK vocabulary — no new effects, triggers, or keywords. MKM is the earliest real printing for all five, so each gets a canonical `CardDefinition` (no `Printing` rows needed).

## Cards

| Card | Cost | Shape |
|---|---|---|
| **Aftermath Analyst** | `{1}{G}` | Enters-mill 3, plus `{3}{G}`, Sacrifice: return all land cards from your graveyard to the battlefield tapped |
| **Hunted Bonebrute** | `{2}{B}` | Menace; enters → target opponent creates two Dogs; dies → each opponent loses 3; Disguise `{1}{B}` |
| **Essence of Antiquity** | `{3}{W}{W}` | Disguise `{2}{W}`; turned face up → creatures you control gain hexproof and untap |
| **Call a Surprise Witness** | `{1}{W}` | Reanimate a creature card with mana value ≤ 3, with a flying counter and the Spirit type added |
| **Dramatic Accusation** | `{2}{U}` | Aura: enters-tap, doesn't-untap static, `{U}{U}`: shuffle the host into its owner's library |

## Implementation notes

- **Aftermath Analyst** reuses the Lumra / Summon: Titan gather → move idiom: `GatherCardsEffect` over land cards in your graveyard, then `MoveCollectionEffect` to the battlefield tapped. Sacrifice is a cost (CR 601.2h), so the Elf is already in the graveyard when the ability resolves — and it is a creature card, not a land, so it never returns itself.
- **Hunted Bonebrute**'s Dogs enter under the *targeted opponent's* control (`Effects.CreateToken(controller = <target opponent>)`). A token effect that quietly defaults to the ability's controller would turn the drawback into an upside, so that has its own assertion. Disguise sidesteps the drawback entirely — turning a permanent face up is not an enters-the-battlefield event.
- **Essence of Antiquity** is one `ForEachInGroup` over creatures you control whose body both grants hexproof and untaps, so a single captured affected set gets both halves.
- **Call a Surprise Witness** is the Abuelo's Awakening shape: one bound target reference survives the graveyard → battlefield move, then takes a **flying counter** (`Counters.FLYING`, the keyword counter — not a granted keyword) and an additive `AddSubtype("Spirit", Duration.Permanent)`.
- **Dramatic Accusation** splits into the enters trigger (tap), the `AbilityFlag.DOESNT_UNTAP` static on the enchanted creature, and a `{U}{U}` activated ability shuffling the host away — the Watery Grasp shape plus the tap trigger.

## Tests

One scenario test file per card (11 tests total), all passing:

- `AftermathAnalystScenarioTest` — mills exactly three; returns only *land* cards and only tapped; leaves an instant behind; the sacrificed Elf stays in the graveyard; the empty-graveyard case is a clean no-op.
- `HuntedBonebruteScenarioTest` — the Dogs land on the opponent's side, not the caster's; dying drains each opponent for 3 and leaves the controller's life alone.
- `EssenceOfAntiquityScenarioTest` — flipping untaps *and* grants hexproof to your creatures including the Golem, while the opponent's tapped creature is untouched; face-down 2/2 vs face-up 1/10.
- `CallASurpriseWitnessScenarioTest` — the flying counter and Spirit subtype land on the returned permanent with the printed Bear type intact; a mana-value-4 creature is rejected as a target.
- `DramaticAccusationScenarioTest` — enters taps and the untap restriction projects; the activated ability shuffles the host into its owner's library and the unattached Aura falls off to the graveyard.

## Verification

- `just build` — green (MKM card snapshot re-blessed; only these five cards moved in the golden)
- `just test-rules` — green
- `just check-card-printing` — ok for all five

MKM: 130 → 135 / 276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)