### PR TITLE
Add five The Hobbit cards with recruit support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2499,6 +2499,16 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `rummage(count?)` — discard then draw.
 - `connive(target?)` — draw 1, discard 1, then put a +1/+1 counter on `target` (default Self) if the discard was a nonland (CR 701.50). Also exposed as `Effects.Connive(target)`.
 - `conniveTargeting(requirement, storeAs?)` — connive whose +1/+1 counter lands on a *reflexively chosen* target: "draw a card, then discard a card. When you discard a nonland card this way, put a +1/+1 counter on target creature you control" (Teo, Spirited Glider). The recipient is selected at resolution via `SelectTargetEffect` *inside* the nonland gate — so the player never chooses up front or when the discard is a land. Pass the recipient's `TargetRequirement` (e.g. `Targets.CreatureYouControl`); do **not** also declare it as a cast-time `target(...)`. Exposed as `Effects.ConniveTargeting(requirement)`.
+- `Patterns.Mechanic.recruit()` — **Recruit** (The Hobbit): "draw a card, then discard a card. If you
+  discarded a nonland card, create a 1/1 white Human Soldier creature token." A keyword *action* with
+  fixed reminder text, not a keyword ability, so there is no `Keyword.RECRUIT` — it is connive's pipeline
+  with a token payoff instead of a +1/+1 counter: `DrawCards(1)` → `GatherCards(FromZone(HAND, You))` →
+  `SelectFromCollection(ChooseExactly 1)` → `MoveCollection(→ graveyard, MoveType.Discard)` →
+  `ConditionalOnCollection(Nonland, ifNotEmpty = CreateToken(1/1 white Human Soldier))`. The discard is a
+  real discard, so madness and "whenever you discard a card" payoffs see it. The gate is the positive
+  "a nonland card was discarded" — an empty hand discards nothing and mints nothing. Token art comes from
+  the set-scoped resolver (`MtgSet.tokenArt`), not a baked-in `imageUri`, because ten HOB cards share the
+  facade. Lake-town Lookout, Patient Instructor, Long Lake Nuisance, Esgaroth Garrison, Great Gilded Boat.
 - `readTheRunes()` — "draw X cards; for each, discard a card unless you sacrifice a permanent." Composes `RepeatDynamicTimesEffect(XValue, ChooseActionEffect(...))` with feasibility guards. Exposed as `Effects.ReadTheRunes()`.
 - `eachOpponentMayPutFromHand(filter?)` — each opponent may dump a matching card.
 - `putFromHand(filter?, count?, entersTapped?, entersAttacking?, anyNumber?, prompt?)` — you may put N

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MechanicPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MechanicPatterns.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.dsl
 
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.GameObjectFilter
@@ -15,6 +16,9 @@ import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
 import com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect
 import com.wingedsheep.sdk.scripting.effects.CollectionFilter
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.EffectChoice
 import com.wingedsheep.sdk.scripting.conditions.CollectionContainsMatch
@@ -27,6 +31,7 @@ import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
 import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
@@ -35,7 +40,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
- * Named MTG keyword-mechanic recipes (Blight, Bolster, Explore, Forage, Gift, Incubate).
+ * Named MTG keyword-mechanic recipes (Blight, Bolster, Explore, Forage, Gift, Incubate, Recruit).
  *
  * Reached through the [Patterns] index — `Patterns.Mechanic.blight(...)`. Each composes existing
  * atomic effects into the printed keyword behaviour; they live here (rather than a zone-based
@@ -341,5 +346,68 @@ object MechanicPatterns {
                 target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0)
             )
         )
+    )
+
+    // =========================================================================
+    // Recruit Pattern (The Hobbit)
+    // =========================================================================
+
+    /**
+     * Recruit (The Hobbit) — "Draw a card, then discard a card. If you discarded a nonland card,
+     * create a 1/1 white Human Soldier creature token."
+     *
+     * A keyword *action* with fixed reminder text (like explore or amass), not a keyword ability,
+     * so it needs no `Keyword` entry. Mechanically it is connive (CR 701.50) with a token payoff
+     * instead of a +1/+1 counter, and it reuses that proven pipeline shape exactly: Draw →
+     * Gather(hand) → Select(1) → Move(Discard) → ConditionalOnCollection(Nonland). See
+     * [HandPatterns.connive].
+     *
+     * Two details the shape is load-bearing for:
+     *
+     * - The discard is a real discard ([MoveType.Discard]), not a bare move to the graveyard, so
+     *   madness and "whenever you discard a card" triggers see it.
+     * - The payoff is gated on the discarded card being a *nonland*, never on "no land was
+     *   discarded": with an empty hand nothing is discarded at all, and CR's "if you discarded a
+     *   nonland card" is then false. `ChooseExactly(1)` auto-resolves on an empty or single-card
+     *   hand, leaving the collection empty so no token is created.
+     *
+     * The draw comes first and is unconditional, so an empty library still sets up the usual
+     * draw-from-empty loss at the next state-based check.
+     *
+     * Token art is left to the set-scoped resolver (`MtgSet.tokenArt`, keyed off the creating
+     * card's printing) rather than baked in here — ten HOB cards share this facade.
+     */
+    fun recruit(): CompositeEffect = CompositeEffect(
+        listOf(
+            DrawCardsEffect(1, EffectTarget.Controller),
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.You),
+                storeAs = "recruit_hand"
+            ),
+            SelectFromCollectionEffect(
+                from = "recruit_hand",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                storeSelected = "recruit_discarded",
+                prompt = "Recruit — choose a card to discard"
+            ),
+            MoveCollectionEffect(
+                from = "recruit_discarded",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                moveType = MoveType.Discard
+            ),
+            ConditionalOnCollectionEffect(
+                collection = "recruit_discarded",
+                filter = GameObjectFilter.Nonland,
+                ifNotEmpty = CreateTokenEffect(
+                    count = DynamicAmount.Fixed(1),
+                    power = 1,
+                    toughness = 1,
+                    colors = setOf(Color.WHITE),
+                    creatureTypes = setOf("Human", "Soldier")
+                )
+            )
+        ),
+        descriptionOverride = "Recruit"
     )
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/TheHobbitSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/TheHobbitSet.kt
@@ -47,6 +47,11 @@ object TheHobbitSet : MtgSet {
             name = "Goblin Army",
             imageUri = "https://cards.scryfall.io/normal/front/2/e/2e2028b1-34c0-40b6-8f65-79f79a279996.jpg?1785497644",
         ),
+        // thob #2 — the Soldier every recruit card in the set mints.
+        TokenPrinting(
+            name = "Human Soldier",
+            imageUri = "https://cards.scryfall.io/art_crop/front/6/0/6007af81-4541-4b55-90ea-03d365362ae5.jpg?1785497653",
+        ),
     )
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.hob.cards"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/EsgarothGarrison.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/EsgarothGarrison.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Esgaroth Garrison
+ * {4}{W}
+ * Creature — Human Soldier
+ * star/5 (power is a characteristic-defining count)
+ *
+ * Esgaroth Garrison's power is equal to the number of creatures you control.
+ * When this creature enters, recruit.
+ *
+ * The characteristic-defining power is a power-only `dynamicPower(...)` over
+ * [DynamicAmount.AggregateBattlefield] counting creatures you control; toughness stays fixed at 5.
+ * The Garrison counts itself once it is on the battlefield, so a lone copy is 1/5. Its own recruit
+ * trigger resolves after it has entered, so a Soldier token minted that way immediately grows it.
+ */
+val EsgarothGarrison = card("Esgaroth Garrison") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Esgaroth Garrison's power is equal to the number of creatures you control.\n" +
+        "When this creature enters, recruit. (Draw a card, then discard a card. If you discarded " +
+        "a nonland card, create a 1/1 white Human Soldier creature token.)"
+    toughness = 5
+
+    dynamicPower(
+        DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature)
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "Leonardo Santanna"
+        flavorText = "\"I suggest we go to Lake-town,\" said Bilbo. \"What else is there?\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/573f67b0-6ce8-4857-a703-4a5728640736.jpg?1785496934"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GreatGildedBoat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GreatGildedBoat.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Great Gilded Boat
+ * {2}{U}
+ * Artifact — Vehicle
+ * 4/4
+ *
+ * Whenever you attack, recruit.
+ * Crew 2
+ *
+ * "Whenever you attack" is the once-per-combat declare-attackers trigger ([Triggers.YouAttack]),
+ * not a per-attacker one — it fires once however many creatures were declared, and it fires even
+ * when the Boat itself is uncrewed and stays home.
+ */
+val GreatGildedBoat = card("Great Gilded Boat") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Whenever you attack, recruit. (Draw a card, then discard a card. If you " +
+        "discarded a nonland card, create a 1/1 white Human Soldier creature token.)\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "42"
+        artist = "Josu Solano"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2fb3995-5b43-4776-88b2-346d353edee0.jpg?1784862975"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LaketownLookout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LaketownLookout.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lake-town Lookout
+ * {W}
+ * Creature — Human Scout
+ * 1/1
+ *
+ * When this creature dies, recruit.
+ *
+ * Recruit is a keyword action with fixed reminder text, composed by
+ * [Patterns.Mechanic.recruit] — draw, discard, and a 1/1 Human Soldier if the discard was a
+ * nonland card. Nothing about it reads the dying creature, so the ordinary SELF-bound
+ * [Triggers.Dies] is all the binding this needs.
+ */
+val LaketownLookout = card("Lake-town Lookout") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    oracleText = "When this creature dies, recruit. (Draw a card, then discard a card. If you " +
+        "discarded a nonland card, create a 1/1 white Human Soldier creature token.)"
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Irina Nordsol"
+        flavorText = "\"Look! The lights again! Last night the watchmen saw them start and fade " +
+            "from midnight until dawn. Something is happening up there.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/178c4cf6-6b11-40e4-9673-c560d6818a6b.jpg?1785496946"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LongLakeNuisance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/LongLakeNuisance.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Long Lake Nuisance
+ * {3}{U}
+ * Creature — Bird
+ * 3/1
+ *
+ * Flying
+ * When this creature enters, recruit.
+ */
+val LongLakeNuisance = card("Long Lake Nuisance") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying\n" +
+        "When this creature enters, recruit. (Draw a card, then discard a card. If you discarded " +
+        "a nonland card, create a 1/1 white Human Soldier creature token.)"
+    power = 3
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Kevin Sidharta"
+        flavorText = "Thrushes carried news between towns and villages. Herons, however, brought " +
+            "nothing more than disruption."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd5af94d-6321-4834-8e5f-e5d0261b3ef3.jpg?1785497055"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/PatientInstructor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/PatientInstructor.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Patient Instructor
+ * {2}{W/U}
+ * Creature — Human Citizen
+ * 2/2
+ *
+ * Vigilance
+ * When this creature enters, recruit.
+ *
+ * The hybrid {W/U} makes the card both white and blue, so the colour identity is "WU".
+ */
+val PatientInstructor = card("Patient Instructor") {
+    manaCost = "{2}{W/U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "Vigilance\n" +
+        "When this creature enters, recruit. (Draw a card, then discard a card. If you discarded " +
+        "a nonland card, create a 1/1 white Human Soldier creature token.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "162"
+        artist = "Joshua Raphael"
+        flavorText = "Lake-town was much diminished from its old grandeur, but still the Long Lake " +
+            "provided for all their needs."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4800508-8bb9-41bb-8712-b55fba7a80a5.jpg?1785323310"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -3336,6 +3336,105 @@
     ]
 }
 
+// Esgaroth Garrison
+{
+    "name": "Esgaroth Garrison",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Esgaroth Garrison's power is equal to the number of creatures you control.\nWhen this creature enters, recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            }
+        },
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "Leonardo Santanna",
+        "flavorText": "\"I suggest we go to Lake-town,\" said Bilbo. \"What else is there?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/573f67b0-6ce8-4857-a703-4a5728640736.jpg?1785496934"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Fateful Discovery
 {
     "name": "Fateful Discovery",
@@ -4686,6 +4785,106 @@
     ]
 }
 
+// Great Gilded Boat
+{
+    "name": "Great Gilded Boat",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Whenever you attack, recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "RARE",
+        "artist": "Josu Solano",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b2fb3995-5b43-4776-88b2-346d353edee0.jpg?1784862975"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Great Ugly-Looking Goblin
 {
     "name": "Great Ugly-Looking Goblin",
@@ -5355,6 +5554,99 @@
     ]
 }
 
+// Lake-town Lookout
+{
+    "name": "Lake-town Lookout",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "When this creature dies, recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Irina Nordsol",
+        "flavorText": "\"Look! The lights again! Last night the watchmen saw them start and fade from midnight until dawn. Something is happening up there.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/178c4cf6-6b11-40e4-9673-c560d6818a6b.jpg?1785496946"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Lake-town Mariners
 {
     "name": "Lake-town Mariners",
@@ -5794,6 +6086,101 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Long Lake Nuisance
+{
+    "name": "Long Lake Nuisance",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhen this creature enters, recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Kevin Sidharta",
+        "flavorText": "Thrushes carried news between towns and villages. Herons, however, brought nothing more than disruption.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd5af94d-6321-4834-8e5f-e5d0261b3ef3.jpg?1785497055"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -7063,6 +7450,102 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Patient Instructor
+{
+    "name": "Patient Instructor",
+    "manaCost": "{2}{W/U}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "Vigilance\nWhen this creature enters, recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "artist": "Joshua Raphael",
+        "flavorText": "Lake-town was much diminished from its old grandeur, but still the Long Lake provided for all their needs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4800508-8bb9-41bb-8712-b55fba7a80a5.jpg?1785323310"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EsgarothGarrisonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EsgarothGarrisonScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.EsgarothGarrison
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Esgaroth Garrison (HOB #13) — {4}{W} Creature — Human Soldier, star/5.
+ *
+ * "Esgaroth Garrison's power is equal to the number of creatures you control."
+ * "When this creature enters, recruit."
+ *
+ * The two abilities interact: the Garrison counts itself, and its own recruit trigger resolves
+ * after it has entered, so a Soldier token minted that way immediately raises its power.
+ */
+class EsgarothGarrisonScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(EsgarothGarrison)
+
+        context("Esgaroth Garrison") {
+
+            test("power counts creatures you control; a recruited Soldier raises it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Esgaroth Garrison")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    // An opposing creature must not be counted — "creatures you control".
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Esgaroth Garrison").error shouldBe null
+                game.resolveStack()
+
+                val garrison = game.findPermanent("Esgaroth Garrison")!!
+                withClue("alone on its side, the Garrison counts only itself") {
+                    game.state.projectedState.getPower(garrison) shouldBe 1
+                }
+                withClue("toughness is printed, not dynamic") {
+                    game.state.projectedState.getToughness(garrison) shouldBe 5
+                }
+
+                withClue("the enters trigger should pause for recruit's discard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val bears = game.findCardsInHand(1, "Grizzly Bears").single()
+                game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                withClue("the nonland discard mints one Human Soldier token") {
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 1
+                }
+                withClue("the Garrison plus its recruited Soldier is two creatures you control") {
+                    game.state.projectedState.getPower(garrison) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GreatGildedBoatScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GreatGildedBoatScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.GreatGildedBoat
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Great Gilded Boat (HOB #42) — {2}{U} Artifact — Vehicle 4/4.
+ *
+ * "Whenever you attack, recruit." + "Crew 2"
+ *
+ * "Whenever you attack" is the once-per-combat declare-attackers trigger, so it fires off someone
+ * else's attack while the Boat sits uncrewed on the battlefield — the case worth pinning, since a
+ * per-attacker reading would make an uncrewed Vehicle do nothing at all.
+ */
+class GreatGildedBoatScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(GreatGildedBoat)
+
+        context("Great Gilded Boat") {
+
+            test("an attack recruits even though the uncrewed Vehicle stays home") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Great Gilded Boat")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the attack trigger should pause for recruit's discard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val bolt = game.findCardsInHand(1, "Lightning Bolt").single()
+                game.selectCards(listOf(bolt))
+                game.resolveStack()
+
+                withClue("recruit drew the Forest") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+                withClue("the discarded nonland is in the graveyard") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                }
+                withClue("the nonland discard mints one Human Soldier token") {
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 1
+                }
+                withClue("the Vehicle itself never attacked — it is not a creature uncrewed") {
+                    game.state.projectedState.isCreature(game.findPermanent("Great Gilded Boat")!!) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LaketownLookoutScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LaketownLookoutScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.LaketownLookout
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Lake-town Lookout (HOB #18) — {W} Creature — Human Scout 1/1.
+ *
+ * "When this creature dies, recruit."
+ *
+ * The dies trigger has to fire from the graveyard-bound `detectLeavesBattlefieldTriggers` pass, and
+ * recruit's discard decision must still surface after the Lookout itself has left the battlefield.
+ */
+class LaketownLookoutScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(LaketownLookout)
+
+        context("Lake-town Lookout") {
+
+            test("dying recruits: draw, discard a nonland, get a Soldier token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Lake-town Lookout")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Lethal damage to the 1/1 → it dies to state-based actions → the dies trigger fires.
+                val lookout = game.findPermanent("Lake-town Lookout")!!
+                game.castSpell(1, "Lightning Bolt", lookout).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Lookout should be in the graveyard") {
+                    game.isInGraveyard(1, "Lake-town Lookout") shouldBe true
+                }
+                withClue("the dies trigger should pause for recruit's discard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                val bears = game.findCardsInHand(1, "Grizzly Bears").single()
+                game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                withClue("recruit drew the Forest") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+                withClue("the nonland discard mints one Human Soldier token") {
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LongLakeNuisanceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LongLakeNuisanceScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.LongLakeNuisance
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Long Lake Nuisance (HOB #45) — {3}{U} Creature — Bird 3/1.
+ *
+ * "Flying" + "When this creature enters, recruit."
+ *
+ * The land-discard case is covered here rather than on the other recruit cards: discarding a land
+ * must leave the battlefield token-free even though a card really was discarded.
+ */
+class LongLakeNuisanceScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(LongLakeNuisance)
+
+        context("Long Lake Nuisance") {
+
+            test("entering recruits; discarding a land mints no Soldier") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Long Lake Nuisance")
+                    .withCardInHand(1, "Mountain")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Long Lake Nuisance").error shouldBe null
+                game.resolveStack()
+
+                withClue("the enters trigger should pause for recruit's discard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val mountain = game.findCardsInHand(1, "Mountain").single()
+                game.selectCards(listOf(mountain))
+                game.resolveStack()
+
+                withClue("recruit drew the Bears before the discard") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("the discarded land is in the graveyard") {
+                    game.isInGraveyard(1, "Mountain") shouldBe true
+                }
+                withClue("a land discard fails 'if you discarded a nonland card' — no token") {
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 0
+                }
+            }
+
+            test("has flying") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Long Lake Nuisance")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bird = game.findPermanent("Long Lake Nuisance")!!
+                withClue("printed flying should be visible in projected state") {
+                    game.state.projectedState.hasKeyword(bird, Keyword.FLYING) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PatientInstructorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PatientInstructorScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.PatientInstructor
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Patient Instructor (HOB #162) — {2}{W/U} Creature — Human Citizen 2/2.
+ *
+ * "Vigilance" + "When this creature enters, recruit."
+ */
+class PatientInstructorScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(PatientInstructor)
+
+        context("Patient Instructor") {
+
+            test("entering recruits; a nonland discard mints a Soldier") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Patient Instructor")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Patient Instructor").error shouldBe null
+                game.resolveStack()
+
+                withClue("the enters trigger should pause for recruit's discard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val bears = game.findCardsInHand(1, "Grizzly Bears").single()
+                game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                withClue("recruit drew the Forest") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+                withClue("the nonland discard mints one Human Soldier token") {
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 1
+                }
+            }
+
+            test("has vigilance") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Patient Instructor")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val instructor = game.findPermanent("Patient Instructor")!!
+                withClue("printed vigilance should be visible in projected state") {
+                    game.state.projectedState.hasKeyword(instructor, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RecruitMechanicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RecruitMechanicScenarioTest.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsDiscardedEvent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the Recruit keyword action (The Hobbit) as a pure pipeline composition —
+ * `Patterns.Mechanic.recruit()`.
+ *
+ * Recruit: "Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white
+ * Human Soldier creature token."
+ *
+ * The composition is Draw → Gather (hand) → Select 1 → FilterCollection partition by Land →
+ * MoveCollection(→ graveyard, [MoveType.Discard]) → GatedEffect over the *nonland* partition. No
+ * bespoke Recruit effect type exists.
+ *
+ * The mechanic-level edge cases live here (one file per mechanic, per AGENTS.md); each of the five
+ * HOB recruit cards has its own scenario test for its own trigger wiring.
+ */
+class RecruitMechanicScenarioTest : ScenarioTestBase() {
+
+    private val recruiter = card("Test Recruiter") {
+        manaCost = "{W}"
+        typeLine = "Creature — Human Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "When this creature enters, recruit."
+
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Patterns.Mechanic.recruit()
+        }
+    }
+
+    init {
+        cardRegistry.register(recruiter)
+
+        // CreateTokenExecutor derives the name as "<types joined> Token" — not the bare type line.
+        fun TestGame.soldierTokens(): Int = findAllPermanents("Human Soldier Token").size
+
+        context("Recruit as a pipeline composition") {
+
+            test("discarding a nonland card mints a 1/1 Human Soldier token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Test Recruiter")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Recruiter").error shouldBe null
+                game.resolveStack()
+
+                withClue("recruit should pause to choose the card to discard") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val bears = game.findCardsInHand(1, "Grizzly Bears").single()
+                game.selectCards(listOf(bears))
+                game.resolveStack()
+
+                withClue("the drawn Forest should be in hand (draw happens before the discard)") {
+                    game.isInHand(1, "Forest") shouldBe true
+                }
+                withClue("the chosen nonland card should be in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("discarding a nonland card creates exactly one Soldier token") {
+                    game.soldierTokens() shouldBe 1
+                }
+            }
+
+            test("discarding a land card creates no token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Test Recruiter")
+                    .withCardInHand(1, "Mountain")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Recruiter").error shouldBe null
+                game.resolveStack()
+
+                val mountain = game.findCardsInHand(1, "Mountain").single()
+                game.selectCards(listOf(mountain))
+                game.resolveStack()
+
+                withClue("the discarded land should be in the graveyard") {
+                    game.isInGraveyard(1, "Mountain") shouldBe true
+                }
+                withClue("'if you discarded a nonland card' is false for a land — no token") {
+                    game.soldierTokens() shouldBe 0
+                }
+            }
+
+            test("the discard is a real discard, not a bare move to the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Test Recruiter")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Recruiter").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findCardsInHand(1, "Grizzly Bears").single()
+                val results = buildList {
+                    add(game.selectCards(listOf(bears)))
+                    addAll(game.resolveStack())
+                }
+
+                withClue("madness and 'whenever you discard' triggers need a CardsDiscardedEvent") {
+                    results.flatMap { it.events }
+                        .filterIsInstance<CardsDiscardedEvent>()
+                        .any { bears in it.cardIds } shouldBe true
+                }
+            }
+
+            test("empty library and empty hand: nothing is discarded, so no token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Test Recruiter")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Recruiter").error shouldBe null
+                game.resolveStack()
+
+                withClue("nothing to draw and nothing to discard — no discard decision") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("no card was discarded, so 'you discarded a nonland card' is false") {
+                    game.soldierTokens() shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the **recruit** keyword action to the SDK and the first five HOB cards that use it.

Recruit: *"Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token."*

It is mechanically **connive** (CR 701.50) with a token payoff instead of a +1/+1 counter, so `Patterns.Mechanic.recruit()` reuses that proven pipeline verbatim:

`DrawCards(1)` → `GatherCards(FromZone(HAND, You))` → `SelectFromCollection(ChooseExactly 1)` → `MoveCollection(→ graveyard, MoveType.Discard)` → `ConditionalOnCollection(Nonland, ifNotEmpty = CreateToken(1/1 white Human Soldier))`

**No new Effect type, executor, or `Keyword` entry** — recruit is a keyword *action* with fixed reminder text, like explore or amass.

### Two details the shape is load-bearing for

- The discard is a **real discard** (`MoveType.Discard`), not a bare move to the graveyard, so madness and "whenever you discard a card" payoffs see it.
- The gate is the *positive* "a nonland card was discarded", never "no land was discarded" — an empty hand discards nothing, so it mints nothing.

Ten HOB cards use recruit, so the facade is well past the inline-until-the-second-user bar. Token art goes in `TheHobbitSet.tokenArt` (thob #2) rather than a baked-in `imageUri`, since every recruit card shares the facade.

## Cards

| Card | Cost | Type | Wiring |
|---|---|---|---|
| Lake-town Lookout (#18) | `{W}` | Human Scout 1/1 | dies trigger |
| Patient Instructor (#162) | `{2}{W/U}` | Human Citizen 2/2 | vigilance, enters trigger |
| Long Lake Nuisance (#45) | `{3}{U}` | Bird 3/1 | flying, enters trigger |
| Esgaroth Garrison (#13) | `{4}{W}` | Human Soldier \*/5 | CDA power = creatures you control, enters trigger |
| Great Gilded Boat (#42) | `{2}{U}` | Artifact — Vehicle 4/4 | crew 2, "whenever you attack" trigger |

HOB goes from 158/193 to 163/193.

## Verification

All ten new scenario tests pass (one file per card, plus one for the mechanic per AGENTS.md):

- `RecruitMechanicScenarioTest` — nonland discard mints a token; land discard does not; the move emits a real `CardsDiscardedEvent`; empty library + empty hand discards nothing and mints nothing
- `LaketownLookoutScenarioTest` — the dies trigger fires from the leaves-battlefield pass and still pauses for the discard choice after the Lookout is gone
- `PatientInstructorScenarioTest` / `LongLakeNuisanceScenarioTest` — enters trigger + printed keyword in projected state; the Nuisance covers the land-discard-no-token case
- `EsgarothGarrisonScenarioTest` — power counts only creatures you control, and its own recruited Soldier raises it from 1 to 2
- `GreatGildedBoatScenarioTest` — "whenever you attack" fires off another creature's attack while the uncrewed Vehicle stays home (and is correctly not a creature)

`just check-card-printing` is clean for all five (HOB is the earliest real printing for each). `just rebless-cards` moved only the five new cards in `HOB.json` — additions only, no existing entry changed.

**Not run:** the full `just build` gate was interrupted before completion, so the wider suite (lint, facade-boundary, cross-module) has not been exercised on this branch. The targeted card, printing, and snapshot gates above all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
