### PR TITLE
Fix all Kotlin compiler warnings across every module

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/Strategist.kt
@@ -282,7 +282,7 @@ class Strategist(
             // Fill in targets on the returned action so the processor can execute it.
             // The committed target is chosen by simulation (not just the heuristic) so the
             // AI sees the real resolved board, including effects already on the stack.
-            best!!.first
+            best.first
         } else {
             pass ?: legalActions.first()
         }
@@ -292,7 +292,7 @@ class Strategist(
                 state, evaluationState, playerId, startNanos,
                 pass = pass, passScore = passScore, adjustedPassScore = adjustedPassScore,
                 adjusted = adjusted, dropped = dropped.orEmpty(),
-                chosenAction = if (takeAction) best!!.first else null,
+                chosenAction = if (takeAction) best.first else null,
             )
         }
         return chosen

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/BlightPaymentAiTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/BlightPaymentAiTest.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.ecl.cards.CinderStrike
 import com.wingedsheep.mtg.sets.definitions.ecl.cards.EvershrikesGift
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -25,7 +26,7 @@ class BlightPaymentAiTest : FunSpec({
         val gift = driver.putCardInGraveyard(player, "Evershrike's Gift")
         val creature = driver.putCreatureOnBattlefield(player, "Force of Nature")
         repeat(2) { driver.putLandOnBattlefield(player, "Plains") }
-        val abilityId = EvershrikesGift.activatedAbilities.first { it.activateFromZone != null }.id
+        val abilityId = EvershrikesGift.activatedAbilities.first { it.activateFromZone == Zone.GRAVEYARD }.id
         val legal = LegalActionEnumerator.create(driver.cardRegistry).enumerate(driver.state, player)
             .single { (it.action as? ActivateAbility)?.abilityId == abilityId }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/repository/RedisGameRepository.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/repository/RedisGameRepository.kt
@@ -14,8 +14,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
 
 /**
  * Redis-backed implementation of GameRepository.
@@ -63,8 +63,7 @@ class RedisGameRepository(
             redisTemplate.opsForValue().set(
                 gameKey(gameSession.sessionId),
                 json,
-                redisProperties.ttlMinutes,
-                TimeUnit.MINUTES
+                Duration.ofMinutes(redisProperties.ttlMinutes)
             )
             logger.debug("Persisted game session ${gameSession.sessionId} to Redis")
         } catch (e: Exception) {
@@ -124,8 +123,7 @@ class RedisGameRepository(
             redisTemplate.opsForValue().set(
                 lobbyLinkKey(gameSessionId),
                 lobbyId,
-                redisProperties.ttlMinutes,
-                TimeUnit.MINUTES
+                Duration.ofMinutes(redisProperties.ttlMinutes)
             )
         } catch (e: Exception) {
             logger.error("Failed to persist lobby link for game $gameSessionId", e)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/repository/RedisLobbyRepository.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/repository/RedisLobbyRepository.kt
@@ -19,8 +19,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
 
 /**
  * Redis-backed implementation of LobbyRepository.
@@ -70,8 +70,7 @@ class RedisLobbyRepository(
             redisTemplate.opsForValue().set(
                 lobbyKey(lobby.lobbyId),
                 json,
-                redisProperties.ttlMinutes,
-                TimeUnit.MINUTES
+                Duration.ofMinutes(redisProperties.ttlMinutes)
             )
             logger.debug("Persisted lobby ${lobby.lobbyId} to Redis")
         } catch (e: Exception) {
@@ -127,8 +126,7 @@ class RedisLobbyRepository(
             redisTemplate.opsForValue().set(
                 sealedKey(session.sessionId),
                 json,
-                redisProperties.ttlMinutes,
-                TimeUnit.MINUTES
+                Duration.ofMinutes(redisProperties.ttlMinutes)
             )
             logger.debug("Persisted sealed session ${session.sessionId} to Redis")
         } catch (e: Exception) {
@@ -180,8 +178,7 @@ class RedisLobbyRepository(
             redisTemplate.opsForValue().set(
                 tournamentKey(lobbyId),
                 json,
-                redisProperties.ttlMinutes,
-                TimeUnit.MINUTES
+                Duration.ofMinutes(redisProperties.ttlMinutes)
             )
             logger.debug("Persisted tournament for lobby $lobbyId to Redis")
         } catch (e: Exception) {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/UserDtoSerializationTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/UserDtoSerializationTest.kt
@@ -1,12 +1,12 @@
 package com.wingedsheep.gameserver.auth
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.wingedsheep.gameserver.controller.AdminUsersController
 import com.wingedsheep.gameserver.controller.AuthController
 import com.wingedsheep.gameserver.stats.AdminUserStat
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.string.shouldContain
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
+import tools.jackson.databind.ObjectMapper
 import java.util.UUID
 
 /**
@@ -16,10 +16,11 @@ import java.util.UUID
  * `isAdmin()` getter and — left unannotated — emits the key `admin`. The client reads `user.isAdmin`
  * / `u.isAdmin` / `detail.isAdmin` (the Admin button, the players-list badge, the promote toggle), so
  * the dropped `is` prefix made a promoted account look un-promoted everywhere. `@JsonProperty` pins
- * the name. This uses Spring's own mapper builder, so it sees exactly the modules Spring MVC uses.
+ * the name. The mapper is taken straight off Spring MVC's own JSON converter, so the test serializes
+ * a response exactly the way the server does.
  */
 class UserDtoSerializationTest : FunSpec({
-    val mapper: ObjectMapper = Jackson2ObjectMapperBuilder.json().build()
+    val mapper: ObjectMapper = JacksonJsonHttpMessageConverter().mapper
     val id: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
 
     test("AuthController.UserDto serializes the admin flag as isAdmin") {

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -3704,7 +3704,7 @@ internal fun EmitCtx.asEntersBlock(rule: JsonObject, condition: String? = null):
                 val condDsl = singleInterveningIfDsl(cond) ?: run { reasons.add("AsPermanentEnters"); return null }
                 // Rebuild an AsPermanentEnters node carrying the inner replacements, preserving the same
                 // scope permanent (first arg), and render it with the recovered condition.
-                val scopePermanent = rule["args"].asArr?.getOrNull(0) as? JsonElement
+                val scopePermanent = rule["args"].asArr?.getOrNull(0)
                     ?: run { reasons.add("AsPermanentEnters"); return null }
                 val synthetic = buildJsonObject {
                     put("_Rule", JsonPrimitive("AsPermanentEnters"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/DamageDrawLifeHandlers.kt
@@ -116,8 +116,8 @@ internal val damageDrawLifeHandlers: Map<String, ActionHandler> = actionHandlers
         // Effects.DamageCantBePreventedThisTurn() (Impractical Joke). Any other game effect or a non-turn
         // expiration has no calibrated facade, so decline -> SCAFFOLD rather than emit a wrong effect.
         val arr = node["args"].asArr ?: return@on null
-        val expiration = arr.firstOrNull { it is JsonObject && (it as JsonObject).containsKey("_Expiration") } as? JsonObject
-        val gameEffect = arr.firstOrNull { it is JsonObject && (it as JsonObject).containsKey("_GameEffect") } as? JsonObject
+        val expiration = arr.firstOrNull { it is JsonObject && it.containsKey("_Expiration") } as? JsonObject
+        val gameEffect = arr.firstOrNull { it is JsonObject && it.containsKey("_GameEffect") } as? JsonObject
         if (expiration?.strField("_Expiration") != "UntilEndOfTurn") return@on null
         if (gameEffect?.strField("_GameEffect") != "DamageCantBePrevented") return@on null
         call("Effects.DamageCantBePreventedThisTurn")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -872,7 +872,7 @@ class TurnManager(
             )
         }
         if (cleanupResult.error != null) {
-            return ExecutionResult.error(cleanupResult.newState, cleanupResult.error!!)
+            return ExecutionResult.error(cleanupResult.newState, cleanupResult.error)
         }
         newState = cleanupResult.newState
         events.addAll(cleanupResult.events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
@@ -467,7 +467,7 @@ class DeathAndLeaveTriggerDetector(
         if (event.fromZone != Zone.BATTLEFIELD || event.toZone != Zone.GRAVEYARD) return
         if (event.lastKnown?.wasToken == true) return
         if (event.lastKnown?.typeLine?.isCreature != true) return
-        if (Keyword.ENDURING.name !in (event.lastKnown?.keywords ?: emptySet())) return
+        if (Keyword.ENDURING.name !in event.lastKnown.keywords) return
 
         val info = resolveDyingEntity(state, event) ?: return
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -3295,7 +3295,7 @@ class TriggerDetector(
             existingCard != null ->
                 existingCard.copy(typeLine = lastKnownTypeLine ?: existingCard.typeLine)
             lastKnownTypeLine != null -> CardComponent(
-                cardDefinitionId = event.lastKnown?.cardDefinitionId ?: event.entityName,
+                cardDefinitionId = event.lastKnown.cardDefinitionId ?: event.entityName,
                 name = event.entityName,
                 manaCost = ManaCost.ZERO,
                 typeLine = lastKnownTypeLine

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -972,7 +972,7 @@ class TriggerMatcher(
             // that was a Food artifact only because of Ygra's continuous effect). The base
             // cardComponent.typeLine in the new zone has only the printed types.
             val typeLine = if (event.fromZone == Zone.BATTLEFIELD && event.lastKnown?.typeLine != null) {
-                event.lastKnown?.typeLine
+                event.lastKnown.typeLine
             } else {
                 cardComponent?.typeLine ?: event.lastKnown?.typeLine
             }
@@ -1033,7 +1033,7 @@ class TriggerMatcher(
                         // have its keywords (e.g., Jackdaw Savior: "whenever a creature you control
                         // with flying dies").
                         if (event.fromZone == Zone.BATTLEFIELD && event.lastKnown?.keywords?.isNotEmpty() == true) {
-                            predicate.keyword.name in (event.lastKnown?.keywords ?: emptySet())
+                            predicate.keyword.name in event.lastKnown.keywords
                         } else {
                             projected.hasKeyword(event.entityId, predicate.keyword)
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -1111,7 +1111,7 @@ class TriggerProcessor(
             val soleLegal = legalTargetsMap[0].orEmpty()
             val isPlayerTarget = soleReq is com.wingedsheep.sdk.scripting.targets.TargetPlayer ||
                 soleReq is com.wingedsheep.sdk.scripting.targets.TargetOpponent
-            if (isPlayerTarget && soleLegal.size == 1 && soleReq!!.count == 1) {
+            if (isPlayerTarget && soleLegal.size == 1 && soleReq.count == 1) {
                 targetsAccum = targetsAccum + listOf(listOf(createChosenTarget(state, soleLegal.first())))
                 ordinal++
                 continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -368,12 +368,12 @@ object DamageUtils {
                 // source's controller, so "whenever you put counters" triggers see them as yours.
                 events.add(CountersAddedEvent(targetId, CounterType.MINUS_ONE_MINUS_ONE.name, effectiveAmount,
                     newState.getEntity(targetId)?.get<CardComponent>()?.name ?: "Creature",
-                    placedBy = sourceId?.let { newState.projectedState.getController(it) }))
+                    placedBy = newState.projectedState.getController(sourceId)))
                 // Wither only changes the FORM of the damage (CR 702.80a); the creature was still
                 // dealt damage by this source, so a deathtouch source still marks it for
                 // destruction as an SBA (CR 702.2b / 704.5h) even though nothing is marked as
                 // normal damage. Record the deathtouch flag without marking damage.
-                if (sourceId != null && projected.hasKeyword(sourceId, Keyword.DEATHTOUCH)) {
+                if (projected.hasKeyword(sourceId, Keyword.DEATHTOUCH)) {
                     newState = newState.updateEntity(targetId) { container ->
                         val existing = container.get<DamageComponent>()
                         container.with(DamageComponent(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ReplacementEffectUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ReplacementEffectUtils.kt
@@ -82,7 +82,6 @@ object ReplacementEffectUtils {
                 val placedByYouOnly = when (effect) {
                     is ModifyCounterPlacement -> effect.placedByYou
                     is DoubleCounterPlacement -> effect.placedByYou
-                    else -> false
                 }
                 if (placedByYouOnly && placerId != sourceControllerId) continue
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TurnFaceUpExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TurnFaceUpExecutor.kt
@@ -67,7 +67,7 @@ class TurnFaceUpExecutor(
                         revealingPlayerId = controllerId,
                         cardIds = listOf(targetId),
                         cardNames = listOf(cardName),
-                        imageUris = listOf(cardComponent?.imageUri),
+                        imageUris = listOf(cardComponent.imageUri),
                         source = "Turned face up (stays face down — not a creature card)"
                     )
                 )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/StormCopyEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/StormCopyEffectExecutor.kt
@@ -373,7 +373,7 @@ class StormCopyEffectExecutor(
                     )
                 }
                 if (hasRiders) {
-                    updated = updated.with(tokenRiders!!)
+                    updated = updated.with(tokenRiders)
                 }
                 updated
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
@@ -284,7 +284,7 @@ class MoveToZoneEffectExecutor(
             com.wingedsheep.engine.handlers.effects.FaceDownTurnUp.dataFor(
                 cardRegistry.getCard(cardComponent.cardDefinitionId),
                 cardComponent.cardDefinitionId,
-                faceDownMode!!
+                faceDownMode
             )
         } else null
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -446,7 +446,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.costUtils.findWaterbendPermanents(state, playerId)
             } else emptyList()
             if (mandatoryWaterbend) {
-                effectiveCost = effectiveCost + if (spellWaterbend!!.isX) {
+                effectiveCost = effectiveCost + if (spellWaterbend.isX) {
                     ManaCost.parse("{X}")
                 } else {
                     ManaCost.parse("{${spellWaterbend.amount}}")
@@ -502,7 +502,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, payableCost, spellContext = spellContext, precomputedSources = cachedSources) ||
                     context.costUtils.canAffordWithWaterbend(
                         state, playerId, payableCost,
-                        waterbendPermanents.take(spellWaterbend!!.amount),
+                        waterbendPermanents.take(spellWaterbend.amount),
                         precomputedSources = cachedSources, spellContext = spellContext
                     )
             } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -643,7 +643,7 @@ internal class AttackPhaseManager(
         if (state.projectedState.mustAttack(attackerId)) return true
         return state.grantedStaticAbilities.any {
             it.entityId == attackerId && it.ability is MustAttack &&
-                (it.ability as MustAttack).filter.scope is Scope.Self
+                it.ability.filter.scope is Scope.Self
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -486,7 +486,7 @@ class CostPaymentService(private val services: EngineServices) {
             // auto-tap path (ActivateAbilityHandler.autoTapForManaCost).
             for (source in solution.sources) {
                 if (source.bonusManaPerTap > 0 && source.bonusManaColor != null) {
-                    combined = combined.add(source.bonusManaColor!!, source.bonusManaPerTap)
+                    combined = combined.add(source.bonusManaColor, source.bonusManaPerTap)
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -295,9 +295,6 @@ internal class EffectApplicator(
                     values.keywords.clear()
                     values.lostAllAbilities = true
                 }
-                is Modification.SetName -> {
-                    values.name = mod.name
-                }
                 is Modification.NoOp -> {
                     // No-op: effect doesn't modify projected state
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -1417,7 +1417,7 @@ class ManaSolver(
                 // (never happens for the two real cards, but keep it sound) the extra colored
                 // leaf still needs `producesColors` non-empty so its color is spendable.
                 if (extraBonusColor != null && combinedColors.isEmpty()) {
-                    combinedColors.add(extraBonusColor!!)
+                    combinedColors.add(extraBonusColor)
                     extraBonusColor = null
                     extraBonusAmount = maxOf(0, extraBonusAmount - 1)
                 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/TapAtomTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/core/TapAtomTest.kt
@@ -38,7 +38,7 @@ class TapAtomTest : ScenarioTestBase() {
 
             newState.getEntity(wurm)?.has<TappedComponent>() shouldBe true
             event.shouldBeInstanceOf<TappedEvent>()
-            event!!.entityId shouldBe wurm
+            event.entityId shouldBe wurm
         }
 
         test("tap() attributes the tap to the permanent's controller by default") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CruelWitnessScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CruelWitnessScenarioTest.kt
@@ -39,7 +39,7 @@ class CruelWitnessScenarioTest : ScenarioTestBase() {
                 withClue("casting a noncreature spell triggers a surveil 1 look at the top card") {
                     val decision = game.getPendingDecision()
                     decision.shouldBeInstanceOf<SelectCardsDecision>()
-                    (decision as SelectCardsDecision).options.size shouldBe 1
+                    decision.options.size shouldBe 1
                 }
                 game.skipSelection() // keep the card out of the graveyard...
                 // ...which leaves it to be put back on top; the surveil pipeline's "put the rest on

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeckListClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeckListClientViewTest.kt
@@ -226,7 +226,7 @@ class DeckListClientViewTest : ScenarioTestBase() {
             )
             val delta = StateDiffCalculator.computeDelta(before, transformer.transform(drawn, p1))
             delta.deck.shouldNotBeNull()
-            delta.deck!!.single().remaining shouldBe 1
+            delta.deck.single().remaining shouldBe 1
         }
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmergeKeywordTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmergeKeywordTest.kt
@@ -168,7 +168,7 @@ class EmergeKeywordTest : FunSpec({
 
         val emerge = actions.firstOrNull { la ->
             (la.action as? CastSpell)?.cardId == gryff &&
-                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+                la.action.alternativeCostType == AlternativeCostType.EMERGE
         }
         emerge shouldNotBe null
         emerge!!.actionType shouldBe "CastWithAlternativeCost"
@@ -190,7 +190,7 @@ class EmergeKeywordTest : FunSpec({
         val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
         val emerge = actions.first { la ->
             (la.action as? CastSpell)?.cardId == gryff &&
-                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+                la.action.alternativeCostType == AlternativeCostType.EMERGE
         }
 
         val costs = emerge.additionalCostInfo!!.costAfterSacrifice
@@ -221,7 +221,7 @@ class EmergeKeywordTest : FunSpec({
 
         actions.none { la ->
             (la.action as? CastSpell)?.cardId == gryff &&
-                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+                la.action.alternativeCostType == AlternativeCostType.EMERGE
         } shouldBe true
     }
 
@@ -237,7 +237,7 @@ class EmergeKeywordTest : FunSpec({
 
         actions.none { la ->
             (la.action as? CastSpell)?.cardId == gryff &&
-                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+                la.action.alternativeCostType == AlternativeCostType.EMERGE
         } shouldBe true
     }
 
@@ -255,7 +255,7 @@ class EmergeKeywordTest : FunSpec({
         val actions = enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
         fun emergeFor(cardId: com.wingedsheep.sdk.model.EntityId) = actions.any { la ->
             (la.action as? CastSpell)?.cardId == cardId &&
-                (la.action as? CastSpell)?.alternativeCostType == AlternativeCostType.EMERGE
+                la.action.alternativeCostType == AlternativeCostType.EMERGE
         }
 
         emergeFor(gryff) shouldBe false

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmeritusCycleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmeritusCycleScenarioTest.kt
@@ -89,7 +89,6 @@ class EmeritusCycleScenarioTest : ScenarioTestBase() {
                     cast shouldNotBe null
                     (cast!!.action as CastSpell).faceIndex shouldBe 0
                     cast.manaCostString shouldBe "{R}"
-                    Unit
                 }
             }
         }
@@ -331,7 +330,6 @@ class EmeritusCycleScenarioTest : ScenarioTestBase() {
                 withClue("Demonic Tutor copy is offered from exile for {1}{B}") {
                     cast shouldNotBe null
                     cast!!.manaCostString shouldBe "{1}{B}"
-                    Unit
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GutlessPlundererScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GutlessPlundererScenarioTest.kt
@@ -64,7 +64,7 @@ class GutlessPlundererScenarioTest : FunSpec({
             when {
                 pending is SelectCardsDecision -> {
                     kept = pending.options.first()
-                    driver.submitCardSelection(pending.playerId, listOf(kept!!))
+                    driver.submitCardSelection(pending.playerId, listOf(kept))
                 }
                 driver.stackSize > 0 -> driver.bothPass()
                 else -> break

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JenniferWaltersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JenniferWaltersScenarioTest.kt
@@ -187,7 +187,7 @@ class JenniferWaltersScenarioTest : ScenarioTestBase() {
                         is ChooseTargetsDecision -> game.selectTargets(listOf(game.player2Id))
                         is YesNoDecision -> {
                             decision.hint.shouldNotBeNull()
-                            hints += decision.hint!!
+                            hints += decision.hint
                             game.answerYesNo(false)
                         }
                         null -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfTransformationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfTransformationScenarioTest.kt
@@ -367,7 +367,7 @@ class LeylineOfTransformationScenarioTest : FunSpec({
         var sawCreatureTypeChoice = false
         var steps = 0
         while (state.pendingDecision != null && steps++ < 10) {
-            val decision = state.pendingDecision!!
+            val decision = state.pendingDecision
             val response = when (decision) {
                 is YesNoDecision -> YesNoResponse(decision.id, true)
                 is ChooseOptionDecision -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaralenFaeAscendantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MaralenFaeAscendantScenarioTest.kt
@@ -410,13 +410,6 @@ class MaralenFaeAscendantScenarioTest : ScenarioTestBase() {
         }
     }
 
-    private fun TestGame.isInExile(playerNumber: Int, cardName: String): Boolean {
-        val playerId = if (playerNumber == 1) player1Id else player2Id
-        return state.getExile(playerId).any { entityId ->
-            state.getEntity(entityId)?.get<CardComponent>()?.name == cardName
-        }
-    }
-
     private fun findCardInExile(game: TestGame, playerNumber: Int, cardName: String): EntityId? {
         val playerId = if (playerNumber == 1) game.player1Id else game.player2Id
         return game.state.getExile(playerId).find { entityId ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalDfcPermanentBackTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalDfcPermanentBackTest.kt
@@ -167,7 +167,7 @@ class ModalDfcPermanentBackTest : ScenarioTestBase() {
 
             val castEvent = result.events.filterIsInstance<SpellCastEvent>().firstOrNull()
             castEvent.shouldNotBeNull()
-            castEvent!!.manaValue shouldBe 2
+            castEvent.manaValue shouldBe 2
             game.state.spellsCastThisTurnByPlayer[game.player1Id]!!.last().manaValue shouldBe 2
         }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PeerPastTheVeilScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PeerPastTheVeilScenarioTest.kt
@@ -32,7 +32,7 @@ class PeerPastTheVeilScenarioTest : ScenarioTestBase() {
                     .build()
 
                 withClue("Graveyard starts with 3 cards (creature, instant, land)") {
-                    game.state.getGraveyard(game.player1Id!!).size shouldBe 3
+                    game.state.getGraveyard(game.player1Id).size shouldBe 3
                 }
 
                 game.castSpell(1, "Peer Past the Veil").error shouldBe null
@@ -42,7 +42,7 @@ class PeerPastTheVeilScenarioTest : ScenarioTestBase() {
                 // Peer Past the Veil itself reaches the graveyard as an instant (already present). So the
                 // card types among graveyard cards = {creature, instant, land} = 3, and 3 cards are drawn.
                 withClue("Hand was discarded then refilled with 3 drawn cards (X = 3 card types)") {
-                    game.state.getHand(game.player1Id!!).size shouldBe 3
+                    game.state.getHand(game.player1Id).size shouldBe 3
                 }
                 withClue("Discarded Grizzly Bears are now in the graveyard") {
                     game.isInGraveyard(1, "Grizzly Bears") shouldBe true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QueensBayPaladinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QueensBayPaladinScenarioTest.kt
@@ -96,7 +96,7 @@ class QueensBayPaladinScenarioTest : ScenarioTestBase() {
             val returned = game.findPermanent("Highborn Vampire")
             withClue("Highborn Vampire returned with a finality counter") {
                 returned.shouldNotBeNull()
-                game.state.getEntity(returned!!)?.get<CountersComponent>()
+                game.state.getEntity(returned)?.get<CountersComponent>()
                     ?.getCount(CounterType.FINALITY) shouldBe 1
             }
             withClue("controller lost 4 life (Highborn Vampire's mana value)") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SayItsNameScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SayItsNameScenarioTest.kt
@@ -71,7 +71,7 @@ class SayItsNameScenarioTest : ScenarioTestBase() {
 
                 val result = game.execute(
                     ActivateAbility(
-                        playerId = game.player1Id!!,
+                        playerId = game.player1Id,
                         sourceId = sourceId,
                         abilityId = abilityId,
                         costPayment = AdditionalCostPayment(exiledCards = copies)
@@ -91,7 +91,7 @@ class SayItsNameScenarioTest : ScenarioTestBase() {
                 // cost is still paid: all three Say Its Name copies are exiled from the graveyard.
                 withClue("All three Say Its Name copies were exiled to pay the cost") {
                     game.findCardsInGraveyard(1, "Say Its Name").size shouldBe 0
-                    game.state.getExile(game.player1Id!!).size shouldBeGreaterThanOrEqual 3
+                    game.state.getExile(game.player1Id).size shouldBeGreaterThanOrEqual 3
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLegendOfYangchenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLegendOfYangchenScenarioTest.kt
@@ -141,11 +141,11 @@ class TheLegendOfYangchenScenarioTest : FunSpec({
         // Accrue lore to 2 → chapter II. Stop on the may (yes/no) decision.
         val may = driver.advanceUntilYesNo()
         may.shouldNotBeNull()
-        withClue("the caster makes the 'you may' decision") { may!!.playerId shouldBe me }
+        withClue("the caster makes the 'you may' decision") { may.playerId shouldBe me }
 
         val myHandBefore = driver.getHandSize(me)
         val oppHandBefore = driver.getHandSize(opp)
-        driver.submitYesNo(may!!.playerId, true)
+        driver.submitYesNo(may.playerId, true)
         driver.drainYangchen()
 
         withClue("target opponent drew three") { driver.getHandSize(opp) shouldBe oppHandBefore + 3 }
@@ -165,7 +165,7 @@ class TheLegendOfYangchenScenarioTest : FunSpec({
         may.shouldNotBeNull()
         val myHandBefore = driver.getHandSize(me)
         val oppHandBefore = driver.getHandSize(opp)
-        driver.submitYesNo(may!!.playerId, false)
+        driver.submitYesNo(may.playerId, false)
         driver.drainYangchen()
 
         withClue("declining draws nothing for either player") {
@@ -227,7 +227,7 @@ class TheLegendOfYangchenScenarioTest : FunSpec({
         withClue("its owner may recast it from exile for a fixed {2}") {
             val grant = driver.state.getEntity(victim)?.get<PlayWithFixedAlternativeManaCostComponent>()
             grant.shouldNotBeNull()
-            grant!!.controllerId shouldBe opp
+            grant.controllerId shouldBe opp
             grant.fixedCost shouldBe ManaCost.parse("{2}")
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WaltzOfRageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WaltzOfRageScenarioTest.kt
@@ -39,7 +39,7 @@ class WaltzOfRageScenarioTest : ScenarioTestBase() {
                     game.findAllPermanents("Grizzly Bears").size shouldBe 0
                 }
                 withClue("Player 1's creature death triggered the delayed impulse-draw to exile") {
-                    game.state.getExile(game.player1Id!!).size shouldBeGreaterThanOrEqual 1
+                    game.state.getExile(game.player1Id).size shouldBeGreaterThanOrEqual 1
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WebSlingingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WebSlingingTest.kt
@@ -415,7 +415,7 @@ class WebSlingingTest : FunSpec({
         driver.bothPass()
         val trig = driver.getTopOfStack()
         trig.shouldNotBeNull()
-        driver.state.getEntity(trig!!)?.get<TriggeredAbilityOnStackComponent>().shouldNotBeNull()
+        driver.state.getEntity(trig)?.get<TriggeredAbilityOnStackComponent>().shouldNotBeNull()
 
         // Counter the triggered ability with the Spider-Sense-style spell.
         driver.giveMana(player, Color.BLUE, 1)
@@ -447,7 +447,7 @@ class WebSlingingTest : FunSpec({
             .isSuccess shouldBe true
         val abilityOnStack = driver.getTopOfStack()
         abilityOnStack.shouldNotBeNull()
-        driver.state.getEntity(abilityOnStack!!)?.get<ActivatedAbilityOnStackComponent>().shouldNotBeNull()
+        driver.state.getEntity(abilityOnStack)?.get<ActivatedAbilityOnStackComponent>().shouldNotBeNull()
 
         // The narrow filter admits triggered abilities but not activated ones, so this target is illegal.
         val counter = driver.putCardInHand(player, "Sense Mirror")

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
@@ -1097,7 +1097,7 @@ abstract class ScenarioTestBase : FunSpec() {
          * Check if a card with the given name is in a player's sideboard ("outside the game").
          */
         fun isInSideboard(playerNumber: Int, cardName: String): Boolean {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = if (playerNumber == 1) player1Id else player2Id
             return state.getZone(playerId, Zone.SIDEBOARD).any { entityId ->
                 state.getEntity(entityId)?.get<CardComponent>()?.name == cardName
             }
@@ -1105,7 +1105,7 @@ abstract class ScenarioTestBase : FunSpec() {
 
         /** Number of cards in a player's sideboard. */
         fun sideboardSize(playerNumber: Int): Int {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = if (playerNumber == 1) player1Id else player2Id
             return state.getZone(playerId, Zone.SIDEBOARD).size
         }
 
@@ -1113,7 +1113,7 @@ abstract class ScenarioTestBase : FunSpec() {
          * Check if a card with the given name is in a player's exile zone.
          */
         fun isInExile(playerNumber: Int, cardName: String): Boolean {
-            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val playerId = if (playerNumber == 1) player1Id else player2Id
             return state.getExile(playerId).any { entityId ->
                 state.getEntity(entityId)?.get<CardComponent>()?.name == cardName
             }


### PR DESCRIPTION
Clears every Kotlin compiler warning in the repo. Two commits: the first covers `rules-engine` and `ai` main sources, the second the remaining 43 across all ten modules and all three source sets.

**No behavior change is intended anywhere**, and for most of the diff that is guaranteed by construction: each removed `!!`, `?.`, and `?:` fallback sits behind a smart cast the compiler now proves, so if it compiles the semantics are identical. The handful of hunks that are *not* mechanical are called out below.

## Warnings cleared

| Module / source set | Count |
|---|---|
| `rules-engine` main | 15 |
| `rules-engine` test | 27 |
| `rules-engine` testFixtures | 6 |
| `ai` main | 1 |
| `ai` test | 1 |
| `game-server` main | 5 |
| `game-server` test | 1 |
| `mtgish-tooling` main | 3 |

## The hunks that aren't mechanical

**`EffectApplicator.kt` — deleted a duplicate `Modification.SetName` branch.** `git log -L` shows the branch was added at line 99 by 648e0d9c (Witness Protection) and then *independently re-added verbatim* at line 294 by 6bad4cb2 (Honest Work), which didn't notice the existing one. Both live in the same `when` opened at line 54, so the second was unreachable and Kotlin flagged it. The bodies are byte-identical, so removing it is behavior-preserving — and it closes a trap where a future edit to one copy would silently do nothing.

**`MaralenFaeAscendantScenarioTest.kt` — deleted a shadowed extension.** The file declared a private `TestGame.isInExile` shadowed by the identical `ScenarioTestBase` member, so both call sites (`:130`, `:222`) already resolved to the member. Dead code.

**`BlightPaymentAiTest.kt` — fixed a vacuous filter.** It selected Evershrike's Gift's ability with `first { it.activateFromZone != null }`, always true: `ActivatedAbility.activateFromZone` is `Zone`, not `Zone?`, defaulting to `BATTLEFIELD`. Now `== Zone.GRAVEYARD`, which is what the test meant and what the card declares.

**`UserDtoSerializationTest.kt` — the test was pinning the wrong mapper.** It built its `ObjectMapper` from the deprecated `Jackson2ObjectMapperBuilder`, and its own comment claimed that meant it saw "exactly the modules Spring MVC uses". Under Spring Boot 4.1 / Framework 7 that is no longer true — Jackson 2 (`com.fasterxml`, 2.21.4) and Jackson 3 (`tools.jackson`, 3.1.4) are both on the classpath, and MVC serializes through `JacksonJsonHttpMessageConverter`, which is Jackson 3. So the test guarding the `isAdmin` wire shape was validating a mapper the server does not use. It now takes the mapper straight off that converter. All three assertions still pass, so the `isAdmin` shape does hold in production.

**Redis TTL — deprecated overload.** Spring Data Redis deprecates `set(key, value, Long, TimeUnit)`; the five call sites move to the equivalent `Duration` overload.

## Verification

- **Compile:** `compileKotlin compileTestKotlin compileTestFixturesKotlin --rerun-tasks` across all ten modules — 21 compile tasks, BUILD SUCCESSFUL, **0 warnings, 0 errors**. `--rerun-tasks` mattered: a plain `just test-rules` came back all-`UP-TO-DATE` in 8s, which is exactly the false-green this repo is prone to.
- **Tests:** every module's suite ran green.

| Module | Tests | Failures | Errors |
|---|---|---|---|
| `rules-engine` | 10,527 | 0 | 0 |
| `game-server` | 483 | 0 | 0 |
| `ai` | 448 | 0 | 0 |
| `mtg-sdk` | 427 | 0 | 0 |
| `mtg-sets` | 342 | 0 | 0 |
| `mtg-search` | 163 | 0 | 0 |
| `mtgish-tooling` | 142 | 0 | 0 |
| `gym` / `gym-server` / `gym-trainer` | 57 | 0 | 0 |
| **Total** | **12,589** | **0** | **0** |

One caveat worth stating rather than burying: the first full `just test` run reported `ConniveTargetingTest > nonland discard` FAILED with a `TimeoutCancellationException` — a coroutine timeout, not an assertion, in a file this PR does not touch. It passes on its own and on a full `rules-engine` re-run (10,527 tests, 0 failures). That is the load-related flake this box is known for, not a regression.

## Notes for the reviewer

- No new SDK types (`Effect` / `Modification` / `Trigger` / `Condition`), so the SDK-elegance bar doesn't bind here.
- No card definitions or `Printing(...)` rows moved, so no `check-card-printing` run applies.
- No CR rule numbers added or changed. The `702.80a` / `702.2b` / `704.5h` / `122.6a` citations visible in the `DamageUtils` hunk are untouched context.
- No `@Suppress` anywhere — warnings are fixed, not silenced.
- No new tests: behavior is provably unchanged by the compiler, so the existing suites passing on a forced rerun is the appropriate evidence.
- The first commit's subject says "in rules-engine and ai", which was accurate for its own scope (main sources only); the second commit completes the claim across the repo.
