### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1598,6 +1598,17 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CantAttackGroupEffect(filter, condition?)` — group-scoped can't-attack.
 - `CantBlockGroupEffect(filter, condition?)` — group-scoped can't-block.
 - `Effects.Suspect(target)` — target becomes Suspected (MKM keyword). Composite: `SetSuspectedEffect` (named status, CR 701.60d dedup) + `GrantKeywordEffect(MENACE)` + `CantBlockEffect`.
+- `Effects.NoLongerSuspected(target = ContextTarget(0))` (`RemoveSuspectedEffect`) — "it's no longer
+  suspected" (CR 701.60c), the exact inverse of `Effects.Suspect`: it removes the named status
+  *together with* the menace grant and the can't-block restriction, since those exist only for as
+  long as the creature is suspected. `RemoveSuspectedExecutor` identifies the bundle by the
+  `(sourceId, timestamp)` the three floating effects share — `CompositeEffect` deliberately doesn't
+  tick `state.timestamp` between children so Rule 613 treats them as one application, and that same
+  shared stamp is the bundle's identity here. The match is narrowed to those three modification
+  kinds on an affected set of exactly this one creature, so menace or can't-block from any other
+  source survives. A no-op on an unsuspected creature; CR 701.60d guarantees a creature never
+  carries two bundles at once. Used by Absolving Lammasu (MKM) — `ForEachInGroup` over
+  `GameObjectFilter.Creature.suspected()` gives "all suspected creatures are no longer suspected".
 - `RemoveFromCombatEffect(target, unblockSoleBlockedAttackers = false)` — yank target out of combat.
   Set `unblockSoleBlockedAttackers = true` for the old-rules behavior (Ydwen Efreet): attackers the
   target was sole blocker of become unblocked (CR 509.1h normally keeps them blocked).
@@ -1641,6 +1652,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `AttackPhaseManager` and removed during cleanup. It composes with the token pipeline for “that
   token attacks this combat if able”: create the token, then target
   `PipelineTarget(CREATED_TOKENS, 0)` with this facade.
+- `Effects.MarkMustBlockThisTurn(target = ContextTarget(0))` (`MarkMustBlockThisTurnEffect`) —
+  "target creature blocks this turn if able". Adds a `Layer.ABILITY` floating
+  `SerializableModification.SetMustBlock` for `Duration.EndOfTurn`, i.e. the same projected
+  `mustBlock` the *static* `MustBlock` (Grand Melee) writes, so
+  `BlockPhaseManager.validateProjectedMustBlockRequirements` enforces it with no extra wiring and
+  the generic end-of-turn cleanup expires it. Distinct from `Effects.ForceBlock`, which pins the
+  creature to blocking one *named* attacker and requires the source to be attacking — this one is
+  satisfied by blocking anything. A requirement, not a guarantee (CR 509.1c): a tapped creature, one
+  that can't block, or one whose every block would be illegal is excused, and its controller is
+  never forced to pay a cost associated with blocking. Used by Culvert Ambusher (MKM).
 - `Effects.SkipNextTurn(target = Controller, count = Fixed(1))` (`SkipNextTurnEffect`) — target skips their next `count` turns. `count` is a `DynamicAmount`, so it can read a pipeline value (e.g. a coin-flip tally via `DynamicAmount.VariableReference`). Skips accumulate on a `SkipNextTurnComponent(turns)`, decremented one turn per the player's turn-start; a resolved count of 0 is a no-op. Used by Lethal Vapors (one turn) and **Ral Zarek, Guest Lecturer** (skip N turns where N = heads).
 - `Effects.FlipCoins(count, storeHeadsAs = "heads")` (`FlipCoinsEffect`) — flip `count` coins and store the number of heads under `storeHeadsAs` in the pipeline (`storedNumbers`) so a later sub-effect in the same composite can scale off it via `DynamicAmount.VariableReference`. The general "flip N coins, count heads" primitive (CR 705); unlike `FlipCoinEffect` (branch on win/lose) and `FlipTwoCoinsEffect` (branch on combined outcome) it only tallies. Each flip emits a `CoinFlipEvent`. **Ral Zarek, Guest Lecturer**'s ultimate composes `FlipCoins(5, "heads")` then `SkipNextTurn(target, count = VariableReference("heads"))`.
 - `Effects.SkipNextDrawStep(target = Controller)` (`SkipNextDrawStepEffect`) — target skips their next draw step. Adds a one-shot `SkipDrawStepComponent` marker consumed by `DrawPhaseManager.performDrawStep` (Elfhame Sanctuary's "you skip your draw step this turn").
@@ -7873,6 +7894,12 @@ default to "you" so card authors don't need to pass it explicitly.
 - `SacrificedWasLegendary` — intervening-if "if the sacrificed creature was legendary". Same
   snapshot path as `SacrificedHadSubtype`, but reads `supertypes` instead of subtypes. Used by
   Nasty End and Gríma Wormtongue (LTR).
+- `SacrificedWasSuspected` — intervening-if "if the sacrificed creature was suspected" (CR 701.60a).
+  Same snapshot path again, reading `EntitySnapshot.wasSuspected`, which `captureEntitySnapshots`
+  freezes from `ProjectedState.isSuspected` at cost-payment time. It *has* to be last-known
+  information (CR 608.2h): the designation is a floating effect keyed on the entity, so it is gone
+  with the creature by the time the ability resolves. Asks "was it suspected", not "did it have
+  menace". Used by Agency Coroner (MKM).
 - `YouSacrificedThisWay` — intervening-if "if you sacrificed a creature this way". Filters
   `EffectContext.sacrificedPermanents` for snapshots whose last-known controller is the source's
   controller — the gate on the personal half of a symmetric edict. Used by Rise of the Witch-king

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1260,6 +1260,13 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentWasLegendary
 
     /**
+     * If at least one permanent sacrificed as part of the cost was suspected (CR 701.60a) at the
+     * moment of sacrifice. Used by MKM's Agency Coroner.
+     */
+    val SacrificedWasSuspected: ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentWasSuspected
+
+    /**
      * If at least one permanent sacrificed "this way" was controlled by the source's
      * controller at the moment of sacrifice. Used to gate the personal half of a
      * symmetric edict (Rise of the Witch-king, LTR).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -63,6 +63,8 @@ import com.wingedsheep.sdk.scripting.effects.CantAttackEffect
 import com.wingedsheep.sdk.scripting.effects.CantBlockEffect
 import com.wingedsheep.sdk.scripting.effects.GoadEffect
 import com.wingedsheep.sdk.scripting.effects.MarkMustAttackThisTurnEffect
+import com.wingedsheep.sdk.scripting.effects.MarkMustBlockThisTurnEffect
+import com.wingedsheep.sdk.scripting.effects.RemoveSuspectedEffect
 import com.wingedsheep.sdk.scripting.effects.SetSuspectedEffect
 import com.wingedsheep.sdk.scripting.effects.CantBlockGroupEffect
 import com.wingedsheep.sdk.scripting.effects.CantActivateLoyaltyAbilitiesEffect
@@ -3839,6 +3841,17 @@ object Effects {
         MarkMustAttackThisTurnEffect(target)
 
     /**
+     * Mark a creature as required to block this turn if able ("target creature blocks this turn if
+     * able", Culvert Ambusher).
+     *
+     * Unrestricted counterpart to [ForceBlock], which pins the creature to blocking one *named*
+     * attacker: this one is satisfied by blocking any attacker at all. A requirement only — a
+     * creature that is tapped or otherwise unable to block just doesn't block (CR 509.1c).
+     */
+    fun MarkMustBlockThisTurn(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
+        MarkMustBlockThisTurnEffect(target)
+
+    /**
      * Target creature becomes suspected (CR 701.60): atomic composite of the
      * named "suspected" status, granted menace, and "can't block".
      *
@@ -3856,6 +3869,17 @@ object Effects {
             ),
             descriptionOverride = "${target.description} becomes suspected"
         )
+
+    /**
+     * Target is no longer suspected (CR 701.60c) — the exact inverse of [Suspect], removing the
+     * named status together with the menace and can't-block halves it applied.
+     *
+     * A single effect rather than a composite of three "remove" effects: the three floating effects
+     * [Suspect] creates are one application (they share a timestamp), so they come off as one too.
+     * Menace or can't-block a creature has from anywhere else survives.
+     */
+    fun NoLongerSuspected(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
+        RemoveSuspectedEffect(target)
 
     // =========================================================================
     // Special Effects

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/SourceConditions.kt
@@ -564,6 +564,26 @@ data object SacrificedPermanentWasLegendary : Condition {
 }
 
 /**
+ * Condition: "If the sacrificed creature was suspected." (CR 701.60a)
+ *
+ * The suspect sibling of [SacrificedPermanentWasLegendary], reading the same
+ * `EffectContext.sacrificedPermanents` snapshots — here the `wasSuspected` flag, frozen at
+ * cost-payment time. It has to be last-known information (CR 608.2h): the suspected designation is
+ * a floating effect keyed on the entity, and by the time the ability resolves the sacrificed
+ * creature and its floating effects are both gone.
+ *
+ * Asks specifically "was it *suspected*", not "did it have menace" — the menace and can't-block
+ * halves of `Effects.Suspect` are separate sub-effects that any number of other cards also grant.
+ *
+ * Used by MKM's Agency Coroner ("If the sacrificed creature was suspected, draw two cards instead").
+ */
+@SerialName("SacrificedPermanentWasSuspected")
+@Serializable
+data object SacrificedPermanentWasSuspected : Condition {
+    override val description: String = "if the sacrificed creature was suspected"
+}
+
+/**
  * Condition: "as long as it's blocking or blocked by a creature of one of [subtypes]".
  *
  * Source-relative combat condition. The "it" is resolved through the source: when the source

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CombatEffects.kt
@@ -516,6 +516,29 @@ data class MarkMustAttackThisTurnEffect(
 }
 
 /**
+ * Mark a creature as "blocks this turn if able" (Culvert Ambusher).
+ *
+ * The blocking mirror of [MarkMustAttackThisTurnEffect], and the *unrestricted* sibling of
+ * [ForceBlockEffect]: this requires the creature to block **some** attacker, not a named one, and
+ * the ability's source need not be attacking (or even be a creature). It is the one-shot,
+ * turn-scoped form of the static [com.wingedsheep.sdk.scripting.MustBlock] (Grand Melee) — both
+ * project the same "must block" requirement that the block-declaration validator enforces.
+ *
+ * Only a *requirement*, never a guarantee (CR 509.1c): a creature that is tapped, that can't block,
+ * or whose every possible block is illegal simply doesn't block, and its controller is never forced
+ * to pay a cost associated with blocking.
+ *
+ * @property target The creature to mark (typically `EffectTarget.ContextTarget(0)` — the ability's target)
+ */
+@SerialName("MarkMustBlockThisTurn")
+@Serializable
+data class MarkMustBlockThisTurnEffect(
+    val target: EffectTarget = EffectTarget.ContextTarget(0)
+) : Effect {
+    override val description: String = "${target.description} blocks this turn if able"
+}
+
+/**
  * Goad a target creature (CR 701.15).
  *
  * Until the goader's next turn, the targeted creature is goaded: it attacks each
@@ -704,6 +727,28 @@ data class SetSuspectedEffect(
     val duration: Duration = Duration.Permanent
 ) : Effect {
     override val description: String = "${target.description} becomes suspected"
+}
+
+/**
+ * "It's no longer suspected" (CR 701.60c) — the inverse of the whole suspect bundle.
+ *
+ * Undoes an [SetSuspectedEffect] *application*, not just its named status: the menace grant and the
+ * "can't block" restriction that [com.wingedsheep.sdk.dsl.Effects.Suspect] applies alongside it go
+ * away too, because they exist only for as long as the creature is suspected. Menace or can't-block
+ * from any *other* source is untouched — un-suspecting is not "lose menace".
+ *
+ * A no-op on a creature that isn't suspected. Suspect is not a copiable value and has no duration,
+ * so this is the only way the designation ever comes off a permanent that stays on the battlefield.
+ *
+ * Used by MKM's Absolving Lammasu ("all suspected creatures are no longer suspected"), and by the
+ * "you may have it become no longer suspected" riders (Airtight Alibi, Deadly Complication).
+ */
+@SerialName("RemoveSuspected")
+@Serializable
+data class RemoveSuspectedEffect(
+    val target: EffectTarget = EffectTarget.ContextTarget(0)
+) : Effect {
+    override val description: String = "${target.description} is no longer suspected"
 }
 
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AbsolvingLammasu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AbsolvingLammasu.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Absolving Lammasu — Murders at Karlov Manor #2
+ * {4}{W} · Creature — Lammasu · 4/3
+ *
+ * Flying
+ * When this creature enters, all suspected creatures are no longer suspected.
+ * When this creature dies, you gain 3 life and suspect up to one target creature an opponent
+ * controls.
+ *
+ * White's answer to a board full of suspects, and then a parting shot that creates a fresh one. The
+ * two halves pull in opposite directions on purpose: the Lammasu clears the table on arrival and
+ * hands the designation back to an opponent's creature when it dies.
+ *
+ * "All suspected creatures" is every creature on the battlefield, not just yours — the ETB is
+ * symmetric and will absolve an opponent's suspected attacker just as readily as it frees your own
+ * blocker. Modelled as [Effects.ForEachInGroup] over the un-scoped `suspected()` filter, which reads
+ * the designation from projected state.
+ *
+ * [Effects.NoLongerSuspected] (CR 701.60c) strips the whole suspect application — status, menace,
+ * and can't-block together — because those two grants exist only for as long as the creature is
+ * suspected. Menace a creature has from anywhere else is untouched.
+ *
+ * The dies trigger is *one* ability with an optional target, so the life gain rides on the same
+ * resolution: per the printed ruling, choosing a target and having it become illegal fizzles the
+ * whole ability and you gain nothing. Choosing **no** target (the "up to one" line) still gains the
+ * 3 life. That's [TargetCreature] with `optional = true`, not two separate abilities.
+ *
+ * The dies trigger fires from the graveyard on last-known information — by the time it resolves the
+ * Lammasu is long gone, which is why nothing in the effect refers back to it.
+ */
+val AbsolvingLammasu = card("Absolving Lammasu") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Lammasu"
+    power = 4
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, all suspected creatures are no longer suspected.\n" +
+        "When this creature dies, you gain 3 life and suspect up to one target creature an " +
+        "opponent controls. (A suspected creature has menace and can't block.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.suspected()),
+            Effects.NoLongerSuspected(EffectTarget.Self)
+        )
+        description = "When this creature enters, all suspected creatures are no longer suspected."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val suspect = target(
+            "up to one target creature an opponent controls",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureOpponentControls)
+        )
+        effect = Effects.Composite(
+            Effects.GainLife(3),
+            Effects.Suspect(suspect)
+        )
+        description = "When this creature dies, you gain 3 life and suspect up to one target " +
+            "creature an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd6e71a1-713e-4eca-bd65-9f0638c16794.jpg?1783912931"
+
+        ruling(
+            "2024-02-02",
+            "You don't have to choose a target for Absolving Lammasu's last ability. However, if " +
+                "you do, and that permanent is an illegal target at the time the ability tries to " +
+                "resolve, it won't resolve and none of its effects will happen. You won't gain life."
+        )
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until it " +
+                "leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "There's no limit to the number of creatures that can be suspected simultaneously. " +
+                "Suspecting a new creature doesn't cause other creatures to stop being suspected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AgencyCoroner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/AgencyCoroner.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Agency Coroner — Murders at Karlov Manor #75
+ * {4}{B} · Creature — Ogre Cleric · 3/6
+ *
+ * {2}{B}, Sacrifice another creature: Draw a card. If the sacrificed creature was suspected,
+ * draw two cards instead.
+ *
+ * The black common's sacrifice outlet, paying double when the body was already a suspect — MKM's
+ * self-suspecting attackers (Frantic Scapegoat, Barbed Servitor) and the set's many "suspect target
+ * creature" riders all feed it.
+ *
+ * "Was suspected" is *last-known information* (CR 608.2h), not a board read. The suspected
+ * designation (CR 701.60a) is a floating effect keyed on the entity, so it dies with the creature
+ * the instant the cost is paid — long before the ability resolves. `Conditions.SacrificedWasSuspected`
+ * therefore reads the flag frozen onto the cost-time `EntitySnapshot`, the same mechanism
+ * `SacrificedWasLegendary` (Nasty End) uses for supertypes.
+ *
+ * The branch is a [ConditionalEffect] over "draw two" / "draw one", never "draw one, then draw one
+ * more if …". The printed word is *instead*: this is a single draw event of one size or the other,
+ * which matters to anything watching draws.
+ *
+ * `Costs.SacrificeAnother` excludes the Coroner itself, so it can't eat itself for value — and with
+ * no other creature on the battlefield the ability simply isn't activatable.
+ */
+val AgencyCoroner = card("Agency Coroner") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Ogre Cleric"
+    power = 3
+    toughness = 6
+    oracleText = "{2}{B}, Sacrifice another creature: Draw a card. If the sacrificed creature was " +
+        "suspected, draw two cards instead."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{B}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.SacrificedWasSuspected,
+            effect = Effects.DrawCards(2),
+            elseEffect = Effects.DrawCards(1)
+        )
+        description = "Draw a card. If the sacrificed creature was suspected, draw two cards instead."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "Uriah Voth"
+        flavorText = "\"Well, cause of death seems pretty straightforward, but what else can you " +
+            "tell me, friend?\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d63f2c23-e877-42e3-9362-5d003a173c6d.jpg?1783912901"
+
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until it " +
+                "leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "If a suspected creature loses all abilities, it will lose menace and \"This creature " +
+                "can't block\", but it won't stop being suspected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CulvertAmbusher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CulvertAmbusher.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Culvert Ambusher — Murders at Karlov Manor #158
+ * {3}{G}{G} · Creature — Wurm Horror · 4/5
+ *
+ * When this creature enters or is turned face up, target creature blocks this turn if able.
+ * Disguise {4}{G}
+ *
+ * Green's disguise ambush: cast it face down for {3}, attack with the 2/2, then flip for {4}{G} in
+ * the declare-blockers step — except the flip trigger drags a creature *into* the block instead of
+ * out of it, so the 4/5 eats whatever it names. Hard-cast for {3}{G}{G} the same trigger forces a
+ * bad block on the defending turn.
+ *
+ * Two trigger conditions on one printed ability, so two `triggeredAbility` blocks (the
+ * [PerimeterEnforcer] idiom). No event satisfies both: turning face up is not entering the
+ * battlefield (CR 707.9a), and a card cast face down enters as a face-down 2/2 — its enters trigger
+ * doesn't exist yet, because a face-down permanent has no abilities. So the face-down line really
+ * does get exactly one trigger, on the flip.
+ *
+ * "Blocks this turn if able" is a *requirement*, not a guarantee (CR 509.1c) — hence
+ * [Effects.MarkMustBlockThisTurn] rather than anything that reaches into block declaration. A
+ * target that is tapped, that can't block, or whose every block would be illegal is excused, and
+ * its controller never has to pay a cost associated with blocking. The target is chosen when the
+ * trigger goes on the stack; if it's gone by resolution the trigger fizzles.
+ *
+ * Note it is plain `target creature` — the Ambusher may target its own controller's creature, and
+ * the requirement is "block *something*", not "block the Ambusher".
+ */
+val CulvertAmbusher = card("Culvert Ambusher") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm Horror"
+    power = 4
+    toughness = 5
+    oracleText = "When this creature enters or is turned face up, target creature blocks this turn " +
+        "if able.\n" +
+        "Disguise {4}{G} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)"
+
+    disguise = "{4}{G}"
+
+    // When this creature enters …
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = Targets.Creature
+        effect = Effects.MarkMustBlockThisTurn()
+        description = "When this creature enters, target creature blocks this turn if able."
+    }
+
+    // … or is turned face up.
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        target = Targets.Creature
+        effect = Effects.MarkMustBlockThisTurn()
+        description = "When this creature is turned face up, target creature blocks this turn if able."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "158"
+        artist = "Slawomir Maniak"
+        flavorText = "The bite at the end of the tunnel."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2ccdc58b-1e7e-402c-88f9-c789ff1dae31.jpg?1783912868"
+
+        ruling(
+            "2024-02-02",
+            "If the target creature is tapped or is affected by a spell or ability that says it " +
+                "can't block, then it doesn't block. If there's a cost associated with having " +
+                "that creature block, its controller isn't forced to pay that cost, so it doesn't " +
+                "have to block in that case either."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GreenbeltRadical.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GreenbeltRadical.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Greenbelt Radical — Murders at Karlov Manor #163
+ * {3}{G} · Creature — Centaur Citizen · 4/4
+ *
+ * Disguise {5}{G}{G}
+ * When this creature is turned face up, put a +1/+1 counter on each creature you control.
+ * Creatures you control gain trample until end of turn.
+ *
+ * Hard-cast for {3}{G} it's a vanilla 4/4; the whole card is the disguise line. Cast face down for
+ * {3}, flip for {5}{G}{G} mid-combat, and the team grows permanently *and* gets trample for the
+ * swing — turning face up is a special action (CR 702.168c) that uses no stack, so the opponent's
+ * only response window is after the trigger is already on the stack.
+ *
+ * Both halves iterate the same group in one [Effects.ForEachInGroup] pass. That is not a shortcut:
+ * "creatures you control" is evaluated once, on resolution, for the whole ability — a creature that
+ * arrives later gets neither the counter nor the trample. The Radical itself *is* in the group,
+ * because it is on the battlefield (face up) before the trigger resolves.
+ *
+ * The counter is permanent and the trample is [com.wingedsheep.sdk.core.Duration.EndOfTurn] (the
+ * `Effects.GrantKeyword` default), so a bounce or a second flip later in the turn leaves the
+ * counters behind and only the trample wears off in cleanup.
+ */
+val GreenbeltRadical = card("Greenbelt Radical") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Citizen"
+    power = 4
+    toughness = 4
+    oracleText = "Disguise {5}{G}{G} (You may cast this card face down for {3} as a 2/2 creature " +
+        "with ward {2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this creature is turned face up, put a +1/+1 counter on each creature you control. " +
+        "Creatures you control gain trample until end of turn."
+
+    disguise = "{5}{G}{G}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self),
+            ),
+        )
+        description = "When this creature is turned face up, put a +1/+1 counter on each creature " +
+            "you control. Creatures you control gain trample until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Andreia Ugrai"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88e62346-cc62-4938-970c-b56beeb79fa6.jpg?1783912865"
+
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ProjektorInspector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ProjektorInspector.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Projektor Inspector — Murders at Karlov Manor #68
+ * {2}{U} · Creature — Human Detective · 3/2
+ *
+ * Whenever this creature or another Detective you control enters and whenever a Detective you
+ * control is turned face up, you may draw a card. If you do, discard a card.
+ *
+ * The blue common that turns MKM's Detective tribal into card selection. A 3/2 for three that loots
+ * on arrival and loots again every time the Detective count goes up.
+ *
+ * As with [PerimeterEnforcer], the printed ability is one ability with **two** trigger conditions,
+ * modelled as two `triggeredAbility` blocks sharing an effect. That's faithful rather than a
+ * compromise: no single event can satisfy both conditions, because turning a permanent face up is
+ * not entering the battlefield (CR 707.9a).
+ *
+ * The "enters" half is [TriggerBinding.ANY], not `OTHER` — the printed text is "this creature **or
+ * another** Detective you control", so the Inspector's own arrival loots. The filter is
+ * Detective-you-control, which the Inspector satisfies itself.
+ *
+ * The "turned face up" half filters on the permanent's **post-flip** characteristics: a face-down
+ * creature is a nameless, typeless 2/2, so a check against the face-down state would never see a
+ * Detective. Practically this is the disguise payoff — flipping [GraniteWitness] or any other MKM
+ * Detective loots as well.
+ *
+ * "You may draw a card. If you do, discard a card." is the coupled loot, so declining draws nothing
+ * *and* discards nothing — [MayEffect] over `Patterns.Hand.loot()`, never two independent effects.
+ */
+val ProjektorInspector = card("Projektor Inspector") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Detective"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever this creature or another Detective you control enters and whenever a " +
+        "Detective you control is turned face up, you may draw a card. If you do, discard a card."
+
+    // Whenever this creature or another Detective you control enters …
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE).youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = MayEffect(Patterns.Hand.loot())
+        description = "Whenever this creature or another Detective you control enters, you may " +
+            "draw a card. If you do, discard a card."
+    }
+
+    // … and whenever a Detective you control is turned face up.
+    triggeredAbility {
+        trigger = Triggers.CreatureTurnedFaceUp(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.DETECTIVE)
+        )
+        effect = MayEffect(Patterns.Hand.loot())
+        description = "Whenever a Detective you control is turned face up, you may draw a card. " +
+            "If you do, discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Leonardo Santanna"
+        flavorText = "\"Bring up the particulars from yesterday's altercation, and enhance.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad378843-e2b0-48d6-90dc-b584e857473d.jpg?1783912907"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1,3 +1,132 @@
+// Absolving Lammasu
+{
+    "name": "Absolving Lammasu",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Lammasu",
+    "oracleText": "Flying\nWhen this creature enters, all suspected creatures are no longer suspected.\nWhen this creature dies, you gain 3 life and suspect up to one target creature an opponent controls. (A suspected creature has menace and can't block.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "IsSuspected"
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "RemoveSuspected",
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, all suspected creatures are no longer suspected."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "SetSuspected",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "up to one target creature an opponent controls"
+                                    }
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "MENACE",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "up to one target creature an opponent controls"
+                                    },
+                                    "duration": "Permanent"
+                                },
+                                {
+                                    "type": "CantBlockTargetCreatures",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "up to one target creature an opponent controls"
+                                    },
+                                    "duration": "Permanent"
+                                }
+                            ],
+                            "descriptionOverride": "target becomes suspected"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "up to one target creature an opponent controls"
+                },
+                "descriptionOverride": "When this creature dies, you gain 3 life and suspect up to one target creature an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd6e71a1-713e-4eca-bd65-9f0638c16794.jpg?1783912931",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You don't have to choose a target for Absolving Lammasu's last ability. However, if you do, and that permanent is an illegal target at the time the ability tries to resolve, it won't resolve and none of its effects will happen. You won't gain life."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "There's no limit to the number of creatures that can be suspected simultaneously. Suspecting a new creature doesn't cause other creatures to stop being suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Aftermath Analyst
 {
     "name": "Aftermath Analyst",
@@ -96,6 +225,86 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Agency Coroner
+{
+    "name": "Agency Coroner",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Ogre Cleric",
+    "oracleText": "{2}{B}, Sacrifice another creature: Draw a card. If the sacrificed creature was suspected, draw two cards instead.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": "SacrificedPermanentWasSuspected"
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "otherwise": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "descriptionOverride": "Draw a card. If the sacrificed creature was suspected, draw two cards instead."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "artist": "Uriah Voth",
+        "flavorText": "\"Well, cause of death seems pretty straightforward, but what else can you tell me, friend?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d63f2c23-e877-42e3-9362-5d003a173c6d.jpg?1783912901",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a suspected creature loses all abilities, it will lose menace and \"This creature can't block\", but it won't stop being suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -1465,6 +1674,81 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Culvert Ambusher
+{
+    "name": "Culvert Ambusher",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Wurm Horror",
+    "oracleText": "When this creature enters or is turned face up, target creature blocks this turn if able.\nDisguise {4}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{G}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": "MarkMustBlockThisTurn",
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, target creature blocks this turn if able."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "TurnFaceUpEvent",
+                "effect": "MarkMustBlockThisTurn",
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "descriptionOverride": "When this creature is turned face up, target creature blocks this turn if able."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "rarity": "UNCOMMON",
+        "artist": "Slawomir Maniak",
+        "flavorText": "The bite at the end of the tunnel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2ccdc58b-1e7e-402c-88f9-c789ff1dae31.jpg?1783912868",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If the target creature is tapped or is affected by a spell or ability that says it can't block, then it doesn't block. If there's a cost associated with having that creature block, its controller isn't forced to pay that cost, so it doesn't have to block in that case either."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -3396,6 +3680,83 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f952d8d-c089-432c-822a-8ef1e605ae38.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Greenbelt Radical
+{
+    "name": "Greenbelt Radical",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Centaur Citizen",
+    "oracleText": "Disguise {5}{G}{G} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, put a +1/+1 counter on each creature you control. Creatures you control gain trample until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}{G}{G}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "When this creature is turned face up, put a +1/+1 counter on each creature you control. Creatures you control gain trample until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Andreia Ugrai",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88e62346-cc62-4938-970c-b56beeb79fa6.jpg?1783912865",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Griffnaut Tracker
@@ -5990,6 +6351,152 @@
     },
     "colorIdentityOverride": [
         "WHITE",
+        "BLUE"
+    ]
+}
+
+// Projektor Inspector
+{
+    "name": "Projektor Inspector",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Whenever this creature or another Detective you control enters and whenever a Detective you control is turned face up, you may draw a card. If you do, discard a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Detective ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever this creature or another Detective you control enters, you may draw a card. If you do, discard a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CreatureTurnedFaceUpEvent",
+                    "filter": "creature Detective"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever a Detective you control is turned face up, you may draw a card. If you do, discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Leonardo Santanna",
+        "flavorText": "\"Bring up the particulars from yesterday's altercation, and enhance.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad378843-e2b0-48d6-90dc-b584e857473d.jpg?1783912907"
+    },
+    "colorIdentityOverride": [
         "BLUE"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -96,6 +96,7 @@ import com.wingedsheep.engine.state.components.battlefield.CastFromGraveyardComp
 import com.wingedsheep.engine.state.components.battlefield.CastFromLibraryComponent
 import com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentHadSubtype
 import com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentWasLegendary
+import com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentWasSuspected
 import com.wingedsheep.sdk.scripting.conditions.YouSacrificedPermanentThisWay
 import com.wingedsheep.sdk.scripting.conditions.AnotherPermanentWithSameNameAsTarget
 import com.wingedsheep.sdk.scripting.conditions.TargetMarkedDamageExceedsToughness
@@ -573,6 +574,7 @@ class ConditionEvaluator(
             }
             is SacrificedPermanentHadSubtype -> ifResolution { evaluateSacrificedPermanentHadSubtype(condition, it) }
             is SacrificedPermanentWasLegendary -> ifResolution { evaluateSacrificedPermanentWasLegendary(it) }
+            is SacrificedPermanentWasSuspected -> ifResolution { evaluateSacrificedPermanentWasSuspected(it) }
             is YouSacrificedPermanentThisWay -> ifResolution { evaluateYouSacrificedPermanentThisWay(it) }
             is TriggeringEntityWasHistoric -> ifResolution { evaluateTriggeringEntityWasHistoric(state, it) }
             is TriggeringEntityWasCast -> ifResolution { evaluateTriggeringEntityWasCast(state, it) }
@@ -1367,6 +1369,10 @@ class ConditionEvaluator(
         return context.sacrificedPermanents.any { snapshot ->
             "LEGENDARY" in snapshot.supertypes
         }
+    }
+
+    private fun evaluateSacrificedPermanentWasSuspected(context: EffectContext): Boolean {
+        return context.sacrificedPermanents.any { snapshot -> snapshot.wasSuspected }
     }
 
     private fun evaluateYouSacrificedPermanentThisWay(context: EffectContext): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CombatExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/CombatExecutors.kt
@@ -26,12 +26,14 @@ class CombatExecutors(
         RemoveFromCombatExecutor(),
         OpponentGuessesTopCardKindExecutor(),
         MarkMustAttackThisTurnExecutor(),
+        MarkMustBlockThisTurnExecutor(),
         GoadExecutor(),
         CanAttackDespiteDefenderThisTurnExecutor(),
         RedirectNextDamageExecutor(),
         RedirectCombatDamageToControllerExecutor(),
         GrantAttackBlockTaxPerCreatureTypeExecutor(),
         GrantKeywordToAttackersBlockedByExecutor(),
-        SetSuspectedExecutor()
+        SetSuspectedExecutor(),
+        RemoveSuspectedExecutor()
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/MarkMustBlockThisTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/MarkMustBlockThisTurnExecutor.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.handlers.effects.combat
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.MarkMustBlockThisTurnEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [MarkMustBlockThisTurnEffect] — "target creature blocks this turn if able."
+ *
+ * Adds a `Layer.ABILITY` floating [SerializableModification.SetMustBlock] to the target for the
+ * rest of the turn. That is the same projection the static `MustBlock` (Grand Melee) writes, so
+ * `BlockPhaseManager.validateProjectedMustBlockRequirements` enforces it with no further wiring:
+ * if the creature can legally block at least one attacker, declaring no block is rejected.
+ *
+ * A floating effect rather than a component (the shape [MarkMustAttackThisTurnExecutor] uses)
+ * precisely because the "must block" reading already flows through projection — reusing it keeps
+ * one enforcement path instead of two, and the `Duration.EndOfTurn` cleanup is the generic one.
+ *
+ * Silently no-ops on a target that has gone (the ability fizzled or the creature left the
+ * battlefield): a requirement on a nonexistent permanent has nothing to constrain.
+ */
+class MarkMustBlockThisTurnExecutor : EffectExecutor<MarkMustBlockThisTurnEffect> {
+
+    override val effectType: KClass<MarkMustBlockThisTurnEffect> = MarkMustBlockThisTurnEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: MarkMustBlockThisTurnEffect,
+        context: EffectContext
+    ): EffectResult {
+        val entityId = TargetResolutionUtils.resolveTarget(effect.target, context, state)
+            ?: return EffectResult.success(state)
+        if (entityId !in state.getBattlefield()) {
+            return EffectResult.success(state)
+        }
+        state.getEntity(entityId)?.get<CardComponent>()
+            ?: return EffectResult.success(state)
+
+        val newState = state.addFloatingEffect(
+            layer = Layer.ABILITY,
+            modification = SerializableModification.SetMustBlock,
+            affectedEntities = setOf(entityId),
+            duration = Duration.EndOfTurn,
+            context = context
+        )
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/RemoveSuspectedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/RemoveSuspectedExecutor.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.handlers.effects.combat
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.RemoveSuspectedEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [RemoveSuspectedEffect] — "it's no longer suspected" (CR 701.60c).
+ *
+ * Suspect has no duration and isn't a copiable value, so the designation only ever comes off a
+ * permanent that stays on the battlefield by an effect like this one. Removing it means removing
+ * the floating effects `Effects.Suspect` created — all three of them, since the menace and the
+ * "can't block" exist only for as long as the creature is suspected.
+ *
+ * **Identifying the bundle.** `Effects.Suspect` is a `CompositeEffect`, and `CompositeEffect`
+ * deliberately does not tick `state.timestamp` between children so that Rule 613 treats the three
+ * sub-effects as one application. That shared `(sourceId, timestamp)` is therefore the bundle's
+ * identity, by design rather than by accident, and it is what this executor keys on. Two
+ * independent suspects of the same creature can't collide: CR 701.60d makes the second a no-op, so
+ * a creature never carries two bundles at once.
+ *
+ * The match is deliberately narrow — only the three modification kinds suspect applies
+ * ([SerializableModification.SetSuspected], `GrantKeyword(MENACE)`, `SetCantBlock`), only where the
+ * effect's affected set is exactly this one creature. Menace or can't-block from any other source
+ * survives untouched; un-suspecting is not "lose menace".
+ *
+ * A creature that isn't suspected yields no matching bundle and the state is returned unchanged.
+ */
+class RemoveSuspectedExecutor : EffectExecutor<RemoveSuspectedEffect> {
+
+    override val effectType: KClass<RemoveSuspectedEffect> = RemoveSuspectedEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: RemoveSuspectedEffect,
+        context: EffectContext
+    ): EffectResult {
+        val entityId = TargetResolutionUtils.resolveTarget(effect.target, context, state)
+            ?: return EffectResult.success(state)
+
+        // The (sourceId, timestamp) pairs of every suspect application on this creature.
+        val bundleKeys = state.floatingEffects
+            .filter { it.effect.modification is SerializableModification.SetSuspected && it.affectsOnly(entityId) }
+            .map { it.sourceId to it.timestamp }
+            .toSet()
+
+        if (bundleKeys.isEmpty()) return EffectResult.success(state)
+
+        val remaining = state.floatingEffects.filterNot { fx ->
+            (fx.sourceId to fx.timestamp) in bundleKeys &&
+                fx.affectsOnly(entityId) &&
+                fx.isSuspectPart()
+        }
+
+        return EffectResult.success(state.copy(floatingEffects = remaining))
+    }
+}
+
+/** The floating effect's affected set is exactly [entityId] — the shape every suspect sub-effect has. */
+private fun ActiveFloatingEffect.affectsOnly(entityId: EntityId): Boolean =
+    effect.affectedEntities == setOf(entityId)
+
+/** One of the three modifications `Effects.Suspect` applies. */
+private fun ActiveFloatingEffect.isSuspectPart(): Boolean =
+    when (val modification = effect.modification) {
+        is SerializableModification.SetSuspected -> true
+        is SerializableModification.SetCantBlock -> true
+        is SerializableModification.GrantKeyword -> modification.keyword == Keyword.MENACE.name
+        else -> false
+    }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -420,6 +420,17 @@ sealed interface SerializableModification {
     data object SetCantBlock : SerializableModification
 
     /**
+     * Blocking requirement: creature blocks this turn if able (Culvert Ambusher).
+     *
+     * Floating counterpart of the static [com.wingedsheep.sdk.scripting.MustBlock] (Grand Melee);
+     * both project onto the same `ProjectedState.mustBlock`, which `BlockPhaseManager` reads when
+     * validating declared blockers. A requirement, not a guarantee — a creature that can't legally
+     * block any attacker is simply excused (CR 509.1c).
+     */
+    @Serializable
+    data object SetMustBlock : SerializableModification
+
+    /**
      * "It can't be turned face up." Used by Unable to Scream while it enchants a face-down
      * creature. Projected onto the affected permanent; [TurnFaceUpHandler] reads it.
      */
@@ -746,6 +757,8 @@ fun SerializableModification.toModification(): Modification = when (this) {
     is SerializableModification.SetCantBeTurnedFaceUp -> Modification.SetCantBeTurnedFaceUp
     // SetCantBlock maps to the layer modification for "can't block" projection
     is SerializableModification.SetCantBlock -> Modification.SetCantBlock
+    // SetMustBlock maps to the layer modification for the "must block" requirement projection
+    is SerializableModification.SetMustBlock -> Modification.SetMustBlock
     // SetSuspected maps to the layer modification for the "suspected" status projection
     is SerializableModification.SetSuspected -> Modification.SetSuspected
     // PreventAllDamageDealtBy doesn't map to a layer modification - it's checked during damage resolution directly

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
@@ -147,6 +147,15 @@ data class EntitySnapshot(
     val wasAttacking: Boolean = false,
     /** True if the leaving entity was a token (CR 704.5d — suppress persist-style return triggers). */
     val wasToken: Boolean = false,
+    /**
+     * True if this permanent carried the suspected designation (CR 701.60a) at capture time.
+     *
+     * Frozen because the designation is a floating effect keyed on the entity, and a sacrificed
+     * permanent's floating effects are torn down with it — so "if the sacrificed creature was
+     * suspected" (Agency Coroner) has to read last-known information (CR 608.2h), exactly as
+     * [supertypes] does for "was legendary".
+     */
+    val wasSuspected: Boolean = false,
     /** Per-player damage dealt to this entity this turn, keyed by source-controller (Grothama). */
     val damageDealtByPlayers: Map<EntityId, Int> = emptyMap(),
     /** Snapshots of the sources that dealt damage to this entity this turn (Shelob, Child of Ungoliant). */
@@ -173,6 +182,7 @@ data class EntitySnapshot(
                 counters = countersOf(state, entityId),
                 keywords = projected.getKeywords(entityId),
                 lostAllAbilities = projected.hasLostAllAbilities(entityId),
+                wasSuspected = projected.isSuspected(entityId),
                 name = state.getEntity(entityId)?.get<CardComponent>()?.name,
             )
         }
@@ -202,6 +212,7 @@ fun captureEntitySnapshots(
         subtypes = projected.getSubtypes(id),
         supertypes = projected.getSupertypes(id),
         controllerId = projected.getController(id),
+        wasSuspected = projected.isSuspected(id),
     )
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -2583,6 +2583,19 @@ class ClientStateTransformer(
                         )
                     )
                 }
+                // The unrestricted requirement (Culvert Ambusher). Badged for the same reason as
+                // "Must Attack": the defending player finds out about it when their declaration is
+                // rejected, which is far too late to be the first they hear of it.
+                is SerializableModification.SetMustBlock -> {
+                    effects.add(
+                        ClientCardEffect(
+                            effectId = "must_block_this_turn",
+                            name = "Must Block",
+                            description = "This creature must block this turn if able",
+                            icon = "must-attack"
+                        )
+                    )
+                }
                 is SerializableModification.PreventAllCombatDamage -> {
                     effects.add(
                         ClientCardEffect(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbsolvingLammasuScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbsolvingLammasuScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.AbsolvingLammasu
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.RepeatOffender
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Absolving Lammasu — "When this creature enters, all suspected creatures are no longer suspected."
+ *
+ * Covers the new `Effects.NoLongerSuspected` vocabulary (CR 701.60c). Three things have to hold and
+ * only the first is obvious:
+ *
+ *  1. the designation comes off — `ProjectedState.isSuspected` goes false;
+ *  2. the menace and can't-block that `Effects.Suspect` applied alongside it come off *too*, since
+ *     they exist only for as long as the creature is suspected. Those are separate floating effects
+ *     with no back-reference to the status, so a naive "clear the status" implementation would leave
+ *     a creature that isn't suspected but still can't block;
+ *  3. it is symmetric — "all suspected creatures" is every creature on the battlefield, so an
+ *     opponent's suspect is absolved as readily as your own.
+ *
+ * Repeat Offender is the suspect source on both sides: its `{2}{B}` ability suspects it when it
+ * isn't already.
+ */
+class AbsolvingLammasuScenarioTest : FunSpec({
+
+    val offenderAbility = RepeatOffender.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AbsolvingLammasu)
+        driver.registerCard(RepeatOffender)
+        return driver
+    }
+
+    /**
+     * Hand priority to [player] without advancing the step. Priority ends up wherever the last
+     * resolution left it, and a player can only act while holding it — with an empty stack a single
+     * pass just moves it across, so this is safe to call unconditionally.
+     */
+    fun handPriorityTo(driver: GameTestDriver, player: EntityId) {
+        driver.priorityPlayer?.takeIf { it != player }?.let { driver.passPriority(it) }
+    }
+
+    /** Put a Repeat Offender under [player] and activate it once so it becomes suspected. */
+    fun suspectedOffender(driver: GameTestDriver, player: EntityId): EntityId {
+        val offender = driver.putCreatureOnBattlefield(player, "Repeat Offender")
+        driver.giveMana(player, Color.BLACK, 3)
+        handPriorityTo(driver, player)
+        driver.submitSuccess(ActivateAbility(player, offender, offenderAbility))
+        driver.bothPass()
+        StateProjector().project(driver.state).isSuspected(offender) shouldBe true
+        return offender
+    }
+
+    test("entering absolves every suspected creature, on both sides, keyword grants included") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mine = suspectedOffender(driver, active)
+        val theirs = suspectedOffender(driver, opponent)
+
+        val lammasu = driver.putCardInHand(active, "Absolving Lammasu")
+        driver.giveMana(active, Color.WHITE, 5)
+        handPriorityTo(driver, active)
+        driver.castSpellWithTargets(active, lammasu, emptyList()).error shouldBe null
+        driver.bothPass() // resolve the creature spell; the enters trigger goes on the stack
+        driver.bothPass() // resolve the trigger
+
+        val projected = StateProjector().project(driver.state)
+        listOf("yours" to mine, "the opponent's" to theirs).forEach { (whose, offender) ->
+            withClue("$whose Offender is no longer suspected") {
+                projected.isSuspected(offender) shouldBe false
+            }
+            withClue("$whose Offender loses the menace the suspect granted") {
+                projected.hasKeyword(offender, Keyword.MENACE) shouldBe false
+            }
+            withClue("$whose Offender can block again") {
+                projected.cantBlock(offender) shouldBe false
+            }
+        }
+    }
+
+    test("an unsuspected board is untouched — absolving is a no-op, not a keyword wipe") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Menace from a printed keyword, not from a suspect — it must survive.
+        val menacing = driver.putCreatureOnBattlefield(active, "Goblin Trailblazer")
+        val plain = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+
+        val lammasu = driver.putCardInHand(active, "Absolving Lammasu")
+        driver.giveMana(active, Color.WHITE, 5)
+        driver.castSpellWithTargets(active, lammasu, emptyList()).error shouldBe null
+        driver.bothPass()
+        driver.bothPass()
+
+        val projected = StateProjector().project(driver.state)
+        withClue("nothing was suspected, so nothing changed") {
+            projected.isSuspected(plain) shouldBe false
+            projected.cantBlock(plain) shouldBe false
+        }
+        withClue("menace a creature has from its own printed text is not a suspect and stays") {
+            projected.hasKeyword(menacing, Keyword.MENACE) shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AgencyCoronerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AgencyCoronerScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.AgencyCoroner
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.RepeatOffender
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Agency Coroner — "{2}{B}, Sacrifice another creature: Draw a card. If the sacrificed creature was
+ * suspected, draw two cards instead."
+ *
+ * Covers the new `Conditions.SacrificedWasSuspected` vocabulary and the `EntitySnapshot.wasSuspected`
+ * flag behind it. The point of the test is the *timing*: the suspected designation is a floating
+ * effect keyed on the creature, so it is destroyed along with the creature the moment the cost is
+ * paid — well before the ability resolves. If the condition read live state instead of the frozen
+ * cost-time snapshot (CR 608.2h), the suspected case would silently draw one card, which is exactly
+ * the failure this test pins down.
+ *
+ * Repeat Offender supplies the suspect: its own `{2}{B}` ability suspects it when it isn't already.
+ */
+class AgencyCoronerScenarioTest : FunSpec({
+
+    val coronerAbility = AgencyCoroner.activatedAbilities.first().id
+    val offenderAbility = RepeatOffender.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AgencyCoroner)
+        driver.registerCard(RepeatOffender)
+        return driver
+    }
+
+    test("sacrificing a suspected creature draws two cards") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val coroner = driver.putCreatureOnBattlefield(active, "Agency Coroner")
+        val offender = driver.putCreatureOnBattlefield(active, "Repeat Offender")
+
+        // Suspect the Offender with its own ability.
+        driver.giveMana(active, Color.BLACK, 3)
+        driver.submitSuccess(ActivateAbility(active, offender, offenderAbility))
+        driver.bothPass()
+        withClue("Repeat Offender's ability suspects it when it isn't already suspected") {
+            StateProjector().project(driver.state).isSuspected(offender) shouldBe true
+        }
+
+        val handBefore = driver.getHandSize(active)
+
+        driver.giveMana(active, Color.BLACK, 3)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = active,
+                sourceId = coroner,
+                abilityId = coronerAbility,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(offender))
+            )
+        )
+        driver.bothPass()
+
+        withClue("the suspected body is worth two cards, read from the cost-time snapshot") {
+            driver.getHandSize(active) shouldBe handBefore + 2
+        }
+        driver.assertInGraveyard(active, "Repeat Offender")
+    }
+
+    test("sacrificing an unsuspected creature draws one card") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val coroner = driver.putCreatureOnBattlefield(active, "Agency Coroner")
+        val bear = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        withClue("a plain creature is not suspected") {
+            StateProjector().project(driver.state).isSuspected(bear) shouldBe false
+        }
+
+        val handBefore = driver.getHandSize(active)
+
+        driver.giveMana(active, Color.BLACK, 3)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = active,
+                sourceId = coroner,
+                abilityId = coronerAbility,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bear))
+            )
+        )
+        driver.bothPass()
+
+        withClue("no suspect, no bonus — the else branch draws exactly one") {
+            driver.getHandSize(active) shouldBe handBefore + 1
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CulvertAmbusherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CulvertAmbusherScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CulvertAmbusher
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Culvert Ambusher — "When this creature enters or is turned face up, target creature blocks this
+ * turn if able."
+ *
+ * Covers the new `Effects.MarkMustBlockThisTurn` vocabulary end to end: the floating
+ * `SetMustBlock` it applies has to reach `ProjectedState.mustBlock`, and `BlockPhaseManager` has to
+ * reject a declaration that ignores it. Both halves matter — a modification that projects but is
+ * never validated is indistinguishable from doing nothing.
+ *
+ * The second test is the CR 509.1c half: "if able" is a requirement, not a guarantee, so a tapped
+ * creature is excused and its controller may declare no blockers at all.
+ */
+class CulvertAmbusherScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CulvertAmbusher)
+        return driver
+    }
+
+    /**
+     * Cast the Ambusher and point its enters trigger at [victim]. Leaves the game with the trigger
+     * fully resolved.
+     */
+    fun castAmbusherTargeting(driver: GameTestDriver, caster: EntityId, victim: EntityId) {
+        val card = driver.putCardInHand(caster, "Culvert Ambusher")
+        driver.giveMana(caster, Color.GREEN, 5)
+        driver.castSpellWithTargets(caster, card, emptyList()).error shouldBe null
+        driver.bothPass() // resolve the creature spell; the enters trigger goes on the stack
+
+        // The trigger's target is chosen as it goes on the stack.
+        driver.pendingDecision.shouldNotBeNull()
+        withClue("the enters trigger must ask for its target") {
+            driver.submitTargetSelection(caster, listOf(victim)).error shouldBe null
+        }
+        driver.bothPass() // resolve the trigger
+    }
+
+    test("the marked creature must block if it can") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        driver.removeSummoningSickness(attacker)
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        castAmbusherTargeting(driver, active, blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(attacker), opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("declaring no blockers ignores the requirement and must be rejected") {
+            driver.declareNoBlockers(opponent).error shouldNotBe null
+        }
+        withClue("blocking with the marked creature satisfies it") {
+            driver.declareBlockers(opponent, mapOf(blocker to listOf(attacker))).error shouldBe null
+        }
+    }
+
+    test("a tapped creature is excused — 'if able' is a requirement, not a guarantee") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val attacker = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        driver.removeSummoningSickness(attacker)
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        castAmbusherTargeting(driver, active, blocker)
+        driver.tapPermanent(blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(attacker), opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        withClue("a tapped creature can't block, so declaring no blockers is legal (CR 509.1c)") {
+            driver.declareNoBlockers(opponent).error shouldBe null
+        }
+    }
+})


### PR DESCRIPTION
Five MKM cards spanning the set's disguise, Detective, and suspect mechanics. Greenbelt Radical and Projektor Inspector compose entirely from existing primitives; the other three each needed one new piece of vocabulary.

## Cards

| Card | | |
|---|---|---|
| **Greenbelt Radical** | `{3}{G}` 4/4 | Disguise `{5}{G}{G}`; turned face up → +1/+1 counter on each creature you control, creatures gain trample UEOT |
| **Projektor Inspector** | `{2}{U}` 3/2 | Whenever this or another Detective you control enters, and whenever a Detective you control is turned face up, you may loot |
| **Culvert Ambusher** | `{3}{G}{G}` 4/5 | Enters or turned face up → target creature blocks this turn if able; Disguise `{4}{G}` |
| **Agency Coroner** | `{4}{B}` 3/6 | `{2}{B}`, Sac another creature: Draw a card — two if the sacrificed creature was suspected |
| **Absolving Lammasu** | `{4}{W}` 4/3 | Flying; ETB all suspected creatures are no longer suspected; dies → gain 3 life and suspect up to one target creature an opponent controls |

## New SDK vocabulary

**`Effects.MarkMustBlockThisTurn`** — "target creature blocks this turn if able". Applies a floating `SetMustBlock` in `Layer.ABILITY`, i.e. the same projected `mustBlock` the *static* `MustBlock` (Grand Melee) writes, so `BlockPhaseManager`'s existing validation enforces it and the generic end-of-turn cleanup expires it. Distinct from `ForceBlock`, which pins a creature to one *named* attacker and requires the source to be attacking.

**`Effects.NoLongerSuspected`** — "it's no longer suspected" (CR 701.60c). Removes the whole suspect application: the named status, the menace grant, and the can't-block, since the latter two exist only for as long as the creature is suspected. The bundle is identified by the `(sourceId, timestamp)` its three floating effects share — `CompositeEffect` deliberately doesn't tick `state.timestamp` between children so Rule 613 treats them as one application, and that shared stamp is the bundle's identity by design. The match is narrowed to those three modification kinds on an affected set of exactly one creature, so menace or can't-block from any *other* source survives.

**`Conditions.SacrificedWasSuspected`** — backed by a new `EntitySnapshot.wasSuspected` frozen at cost-payment time. This has to be last-known information (CR 608.2h): the designation is a floating effect keyed on the entity, so it dies with the creature the moment the cost is paid, long before the ability resolves. A live read would silently draw one card in the suspected case.

## UX

Badges **"Must Block"** in `ClientStateTransformer` alongside the existing "Must Attack" — otherwise the defending player first learns about the requirement when their no-block declaration is rejected, which is far too late.

## Tests

One scenario test file per card that needed new vocabulary:

- `CulvertAmbusherScenarioTest` — the requirement is both projected and validated; a tapped creature is excused (CR 509.1c).
- `AgencyCoronerScenarioTest` — suspected body draws two, plain body draws one, proving the read is the frozen snapshot rather than live state.
- `AbsolvingLammasuScenarioTest` — absolves both players' suspects, strips the menace/can't-block the suspect granted, and leaves menace a creature has from its own printed text alone.

## Verification

`just build`, `just test`, and `just check` all green. `just rebless-cards` moved only these five cards in the MKM golden. Every card's mechanical fields (mana cost, type line, P/T, rarity, collector number, artist, image URI) re-checked field-by-field against Scryfall. `just check-card-printing` clean for all five — MKM is the canonical printing for each, no reprint rows needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)