### PR TITLE
Add three The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LastLightOfDurinsDay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LastLightOfDurinsDay.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Last Light of Durin's Day
+ * {1}{R}
+ * Enchantment
+ *
+ * Whenever a Mountain you control enters, put a quest counter on this enchantment. If it has six or
+ * more quest counters on it, sacrifice it. If you do, search your hand and/or library for a Dragon
+ * card and put it onto the battlefield. If you search your library this way, shuffle.
+ * Mountaincycling {2}
+ *
+ * Modeling notes — pure composition, no new engine vocabulary:
+ *  - **Trigger** — "a Mountain you control" is any *land* with the Mountain subtype (a nonbasic dual
+ *    with the type counts), so the filter is `Land.withSubtype(MOUNTAIN).youControl()` with an `ANY`
+ *    binding rather than a basic-land-only filter.
+ *  - **Threshold** — the counter goes on unconditionally, then a [ConditionalEffect] gated on the
+ *    *live* count ([Conditions.SourceCounterCountAtLeast]`(QUEST, 6)`) fires the payoff, exactly
+ *    like the Ascension cycle. "Six or more" (not "exactly six") matters because proliferate can
+ *    overshoot six between triggers.
+ *  - **Search** — [Patterns.Library.searchMultipleZones] over `HAND` + `LIBRARY` is the "search your
+ *    hand and/or library" shape (Fang-Druid Summoner's library+graveyard sibling); it shuffles and
+ *    emits the searched-library event only because `LIBRARY` is among the zones, which is exactly
+ *    what the printed "If you search your library this way, shuffle" rider says. "Dragon **card**"
+ *    is `Any.withSubtype(DRAGON)`, not `Creature.withSubtype(...)` — the text asks for the subtype,
+ *    not the card type.
+ *  - **Mountaincycling {2}** — the generic [KeywordAbility.typecycling] with the Mountain land type.
+ *
+ * Edge cases: the search is not optional in wording, but `searchMultipleZones` uses a choose-up-to-1
+ * selection, which is how the engine expresses the always-legal "fail to find" (CR 701.19c) — a
+ * player with no Dragon simply finds nothing. The sacrifice is sequenced before the search so the
+ * enchantment is already gone when the Dragon arrives; if the enchantment has left the battlefield
+ * before this trigger resolves, the counter count reads zero and the payoff never starts.
+ */
+val LastLightOfDurinsDay = card("Last Light of Durin's Day") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a Mountain you control enters, put a quest counter on this enchantment. " +
+        "If it has six or more quest counters on it, sacrifice it. If you do, search your hand " +
+        "and/or library for a Dragon card and put it onto the battlefield. If you search your " +
+        "library this way, shuffle.\n" +
+        "Mountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, " +
+        "reveal it, put it into your hand, then shuffle.)"
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Land.withSubtype(Subtype.MOUNTAIN).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.QUEST, 1, EffectTarget.Self),
+            ConditionalEffect(
+                condition = Conditions.SourceCounterCountAtLeast(Counters.QUEST, 6),
+                effect = Effects.Composite(
+                    Effects.SacrificeTarget(EffectTarget.Self),
+                    Patterns.Library.searchMultipleZones(
+                        zones = listOf(Zone.HAND, Zone.LIBRARY),
+                        filter = GameObjectFilter.Any.withSubtype(Subtype.DRAGON),
+                        count = 1,
+                        destination = SearchDestination.BATTLEFIELD
+                    )
+                )
+            )
+        )
+        description = "Whenever a Mountain you control enters, put a quest counter on this " +
+            "enchantment. If it has six or more quest counters on it, sacrifice it. If you do, " +
+            "search your hand and/or library for a Dragon card and put it onto the battlefield. " +
+            "If you search your library this way, shuffle."
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Mountain", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "103"
+        artist = "Harkalé Linaï"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df29484b-de4b-4bab-995a-7605745780d9.jpg?1784798201"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SupperForSpiders.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SupperForSpiders.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.BecomeArtifactEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Supper for Spiders
+ * {1}{B}
+ * Instant
+ *
+ * Put onto the battlefield under your control all creature cards in your opponents' graveyards that
+ * were put there from the battlefield this turn. They are Food artifacts with "{2}, {T}, Sacrifice
+ * this artifact: You gain 3 life." (They lose all other types and subtypes.)
+ *
+ * Modeling notes — composition only:
+ *  - **"…that were put there from the battlefield this turn"** is the existing
+ *    `putIntoGraveyardFromBattlefieldThisTurn()` filter predicate (Lobelia Sackville-Baggins), so a
+ *    creature card discarded or milled into a graveyard this turn is correctly *not* eligible.
+ *  - **Untargeted mass reanimation** — no "target" appears in the text, so the cards are gathered at
+ *    resolution: `CardSource.FromZone(GRAVEYARD, Player.EachOpponent, …)` reads every opponent's
+ *    graveyard at once, and the move names `Player.You` as the destination controller ("under your
+ *    control") while the cards stay owned by their owners.
+ *  - **The Food transform** is [BecomeArtifactEffect] per returned card, mirroring Vraska, the
+ *    Silencer's Treasure conversion: Layer 4 `SetCardTypes(ARTIFACT)` + `SetAllSubtypes(Food)` is
+ *    exactly "they lose all other types and subtypes", and the sac-for-life ability is the durable
+ *    `grantedAbility`. Two deliberate departures from Vraska: `colors = null` (the reminder text
+ *    mentions only types and subtypes, so the cards keep their own colors) and
+ *    `loseAllAbilities = false` (nothing in the text removes abilities — a reanimated Blood Artist
+ *    still has its trigger, it just isn't a creature any more). [Duration.Permanent] keeps the
+ *    transform in force until the permanent next leaves the battlefield.
+ *  - The transform runs *after* the move, once per card, with `EffectTarget.Self` bound to each
+ *    iterated entity — the entity id survives the graveyard → battlefield transition, so the
+ *    continuous effects land on the permanents that just entered.
+ *
+ * Edge cases: nothing died from an opponent's battlefield this turn → the gather is empty and the
+ * spell resolves with no effect (it still resolves; it has no targets to fizzle on). The returned
+ * permanents are artifacts, not creatures, so they have no summoning sickness concern for the
+ * `{T}` in the granted ability beyond the ordinary artifact rule — CR 302.6's tap restriction
+ * applies to creatures, and these are not.
+ */
+
+/** The Food token's printed ability, granted to each card returned this way. */
+private val foodSacrificeAbility = ActivatedAbility(
+    cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf),
+    effect = Effects.GainLife(3),
+    descriptionOverride = "{2}, {T}, Sacrifice this artifact: You gain 3 life."
+)
+
+val SupperForSpiders = card("Supper for Spiders") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Put onto the battlefield under your control all creature cards in your opponents' " +
+        "graveyards that were put there from the battlefield this turn. They are Food artifacts " +
+        "with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\" (They lose all other types " +
+        "and subtypes.)"
+
+    spell {
+        effect = Effects.Pipeline {
+            val fallen = gather(
+                CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.EachOpponent,
+                    filter = GameObjectFilter.Creature.putIntoGraveyardFromBattlefieldThisTurn()
+                )
+            )
+            move(fallen, CardDestination.ToZone(Zone.BATTLEFIELD, Player.You))
+            run(
+                ForEachInCollectionEffect(
+                    collection = fallen.key,
+                    effect = BecomeArtifactEffect(
+                        target = EffectTarget.Self,
+                        cardTypes = setOf("ARTIFACT"),
+                        subtypes = setOf(Subtype.FOOD.value),
+                        colors = null,
+                        loseAllAbilities = false,
+                        grantedAbility = foodSacrificeAbility,
+                        duration = Duration.Permanent
+                    )
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "86"
+        artist = "Michele Giorgi"
+        flavorText = "The spiders laughed. \"You were quite right,\" they said, \"the meat's alive and kicking!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b25e454-06bb-43ca-9a9f-57164f7a70c4.jpg?1784376962"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThorinMountainKing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThorinMountainKing.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.CollectionContainsMatch
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Thorin, Mountain-king
+ * {3}{R}
+ * Legendary Creature — Dwarf Noble
+ * 3/4
+ *
+ * Trample
+ * When Thorin enters, attach any number of target Equipment you control to target creature you
+ * control. When one or more Equipment become attached to that creature this way, that creature
+ * deals damage equal to its power to up to one target creature.
+ *
+ * Modeling notes — composition over existing primitives:
+ *  - **Target order is load-bearing.** The printed text names the Equipment first, but an unbounded
+ *    (`unlimited`) requirement has to be declared *last*: targets are matched to requirements
+ *    positionally, so anything after an unbounded slot loses its slice. Declaring the creature first
+ *    also pins it to `ContextTarget(0)` no matter how many Equipment the unbounded slot swallowed
+ *    (same trick as Graceful Takedown).
+ *  - **The attach loop** gathers the still-legal [CardSource.ChosenTargets], splits them into the
+ *    Equipment and the one creature (set difference, so no type test can mis-sort them), and runs
+ *    [Effects.AttachTargetEquipmentToCreature] once per Equipment with `EffectTarget.Self` bound to
+ *    the iterated Equipment (Beatrix, Loyal General's loop). Reading the targets through the gather
+ *    is what gives CR 608.2b partial legality for free: an Equipment that became illegal simply
+ *    isn't in the collection.
+ *  - **"When one or more Equipment become attached … this way"** is a genuine CR 603.12 reflexive
+ *    trigger — a second stack object whose "up to one target creature" is chosen when it goes on the
+ *    stack, after the attaching has happened — so it is a [ReflexiveTriggerEffect] with
+ *    `optional = false` (nothing here is a "may"). Its damage is dealt *by the equipped creature*,
+ *    not by Thorin, so the payoff is a one-iteration [ForEachInCollectionEffect] over the creature
+ *    collection: `EffectTarget.Self` makes the creature the damage source (lifelink, deathtouch and
+ *    "dealt damage by a creature" reactions all see the creature) and `EntityReference.IterationEntity`
+ *    reads *its* power, at reflexive-resolution time. The collection reaches the reflexive because
+ *    the executor carries the action's pipeline onto the reflexive event.
+ *  - **The "one or more" guard** is the [ConditionalEffect] wrapping the whole reflexive: both the
+ *    Equipment collection and the creature collection must be non-empty. Without it, choosing zero
+ *    Equipment (legal — "any number" allows none) or losing the creature target would still fire the
+ *    damage half, which the printed trigger condition forbids.
+ *
+ * Edge cases: zero Equipment chosen → nothing attaches and no damage trigger; the creature target
+ * illegal on resolution → the Equipment targets are still legal so the ability resolves, but nothing
+ * attaches and no damage trigger; the reflexive's creature target is "up to one", so declining it
+ * resolves the reflexive with no damage dealt. Re-attaching an already-equipped Equipment is
+ * correct — the attach executor detaches it from its current host first.
+ */
+val ThorinMountainKing = card("Thorin, Mountain-king") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dwarf Noble"
+    power = 3
+    toughness = 4
+    oracleText = "Trample\n" +
+        "When Thorin enters, attach any number of target Equipment you control to target creature " +
+        "you control. When one or more Equipment become attached to that creature this way, that " +
+        "creature deals damage equal to its power to up to one target creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        // Declared first so its ContextTarget index stays stable ahead of the unbounded slot.
+        val equippedCreature = target("target creature you control", Targets.CreatureYouControl)
+        target(
+            "any number of target Equipment you control",
+            TargetPermanent(
+                unlimited = true,
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).youControl()
+                )
+            )
+        )
+
+        effect = Effects.Pipeline {
+            val chosen = gather(CardSource.ChosenTargets)
+            val equipment = filter(
+                chosen,
+                GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT)
+            )
+            // Whatever is left of the chosen targets is the one "target creature you control".
+            val creature = exclude(chosen, equipment)
+
+            run(
+                ConditionalEffect(
+                    condition = Conditions.All(
+                        CollectionContainsMatch(equipment.key),
+                        CollectionContainsMatch(creature.key)
+                    ),
+                    effect = ReflexiveTriggerEffect(
+                        optional = false,
+                        action = ForEachInCollectionEffect(
+                            collection = equipment.key,
+                            effect = Effects.AttachTargetEquipmentToCreature(
+                                equipmentTarget = EffectTarget.Self,
+                                creatureTarget = equippedCreature
+                            )
+                        ),
+                        reflexiveEffect = ForEachInCollectionEffect(
+                            collection = creature.key,
+                            effect = DealDamageEffect(
+                                amount = DynamicAmount.EntityProperty(
+                                    EntityReference.IterationEntity,
+                                    EntityNumericProperty.Power
+                                ),
+                                target = EffectTarget.ContextTarget(0),
+                                damageSource = EffectTarget.Self
+                            )
+                        ),
+                        reflexiveTargetRequirements = listOf(
+                            TargetCreature(optional = true)
+                        ),
+                        descriptionOverride = "Attach the chosen Equipment to that creature. When " +
+                            "one or more Equipment become attached to it this way, it deals damage " +
+                            "equal to its power to up to one target creature."
+                    )
+                )
+            )
+        }
+        description = "When Thorin enters, attach any number of target Equipment you control to " +
+            "target creature you control. When one or more Equipment become attached to that " +
+            "creature this way, that creature deals damage equal to its power to up to one target " +
+            "creature."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "114"
+        artist = "Javier Charro"
+        flavorText = "\"To me! O my kinsfolk!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/117347af-0dd7-4350-901d-8c8a81387e22.jpg?1783902784"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -5588,6 +5588,136 @@
     ]
 }
 
+// Last Light of Durin's Day
+{
+    "name": "Last Light of Durin's Day",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a Mountain you control enters, put a quest counter on this enchantment. If it has six or more quest counters on it, sacrifice it. If you do, search your hand and/or library for a Dragon card and put it onto the battlefield. If you search your library this way, shuffle.\nMountaincycling {2} ({2}, Discard this card: Search your library for a Mountain card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Mountain"
+                    }
+                ]
+            },
+            "displayPrefix": "Mountaincycling"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land Mountain ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "quest",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": {
+                                            "type": "CounterCount",
+                                            "counterType": {
+                                                "type": "Named",
+                                                "name": "quest"
+                                            }
+                                        }
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 6
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SacrificeTarget",
+                                        "target": "Self"
+                                    },
+                                    {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "FromMultipleZones",
+                                                    "zones": [
+                                                        "Hand",
+                                                        "Library"
+                                                    ],
+                                                    "filter": "Dragon"
+                                                },
+                                                "storeAs": "searchable"
+                                            },
+                                            {
+                                                "type": "SelectFromCollection",
+                                                "from": "searchable",
+                                                "selection": {
+                                                    "type": "ChooseUpTo",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 1
+                                                    }
+                                                },
+                                                "storeSelected": "found"
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "found",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Battlefield"
+                                                }
+                                            },
+                                            "ShuffleLibrary",
+                                            "EmitLibrarySearchedEvent"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a Mountain you control enters, put a quest counter on this enchantment. If it has six or more quest counters on it, sacrifice it. If you do, search your hand and/or library for a Dragon card and put it onto the battlefield. If you search your library this way, shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "rarity": "RARE",
+        "artist": "Harkalé Linaï",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df29484b-de4b-4bab-995a-7605745780d9.jpg?1784798201"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Little Bear
 {
     "name": "Little Bear",
@@ -8566,6 +8696,97 @@
     ]
 }
 
+// Supper for Spiders
+{
+    "name": "Supper for Spiders",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Put onto the battlefield under your control all creature cards in your opponents' graveyards that were put there from the battlefield this turn. They are Food artifacts with \"{2}, {T}, Sacrifice this artifact: You gain 3 life.\" (They lose all other types and subtypes.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "player": "EachOpponent",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "PutIntoGraveyardFromBattlefieldThisTurn"
+                            ]
+                        }
+                    },
+                    "storeAs": "gathered0"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "gathered0",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "gathered0"
+                    },
+                    "body": {
+                        "type": "BecomeArtifact",
+                        "target": "Self",
+                        "subtypes": [
+                            "Food"
+                        ],
+                        "colors": null,
+                        "loseAllAbilities": false,
+                        "grantedAbility": {
+                            "id": "ability_1",
+                            "cost": {
+                                "type": "CostComposite",
+                                "costs": [
+                                    {
+                                        "type": "CostAtomWrapper",
+                                        "atom": {
+                                            "type": "AtomMana",
+                                            "cost": "{2}"
+                                        }
+                                    },
+                                    "CostTap",
+                                    "CostSacrificeSelf"
+                                ]
+                            },
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "descriptionOverride": "{2}, {T}, Sacrifice this artifact: You gain 3 life."
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "RARE",
+        "artist": "Michele Giorgi",
+        "flavorText": "The spiders laughed. \"You were quite right,\" they said, \"the meat's alive and kicking!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b25e454-06bb-43ca-9a9f-57164f7a70c4.jpg?1784376962"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // The Arkenstone
 {
     "name": "The Arkenstone",
@@ -9627,6 +9848,156 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Thorin, Mountain-king
+{
+    "name": "Thorin, Mountain-king",
+    "manaCost": "{3}{R}",
+    "typeLine": "Legendary Creature — Dwarf Noble",
+    "oracleText": "Trample\nWhen Thorin enters, attach any number of target Equipment you control to target creature you control. When one or more Equipment become attached to that creature this way, that creature deals damage equal to its power to up to one target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "gathered0",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "artifact Equipment"
+                            },
+                            "storeMatching": "matching1"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "gathered0",
+                            "filter": {
+                                "type": "ExcludeOtherCollection",
+                                "otherCollectionName": "matching1"
+                            },
+                            "storeMatching": "matching2"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "All",
+                                    "conditions": [
+                                        {
+                                            "type": "CollectionContainsMatch",
+                                            "collection": "matching1"
+                                        },
+                                        {
+                                            "type": "CollectionContainsMatch",
+                                            "collection": "matching2"
+                                        }
+                                    ]
+                                }
+                            },
+                            "then": {
+                                "type": "ReflexiveTrigger",
+                                "action": {
+                                    "type": "ForEach",
+                                    "space": {
+                                        "type": "IterationSpace.Collection",
+                                        "collection": "matching1"
+                                    },
+                                    "body": {
+                                        "type": "AttachTargetEquipmentToCreature",
+                                        "equipmentTarget": "Self",
+                                        "creatureTarget": {
+                                            "type": "BoundVariable",
+                                            "name": "target creature you control"
+                                        }
+                                    }
+                                },
+                                "optional": false,
+                                "reflexiveEffect": {
+                                    "type": "ForEach",
+                                    "space": {
+                                        "type": "IterationSpace.Collection",
+                                        "collection": "matching2"
+                                    },
+                                    "body": {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "EntityProperty",
+                                            "entity": "IterationEntity",
+                                            "numericProperty": "Power"
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "damageSource": "Self"
+                                    }
+                                },
+                                "reflexiveTargetRequirements": [
+                                    {
+                                        "type": "TargetObject",
+                                        "optional": true,
+                                        "filter": {
+                                            "baseFilter": "creature"
+                                        }
+                                    }
+                                ],
+                                "descriptionOverride": "Attach the chosen Equipment to that creature. When one or more Equipment become attached to it this way, it deals damage equal to its power to up to one target creature."
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "unlimited": true,
+                        "filter": {
+                            "baseFilter": "artifact Equipment ctrl:you"
+                        },
+                        "id": "any number of target Equipment you control"
+                    }
+                ],
+                "descriptionOverride": "When Thorin enters, attach any number of target Equipment you control to target creature you control. When one or more Equipment become attached to that creature this way, that creature deals damage equal to its power to up to one target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "rarity": "MYTHIC",
+        "artist": "Javier Charro",
+        "flavorText": "\"To me! O my kinsfolk!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/117347af-0dd7-4350-901d-8c8a81387e22.jpg?1783902784"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LastLightOfDurinsDayScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LastLightOfDurinsDayScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Last Light of Durin's Day (HOB #103) — {1}{R} Enchantment.
+ *
+ * "Whenever a Mountain you control enters, put a quest counter on this enchantment. If it has six
+ * or more quest counters on it, sacrifice it. If you do, search your hand and/or library for a
+ * Dragon card and put it onto the battlefield. If you search your library this way, shuffle."
+ * Mountaincycling {2}.
+ *
+ * Covers the three things composition could get wrong: the trigger firing on a Mountain (and only
+ * once, below threshold, without paying off), the six-counter payoff sacrificing the enchantment
+ * and reanimating a Dragon, and the search reaching the *hand* as well as the library — the half
+ * that a plain `searchLibrary` would silently drop.
+ */
+class LastLightOfDurinsDayScenarioTest : ScenarioTestBase() {
+
+    private fun questCount(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.QUEST) ?: 0
+
+    private fun seedQuestCounters(game: TestGame, id: EntityId, count: Int) {
+        game.state = game.state.updateEntity(id) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(CounterType.QUEST, count))
+        }
+    }
+
+    private fun playMountain(game: TestGame) {
+        val mountain = game.findCardsInHand(1, "Mountain").first()
+        game.execute(PlayLand(game.player1Id, mountain)).error shouldBe null
+        game.resolveStack()
+    }
+
+    init {
+        test("a Mountain entering adds a quest counter and, below six, nothing else happens") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Last Light of Durin's Day")
+                .withCardInHand(1, "Mountain")
+                .withCardInLibrary(1, "Shivan Dragon")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lastLight = game.findPermanent("Last Light of Durin's Day")!!
+
+            playMountain(game)
+
+            withClue("one quest counter, enchantment still around, no Dragon yet") {
+                questCount(game, lastLight) shouldBe 1
+                game.isOnBattlefield("Last Light of Durin's Day") shouldBe true
+                game.isOnBattlefield("Shivan Dragon") shouldBe false
+            }
+        }
+
+        test("the sixth quest counter sacrifices it and puts a Dragon from the library onto the battlefield") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Last Light of Durin's Day")
+                .withCardInHand(1, "Mountain")
+                .withCardInLibrary(1, "Shivan Dragon")
+                .withCardInLibrary(1, "Plains")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lastLight = game.findPermanent("Last Light of Durin's Day")!!
+            seedQuestCounters(game, lastLight, 5)
+
+            playMountain(game)
+
+            // The search pauses to choose the Dragon among the eligible cards.
+            val search = game.getPendingDecision()
+            withClue("the payoff pauses for the hand/library search") { (search != null) shouldBe true }
+            game.selectCards(game.findCardsInLibrary(1, "Shivan Dragon"))
+            game.resolveStack()
+
+            withClue("sacrificed itself and reanimated the Dragon onto the battlefield") {
+                game.isOnBattlefield("Last Light of Durin's Day") shouldBe false
+                game.isInGraveyard(1, "Last Light of Durin's Day") shouldBe true
+                game.isOnBattlefield("Shivan Dragon") shouldBe true
+            }
+        }
+
+        test("the search also reaches a Dragon in hand, not just the library") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Last Light of Durin's Day")
+                .withCardInHand(1, "Mountain")
+                .withCardInHand(1, "Shivan Dragon")
+                .withCardInLibrary(1, "Plains")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lastLight = game.findPermanent("Last Light of Durin's Day")!!
+            seedQuestCounters(game, lastLight, 5)
+
+            playMountain(game)
+
+            val search = game.getPendingDecision()
+            withClue("the Dragon in hand is offered by the search") { (search != null) shouldBe true }
+            game.selectCards(game.findCardsInHand(1, "Shivan Dragon"))
+            game.resolveStack()
+
+            withClue("the hand Dragon is on the battlefield and no longer in hand") {
+                game.isOnBattlefield("Shivan Dragon") shouldBe true
+                game.isInHand(1, "Shivan Dragon") shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SupperForSpidersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SupperForSpidersScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Supper for Spiders (HOB #86) — {1}{B} Instant.
+ *
+ * "Put onto the battlefield under your control all creature cards in your opponents' graveyards
+ * that were put there from the battlefield this turn. They are Food artifacts with '{2}, {T},
+ * Sacrifice this artifact: You gain 3 life.' (They lose all other types and subtypes.)"
+ *
+ * Three things worth proving: the "from the battlefield this turn" gate really excludes a creature
+ * card that reached the graveyard another way, the returned card lands under *your* control, and
+ * the transform replaces card types and subtypes (artifact Food, no longer a creature Bear) without
+ * stripping the card's own abilities — the text removes types, not abilities.
+ */
+class SupperForSpidersScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        test("reanimates an opponent's creature that died this turn, as a Food artifact you control") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Shock")
+                .withCardInHand(1, "Supper for Spiders")
+                .withLandsOnBattlefield(1, "Swamp", 4)
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Shock", bears).error shouldBe null
+            game.resolveStack()
+            game.checkStateBasedActions()
+
+            withClue("the Bears died from the battlefield this turn") {
+                game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            }
+
+            game.castSpell(1, "Supper for Spiders").error shouldBe null
+            game.resolveStack()
+
+            val returned = game.findPermanent("Grizzly Bears")
+            withClue("the Bears came back onto the battlefield") { (returned != null) shouldBe true }
+
+            val projected = stateProjector.project(game.state)
+            withClue("under your control, not its owner's") {
+                projected.getController(returned!!) shouldBe game.player1Id
+            }
+            withClue("it is a Food artifact and no longer a creature or a Bear") {
+                projected.hasType(returned!!, "ARTIFACT") shouldBe true
+                projected.isCreature(returned) shouldBe false
+                projected.getSubtypes(returned) shouldBe setOf("Food")
+            }
+        }
+
+        test("a creature card that reached the graveyard another way is left behind") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Supper for Spiders")
+                .withLandsOnBattlefield(1, "Swamp", 4)
+                .withCardInGraveyard(2, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Supper for Spiders").error shouldBe null
+            game.resolveStack()
+
+            withClue("it was never on the battlefield this turn, so it stays in the graveyard") {
+                game.isInGraveyard(2, "Hill Giant") shouldBe true
+                game.isOnBattlefield("Hill Giant") shouldBe false
+            }
+        }
+
+        test("your own dead creatures are not returned — only your opponents'") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Shock")
+                .withCardInHand(1, "Supper for Spiders")
+                .withLandsOnBattlefield(1, "Swamp", 4)
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ownBears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Shock", ownBears).error shouldBe null
+            game.resolveStack()
+            game.checkStateBasedActions()
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+
+            game.castSpell(1, "Supper for Spiders").error shouldBe null
+            game.resolveStack()
+
+            withClue("the spell only reads opponents' graveyards") {
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                game.isOnBattlefield("Grizzly Bears") shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThorinMountainKingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThorinMountainKingScenarioTest.kt
@@ -1,0 +1,167 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thorin, Mountain-king (HOB #114) — {3}{R} Legendary Creature — Dwarf Noble 3/4, trample.
+ *
+ * "When Thorin enters, attach any number of target Equipment you control to target creature you
+ * control. When one or more Equipment become attached to that creature this way, that creature
+ * deals damage equal to its power to up to one target creature."
+ *
+ * The interesting parts are all composition seams, so each gets a test:
+ *  - two target requirements with the unbounded Equipment slot declared *last*, and the creature
+ *    slot therefore stable at index 0;
+ *  - the attach loop, which must re-attach Equipment already sitting on another creature;
+ *  - the CR 603.12 reflexive trigger, whose damage is dealt by the *equipped creature* for *its*
+ *    post-attach power — proving the equipped-creature collection survives onto the reflexive;
+ *  - the "one or more Equipment become attached" guard: choosing zero Equipment must not fire the
+ *    damage half at all.
+ */
+class ThorinMountainKingScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        test("attaches both target Equipment, then the equipped creature deals its boosted power") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Thorin, Mountain-king")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Buster Sword") // +3/+2
+                .withCardOnBattlefield(1, "Buster Sword") // +3/+2
+                .withCardOnBattlefield(2, "Thing from the Deep") // 9/9, survives 8 damage
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val swords = game.findPermanents("Buster Sword")
+            val leviathan = game.findPermanent("Thing from the Deep")!!
+            swords.size shouldBe 2
+
+            game.castSpell(1, "Thorin, Mountain-king").error shouldBe null
+            game.resolveStack()
+
+            // The ETB trigger targets: slot 0 = the creature, slot 1 = any number of Equipment.
+            val etbTargets = game.getPendingDecision()
+            withClue("the enters trigger asks for its targets") { etbTargets shouldBe game.getPendingDecision() }
+            game.submitDecision(
+                TargetsResponse(etbTargets!!.id, mapOf(0 to listOf(bears), 1 to swords))
+            )
+            game.resolveStack()
+
+            withClue("both Equipment attached to the target creature") {
+                swords.forEach { sword ->
+                    game.state.getEntity(sword)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                }
+                val projected = stateProjector.project(game.state)
+                projected.getPower(bears) shouldBe 8
+                projected.getToughness(bears) shouldBe 6
+            }
+
+            // The reflexive "when one or more Equipment become attached" trigger picks its own target.
+            val reflexiveTargets = game.getPendingDecision()
+            withClue("the reflexive trigger asks for its own 'up to one target creature'") {
+                (reflexiveTargets != null) shouldBe true
+            }
+            game.submitDecision(
+                TargetsResponse(reflexiveTargets!!.id, mapOf(0 to listOf(leviathan)))
+            )
+            game.resolveStack()
+
+            withClue("the equipped creature deals damage equal to its post-attach power (2 + 3 + 3)") {
+                game.state.getEntity(leviathan)?.get<DamageComponent>()?.amount shouldBe 8
+            }
+        }
+
+        test("re-attaches an Equipment already equipping something else") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Thorin, Mountain-king")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                .withCardOnBattlefield(1, "Buster Sword")
+                .withCardAttachedTo(1, "Buster Sword", "Hill Giant")
+                .withCardOnBattlefield(2, "Thing from the Deep")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val giant = game.findPermanent("Hill Giant")!!
+            val sword = game.findPermanent("Buster Sword")!!
+            val leviathan = game.findPermanent("Thing from the Deep")!!
+
+            game.castSpell(1, "Thorin, Mountain-king").error shouldBe null
+            game.resolveStack()
+
+            val etbTargets = game.getPendingDecision()!!
+            game.submitDecision(
+                TargetsResponse(etbTargets.id, mapOf(0 to listOf(bears), 1 to listOf(sword)))
+            )
+            game.resolveStack()
+
+            withClue("the Equipment moved off Hill Giant and onto Grizzly Bears") {
+                game.state.getEntity(sword)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                val projected = stateProjector.project(game.state)
+                projected.getPower(bears) shouldBe 5
+                projected.getPower(giant) shouldBe 3
+            }
+
+            val reflexiveTargets = game.getPendingDecision()!!
+            game.submitDecision(
+                TargetsResponse(reflexiveTargets.id, mapOf(0 to listOf(leviathan)))
+            )
+            game.resolveStack()
+
+            withClue("damage is the equipped creature's power after the move (2 + 3)") {
+                game.state.getEntity(leviathan)?.get<DamageComponent>()?.amount shouldBe 5
+            }
+        }
+
+        test("choosing zero Equipment attaches nothing and never fires the damage trigger") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Thorin, Mountain-king")
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Buster Sword")
+                .withCardOnBattlefield(2, "Thing from the Deep")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val sword = game.findPermanent("Buster Sword")!!
+            val leviathan = game.findPermanent("Thing from the Deep")!!
+
+            game.castSpell(1, "Thorin, Mountain-king").error shouldBe null
+            game.resolveStack()
+
+            // "Any number of target Equipment" allows none — submit only the creature slot.
+            val etbTargets = game.getPendingDecision()!!
+            game.submitDecision(
+                TargetsResponse(etbTargets.id, mapOf(0 to listOf(bears), 1 to emptyList()))
+            )
+            game.resolveStack()
+
+            withClue("nothing attached, and no reflexive damage trigger was created") {
+                game.state.getEntity(sword)?.get<AttachedToComponent>() shouldBe null
+                stateProjector.project(game.state).getPower(bears) shouldBe 2
+                game.hasPendingDecision() shouldBe false
+                game.state.getEntity(leviathan)?.get<DamageComponent>()?.amount shouldBe null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Three HOB cards, all pure composition over existing SDK vocabulary — no engine or SDK changes.

## Cards

**Last Light of Durin's Day** ({1}{R} Enchantment, #103)
Quest counters on a "Mountain you control enters" trigger; at six or more it sacrifices itself and searches your **hand and/or library** for a Dragon card, putting it onto the battlefield.
- The trigger filter is `Land.withSubtype(MOUNTAIN).youControl()` — a nonbasic dual with the Mountain type counts, so a basic-land-only filter would be wrong.
- The search is `Patterns.Library.searchMultipleZones(zones = [HAND, LIBRARY], …)` (Fang-Druid Summoner's library+graveyard sibling). Including `LIBRARY` in the zone list is also what makes the printed "If you search your library this way, shuffle" rider fire.
- "Dragon **card**" is `Any.withSubtype(DRAGON)`, not `Creature.withSubtype(...)`.
- Mountaincycling {2} via `KeywordAbility.typecycling`.

**Thorin, Mountain-king** ({3}{R} Legendary Creature — Dwarf Noble 3/4, #114)
Trample; ETB attaches any number of target Equipment you control to target creature you control, then a reflexive trigger has that creature deal damage equal to its power.
- **Target order is load-bearing**: the unbounded Equipment requirement is declared *last* (targets match requirements positionally), which also pins the creature to a stable index — the Graceful Takedown trick.
- The attach loop gathers `CardSource.ChosenTargets` and splits it by set difference, so CR 608.2b partial legality is free: an Equipment that became illegal simply isn't in the collection.
- "When one or more Equipment become attached … this way" is a genuine CR 603.12 `ReflexiveTriggerEffect` — a second stack object whose "up to one target creature" is chosen after the attaching. Its damage is dealt *by the equipped creature* (so lifelink/deathtouch and "dealt damage by a creature" reactions see the creature) for its **post-attach** power.
- A `ConditionalEffect` guards the reflexive on both collections being non-empty, so choosing zero Equipment — legal, "any number" allows none — never fires the damage half.

**Supper for Spiders** ({1}{B} Instant, #86)
Mass reanimation of creature cards that hit opponents' graveyards *from the battlefield* this turn, as Food artifacts.
- The turn/zone gate is the existing `putIntoGraveyardFromBattlefieldThisTurn()` predicate (Lobelia Sackville-Baggins), so a creature discarded or milled this turn is correctly ineligible.
- Untargeted: `CardSource.FromZone(GRAVEYARD, EachOpponent, …)` reads every opponent's graveyard at resolution; the move names `Player.You` as destination controller.
- The transform is `BecomeArtifactEffect` per card, mirroring Vraska, the Silencer — with two deliberate departures: `colors = null` (the reminder text mentions only types and subtypes) and `loseAllAbilities = false` (nothing in the text removes abilities — a reanimated Blood Artist keeps its trigger, it just isn't a creature any more).

## Tests

One scenario test file per card (9 tests), each covering the payoff, the guard, and the decline/negative path:
- `ThorinMountainKingScenarioTest` — multi-attach + reflexive damage at boosted power, re-attaching an already-equipped Equipment (damage tracks the move), zero Equipment chosen → nothing attaches and no damage trigger is created.
- `LastLightOfDurinsDayScenarioTest` — counter below threshold does nothing, the sixth counter sacrifices and reanimates from the library, and the search reaches a Dragon in **hand** (the half a plain `searchLibrary` would silently drop).
- `SupperForSpidersScenarioTest` — reanimates an opponent's creature that died this turn under *your* control as a Food artifact (no longer a creature or a Bear), leaves behind a creature card that reached the graveyard another way, and ignores your own dead creatures.

## Verification

- `just build` green (includes the full rules-engine suite).
- HOB card snapshot re-blessed; the diff is exactly these three cards.
- `just check-card-printing` ok for all three — HOB is the earliest real printing, canonical placement correct.
- Image URIs verified HTTP 200; all metadata re-checked field-by-field against Scryfall.

HOB goes 155 → 158 of 193. The remaining tail is still dominated by the unimplemented **recruit**, **storied**, and **hone** keywords plus a handful of cards needing genuine engine work — notably "if they were a creature" last-known-card-type plumbing (Tom, Bert, and William), a zone-excluding cost reduction (Bilbo, Thief in the Night), and a graveyard-sourced "has all activated abilities of" static (Thranduil, the Elvenking). Those are `add-feature`, not `add-card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)