### PR TITLE
Add five Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BlinkmothWell.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BlinkmothWell.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Blinkmoth Well — Mirrodin #279 (canonical printing, only printing)
+ * Land
+ *
+ * {T}: Add {C}.
+ * {2}, {T}: Tap target noncreature artifact.
+ *
+ * Two plain activated abilities. The second shares the `IsArtifact + IsNoncreature` target
+ * filter shape used by Overwhelming Surge — it deliberately misses artifact *creatures*
+ * (including one an opponent has animated with Karn or Titania's Song), which is exactly what
+ * keeps this a soft answer to Mindslaver and the Blinkmoth Urn family rather than generic
+ * creature removal. Both abilities cost the land's own tap, so they compete for it.
+ */
+private val NoncreatureArtifact = TargetFilter(
+    GameObjectFilter(cardPredicates = listOf(CardPredicate.IsArtifact, CardPredicate.IsNoncreature))
+)
+
+val BlinkmothWell = card("Blinkmoth Well") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n{2}, {T}: Tap target noncreature artifact."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val artifact = target("noncreature artifact", TargetPermanent(filter = NoncreatureArtifact))
+        effect = Effects.Tap(artifact)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "279"
+        artist = "David Martin"
+        flavorText = "When dictated by blinkmoth migratory patterns, clouds of tiny lights well up from Mirrodin's core."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4c79155-b6d8-46df-891f-487b24c4e0d5.jpg?1783944494"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Disarm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Disarm.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Disarm — Mirrodin #32 (canonical printing, only printing)
+ * {U} · Instant
+ *
+ * Unattach all Equipment from target creature.
+ *
+ * Composed rather than given its own effect type: [CardSource.AttachedTo] gathers the Equipment
+ * currently attached to the target (the same gather Light of Judgment uses), then
+ * [ForEachInCollectionEffect] runs [Effects.UnattachEquipment] once per gathered Equipment with
+ * `EffectTarget.Self` bound to the iteration entity. No selection step — the oracle text says
+ * "all", so nothing is chosen and nothing is targeted beyond the creature itself.
+ *
+ * Per the 2004-12-01 ruling, each Equipment stays on the battlefield under its controller's
+ * control; only the attachment link is broken (CR 701.3d) — which is exactly what
+ * `UnattachEquipment` does. Auras on the creature are untouched: the gather filters to the
+ * Equipment subtype. Resolving with no Equipment attached (or with the creature's Equipment
+ * already gone) is a silent no-op; the spell still fizzles outright if the creature itself is an
+ * illegal target on resolution.
+ */
+val Disarm = card("Disarm") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Unattach all Equipment from target creature."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Pipeline {
+            val equipment = gather(
+                CardSource.AttachedTo(
+                    host = creature,
+                    filter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT),
+                )
+            )
+            run(
+                ForEachInCollectionEffect(
+                    collection = equipment.key,
+                    effect = Effects.UnattachEquipment(EffectTarget.Self),
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Alex Horley-Orlandelli"
+        flavorText = "\"Be thankful I left you your clothes.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/427c6350-af52-45f1-8024-5f31aa62a0d0.jpg?1783944556"
+        ruling(
+            "2004-12-01",
+            "The Equipment remains on the battlefield under its controller's control, but is no " +
+                "longer attached to that creature."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GoblinDirigible.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GoblinDirigible.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Goblin Dirigible — Mirrodin #177 (canonical printing, only printing)
+ * {6} · Artifact Creature — Construct · 4/4
+ *
+ * Flying
+ * This creature doesn't untap during your untap step.
+ * At the beginning of your upkeep, you may pay {4}. If you do, untap this creature.
+ *
+ * The Brass Man / Colossus of Sardia shape, with a bigger toll: [AbilityFlag.DOESNT_UNTAP] takes
+ * it out of the untap step, and a [Triggers.YourUpkeep] trigger offers the buy-back via
+ * [MayPayManaEffect] — a mandatory trigger with an optional payment, so declining is a legal
+ * choice each upkeep and the Dirigible simply stays tapped. The untap is [EffectTarget.Self],
+ * so the trigger does nothing if the creature has already left the battlefield.
+ */
+val GoblinDirigible = card("Goblin Dirigible") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "This creature doesn't untap during your untap step.\n" +
+        "At the beginning of your upkeep, you may pay {4}. If you do, untap this creature."
+
+    keywords(Keyword.FLYING)
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = MayPayManaEffect(ManaCost.parse("{4}"), Effects.Untap(EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "177"
+        artist = "Michael Sutfin"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2ed2990-e5bf-4567-9a41-1846108a8aeb.jpg?1783944520"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GridMonitor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GridMonitor.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PlayersCantCastSpells
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Grid Monitor — Mirrodin #183 (canonical printing, only printing)
+ * {4} · Artifact Creature — Construct · 4/6
+ *
+ * You can't cast creature spells.
+ *
+ * The drawback is the reused [PlayersCantCastSpells] primitive (Grand Abolisher / Brisela
+ * family) turned inward: `affected = Player.You` scopes the prohibition to the permanent's own
+ * controller, and `spellFilter = GameObjectFilter.Creature` narrows it to creature spells. Read
+ * at cast-legality time across every casting zone, so it also stops creature spells cast from
+ * exile, the graveyard, or the top of the library — the oracle text restricts the *cast*, not a
+ * zone. Artifact creature spells are creature spells too, so Grid Monitor locks out its own kin.
+ */
+val GridMonitor = card("Grid Monitor") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 4
+    toughness = 6
+    oracleText = "You can't cast creature spells."
+
+    staticAbility {
+        ability = PlayersCantCastSpells(
+            affected = Player.You,
+            spellFilter = GameObjectFilter.Creature,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "183"
+        artist = "Arnie Swekel"
+        flavorText = "The vedalken protect the Knowledge Pool at any cost."
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4ab6c59-cd0f-4c29-8e26-6882dca61fb7.jpg?1783944518"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RelicBane.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RelicBane.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Relic Bane — Mirrodin #76 (canonical printing, only printing)
+ * {1}{B}{B} · Enchantment — Aura
+ *
+ * Enchant artifact
+ * Enchanted artifact has "At the beginning of your upkeep, you lose 2 life."
+ *
+ * The Aura grants the upkeep trigger to the *enchanted artifact*, not to the Aura itself — the
+ * Essence Leak shape: [GrantTriggeredAbility] over [GroupFilter.attachedCreature] (scope-by-
+ * attachment, so it works for any permanent type, artifacts included). Granting it rather than
+ * printing the trigger on the Aura is what makes "your" mean the *artifact's* controller: the
+ * granted ability is controlled by whoever controls the artifact, so stealing the artifact
+ * moves the life loss with it, and Relic Bane's own controller is irrelevant to who pays.
+ */
+val RelicBane = card("Relic Bane") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant artifact\n" +
+        "Enchanted artifact has \"At the beginning of your upkeep, you lose 2 life.\""
+
+    auraTarget = Targets.Artifact
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.YourUpkeep.event,
+                binding = Triggers.YourUpkeep.binding,
+                effect = Effects.LoseLife(2, EffectTarget.PlayerRef(Player.You)),
+            ),
+            filter = GroupFilter.attachedCreature(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Eric Peterson"
+        flavorText = "A sword that has seen cowardice in battle exacts the price of honor from its wielder."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cbafa51-693b-485c-807d-64020540f16a.jpg?1783944545"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -354,6 +354,71 @@
     ]
 }
 
+// Blinkmoth Well
+{
+    "name": "Blinkmoth Well",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{2}, {T}: Tap target noncreature artifact.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "noncreature artifact"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact noncreature"
+                        },
+                        "id": "noncreature artifact"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "279",
+        "rarity": "UNCOMMON",
+        "artist": "David Martin",
+        "flavorText": "When dictated by blinkmoth migratory patterns, clouds of tiny lights well up from Mirrodin's core.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4c79155-b6d8-46df-891f-487b24c4e0d5.jpg?1783944494"
+    },
+    "colorIdentityOverride": []
+}
+
 // Bloodscent
 {
     "name": "Bloodscent",
@@ -976,6 +1041,65 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Disarm
+{
+    "name": "Disarm",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Unattach all Equipment from target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "AttachedToTarget",
+                        "host": {
+                            "type": "BoundVariable",
+                            "name": "target creature"
+                        },
+                        "filter": "artifact Equipment"
+                    },
+                    "storeAs": "gathered0"
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "gathered0"
+                    },
+                    "body": "UnattachEquipment"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Alex Horley-Orlandelli",
+        "flavorText": "\"Be thankful I left you your clothes.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/427c6350-af52-45f1-8024-5f31aa62a0d0.jpg?1783944556",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "The Equipment remains on the battlefield under its controller's control, but is no longer attached to that creature."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -1741,6 +1865,58 @@
     "colorIdentityOverride": []
 }
 
+// Goblin Dirigible
+{
+    "name": "Goblin Dirigible",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Flying\nThis creature doesn't untap during your untap step.\nAt the beginning of your upkeep, you may pay {4}. If you do, untap this creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "flags": [
+        "DOESNT_UNTAP"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{4}"
+                        }
+                    },
+                    "then": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "rarity": "UNCOMMON",
+        "artist": "Michael Sutfin",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2ed2990-e5bf-4567-9a41-1846108a8aeb.jpg?1783944520"
+    },
+    "colorIdentityOverride": []
+}
+
 // Goblin Replica
 {
     "name": "Goblin Replica",
@@ -2014,6 +2190,39 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Grid Monitor
+{
+    "name": "Grid Monitor",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "You can't cast creature spells.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "PlayersCantCastSpells",
+                "affected": "You",
+                "spellFilter": {
+                    "cardPredicates": [
+                        "IsCreature"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "RARE",
+        "artist": "Arnie Swekel",
+        "flavorText": "The vedalken protect the Knowledge Pool at any cost.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4ab6c59-cd0f-4c29-8e26-6882dca61fb7.jpg?1783944518"
+    },
+    "colorIdentityOverride": []
 }
 
 // Heartwood Shard
@@ -4788,6 +4997,56 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Relic Bane
+{
+    "name": "Relic Bane",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant artifact\nEnchanted artifact has \"At the beginning of your upkeep, you lose 2 life.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "You"
+                        }
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "artifact"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Peterson",
+        "flavorText": "A sword that has seen cowardice in battle exacts the price of honor from its wielder.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cbafa51-693b-485c-807d-64020540f16a.jpg?1783944545"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisarmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisarmScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Bonesplitter
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Disarm
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.LeoninScimitar
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Disarm — "Unattach all Equipment from target creature." ({U} instant, MRD #32)
+ *
+ * The card is a composition rather than a bespoke effect: `CardSource.AttachedTo` gathers the
+ * Equipment on the target, then `ForEachInCollectionEffect` unattaches each one. These tests pin
+ * the two things that composition could plausibly get wrong — that *every* Equipment comes off
+ * (not just the first), and that unattaching does not move anything to another zone (the
+ * 2004-12-01 ruling).
+ */
+class DisarmScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + Bonesplitter + LeoninScimitar + Disarm)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Equip [equipment] (already on the battlefield) to [creature], paying its {1} equip cost. */
+    fun GameTestDriver.equip(
+        player: com.wingedsheep.sdk.model.EntityId,
+        equipment: com.wingedsheep.sdk.model.EntityId,
+        abilityId: com.wingedsheep.sdk.scripting.AbilityId,
+        creature: com.wingedsheep.sdk.model.EntityId,
+    ) {
+        giveColorlessMana(player, 1)
+        submit(
+            ActivateAbility(player, equipment, abilityId, targets = listOf(ChosenTarget.Permanent(creature)))
+        ).isSuccess shouldBe true
+        bothPass()
+    }
+
+    test("all Equipment comes off — both swords unattach and their buffs stop applying") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        val splitter = driver.putPermanentOnBattlefield(you, "Bonesplitter")  // +2/+0
+        val scimitar = driver.putPermanentOnBattlefield(you, "Leonin Scimitar") // +1/+1
+
+        driver.equip(you, splitter, Bonesplitter.activatedAbilities.first().id, courser)
+        driver.equip(you, scimitar, LeoninScimitar.activatedAbilities.first().id, courser)
+
+        // Precondition: both attached, both buffs live (3/3 +2/+0 +1/+1 = 6/4).
+        driver.state.getEntity(splitter)?.get<AttachedToComponent>()?.targetId shouldBe courser
+        driver.state.getEntity(scimitar)?.get<AttachedToComponent>()?.targetId shouldBe courser
+        projector.getProjectedPower(driver.state, courser) shouldBe 6
+        projector.getProjectedToughness(driver.state, courser) shouldBe 4
+
+        val disarm = driver.putCardInHand(you, "Disarm")
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLUE, 1)
+        driver.castSpellWithTargets(you, disarm, listOf(ChosenTarget.Permanent(courser)))
+            .isSuccess shouldBe true
+        driver.bothPass()
+
+        // Every Equipment is unattached — the ForEach ran over the whole gathered collection,
+        // not just its first element.
+        driver.state.getEntity(splitter)?.get<AttachedToComponent>().shouldBeNull()
+        driver.state.getEntity(scimitar)?.get<AttachedToComponent>().shouldBeNull()
+
+        // Both buffs are gone: back to a base 3/3.
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+    }
+
+    test("the Equipment stays on the battlefield under its controller's control (2004-12-01 ruling)") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val splitter = driver.putPermanentOnBattlefield(you, "Bonesplitter")
+        driver.equip(you, splitter, Bonesplitter.activatedAbilities.first().id, courser)
+
+        val disarm = driver.putCardInHand(you, "Disarm")
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLUE, 1)
+        driver.castSpellWithTargets(you, disarm, listOf(ChosenTarget.Permanent(courser)))
+            .isSuccess shouldBe true
+        driver.bothPass()
+
+        // Unattached, but not destroyed, bounced, or exiled — still a permanent you control.
+        driver.state.getEntity(splitter)?.get<AttachedToComponent>().shouldBeNull()
+        driver.findPermanent(you, "Bonesplitter") shouldBe splitter
+        driver.getController(splitter) shouldBe you
+    }
+
+    test("a creature carrying no Equipment is a legal target and a silent no-op") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+
+        val disarm = driver.putCardInHand(you, "Disarm")
+        driver.giveMana(you, com.wingedsheep.sdk.core.Color.BLUE, 1)
+        driver.castSpellWithTargets(you, disarm, listOf(ChosenTarget.Permanent(courser)))
+            .isSuccess shouldBe true
+        driver.bothPass()
+
+        // Nothing to unattach: the creature survives untouched.
+        driver.findPermanent(you, "Centaur Courser") shouldBe courser
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RelicBaneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RelicBaneScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Relic Bane — "Enchant artifact. Enchanted artifact has 'At the beginning of your upkeep, you
+ * lose 2 life.'" ({1}{B}{B} Aura, MRD #76)
+ *
+ * The upkeep trigger is *granted to the enchanted artifact*, not printed on the Aura, which is
+ * what makes "your" mean the artifact's controller rather than Relic Bane's. These tests pin
+ * that distinction: the same Aura drains its own controller when it enchants their artifact, and
+ * drains the *opponent* when it enchants theirs. Granting onto a non-creature host is the part
+ * worth proving — `GroupFilter.attachedCreature()` is scope-by-attachment despite the name, and
+ * a filter that actually required a creature would make this card do nothing at all.
+ */
+class RelicBaneScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Relic Bane's granted upkeep trigger drains the enchanted artifact's controller") {
+
+            test("enchanting an opponent's artifact drains the opponent, not Relic Bane's controller") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    // Bob controls the artifact; Alice controls the Aura on it.
+                    .withCardOnBattlefield(2, "Steel Wall")
+                    .withCardAttachedTo(1, "Relic Bane", "Steel Wall")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.getLifeTotal(1) shouldBe 20
+                game.getLifeTotal(2) shouldBe 20
+
+                // Advance into Bob's upkeep and let the granted trigger resolve.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("Bob controls the enchanted artifact, so 'you lose 2 life' is Bob's") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("Alice merely controls the Aura — the granted ability is not hers") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+
+            test("it does not fire during the other player's upkeep") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Steel Wall")
+                    .withCardAttachedTo(1, "Relic Bane", "Steel Wall")
+                    // Start on Bob's turn so the next upkeep reached is Alice's, not Bob's.
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("the artifact is Alice's, so Alice pays at her own upkeep") {
+                    game.getLifeTotal(1) shouldBe 18
+                }
+                withClue("Bob never controlled the artifact and loses nothing") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five Mirrodin cards, each composed from existing SDK primitives — no new engine vocabulary, no new effect types.

| Card | Oracle text | How it's modeled |
|---|---|---|
| **Grid Monitor** `{4}` 4/6 | You can't cast creature spells. | `PlayersCantCastSpells(affected = You, spellFilter = Creature)` — the Grand Abolisher / Brisela primitive turned inward. Read at cast-legality time across every casting zone, so it also stops creature spells cast from exile or a graveyard. |
| **Blinkmoth Well** (Land) | `{T}`: Add `{C}`. `{2}`, `{T}`: Tap target noncreature artifact. | Two plain activated abilities sharing the land's tap. The second reuses the `IsArtifact + IsNoncreature` target filter from Overwhelming Surge — it deliberately misses animated artifact *creatures*. |
| **Disarm** `{U}` | Unattach all Equipment from target creature. | `CardSource.AttachedTo` gathers the target's Equipment (the Light of Judgment gather), then `ForEachInCollectionEffect` runs `UnattachEquipment` per entity. No selection step — "all" chooses nothing. |
| **Relic Bane** `{1}{B}{B}` | Enchant artifact. Enchanted artifact has "At the beginning of your upkeep, you lose 2 life." | `GrantTriggeredAbility` over `GroupFilter.attachedCreature()` (scope-by-attachment, works for any permanent type). Granting rather than printing is what makes "your" the *artifact's* controller. |
| **Goblin Dirigible** `{6}` 4/4 | Flying. Doesn't untap during your untap step. At the beginning of your upkeep, you may pay `{4}`. If you do, untap this creature. | The Brass Man / Colossus of Sardia shape: `AbilityFlag.DOESNT_UNTAP` plus a `YourUpkeep` trigger wrapping `MayPayManaEffect({4}, Untap(Self))`. |

## Tests

Scenario tests cover the two cards whose *composition* the snapshot net can't prove behaviorally:

**`DisarmScenarioTest`**
- Two Equipment on one creature: both unattach and both stat buffs stop applying (the `ForEach` runs the whole collection, not just its head).
- The Equipment stays on the battlefield under its controller's control — the 2004-12-01 ruling, i.e. unattach is not a zone change.
- A creature with no Equipment is still a legal target and resolves as a silent no-op.

**`RelicBaneScenarioTest`**
- Alice's Aura on Bob's artifact drains **Bob**, not Alice — pinning that the granted ability belongs to the host's controller.
- It fires only on that player's upkeep, not the other player's.

Grid Monitor, Blinkmoth Well, and Goblin Dirigible are each a direct reuse of a primitive already proven elsewhere (Grand Abolisher, Auriok Transfixer, Brass Man), so they ride the snapshot and lint nets.

## Verification

- `just build` — **green** (compile + `mtg-sets` snapshot + `CardLintTest` + `FacadeBoundaryTest` + rules-engine suite).
- `just rebless-cards` — `MRD.json` diff is **259 insertions, 0 deletions**; only these five cards moved.
- `just test-class DisarmScenarioTest` / `RelicBaneScenarioTest` — 5 tests, all passing.
- `just check-card-printing` for all five — each is the card's only printing, canonical correctly in `mrd`.
- Every `imageUri` verified HTTP 200 against Scryfall.

No Mirrodin backlog file exists, so there was no checklist to tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
