### PR TITLE
Add three The Hobbit recruit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/CelebrateTheMountainKing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/CelebrateTheMountainKing.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Celebrate the Mountain-king
+ * {3}{W}
+ * Enchantment
+ *
+ * When this enchantment enters, for each opponent, exile up to one target nonland permanent that
+ * player controls until this enchantment leaves the battlefield.
+ * When this enchantment enters, recruit.
+ *
+ * Two separate enters triggers, exactly as printed — they go on the stack together and their
+ * controller orders them, so the recruit can be resolved before or after the exile.
+ *
+ * "For each opponent, … up to one target … that player controls" follows the corpus convention for
+ * this wording (Blatant Thievery, Riptide Gearhulk, Omega, Heartless Evolution): one *optional*
+ * target restricted to a nonland permanent an opponent controls — exactly right in 1v1, and the
+ * shape the multiplayer per-opponent targeting work generalizes. `optional = true` carries the "up
+ * to one", so declining is legal and the trigger still resolves.
+ *
+ * The exile half is the Banishing Light pair: [Effects.ExileUntilLeaves] links the exiled card to
+ * this enchantment, and a [Triggers.LeavesBattlefield] trigger returns the linked pile under its
+ * owner's control. Bouncing or destroying the enchantment in response to its own enters trigger
+ * gives the usual O-Ring result — the leaves trigger resolves with an empty linked pile and the
+ * exile then never happens.
+ */
+val CelebrateTheMountainKing = card("Celebrate the Mountain-king") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, for each opponent, exile up to one target nonland " +
+        "permanent that player controls until this enchantment leaves the battlefield.\n" +
+        "When this enchantment enters, recruit. (Draw a card, then discard a card. If you " +
+        "discarded a nonland card, create a 1/1 white Human Soldier creature token.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val exiled = target(
+            "up to one target nonland permanent that player controls",
+            TargetPermanent(count = 1, optional = true, filter = TargetFilter.NonlandPermanentOpponentControls)
+        )
+        effect = Effects.ExileUntilLeaves(exiled)
+        description = "When this enchantment enters, for each opponent, exile up to one target " +
+            "nonland permanent that player controls until this enchantment leaves the battlefield."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileUnderOwnersControl()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Tomas Duchek"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42fbd61d-e1a6-465d-b1a3-f5ee0869d3af.jpg?1785496910"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SoundTheTrumpets.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/SoundTheTrumpets.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sound the Trumpets
+ * {1}{U}{U}
+ * Instant
+ *
+ * Counter target spell. If that spell's mana value was 2 or less, recruit.
+ *
+ * The mana-value test is deliberately hoisted *above* the counter rather than sequenced after it
+ * ([ConditionalEffect] wrapping both branches, Prohibit's shape) so it reads the spell while it is
+ * still on the stack. Two things would go wrong reading it afterwards: an X spell's mana value
+ * counts its chosen X only on the stack (CR 202.3b) and drops to X=0 once the card is in the
+ * graveyard, and the check would then be evaluating a card, not the spell the oracle text refers to
+ * in the past tense ("was 2 or less"). Ordering is unchanged from the printed text — the counter
+ * still happens before the recruit, and no player gets priority in between.
+ *
+ * The else branch repeats the bare counter because the condition gates only the recruit rider: a
+ * mana value of 3 or more still gets countered, it just mints nothing. A spell that can't be
+ * countered stays on the stack (the engine's counter is a no-op there), but the recruit rider is
+ * keyed to the mana value, not to the counter succeeding, so it still happens — matching CR, since
+ * "counter target spell" that fails to counter does not stop the rest of the resolution.
+ */
+val SoundTheTrumpets = card("Sound the Trumpets") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. If that spell's mana value was 2 or less, recruit. " +
+        "(Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white " +
+        "Human Soldier creature token.)"
+
+    spell {
+        target = Targets.Spell
+        effect = ConditionalEffect(
+            condition = Conditions.TargetSpellManaValueAtMost(DynamicAmount.Fixed(2)),
+            effect = Effects.Composite(
+                Effects.CounterSpell(),
+                Patterns.Mechanic.recruit(),
+            ),
+            elseEffect = Effects.CounterSpell(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "55"
+        artist = "Nereida"
+        flavorText = "The warning trumpets were suddenly sounded, and echoed along the rocky " +
+            "shores. So it was that the Dragon did not find them quite unprepared."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd32a1dd-3541-4572-a717-1deabc14b827.jpg?1784760160"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheMountainKingsReturn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheMountainKingsReturn.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * The Mountain-king's Return
+ * {2}{W}
+ * Enchantment — Saga
+ *
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Recruit.
+ * II — Return target creature card with mana value 3 or less from your graveyard to the battlefield.
+ * III — Put a +1/+1 counter on up to one target creature.
+ *
+ * Chapter I is the bare [Patterns.Mechanic.recruit] facade — no target, so the chapter ability goes
+ * on the stack untargeted and pauses for the discard choice when it resolves.
+ *
+ * Chapter II is the Helping Hand reanimation shape ([CardPredicate.IsCreature] +
+ * [CardPredicate.ManaValueAtMost] `(3)` owned by you, in [Zone.GRAVEYARD]) but *untapped* — this
+ * card omits Helping Hand's "tapped" rider.
+ *
+ * Chapter III's "up to one target" is `optional = true` on [TargetCreature]; declining leaves the
+ * [Effects.AddCounters] a no-op, and the chapter still resolves and the Saga is still sacrificed.
+ */
+val TheMountainKingsReturn = card("The Mountain-king's Return") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a " +
+        "1/1 white Human Soldier creature token.)\n" +
+        "II — Return target creature card with mana value 3 or less from your graveyard to the battlefield.\n" +
+        "III — Put a +1/+1 counter on up to one target creature."
+
+    // I — Recruit.
+    sagaChapter(1) {
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    // II — Return target creature card with mana value 3 or less from your graveyard to the battlefield.
+    sagaChapter(2) {
+        val reanimated = target(
+            "target creature card with mana value 3 or less from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(CardPredicate.IsCreature, CardPredicate.ManaValueAtMost(3)),
+                        controllerPredicate = ControllerPredicate.OwnedByYou,
+                    ),
+                    zone = Zone.GRAVEYARD,
+                )
+            )
+        )
+        effect = Effects.PutOntoBattlefield(reanimated)
+    }
+
+    // III — Put a +1/+1 counter on up to one target creature.
+    sagaChapter(3) {
+        val boosted = target(
+            "up to one target creature",
+            TargetCreature(count = 1, optional = true)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, boosted)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "22"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68f4893d-e9a5-4f89-ade3-9ab78a834ad5.jpg?1784631780"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1411,6 +1411,143 @@
     ]
 }
 
+// Celebrate the Mountain-king
+{
+    "name": "Celebrate the Mountain-king",
+    "manaCost": "{3}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, for each opponent, exile up to one target nonland permanent that player controls until this enchantment leaves the battlefield.\nWhen this enchantment enters, recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target nonland permanent that player controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "nonland permanent ctrl:opponent"
+                    },
+                    "id": "up to one target nonland permanent that player controls"
+                },
+                "descriptionOverride": "When this enchantment enters, for each opponent, exile up to one target nonland permanent that player controls until this enchantment leaves the battlefield."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "underOwnersControl": true
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "UNCOMMON",
+        "artist": "Tomas Duchek",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42fbd61d-e1a6-465d-b1a3-f5ee0869d3af.jpg?1785496910"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Chief Warg's Company
 {
     "name": "Chief Warg's Company",
@@ -8866,6 +9003,121 @@
     ]
 }
 
+// Sound the Trumpets
+{
+    "name": "Sound the Trumpets",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. If that spell's mana value was 2 or less, recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "ManaValue"
+                    },
+                    "operator": "LTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            },
+            "then": {
+                "type": "Composite",
+                "effects": [
+                    "Counter",
+                    {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "recruit_hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "recruit_hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "recruit_discarded",
+                                "prompt": "Recruit — choose a card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "recruit_discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            },
+                            {
+                                "type": "ConditionalOnCollection",
+                                "collection": "recruit_discarded",
+                                "ifNotEmpty": {
+                                    "type": "CreateToken",
+                                    "power": 1,
+                                    "toughness": 1,
+                                    "colors": [
+                                        "WHITE"
+                                    ],
+                                    "creatureTypes": [
+                                        "Human",
+                                        "Soldier"
+                                    ]
+                                },
+                                "filter": "nonland"
+                            }
+                        ],
+                        "descriptionOverride": "Recruit"
+                    }
+                ]
+            },
+            "otherwise": "Counter"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "UNCOMMON",
+        "artist": "Nereida",
+        "flavorText": "The warning trumpets were suddenly sounded, and echoed along the rocky shores. So it was that the Dragon did not find them quite unprepared.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd32a1dd-3541-4572-a717-1deabc14b827.jpg?1784760160"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Stir Up Trouble
 {
     "name": "Stir Up Trouble",
@@ -10095,6 +10347,129 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// The Mountain-king's Return
+{
+    "name": "The Mountain-king's Return",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)\nII — Return target creature card with mana value 3 or less from your graveyard to the battlefield.\nIII — Put a +1/+1 counter on up to one target creature.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card with mana value 3 or less from your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature mv<=3 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card with mana value 3 or less from your graveyard"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to one target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "UNCOMMON",
+        "artist": "Rovina Cai",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68f4893d-e9a5-4f89-ade3-9ab78a834ad5.jpg?1784631780"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CelebrateTheMountainKingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CelebrateTheMountainKingScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.CelebrateTheMountainKing
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Celebrate the Mountain-king (HOB #7) — {3}{W} Enchantment.
+ *
+ * "When this enchantment enters, for each opponent, exile up to one target nonland permanent that
+ * player controls until this enchantment leaves the battlefield."
+ * "When this enchantment enters, recruit."
+ *
+ * Two enters triggers fire together, and the recruit one pauses mid-resolution for its discard —
+ * the case where a queued sibling trigger is easiest to lose. The test pins that both halves land,
+ * and that destroying the enchantment afterwards gives the exiled permanent back (the Banishing
+ * Light linked-exile pair).
+ */
+class CelebrateTheMountainKingScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CelebrateTheMountainKing))
+        return driver
+    }
+
+    fun GameTestDriver.drain(onDecision: (GameTestDriver) -> Unit) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 50) {
+            if (state.pendingDecision != null) onDecision(this) else bothPass()
+            guard++
+        }
+    }
+
+    test("exiles an opponent's permanent and recruits; the exile comes back when it leaves") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim: EntityId = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val lions = driver.putCardInHand(me, "Savannah Lions") // recruit's nonland discard
+
+        driver.giveMana(me, Color.WHITE, 4)
+        val enchantment = driver.putCardInHand(me, "Celebrate the Mountain-king")
+        driver.castSpell(me, enchantment).error shouldBe null
+
+        driver.drain { d ->
+            when (val decision = d.state.pendingDecision) {
+                is ChooseTargetsDecision -> d.submitTargetSelection(me, listOf(victim))
+                is SelectCardsDecision ->
+                    if (lions in decision.options) d.submitCardSelection(me, listOf(lions))
+                    else d.autoResolveDecision()
+                else -> d.autoResolveDecision()
+            }
+        }
+
+        val permanent = driver.findPermanent(me, "Celebrate the Mountain-king")
+        permanent shouldNotBe null
+
+        driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
+        driver.state.getZone(opponent, Zone.EXILE).contains(victim) shouldBe true
+
+        driver.state.getZone(me, Zone.GRAVEYARD).contains(lions) shouldBe true
+        driver.getPermanents(me).count { driver.getCardName(it) == "Human Soldier Token" } shouldBe 1
+
+        // Destroy the enchantment — the leaves trigger returns the linked exile.
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveColorlessMana(me, 1)
+        val disenchant = driver.putCardInHand(me, "Disenchant")
+        driver.castSpellWithTargets(
+            me,
+            disenchant,
+            listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(permanent!!))
+        ).error shouldBe null
+        driver.drain { it.autoResolveDecision() }
+
+        driver.findPermanent(me, "Celebrate the Mountain-king") shouldBe null
+        driver.findPermanent(opponent, "Grizzly Bears") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoundTheTrumpetsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoundTheTrumpetsScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.SoundTheTrumpets
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sound the Trumpets (HOB #55) — {1}{U}{U} Instant.
+ *
+ * "Counter target spell. If that spell's mana value was 2 or less, recruit."
+ *
+ * The card hoists the mana-value test above the counter so it reads the spell while it is still on
+ * the stack. These tests pin both sides of that gate: a mana value of 2 recruits, a mana value of 4
+ * is countered with no recruit at all (no discard prompt, no Soldier).
+ */
+class SoundTheTrumpetsScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(SoundTheTrumpets)
+
+        context("Sound the Trumpets") {
+
+            test("countering a mana value 2 spell recruits") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sound the Trumpets")
+                    .withCardInHand(1, "Savannah Lions") // the nonland card recruit will discard
+                    .withCardInLibrary(1, "Island") // recruit draws this first
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInHand(2, "Grizzly Bears") // {1}{G} — mana value 2
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+                game.castSpellTargetingStackSpell(1, "Sound the Trumpets", "Grizzly Bears")
+                    .error shouldBe null
+                game.resolveStack()
+
+                withClue("mana value 2 passes the gate, so recruit pauses for the discard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                withClue("recruit drew before the discard") {
+                    game.isInHand(1, "Island") shouldBe true
+                }
+
+                val lions = game.findCardsInHand(1, "Savannah Lions").single()
+                game.selectCards(listOf(lions))
+                game.resolveStack()
+
+                withClue("the Bears were countered") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("discarding a nonland card mints a Soldier") {
+                    game.isInGraveyard(1, "Savannah Lions") shouldBe true
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 1
+                }
+            }
+
+            test("countering a mana value 4 spell does not recruit") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sound the Trumpets")
+                    .withCardInHand(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Island")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInHand(2, "Hill Giant") // {3}{R} — mana value 4
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Hill Giant").error shouldBe null
+                game.passPriority()
+                game.castSpellTargetingStackSpell(1, "Sound the Trumpets", "Hill Giant")
+                    .error shouldBe null
+                game.resolveStack()
+
+                withClue("the Giant was still countered — the gate only guards the recruit rider") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+                withClue("no recruit: no discard prompt") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("no recruit: nothing drawn, nothing discarded, no Soldier") {
+                    game.isInHand(1, "Island") shouldBe false
+                    game.isInHand(1, "Savannah Lions") shouldBe true
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMountainKingsReturnScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMountainKingsReturnScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.TheMountainKingsReturn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * The Mountain-king's Return (HOB #22) — {2}{W} Enchantment — Saga.
+ *
+ * I — Recruit.
+ * II — Return target creature card with mana value 3 or less from your graveyard to the battlefield.
+ * III — Put a +1/+1 counter on up to one target creature.
+ *
+ * Walks all three chapters in one game: the chapter I recruit must pause for its discard, chapter II
+ * must reanimate the mana-value-2 Bears (untapped — this Saga has no "tapped" rider), and chapter III
+ * must put a +1/+1 counter on the creature it targets. The Saga is sacrificed after III.
+ */
+class TheMountainKingsReturnScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheMountainKingsReturn))
+        return driver
+    }
+
+    /** Drain the stack, answering the decisions each chapter raises via [onDecision]. */
+    fun GameTestDriver.drain(onDecision: (GameTestDriver) -> Unit) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 50) {
+            if (state.pendingDecision != null) onDecision(this) else bothPass()
+            guard++
+        }
+    }
+
+    /**
+     * Advance to the precombat main phase of the starting player's [nth] turn — the clock a Saga's
+     * lore counters run on. `turnNumber` counts player turns and the two seats alternate, so the
+     * starting player's nth turn is turn `2n - 1`.
+     */
+    fun GameTestDriver.advanceToMain(nth: Int) {
+        val targetTurn = nth * 2 - 1
+        var guard = 0
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            if (state.gameOver) throw AssertionError("Game ended while advancing to turn $targetTurn")
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+            guard++
+        }
+    }
+
+    fun GameTestDriver.lore(saga: EntityId): Int =
+        state.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) ?: 0
+
+    fun GameTestDriver.plusOneCounters(entity: EntityId): Int =
+        state.getEntity(entity)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("walks chapters I through III: recruit, reanimate, then a +1/+1 counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Chapter II's reanimation target: Grizzly Bears is {1}{G}, mana value 2.
+        val bearsCard = driver.putCardInGraveyard(me, "Grizzly Bears")
+        // The nonland card chapter I's recruit will discard.
+        val lions = driver.putCardInHand(me, "Savannah Lions")
+
+        driver.giveMana(me, Color.WHITE, 3)
+        val saga = driver.putCardInHand(me, "The Mountain-king's Return")
+        driver.castSpell(me, saga).error shouldBe null
+
+        // --- Chapter I: recruit ---
+        driver.drain { d ->
+            val decision = d.state.pendingDecision
+            if (decision is SelectCardsDecision && lions in decision.options) {
+                d.submitCardSelection(me, listOf(lions))
+            } else {
+                d.autoResolveDecision()
+            }
+        }
+
+        val sagaPermanent = driver.findPermanent(me, "The Mountain-king's Return")
+        sagaPermanent shouldNotBe null
+        driver.lore(sagaPermanent!!) shouldBe 1
+        driver.state.getZone(me, com.wingedsheep.sdk.core.Zone.GRAVEYARD).contains(lions) shouldBe true
+        driver.getPermanents(me).count { driver.getCardName(it) == "Human Soldier Token" } shouldBe 1
+
+        // --- Chapter II: return the Bears from the graveyard to the battlefield ---
+        driver.advanceToMain(2)
+        driver.drain { d ->
+            if (d.state.pendingDecision is ChooseTargetsDecision) {
+                d.submitTargetSelection(me, listOf(bearsCard))
+            } else {
+                d.autoResolveDecision()
+            }
+        }
+
+        driver.lore(sagaPermanent) shouldBe 2
+        val bears = driver.findPermanent(me, "Grizzly Bears")
+        bears shouldNotBe null
+        driver.isTapped(bears!!) shouldBe false
+
+        // --- Chapter III: +1/+1 counter on the targeted creature ---
+        driver.advanceToMain(3)
+        driver.drain { d ->
+            val decision = d.state.pendingDecision
+            if (decision is ChooseTargetsDecision) {
+                d.submitTargetSelection(me, listOf(bears))
+            } else {
+                d.autoResolveDecision()
+            }
+        }
+
+        driver.plusOneCounters(bears) shouldBe 1
+        // Sacrificed after III.
+        driver.findPermanent(me, "The Mountain-king's Return") shouldBe null
+    }
+})


### PR DESCRIPTION
Implements the three remaining recruit cards from **The Hobbit** that compose cleanly from existing SDK primitives. No SDK changes — `Patterns.Mechanic.recruit()` already landed in #1772's follow-up.

HOB **163/193 → 166/193**.

## Cards

**Sound the Trumpets** — {1}{U}{U} Instant · "Counter target spell. If that spell's mana value was 2 or less, recruit."

The mana-value test is hoisted *above* the counter (Prohibit's `ConditionalEffect` shape) rather than sequenced after it, so it reads the spell while it is still on the stack. Reading it afterwards would be wrong twice over: an X spell's mana value counts its chosen X only on the stack (CR 202.3b) and drops to X=0 once the card is in the graveyard, and the check would be evaluating a card rather than the spell the oracle text refers to in the past tense. Printed ordering is unchanged — the counter still happens before the recruit, and no player gets priority in between. The else branch repeats the bare counter because the gate guards only the recruit rider.

**The Mountain-king's Return** — {2}{W} Enchantment — Saga

- I — the bare `Patterns.Mechanic.recruit()` facade, untargeted.
- II — Helping Hand's reanimation shape (`IsCreature` + `ManaValueAtMost(3)`, owned by you, in the graveyard) *without* Helping Hand's "tapped" rider.
- III — `optional = true` carries "up to one target"; declining leaves `AddCounters` a no-op and the Saga is still sacrificed.

**Celebrate the Mountain-king** — {3}{W} Enchantment

Two separate enters triggers exactly as printed, so their controller orders them. The exile half is the Banishing Light pair (`ExileUntilLeaves` + a `LeavesBattlefield` trigger returning the linked pile). "For each opponent, … up to one target … that player controls" follows the corpus convention for this wording (Blatant Thievery, Riptide Gearhulk, Omega) — one optional target restricted to a nonland permanent an opponent controls.

## Tests

One scenario test per card:

- `SoundTheTrumpetsScenarioTest` — both sides of the gate: a mana value 2 spell is countered *and* recruits; a mana value 4 spell is countered with no discard prompt, no draw, and no Soldier.
- `TheMountainKingsReturnScenarioTest` — walks all three chapters in one game, including the chapter I recruit pause and the untapped reanimation.
- `CelebrateTheMountainKingScenarioTest` — the exile and the recruit both land (the recruit pauses mid-resolution, which is where a queued sibling trigger is easiest to lose), then Disenchanting the enchantment gives the exiled permanent back.

## Verification

- `just build` — green (full compile + all module tests).
- `just rebless-cards` — only the three new cards moved in the HOB golden.
- `just check-card-printing` — canonical placement clean for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)