### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4407,7 +4407,11 @@ Triggers.youCastSpell(
 ### State change & misc
 
 - `TurnedFaceUp` — source turns face up. Use `turnedFaceUp(binding)` for the ATTACHED-binding aura variant (Fatal Mutation).
-- `CreatureTurnedFaceUp(player?)` — when a creature you control turns face up.
+- `CreatureTurnedFaceUp(player?, filter?)` — when a creature you control turns face up. `filter`
+  narrows *which* creature and is evaluated against the permanent's **post-flip** characteristics
+  (a face-down creature is a nameless 2/2 with no subtypes, so a face-down check could never match):
+  `CreatureTurnedFaceUp(filter = GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE))` is
+  "whenever a Detective you control is turned face up" (Perimeter Enforcer).
 - `GainControlOfSelf` — you gain control of source. Built on `ControlChangeEvent(ControlChangeDirection.GAINED)`
   + `TriggerBinding.SELF` — the resident "when you gain control of this" self-trigger (Risky Move).
 - `LoseControlOfWatched` — `ControlChangeEvent(ControlChangeDirection.LOST)` + `TriggerBinding.SELF`,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -719,10 +719,17 @@ object Triggers {
 
     /**
      * Whenever a creature is turned face up (any controller).
-     * Use [player] to filter: Player.You (default), Player.Any, etc.
+     * Use [player] to filter whose creature: Player.You (default), Player.Any, etc.
+     * Use [filter] to narrow which creature — evaluated against the permanent's post-flip
+     * (face-up) characteristics, so "whenever a Detective you control is turned face up"
+     * (Perimeter Enforcer) is
+     * `CreatureTurnedFaceUp(filter = GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE))`.
      */
-    fun CreatureTurnedFaceUp(player: Player = Player.You): TriggerSpec = TriggerSpec(
-        event = CreatureTurnedFaceUpEvent(player),
+    fun CreatureTurnedFaceUp(
+        player: Player = Player.You,
+        filter: GameObjectFilter = GameObjectFilter.Any,
+    ): TriggerSpec = TriggerSpec(
+        event = CreatureTurnedFaceUpEvent(player, filter),
         binding = TriggerBinding.ANY
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1694,14 +1694,19 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     /**
      * When a creature is turned face up.
      * [player] filters whose creature: [Player.You] (default), [Player.Any], etc.
+     * [filter] narrows *which* creature, evaluated against the permanent's post-flip
+     * (face-up) characteristics — "whenever a Detective you control is turned face up"
+     * (Perimeter Enforcer) is `filter = Creature.withSubtype(Subtype.DETECTIVE)`.
+     * Defaults to [GameObjectFilter.Any], i.e. any creature turned face up.
      */
     @SerialName("CreatureTurnedFaceUpEvent")
     @Serializable
     data class CreatureTurnedFaceUpEvent(
-        val player: Player = Player.You
+        val player: Player = Player.You,
+        val filter: GameObjectFilter = GameObjectFilter.Any
     ) : EventPattern {
         override val description: String = buildString {
-            append("a creature ")
+            append(if (filter == GameObjectFilter.Any) "a creature " else "a ${filter.description} ")
             when (player) {
                 is Player.You -> append("you control ")
                 is Player.Any -> {}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CaughtRedHanded.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CaughtRedHanded.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Caught Red-Handed — Murders at Karlov Manor #115
+ * {4}{R} · Instant
+ *
+ * This spell can't be countered. (This includes by the ward ability.)
+ * Gain control of target creature until end of turn. Untap that creature. It gains haste until end
+ * of turn. Suspect it.
+ *
+ * A Threaten at instant speed with two riders: it dodges counterspells and it leaves the borrowed
+ * creature suspected, so once it goes back its controller can't block with it either.
+ *
+ * `cantBeCountered` stamps `CantBeCounteredComponent` on the spell (the Long Goodbye idiom), which
+ * every counter path checks — ward included, since ward routes through
+ * `StackResolver.counterSpell`. Targeting a warded creature still offers the ward cost; declining
+ * leaves this on the stack to resolve anyway.
+ *
+ * The four clauses resolve in printed order against the single declared target: control change
+ * (`Duration.EndOfTurn`, so it reverts in the cleanup step), untap, haste until end of turn, then
+ * suspect. Suspect is deliberately **permanent** and not tied to the control change — per the
+ * printed rulings a creature stays suspected until it leaves the battlefield or another effect
+ * un-suspects it, so it is still suspected after control reverts. `Effects.Suspect` defaults to
+ * `Duration.Permanent` for exactly that reason.
+ */
+val CaughtRedHanded = card("Caught Red-Handed") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "This spell can't be countered. (This includes by the ward ability.)\n" +
+        "Gain control of target creature until end of turn. Untap that creature. It gains haste " +
+        "until end of turn. Suspect it. (It has menace and can't block.)"
+
+    cantBeCountered = true
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.GainControl(creature, Duration.EndOfTurn),
+            Effects.Untap(creature),
+            Effects.GrantKeyword(Keyword.HASTE, creature),
+            Effects.Suspect(creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "115"
+        artist = "Donato Giancola"
+        flavorText = "\"Wait, stop! I've been framed! Extremely convincingly!\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95bc5f89-2f01-40c4-9883-4c90ab89fcbb.jpg?1783912886"
+
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until " +
+                "it leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "If a suspected creature loses all abilities, it will lose menace and \"This creature " +
+                "can't block\", but it won't stop being suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected " +
+                "creature, it won't be suspected."
+        )
+        ruling("2024-02-02", "If a creature is already suspected, suspecting it again won't have any effect.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OutCold.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/OutCold.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Out Cold — Murders at Karlov Manor #66
+ * {3}{U} · Instant
+ *
+ * This spell can't be countered. (This includes by the ward ability.)
+ * Tap up to two target creatures and put a stun counter on each of them. Investigate.
+ *
+ * `cantBeCountered` stamps `CantBeCounteredComponent` on the spell, which every counter path —
+ * ward included, since ward routes through `StackResolver.counterSpell` — checks before removing
+ * the spell from the stack. That is exactly the printed ruling: targeting a warded creature still
+ * *offers* the ward cost, and declining leaves Out Cold on the stack to resolve anyway.
+ *
+ * "Up to two target creatures" is **one** target requirement taking up to two objects
+ * (`TargetCreature(count = 2, optional = true)` → `minCount = 0`), not two independent slots — so
+ * the two picks must be different creatures (CR 601.2c) and choosing zero is legal. The tap and the
+ * stun counter are applied once per chosen creature via [ForEachTargetEffect]; with zero targets
+ * chosen the iteration is empty and only the investigate happens.
+ *
+ * The investigate sits *outside* the per-target iteration: the card investigates once, not once per
+ * creature tapped. It is also not conditional on any creature actually being tapped — but per the
+ * printed ruling, if targets were chosen and all of them are illegal on resolution the whole spell
+ * is countered by the rules and you don't investigate either, which falls out of ordinary
+ * fizzle handling rather than anything modelled here.
+ */
+val OutCold = card("Out Cold") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell can't be countered. (This includes by the ward ability.)\n" +
+        "Tap up to two target creatures and put a stun counter on each of them. Investigate. " +
+        "(If a permanent with a stun counter would become untapped, remove one from it instead.)"
+
+    cantBeCountered = true
+
+    spell {
+        target("up to two target creatures", TargetCreature(count = 2, optional = true))
+        effect = Effects.Composite(
+            ForEachTargetEffect(
+                listOf(
+                    Effects.Tap(EffectTarget.ContextTarget(0)),
+                    Effects.AddCounters(Counters.STUN, 1, EffectTarget.ContextTarget(0))
+                )
+            ),
+            Effects.Investigate()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Tuan Duong Chu"
+        flavorText = "\"We'll get their statements after they defrost.\"\n" +
+            "—Dvika of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aabfada0-3c1b-4237-b06c-573071ccd68d.jpg?1783912907"
+
+        ruling(
+            "2024-02-02",
+            "If you target a creature with ward, you may still pay the ward cost, but Out Cold " +
+                "won't be countered even if you don't."
+        )
+        ruling(
+            "2024-02-02",
+            "You don't have to choose any targets for Out Cold. However, if you do, and all of " +
+                "those creatures are illegal targets at the time Out Cold tries to resolve, it " +
+                "won't resolve and none of its effects will happen. You won't investigate."
+        )
+        ruling(
+            "2024-02-02",
+            "Clue is an artifact type. Even though it appears on some cards with other permanent " +
+                "types, it's never a creature type, a land type, or anything but an artifact type."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PerimeterEnforcer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PerimeterEnforcer.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Perimeter Enforcer — Murders at Karlov Manor #31
+ * {1}{W} · Creature — Human Detective 1/1
+ *
+ * Flying, lifelink
+ * Whenever another Detective you control enters and whenever a Detective you control is turned face
+ * up, this creature gets +1/+1 until end of turn.
+ *
+ * A 1/1 flying lifelinker that grows for the turn every time the Detective count goes up — the
+ * white half of MKM's Detective tribal, and the payoff that makes the set's disguise creatures pull
+ * double duty.
+ *
+ * The printed ability is one ability with **two** trigger conditions, which the engine models as
+ * two `triggeredAbility` blocks with the same effect. That's not a fidelity compromise: two
+ * separate triggers is exactly how the ability behaves — if a face-down Detective is turned face up
+ * it fires once (it isn't entering), and both conditions can never be satisfied by the same event.
+ *
+ * The "enters" half is [TriggerBinding.OTHER] with a Detective-you-control filter, so the Enforcer's
+ * own arrival doesn't pump it ("*another* Detective"). The "turned face up" half deliberately has
+ * **no** "another" clause on the printed card, so it fires even when the Enforcer itself is the
+ * creature turned face up — hence [Triggers.CreatureTurnedFaceUp] (ANY binding), not an OTHER one.
+ * That filter is evaluated against the permanent's post-flip characteristics, which is the only
+ * reading that works: a face-down creature is a nameless, typeless 2/2, so nothing would ever be a
+ * Detective at the moment it's turned face up if the check read the face-down state.
+ *
+ * The pump is [EffectTarget.Self] with the default `Duration.EndOfTurn` — it stacks with itself
+ * across multiple triggers in a turn and wears off in the cleanup step.
+ */
+val PerimeterEnforcer = card("Perimeter Enforcer") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Detective"
+    power = 1
+    toughness = 1
+    oracleText = "Flying, lifelink\n" +
+        "Whenever another Detective you control enters and whenever a Detective you control is " +
+        "turned face up, this creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    // Whenever another Detective you control enters …
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE).youControl(),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Whenever another Detective you control enters, this creature gets +1/+1 until end of turn."
+    }
+
+    // … and whenever a Detective you control is turned face up.
+    triggeredAbility {
+        trigger = Triggers.CreatureTurnedFaceUp(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE)
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Whenever a Detective you control is turned face up, this creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "31"
+        artist = "Josh Hass"
+        flavorText = "He makes sure no one sets foot in a fresh crime scene—not even himself."
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f88d077-5082-4a67-91e4-97aafb9a5e91.jpg?1783912919"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SceneOfTheCrime.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SceneOfTheCrime.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Scene of the Crime — Murders at Karlov Manor #267
+ * Artifact Land — Clue
+ *
+ * This land enters tapped.
+ * {T}: Add {C}.
+ * {T}, Tap an untapped creature you control: Add one mana of any color.
+ * {2}, Sacrifice this land: Draw a card.
+ *
+ * The set's "the crime scene is itself evidence" land: an artifact land that is also a Clue, so the
+ * sacrifice-to-draw is the Clue's own ability and every "sacrifice a Clue" payoff in the set can eat
+ * it straight off the type line (Scryfall's ruling: "If an effect refers to a Clue, it means any
+ * Clue artifact, not just a Clue artifact token").
+ *
+ * Both mana abilities are `manaAbility = true`, so they don't use the stack and can't be responded
+ * to. The any-color one is the Springleaf Drum idiom — `Costs.Composite(Costs.Tap, TapPermanents(1,
+ * Creature))`, where `Costs.Tap` taps the land itself and `TapPermanents` taps a *separate* untapped
+ * creature you control. Note there's no summoning-sickness clause on the tapped creature: tapping a
+ * creature as a cost only requires the creature to be untapped when the ability doesn't use that
+ * creature's own {T} symbol, so a freshly-cast creature works.
+ *
+ * The draw is a normal (non-mana) activated ability: `{2}` plus [Costs.SacrificeSelf], matching the
+ * printed Clue text.
+ */
+val SceneOfTheCrime = card("Scene of the Crime") {
+    colorIdentity = ""
+    typeLine = "Artifact Land — Clue"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {C}.\n" +
+        "{T}, Tap an untapped creature you control: Add one mana of any color.\n" +
+        "{2}, Sacrifice this land: Draw a card."
+
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {C}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    // {T}, Tap an untapped creature you control: Add one mana of any color.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.TapPermanents(1, GameObjectFilter.Creature))
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+    }
+
+    // {2}, Sacrifice this land: Draw a card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "267"
+        artist = "Jokubas Uogintas"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de039992-631b-4feb-a522-acdb0a6d1f26.jpg?1783912824"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ThinkingCap.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ThinkingCap.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Thinking Cap — Murders at Karlov Manor #257
+ * {1} · Artifact — Equipment
+ *
+ * Equipped creature gets +1/+2.
+ * Equip Detective {1}
+ * Equip {3}
+ *
+ * "Equip Detective {1}" is a variant equip keyword ("{1}: Attach to target Detective creature you
+ * control. Equip only as a sorcery.") — the Pirate Hat / Dúnedain Blade idiom, modelled as its own
+ * sorcery-speed activated ability whose target is restricted to a Detective you control. The plain
+ * "Equip {3}" goes through the [equipAbility] facade.
+ *
+ * The two are genuinely separate abilities, not one ability with a discount: a Detective can be
+ * equipped either way, and a non-Detective only via the {3} ability. Modelling the Detective clause
+ * as a cost reduction on a single equip ability would wrongly let you point the cheap version at a
+ * non-Detective (it would just cost more), so the two-ability shape is the faithful one.
+ *
+ * The hand-rolled Detective ability sets `isEquipAbility = true` — it *is* an equip ability
+ * (CR 702.6), so the flags that read that bit have to see it: "you may activate equip abilities any
+ * time you could cast an instant" (Leonin Shikari) and "equip abilities cost {N} less" both apply to
+ * it, not just to the plain "Equip {3}".
+ *
+ * Unlike this set's murder-weapon Equipment (Knife, Wrench, Rope, …) this one is *not* a Clue — it
+ * has no sacrifice-to-draw and the type line carries no Clue subtype.
+ */
+val ThinkingCap = card("Thinking Cap") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+2.\n" +
+        "Equip Detective {1}\n" +
+        "Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    // Equipped creature gets +1/+2.
+    staticAbility {
+        ability = ModifyStats(+1, +2, Filters.EquippedCreature)
+    }
+
+    // Equip Detective {1}: attach only to a Detective you control, sorcery speed.
+    activatedAbility {
+        cost = Costs.Mana("{1}")
+        timing = TimingRule.SorcerySpeed
+        isEquipAbility = true
+        val detective = target(
+            "Detective creature you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.DETECTIVE))
+        )
+        effect = AttachEquipmentEffect(detective)
+        description = "Equip Detective {1}"
+    }
+
+    // Equip {3}: attach to any creature you control, sorcery speed.
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "257"
+        artist = "Tony Foti"
+        flavorText = "\"I find that my greatest insights rarely arrive when my ears are cold.\"\n" +
+            "—Senior Inspector Holjo"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d2565e1-dd7b-462b-8270-a17913277793.jpg?1783912825"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -772,6 +772,113 @@
     ]
 }
 
+// Caught Red-Handed
+{
+    "name": "Caught Red-Handed",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be countered. (This includes by the ward ability.)\nGain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Suspect it. (It has menace and can't block.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SetSuspected",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            },
+                            "duration": "Permanent"
+                        }
+                    ],
+                    "descriptionOverride": "target becomes suspected"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "UNCOMMON",
+        "artist": "Donato Giancola",
+        "flavorText": "\"Wait, stop! I've been framed! Extremely convincingly!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95bc5f89-2f01-40c4-9883-4c90ab89fcbb.jpg?1783912886",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a suspected creature loses all abilities, it will lose menace and \"This creature can't block\", but it won't stop being suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Being suspected isn't a copiable value. If a permanent becomes a copy of a suspected creature, it won't be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature is already suspected, suspecting it again won't have any effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cerebral Confiscation
 {
     "name": "Cerebral Confiscation",
@@ -5536,6 +5643,158 @@
     ]
 }
 
+// Out Cold
+{
+    "name": "Out Cold",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell can't be countered. (This includes by the ward ability.)\nTap up to two target creatures and put a stun counter on each of them. Investigate. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "TapUntap",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "AddCounters",
+                                "counterType": "stun",
+                                "count": 1,
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "up to two target creatures"
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Tuan Duong Chu",
+        "flavorText": "\"We'll get their statements after they defrost.\"\n—Dvika of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aabfada0-3c1b-4237-b06c-573071ccd68d.jpg?1783912907",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you target a creature with ward, you may still pay the ward cost, but Out Cold won't be countered even if you don't."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You don't have to choose any targets for Out Cold. However, if you do, and all of those creatures are illegal targets at the time Out Cold tries to resolve, it won't resolve and none of its effects will happen. You won't investigate."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Clue is an artifact type. Even though it appears on some cards with other permanent types, it's never a creature type, a land type, or anything but an artifact type."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Perimeter Enforcer
+{
+    "name": "Perimeter Enforcer",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Flying, lifelink\nWhenever another Detective you control enters and whenever a Detective you control is turned face up, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Detective ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever another Detective you control enters, this creature gets +1/+1 until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CreatureTurnedFaceUpEvent",
+                    "filter": "creature Detective"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever a Detective you control is turned face up, this creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "rarity": "UNCOMMON",
+        "artist": "Josh Hass",
+        "flavorText": "He makes sure no one sets foot in a fresh crime scene—not even himself.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f88d077-5082-4a67-91e4-97aafb9a5e91.jpg?1783912919"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Person of Interest
 {
     "name": "Person of Interest",
@@ -6953,6 +7212,81 @@
     "colorIdentityOverride": []
 }
 
+// Scene of the Crime
+{
+    "name": "Scene of the Crime",
+    "manaCost": "",
+    "typeLine": "Artifact Land — Clue",
+    "oracleText": "This land enters tapped.\n{T}: Add {C}.\n{T}, Tap an untapped creature you control: Add one mana of any color.\n{2}, Sacrifice this land: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomTapPermanents",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "267",
+        "rarity": "UNCOMMON",
+        "artist": "Jokubas Uogintas",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de039992-631b-4feb-a522-acdb0a6d1f26.jpg?1783912824"
+    },
+    "colorIdentityOverride": []
+}
+
 // Seasoned Consultant
 {
     "name": "Seasoned Consultant",
@@ -7598,6 +7932,90 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Thinking Cap
+{
+    "name": "Thinking Cap",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+2.\nEquip Detective {1}\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "Detective creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Detective ctrl:you"
+                        },
+                        "id": "Detective creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true,
+                "descriptionOverride": "Equip Detective {1}"
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 2
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "257",
+        "artist": "Tony Foti",
+        "flavorText": "\"I find that my greatest insights rarely arrive when my ears are cold.\"\n—Senior Inspector Holjo",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d2565e1-dd7b-462b-8270-a17913277793.jpg?1783912825"
+    },
+    "colorIdentityOverride": []
 }
 
 // Thundering Falls

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -630,7 +630,27 @@ class TriggerMatcher(
             }
             is EventPattern.CreatureTurnedFaceUpEvent -> {
                 if (event !is TurnFaceUpEvent) return false
-                matchesPlayer(trigger.player, event.controllerId, controllerId)
+                if (!matchesPlayer(trigger.player, event.controllerId, controllerId)) return false
+                // "a Detective you control is turned face up" — the filter reads the permanent's
+                // post-flip characteristics, which is what the projected state already holds by
+                // detection time (the flip has happened; the event is the notification).
+                if (trigger.filter != GameObjectFilter.Any) {
+                    val predicateContext = com.wingedsheep.engine.handlers.PredicateContext(
+                        controllerId = controllerId,
+                        sourceId = sourceId
+                    )
+                    if (!predicateEvaluator.matches(
+                            state,
+                            state.projectedState,
+                            event.entityId,
+                            trigger.filter,
+                            predicateContext
+                        )
+                    ) {
+                        return false
+                    }
+                }
+                true
             }
             is EventPattern.TransformEvent -> {
                 if (event !is TransformedEvent) return false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PerimeterEnforcerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PerimeterEnforcerScenarioTest.kt
@@ -1,0 +1,254 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.handlers.effects.FaceDownTurnUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownModeComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.MuseumNightwatch
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.NoviceInspector
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.PerimeterEnforcer
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.UndercoverCrocodelf
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Perimeter Enforcer (MKM #31) — "Whenever another Detective you control enters and whenever a
+ * Detective you control is turned face up, this creature gets +1/+1 until end of turn."
+ *
+ * The card is the reason `Triggers.CreatureTurnedFaceUp` grew a `filter` parameter: before this
+ * there was no way to say "a **Detective** you control is turned face up", only "a creature". These
+ * tests pin both halves of the ability and, more importantly, the two things a filter can get wrong
+ * — matching creatures it shouldn't, and (because a face-down permanent is a nameless, subtypeless
+ * 2/2) matching nothing at all because it read the pre-flip characteristics.
+ */
+class PerimeterEnforcerScenarioTest : FunSpec({
+
+    val allCards = TestCards.all + listOf(
+        PerimeterEnforcer, NoviceInspector, UndercoverCrocodelf, MuseumNightwatch
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    /** Put [cardName] onto the battlefield face down, deriving turn-up data as a real cast would. */
+    fun GameTestDriver.putFaceDown(playerId: EntityId, cardName: String): EntityId {
+        val id = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = cardRegistry.requireCard(cardName)
+        replaceState(
+            state.updateEntity(id) { container ->
+                var c = container.with(FaceDownComponent).with(FaceDownModeComponent(FaceDownMode.DISGUISE))
+                FaceDownTurnUp.dataFor(cardDef, cardName, FaceDownMode.DISGUISE)?.let { c = c.with(it) }
+                c
+            }
+        )
+        removeSummoningSickness(id)
+        return id
+    }
+
+    /** Settle the stack without letting the turn advance past the end-of-turn pump expiry. */
+    fun GameTestDriver.settle() {
+        repeat(4) { if (state.priorityPlayerId != null && stackSize > 0) bothPass() }
+    }
+
+    context("whenever another Detective you control enters") {
+
+        test("a Detective entering under your control pumps the Enforcer to 2/2") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val enforcer = driver.putCreatureOnBattlefield(player, "Perimeter Enforcer")
+            driver.state.projectedState.getPower(enforcer) shouldBe 1
+
+            val inspector = driver.putCardInHand(player, "Novice Inspector")
+            driver.giveMana(player, Color.WHITE, 1)
+            driver.castSpell(player, inspector).error shouldBe null
+            driver.settle()
+
+            driver.state.projectedState.getPower(enforcer) shouldBe 2
+            driver.state.projectedState.getToughness(enforcer) shouldBe 2
+        }
+
+        test("two Detectives entering stack the pump to 3/3") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val enforcer = driver.putCreatureOnBattlefield(player, "Perimeter Enforcer")
+
+            repeat(2) {
+                val inspector = driver.putCardInHand(player, "Novice Inspector")
+                driver.giveMana(player, Color.WHITE, 1)
+                driver.castSpell(player, inspector).error shouldBe null
+                driver.settle()
+            }
+
+            driver.state.projectedState.getPower(enforcer) shouldBe 3
+            driver.state.projectedState.getToughness(enforcer) shouldBe 3
+        }
+
+        test("a non-Detective creature entering does not pump it") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val enforcer = driver.putCreatureOnBattlefield(player, "Perimeter Enforcer")
+
+            val bears = driver.putCardInHand(player, "Grizzly Bears")
+            driver.giveMana(player, Color.GREEN, 2)
+            driver.castSpell(player, bears).error shouldBe null
+            driver.settle()
+
+            driver.state.projectedState.getPower(enforcer) shouldBe 1
+        }
+
+        test("an opponent's Detective entering does not pump it — 'you control'") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            // The Enforcer belongs to the non-active player; the active player casts the Detective.
+            val enforcer = driver.putCreatureOnBattlefield(opponent, "Perimeter Enforcer")
+
+            val inspector = driver.putCardInHand(player, "Novice Inspector")
+            driver.giveMana(player, Color.WHITE, 1)
+            driver.castSpell(player, inspector).error shouldBe null
+            driver.settle()
+
+            driver.state.projectedState.getPower(enforcer) shouldBe 1
+        }
+
+        test("its own arrival does not pump it — 'another'") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val card = driver.putCardInHand(player, "Perimeter Enforcer")
+            driver.giveMana(player, Color.WHITE, 2)
+            driver.castSpell(player, card).error shouldBe null
+            driver.settle()
+
+            val enforcer = driver.findPermanent(player, "Perimeter Enforcer")!!
+            driver.state.projectedState.getPower(enforcer) shouldBe 1
+        }
+    }
+
+    context("whenever a Detective you control is turned face up") {
+
+        test("flipping a face-down Detective pumps the Enforcer") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val enforcer = driver.putCreatureOnBattlefield(player, "Perimeter Enforcer")
+            // Undercover Crocodelf — Elf Crocodile Detective, disguise {3}{G/U}{G/U}.
+            val croc = driver.putFaceDown(player, "Undercover Crocodelf")
+            driver.giveMana(player, Color.GREEN, 5)
+
+            driver.submit(
+                TurnFaceUp(
+                    playerId = player,
+                    sourceId = croc,
+                    paymentStrategy = PaymentStrategy.FromPool
+                )
+            ).error shouldBe null
+            driver.settle()
+
+            driver.state.getEntity(croc)?.get<FaceDownComponent>() shouldBe null
+            driver.state.projectedState.getPower(enforcer) shouldBe 2
+            driver.state.projectedState.getToughness(enforcer) shouldBe 2
+        }
+
+        test("flipping a face-down non-Detective does not pump it") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val enforcer = driver.putCreatureOnBattlefield(player, "Perimeter Enforcer")
+            // Museum Nightwatch — Centaur Soldier, disguise {1}{W}. Same face-down 2/2 as the
+            // Crocodelf, so only the post-flip type line can tell the two cases apart.
+            val nightwatch = driver.putFaceDown(player, "Museum Nightwatch")
+            driver.giveMana(player, Color.WHITE, 2)
+
+            driver.submit(
+                TurnFaceUp(
+                    playerId = player,
+                    sourceId = nightwatch,
+                    paymentStrategy = PaymentStrategy.FromPool
+                )
+            ).error shouldBe null
+            driver.settle()
+
+            driver.state.getEntity(nightwatch)?.get<FaceDownComponent>() shouldBe null
+            driver.state.projectedState.getPower(enforcer) shouldBe 1
+        }
+
+        test("an opponent flipping their Detective does not pump it — 'you control'") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+            val player = driver.activePlayer!!
+            val opponent = driver.getOpponent(player)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            // The Enforcer sits with the non-active player; the active player — who has priority,
+            // and so can take the turn-up special action — flips their own Detective.
+            val enforcer = driver.putCreatureOnBattlefield(opponent, "Perimeter Enforcer")
+            val croc = driver.putFaceDown(player, "Undercover Crocodelf")
+            driver.giveMana(player, Color.GREEN, 5)
+
+            driver.submit(
+                TurnFaceUp(
+                    playerId = player,
+                    sourceId = croc,
+                    paymentStrategy = PaymentStrategy.FromPool
+                )
+            ).error shouldBe null
+            driver.settle()
+
+            driver.state.getEntity(croc)?.get<FaceDownComponent>() shouldBe null
+            driver.state.projectedState.getPower(enforcer) shouldBe 1
+        }
+    }
+
+    context("duration") {
+
+        test("the pump wears off at end of turn") {
+            val driver = createDriver()
+            driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+            val player = driver.activePlayer!!
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val enforcer = driver.putCreatureOnBattlefield(player, "Perimeter Enforcer")
+            val inspector = driver.putCardInHand(player, "Novice Inspector")
+            driver.giveMana(player, Color.WHITE, 1)
+            driver.castSpell(player, inspector).error shouldBe null
+            driver.settle()
+            driver.state.projectedState.getPower(enforcer) shouldBe 2
+
+            driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            driver.state.projectedState.getPower(enforcer) shouldBe 1
+            driver.state.projectedState.getToughness(enforcer) shouldBe 1
+        }
+    }
+})


### PR DESCRIPTION
Five MKM cards, all canonical in MKM (no reprint rows needed).

| Card | Cost | Shape |
|---|---|---|
| **Out Cold** | `{3}{U}` Instant | Uncounterable; taps up to two target creatures, a stun counter on each, then investigate |
| **Caught Red-Handed** | `{4}{R}` Instant | Uncounterable instant-speed Threaten that also suspects the borrowed creature |
| **Scene of the Crime** | Artifact Land — Clue | Enters tapped; `{T}: {C}`, the Springleaf Drum any-color ability, and the Clue sac-to-draw |
| **Perimeter Enforcer** | `{1}{W}` 1/1 | Flying, lifelink; +1/+1 UEOT on Detective entries *and* Detective face-up flips |
| **Thinking Cap** | `{1}` Equipment | +1/+2; the variant "Equip Detective {1}" alongside the plain Equip {3} |

## Modelling notes

- **Out Cold** — "up to two target creatures" is one requirement taking up to two objects (`TargetCreature(count = 2, optional = true)`), not two slots, so the picks must differ (CR 601.2c) and zero is legal. Tap + stun run per-target via `ForEachTargetEffect`; the investigate sits outside the iteration (once, not once per creature).
- **Caught Red-Handed** — the suspect is deliberately `Duration.Permanent`, not tied to the control change: per the printed ruling a creature stays suspected after control reverts.
- **Scene of the Crime** — the Clue subtype is on the type line, so the set's "sacrifice a Clue" payoffs can eat it (Scryfall: "if an effect refers to a Clue, it means any Clue artifact").
- **Thinking Cap** — the hand-rolled Detective equip sets `isEquipAbility = true`. It *is* an equip ability (CR 702.6), so instant-speed-equip permission (Leonin Shikari) and "equip abilities cost {N} less" have to see it. This is stricter than the existing Pirate Hat / Dúnedain Blade precedent, which leaves the flag off.

## SDK change

`Triggers.CreatureTurnedFaceUp` gains a `filter` parameter — before this there was no way to say "whenever a **Detective** you control is turned face up", only "a creature".

The filter reads the permanent's **post-flip** characteristics, which is the only reading that works: a face-down permanent is a nameless, subtypeless 2/2, so a pre-flip check could never match anything. `TriggerMatcher` applies it with the same `PredicateEvaluator` pattern the counters-placed / counters-removed triggers already use, and the default `GameObjectFilter.Any` leaves every existing call site (and its serialized form) unchanged.

`docs/card-sdk-language-reference.md` updated in the same change.

## Tests

`PerimeterEnforcerScenarioTest` (9 tests) covers both halves of the ability plus the three ways the new filter could go wrong — matching a non-Detective flip, matching an opponent's flip, and matching nothing because it read the face-down state. The two flip cases use Undercover Crocodelf (Detective) and Museum Nightwatch (non-Detective), which are the same face-down 2/2, so only the post-flip type line separates them.

## Verification

- `just build` — green
- `just test` — green
- `just test-class PerimeterEnforcerScenarioTest` — 9/9
- `just check-card-printing` for all five — canonical in MKM
- Card snapshot re-blessed: pure additions, only the five new cards moved
- Every mechanical field re-checked against Scryfall (name, cost, type line, P/T, rarity, collector number, artist, image URI) — 0 mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)