### PR TITLE
Add five Mirrodin cards: Granite Shard, Skeleton Shard, Inertia Bubble, Groffskithur, Stalking Stones

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GraniteShard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/GraniteShard.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Granite Shard — Mirrodin #182 (canonical printing, only printing)
+ * {3} · Artifact
+ *
+ * {3}, {T} or {R}, {T}: This artifact deals 1 damage to any target.
+ *
+ * The "{3}, {T} or {R}, {T}" template is one printed ability with two alternative cost sets, and the
+ * 2004-10-04 ruling is explicit that you pay one or the other, never both. Two `activatedAbility`
+ * blocks with identical effects model exactly that: each offers its own cost, and because both
+ * include the shard's own `{T}` they compete for the same tap, so only one can be activated per
+ * untap — the same play pattern as the single printed ability. (There is no "either cost" cost atom
+ * in the SDK, and adding one would only re-derive this.)
+ *
+ * `colorIdentity = "R"` because the {R} alternative puts red in the card's identity even though the
+ * card itself is colorless (CR 903.4).
+ */
+val GraniteShard = card("Granite Shard") {
+    manaCost = "{3}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "{3}, {T} or {R}, {T}: This artifact deals 1 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val victim = target("any target", AnyTarget())
+        effect = Effects.DealDamage(1, victim)
+        description = "{3}, {T}: This artifact deals 1 damage to any target."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{R}"), Costs.Tap)
+        val victim = target("any target", AnyTarget())
+        effect = Effects.DealDamage(1, victim)
+        description = "{R}, {T}: This artifact deals 1 damage to any target."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "182"
+        artist = "Doug Chaffee"
+        flavorText = "It's a piece of a world the goblins have never seen but would dearly like to blow up."
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e197af6a-24ac-4f3b-ab3c-736f4057748b.jpg?1783944519"
+        ruling("2004-10-04", "You can pay either of the two costs (but not both at the same time) to activate the ability.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Groffskithur.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Groffskithur.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Groffskithur — Mirrodin #121 (canonical printing; the Salvat 2005 boxes are later reprints)
+ * {5}{G} · Creature — Beast · 3/3
+ *
+ * Whenever this creature becomes blocked, you may return target card named Groffskithur from your
+ * graveyard to your hand.
+ *
+ * `Triggers.BecomesBlocked` fires once per combat no matter how many creatures block, which is the
+ * printed behaviour — the ability isn't the "becomes blocked by a creature" per-blocker variant.
+ *
+ * The target is a *card named Groffskithur* in your graveyard, not "another Groffskithur creature
+ * card": the filter is `GameObjectFilter.Any.named(...)`, so it would also find a copy that had been
+ * turned into a noncreature card. `optional = true` is the "you may" — for a targeted trigger it
+ * lets the controller decline by choosing no targets, and the trigger simply does nothing when no
+ * legal target exists (the usual case, since a second Groffskithur in the yard is uncommon).
+ */
+val Groffskithur = card("Groffskithur") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever this creature becomes blocked, you may return target card named " +
+        "Groffskithur from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.BecomesBlocked
+        optional = true
+        val card = target(
+            "target card named Groffskithur from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Any.named("Groffskithur").ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.ReturnToHand(card)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "John Matson"
+        flavorText = "It growls not to threaten, but to summon."
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75e84098-c15c-40f4-9d8a-3fa5da26a268.jpg?1783944533"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/InertiaBubble.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/InertiaBubble.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Inertia Bubble — Mirrodin #37 (canonical printing, only printing)
+ * {1}{U} · Enchantment — Aura
+ *
+ * Enchant artifact
+ * Enchanted artifact doesn't untap during its controller's untap step.
+ *
+ * The Charmed Sleep shape pointed at an artifact instead of a creature: the bare
+ * [GrantKeyword] static with no filter scopes to the attached permanent. Note the Aura only stops
+ * the untap step — it doesn't tap the artifact on entry, so against an untapped artifact it does
+ * nothing until that artifact taps itself.
+ */
+val InertiaBubble = card("Inertia Bubble") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant artifact\nEnchanted artifact doesn't untap during its controller's untap step."
+
+    auraTarget = Targets.Artifact
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Hugh Jamieson"
+        flavorText = "\"I wouldn't want you to hurt yourself.\"\n—Bruenna, Neurok leader"
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72b2d227-68b3-40e8-bef7-45ea43e17318.jpg?1783944554"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SkeletonShard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SkeletonShard.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Skeleton Shard — Mirrodin #242 (canonical printing; Planechase 2009 is a later reprint)
+ * {3} · Artifact
+ *
+ * {3}, {T} or {B}, {T}: Return target artifact creature card from your graveyard to your hand.
+ *
+ * Same "pay one cost or the other" template as its cycle-mate Granite Shard — see that card's KDoc
+ * for why two `activatedAbility` blocks are the faithful model rather than one ability with a
+ * synthetic either-cost atom. Both alternatives include the shard's own {T}, so they compete for the
+ * same tap.
+ *
+ * The target is a card in *your* graveyard (`ownedByYou()` — a graveyard card's owner is its
+ * graveyard's player, CR 108.3) that is both an artifact and a creature card.
+ */
+private val ArtifactCreatureInYourGraveyard = TargetFilter(
+    baseFilter = GameObjectFilter.ArtifactCreature.ownedByYou(),
+    zone = Zone.GRAVEYARD,
+)
+
+val SkeletonShard = card("Skeleton Shard") {
+    manaCost = "{3}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "{3}, {T} or {B}, {T}: Return target artifact creature card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val card = target(
+            "target artifact creature card from your graveyard",
+            TargetObject(filter = ArtifactCreatureInYourGraveyard),
+        )
+        effect = Effects.ReturnToHand(card)
+        description = "{3}, {T}: Return target artifact creature card from your graveyard to your hand."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}"), Costs.Tap)
+        val card = target(
+            "target artifact creature card from your graveyard",
+            TargetObject(filter = ArtifactCreatureInYourGraveyard),
+        )
+        effect = Effects.ReturnToHand(card)
+        description = "{B}, {T}: Return target artifact creature card from your graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "242"
+        artist = "Doug Chaffee"
+        flavorText = "Metal permeates the marrow of every bone in Mephidross—except one."
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eeffcd61-ea1f-4ccd-b3d3-79efa9d4a0cf.jpg?1783944504"
+        ruling("2004-10-04", "You can pay either of the two costs (but not both at the same time) to activate the ability.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/StalkingStonesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/StalkingStonesReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stalking Stones reprint in MRD. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Tempest, the card's earliest printing;
+ * this file contributes only presentation data.
+ */
+val StalkingStonesReprint = Printing(
+    oracleId = "f3658894-3d3d-4cd4-b0ac-c53e1d08747c",
+    name = "Stalking Stones",
+    setCode = "MRD",
+    collectorNumber = "284",
+    scryfallId = "c96d7230-c7ca-4613-ae7e-88a0e6270b98",
+    artist = "David Day",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c96d7230-c7ca-4613-ae7e-88a0e6270b98.jpg?1783944493",
+    releaseDate = "2003-10-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/StalkingStones.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/StalkingStones.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stalking Stones — Tempest #327 (canonical printing; Mirrodin, Duel Decks, Tempest Remastered and
+ * The List are later reprints)
+ * Land
+ *
+ * {T}: Add {C}.
+ * {6}: This land becomes a 3/3 Elemental artifact creature that's still a land.
+ * (This effect lasts indefinitely.)
+ *
+ * The Mishra's Factory animate shape with two differences that matter: [Duration.Permanent] rather
+ * than end-of-turn — "indefinitely" means the effect never wears off, only ends if the permanent
+ * leaves — and `addTypes = ARTIFACT` so it becomes an *artifact* creature while keeping its printed
+ * Land type ("that's still a land"; Layer 4 type-adding is additive).
+ *
+ * The animate ability costs mana only, with no {T} in it, so it can be activated the turn the land
+ * enters — but the resulting creature still has summoning sickness unless its controller has
+ * controlled the land since their most recent turn began (the 2008-08-01 ruling), which is what
+ * stops it attacking immediately.
+ */
+val StalkingStones = card("Stalking Stones") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{6}: This land becomes a 3/3 Elemental artifact creature that's still a land. " +
+        "(This effect lasts indefinitely.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{6}")
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = 3,
+            toughness = 3,
+            creatureTypes = setOf(Subtype.ELEMENTAL.value),
+            addTypes = setOf(CardType.ARTIFACT.name),
+            duration = Duration.Permanent,
+        )
+        description = "{6}: This land becomes a 3/3 Elemental artifact creature that's still a land."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "327"
+        artist = "Stephen Daniele"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4d3d349-5c23-43a9-b25e-0e1a35b84673.jpg?1783946596"
+        ruling(
+            "2009-10-01",
+            "Activating the ability that turns it into a creature while it's already a creature will " +
+                "override any effects that set its power and/or toughness to a specific number. However, " +
+                "any effect that raises or lowers power and/or toughness (such as the effect created by " +
+                "Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+        )
+        ruling(
+            "2008-08-01",
+            "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be " +
+                "activated, only if its controller has continuously controlled that permanent since the " +
+                "beginning of their most recent turn. It doesn't matter how long the permanent has been a " +
+                "creature."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -2161,6 +2161,102 @@
     "colorIdentityOverride": []
 }
 
+// Granite Shard
+{
+    "name": "Granite Shard",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T} or {R}, {T}: This artifact deals 1 damage to any target.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{3}, {T}: This artifact deals 1 damage to any target."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{R}, {T}: This artifact deals 1 damage to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "rarity": "UNCOMMON",
+        "artist": "Doug Chaffee",
+        "flavorText": "It's a piece of a world the goblins have never seen but would dearly like to blow up.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e197af6a-24ac-4f3b-ab3c-736f4057748b.jpg?1783944519",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "You can pay either of the two costs (but not both at the same time) to activate the ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Great Furnace
 {
     "name": "Great Furnace",
@@ -2223,6 +2319,52 @@
         "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4ab6c59-cd0f-4c29-8e26-6882dca61fb7.jpg?1783944518"
     },
     "colorIdentityOverride": []
+}
+
+// Groffskithur
+{
+    "name": "Groffskithur",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Whenever this creature becomes blocked, you may return target card named Groffskithur from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "BecomesBlockedEvent",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card named Groffskithur from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "optional": true,
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "name:Groffskithur own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target card named Groffskithur from your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "John Matson",
+        "flavorText": "It growls not to threaten, but to summon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75e84098-c15c-40f4-9d8a-3fa5da26a268.jpg?1783944533"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Heartwood Shard
@@ -2363,6 +2505,37 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Inertia Bubble
+{
+    "name": "Inertia Bubble",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant artifact\nEnchanted artifact doesn't untap during its controller's untap step.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "artifact"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Hugh Jamieson",
+        "flavorText": "\"I wouldn't want you to hurt yourself.\"\n—Bruenna, Neurok leader",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72b2d227-68b3-40e8-bef7-45ea43e17318.jpg?1783944554"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -5508,6 +5681,104 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Skeleton Shard
+{
+    "name": "Skeleton Shard",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T} or {B}, {T}: Return target artifact creature card from your graveyard to your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact creature card from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target artifact creature card from your graveyard"
+                    }
+                ],
+                "descriptionOverride": "{3}, {T}: Return target artifact creature card from your graveyard to your hand."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact creature card from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact creature own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "target artifact creature card from your graveyard"
+                    }
+                ],
+                "descriptionOverride": "{B}, {T}: Return target artifact creature card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "UNCOMMON",
+        "artist": "Doug Chaffee",
+        "flavorText": "Metal permeates the marrow of every bone in Mephidross—except one.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eeffcd61-ea1f-4ccd-b3d3-79efa9d4a0cf.jpg?1783944504",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "You can pay either of the two costs (but not both at the same time) to activate the ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -2276,6 +2276,77 @@
     ]
 }
 
+// Stalking Stones
+{
+    "name": "Stalking Stones",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{6}: This land becomes a 3/3 Elemental artifact creature that's still a land. (This effect lasts indefinitely.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{6}"
+                    }
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "creatureTypes": [
+                        "Elemental"
+                    ],
+                    "addTypes": [
+                        "ARTIFACT"
+                    ],
+                    "duration": "Permanent"
+                },
+                "descriptionOverride": "{6}: This land becomes a 3/3 Elemental artifact creature that's still a land."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "327",
+        "rarity": "UNCOMMON",
+        "artist": "Stephen Daniele",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4d3d349-5c23-43a9-b25e-0e1a35b84673.jpg?1783946596",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "Activating the ability that turns it into a creature while it's already a creature will override any effects that set its power and/or toughness to a specific number. However, any effect that raises or lowers power and/or toughness (such as the effect created by Giant Growth, Glorious Anthem, or a +1/+1 counter) will continue to apply."
+            },
+            {
+                "date": "2008-08-01",
+                "text": "A noncreature permanent that turns into a creature can attack, and its {T} abilities can be activated, only if its controller has continuously controlled that permanent since the beginning of their most recent turn. It doesn't matter how long the permanent has been a creature."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Staunch Defenders
 {
     "name": "Staunch Defenders",


### PR DESCRIPTION
Implements five missing Mirrodin cards. All five compose existing SDK primitives — no new effect, trigger, keyword, or condition types, and no engine changes.

## Cards

| Card | Modelling notes |
|---|---|
| **Granite Shard** ({3} Artifact, MRD #182) | `{3}, {T} or {R}, {T}: deals 1 damage to any target` |
| **Skeleton Shard** ({3} Artifact, MRD #242) | `{3}, {T} or {B}, {T}: return target artifact creature card from your graveyard to your hand` |
| **Inertia Bubble** ({1}{U} Aura, MRD #37) | Enchant artifact; `AbilityFlag.DOESNT_UNTAP` on the attached permanent |
| **Groffskithur** ({5}{G} 3/3 Beast, MRD #121) | `Triggers.BecomesBlocked` + optional graveyard target named Groffskithur |
| **Stalking Stones** (Land, TMP #327 canonical / MRD #284 reprint) | `{6}`: becomes a 3/3 Elemental artifact creature, indefinitely |

## Design decisions worth a look

**The two Shards' "or" cost.** `{3}, {T} or {R}, {T}` is one printed ability with two alternative cost sets; the 2004-10-04 ruling is explicit that you pay one or the other, never both. Modelled as two `activatedAbility` blocks with identical effects — each offers its own cost, and because both include the shard's own `{T}` they compete for the same tap, so only one can be activated per untap. That reproduces the printed play pattern exactly. There is no "either cost" cost atom in the SDK and adding one would only re-derive this, so it stays composition-only. Both blocks carry an explicit `description` so the action menu shows two clearly-priced buttons rather than two identical ones.

**Stalking Stones' canonical placement.** Its earliest real printing is Tempest (1997), not Mirrodin, so the `CardDefinition` lives in `definitions/tmp/cards/` and Mirrodin gets a `Printing` row. `just check-card-printing "Stalking Stones"` confirms the chain (tmp canonical → mrd reprint). The animate uses `Duration.Permanent` for "indefinitely" and `addTypes = setOf(ARTIFACT)` so the land keeps its Land type in Layer 4 ("that's still a land") — the Mishra's Factory shape with a permanent duration.

**Groffskithur's "you may".** `optional = true` on a targeted trigger lets the controller decline by choosing no targets, and the trigger does nothing when no legal target exists — which is the usual case, since it needs a *second* Groffskithur already in the graveyard. The filter is `GameObjectFilter.Any.named("Groffskithur")`, not a creature-card filter, matching the printed "target card named Groffskithur".

**Inertia Bubble** is the Charmed Sleep static pointed at an artifact instead of a creature. Worth noting it only stops the untap step — it does *not* tap the artifact on entry, so against an already-untapped artifact it does nothing until that artifact taps itself.

## Verification

- `just build` — passing
- `just check` — passing (no formatter changes)
- `just check-card-printing` — clean for all five
- MRD/TMP card snapshots re-blessed; the diff is **additions only** (342 inserted lines, 0 deleted), and only these five cards appear in it
- Neither card sits in a `backlog/sets/*` checklist, so no backlog bookkeeping was needed

No scenario tests: per the `add-card` skill, tests are required when a change adds new SDK vocabulary, and nothing here does — these are covered by the snapshot and lint nets. Every primitive used has an existing card precedent in the pool (Blinkmoth Well, Charmed Sleep, Zoetic Glyph, Crypt Angel, Leery Fogbeast, Mishra's Factory, Abuelo's Awakening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)