### PR TITLE
Add three The Hobbit cards with two trigger extensions

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4239,6 +4239,13 @@ Named sugar for the common type-primitive cases; reach for `youCastSpell(...)` p
   with `Effects.DealDamage(n, EffectTarget.PlayerRef(Player.TriggeringPlayer))` to punish the activator (Flamescroll
   Celebrant). Backed by `EventPattern.AbilityActivatedEvent(player)`.
 - `YouActivateAbility` — you activate an ability that isn't a mana ability (the `Player.You` form of the above).
+- `activatesAbilityOf(sourceFilter, player?)` — the source-scoped form of the above: an ability that isn't a mana
+  ability, activated from a permanent matching `sourceFilter`. Elrond, Moon-Reader's "whenever you activate an
+  ability of a creature" is `activatesAbilityOf(GameObjectFilter.Creature)`; pair it with `oncePerTurn = true` on
+  the triggered ability for the "this ability triggers only once each turn" clause. Backed by
+  `EventPattern.AbilityActivatedEvent(player, sourceFilter)`. Unlike `activatesAbilityWithoutTap` (below), which
+  keys on the literal `{T}`-in-cost wording, this keeps the "isn't a mana ability" gate — so a creature's
+  tap-for-mana never fires it while a `{T}`-costed non-mana ability does.
 - `YouActivateExhaustAbility` — you activate an ability marked `isExhaust`. Backed by
   `EventPattern.AbilityActivatedEvent(player = Player.You, requireExhaust = true)` and the activation event's
   `isExhaust` flag. The event is emitted as soon as the exhaust ability is put on the stack, so the triggered
@@ -4773,7 +4780,13 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
 
 ### Conditional
 
-- `NthSpellCast(n, player?)` — fires on the Nth spell cast.
+- `NthSpellCast(n, player?, spellFilter?)` — fires on the Nth spell cast each turn. `spellFilter` makes the
+  ordinal per-kind rather than over every spell — The Queen of Dale's "whenever an opponent casts their **first
+  noncreature** spell each turn" is `NthSpellCast(1, Player.EachOpponent, GameObjectFilter.Noncreature)`. With a
+  filter the count runs over the caster's `spellsCastThisTurnByPlayer` records (the same history
+  `CostGating.NthOfTypePerTurn` and the `nthOfTypePerTurn` flash gate read) instead of the flat
+  `playerSpellsCastThisTurn` total, so it counts **casts, not resolutions**: a matching spell that was countered
+  still closes the window for that turn. Without a filter it is the flat total, the Hearthborn Battler shape.
 - `WhenYouCastThisSpell()` — a "cast trigger" that fires on the spell's **own** cast while it is on
   the stack (`EventPattern.CastThisSpellEvent`, `binding = SELF`). Distinct from a battlefield
   `SpellCast`/`NthSpellCast` trigger that observes *other* spells: this one travels with the spell

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1216,6 +1216,24 @@ object Triggers {
     )
 
     /**
+     * Whenever [player] activates an ability *of a permanent matching [sourceFilter]* that isn't a
+     * mana ability — Elrond, Moon-Reader's "whenever you activate an ability of a creature".
+     *
+     * The source-scoped sibling of [YouActivateAbility]: same "isn't a mana ability" gate (CR 605 /
+     * 606), plus the activated ability's source permanent must match. Unlike
+     * [activatesAbilityWithoutTap], which keys on the literal "{T} in its activation cost" wording,
+     * this leaves the tap cost alone — a {T} ability of a creature fires it just as a costless one
+     * does.
+     */
+    fun activatesAbilityOf(
+        sourceFilter: GameObjectFilter,
+        player: Player = Player.You
+    ): TriggerSpec = TriggerSpec(
+        event = AbilityActivatedEvent(player = player, sourceFilter = sourceFilter),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * Whenever you activate an exhaust ability (CR 702.177). The plain Aetherdrift wording —
      * Adrenaline Jockey, Rangers' Refueler, Rangers' Aetherhive, Afterburner Expert — which counts
      * an exhaust *mana* ability as well. For the "that isn't a mana ability" variant see
@@ -2199,11 +2217,20 @@ object Triggers {
      * Whenever a player casts their Nth spell each turn.
      * Example: "Whenever a player casts their second spell each turn" → NthSpellCast(2)
      *
+     * [spellFilter] makes the ordinal per-kind — "their first noncreature spell each turn" (The
+     * Queen of Dale) is `NthSpellCast(1, Player.EachOpponent, GameObjectFilter.Noncreature)`. The
+     * count runs over the caster's cast history, so it counts casts rather than resolutions.
+     *
      * @param n The spell number (e.g., 2 for "second spell")
      * @param player Which player's spell count to track (default: any player)
+     * @param spellFilter Restricts which spells are counted; null (default) counts every spell
      */
-    fun NthSpellCast(n: Int, player: Player = Player.Each): TriggerSpec = TriggerSpec(
-        event = NthSpellCastEvent(nthSpell = n, player = player),
+    fun NthSpellCast(
+        n: Int,
+        player: Player = Player.Each,
+        spellFilter: GameObjectFilter? = null
+    ): TriggerSpec = TriggerSpec(
+        event = NthSpellCastEvent(nthSpell = n, player = player, spellFilter = spellFilter),
         binding = TriggerBinding.ANY
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1172,24 +1172,41 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      *
      * Used by cards like Hearthborn Battler: "Whenever a player casts their second spell each turn"
      *
+     * [spellFilter] narrows *which* spells the count runs over, so the ordinal is per-kind rather
+     * than over every spell: The Queen of Dale's "casts their first **noncreature** spell each turn"
+     * is `nthSpell = 1, spellFilter = GameObjectFilter.Noncreature`. The count reads the caster's
+     * cast history, so it tracks casts and not resolutions — a matching spell already cast this turn
+     * closes the window even if it was countered, exactly as `nthOfTypePerTurn` does for cost and
+     * flash gates. `null` (the default) counts every spell, the Hearthborn Battler shape.
+     *
      * @param nthSpell The spell number that triggers this (e.g., 2 for "second spell")
      * @param player Which player's spell count to track
+     * @param spellFilter Restricts the count to matching spells; null counts all of them
      */
     @SerialName("NthSpellCastEvent")
     @Serializable
     data class NthSpellCastEvent(
         val nthSpell: Int,
-        val player: Player = Player.Each
+        val player: Player = Player.Each,
+        val spellFilter: GameObjectFilter? = null
     ) : EventPattern {
         override val description: String = buildString {
             append(player.description)
             append(" casts their ")
             append(when (nthSpell) {
+                1 -> "first"
                 2 -> "second"
                 3 -> "third"
                 else -> "${nthSpell}th"
             })
-            append(" spell each turn")
+            append(" ")
+            spellFilter?.let { append(it.description).append(" ") }
+            append("spell each turn")
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): EventPattern {
+            val newFilter = spellFilter?.applyTextReplacement(replacer)
+            return if (newFilter !== spellFilter) copy(spellFilter = newFilter) else this
         }
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BardsCompany.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BardsCompany.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bard's Company
+ * {2}{W}{U}
+ * Creature — Human Citizen
+ * 2/3
+ *
+ * You may cast this spell as though it had flash if you control a Human.
+ * Other creatures you control get +1/+1.
+ * Whenever this creature enters or attacks, recruit.
+ *
+ * Three separate clauses, each on its own existing primitive:
+ *
+ * - The flash clause is card-level [conditionalFlash], not a battlefield static — the permission has
+ *   to be readable while the card is still in hand, which is exactly what that field is for
+ *   (Illusion Spinners, Colossal Rattlewurm). "A Human" is any permanent with the subtype, so the
+ *   filter is [GameObjectFilter.Permanent], not `Creature`; a noncreature permanent that has been
+ *   made a Human still turns the clause on.
+ * - The anthem is a plain [ModifyStats] over other creatures you control (Benalish Marshal).
+ * - "Enters or attacks" is two triggered abilities, the established shape here (Sentinel of the
+ *   Nameless City) — one event each, so a creature that enters attacking would fire both, as CR
+ *   requires.
+ */
+val BardsCompany = card("Bard's Company") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "You may cast this spell as though it had flash if you control a Human.\n" +
+        "Other creatures you control get +1/+1.\n" +
+        "Whenever this creature enters or attacks, recruit. (Draw a card, then discard a card. " +
+        "If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)"
+    power = 2
+    toughness = 3
+
+    conditionalFlash = Conditions.YouControl(GameObjectFilter.Permanent.withSubtype(Subtype.HUMAN))
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter.OtherCreaturesYouControl
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "146"
+        artist = "Jarel Threat"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d14aa2ff-7bbd-47a6-8e36-481e56302a62.jpg?1785152250"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ElrondMoonReader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ElrondMoonReader.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Elrond, Moon-Reader
+ * {2}{U}
+ * Legendary Creature — Elf Noble
+ * 3/3
+ *
+ * Whenever you activate an ability of a creature, draw a card. This ability triggers only once
+ * each turn.
+ * {5}{U}{U}: Exile up to two other target nonland permanents you control. Return those cards to
+ * the battlefield under their owner's control at the beginning of the next end step.
+ *
+ * The trigger is [Triggers.activatesAbilityOf] — the source-scoped form of the existing "whenever
+ * you activate an ability that isn't a mana ability" event, so a creature's mana ability doesn't
+ * fire it, but a {T} ability does. `oncePerTurn` carries the "only once each turn" clause; a
+ * per-permanent restriction would be wrong here since the clause bounds the *ability*, not the
+ * creatures it watches. The filter is unrestricted by controller — the oracle says "a creature",
+ * not "a creature you control" — so an ability of a creature you don't control but may activate
+ * still triggers it.
+ *
+ * The activated ability is the blink pattern from Hide on the Ceiling: one target requirement of
+ * `count = 2, optional = true` for "up to two", then [ForEachTargetEffect] running
+ * [Patterns.Exile.exileUntilEndStep] per chosen permanent so each gets its own delayed return
+ * trigger. "Other" is [TargetFilter.OtherNonlandPermanent]'s `excludeSelf`; Elrond can't blink
+ * itself, which also means the delayed return is unaffected by his leaving.
+ */
+val ElrondMoonReader = card("Elrond, Moon-Reader") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Elf Noble"
+    oracleText = "Whenever you activate an ability of a creature, draw a card. This ability " +
+        "triggers only once each turn.\n" +
+        "{5}{U}{U}: Exile up to two other target nonland permanents you control. Return those " +
+        "cards to the battlefield under their owner's control at the beginning of the next end step."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.activatesAbilityOf(GameObjectFilter.Creature)
+        oncePerTurn = true
+        effect = DrawCardsEffect(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{U}{U}")
+        target = TargetPermanent(
+            count = 2,
+            optional = true,
+            filter = TargetFilter.OtherNonlandPermanent.youControl()
+        )
+        effect = ForEachTargetEffect(
+            listOf(Patterns.Exile.exileUntilEndStep(EffectTarget.ContextTarget(0)))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "36"
+        artist = "Christina Kraus"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbcb310c-be73-46f8-8e65-8632454ccc6e.jpg?1784376948"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheQueenOfDale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheQueenOfDale.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * The Queen of Dale
+ * {1}{W}
+ * Legendary Creature — Human Noble
+ * 2/1
+ *
+ * Whenever an opponent casts their first noncreature spell each turn, you recruit.
+ *
+ * The ordinal is per-kind — an opponent who leads with two creature spells and then a noncreature
+ * one still hands you a recruit, because the count runs over that opponent's *noncreature* casts
+ * only. That's the `spellFilter` on [Triggers.NthSpellCast], counted off the caster's cast history,
+ * so it counts casts rather than resolutions: a countered noncreature spell still burns the
+ * opponent's window for the turn.
+ *
+ * "Each turn" is per turn and per opponent, not per turn total — the count is keyed to the caster,
+ * so in a multiplayer game each opponent's own first noncreature spell triggers separately.
+ */
+val TheQueenOfDale = card("The Queen of Dale") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Noble"
+    oracleText = "Whenever an opponent casts their first noncreature spell each turn, you recruit. " +
+        "(Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white " +
+        "Human Soldier creature token.)"
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.NthSpellCast(
+            n = 1,
+            player = Player.EachOpponent,
+            spellFilter = GameObjectFilter.Noncreature
+        )
+        effect = Patterns.Mechanic.recruit()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "24"
+        artist = "Magali Villeneuve"
+        flavorText = "Dale may grow to reclaim its former glory and splendor, as in the days " +
+            "before the Dragon came."
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c977fb5f-4436-41d0-af68-93b6d05897e5.jpg?1784376948"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -262,6 +262,180 @@
     ]
 }
 
+// Bard's Company
+{
+    "name": "Bard's Company",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "You may cast this spell as though it had flash if you control a Human.\nOther creatures you control get +1/+1.\nWhenever this creature enters or attacks, recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ],
+        "conditionalFlash": {
+            "type": "Exists",
+            "player": "You",
+            "zone": "Battlefield",
+            "filter": "permanent Human"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "RARE",
+        "artist": "Jarel Threat",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d14aa2ff-7bbd-47a6-8e36-481e56302a62.jpg?1785152250"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Bejeweled Warg
 {
     "name": "Bejeweled Warg",
@@ -3119,6 +3293,99 @@
     },
     "colorIdentityOverride": [
         "WHITE",
+        "BLUE"
+    ]
+}
+
+// Elrond, Moon-Reader
+{
+    "name": "Elrond, Moon-Reader",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Elf Noble",
+    "oracleText": "Whenever you activate an ability of a creature, draw a card. This ability triggers only once each turn.\n{5}{U}{U}: Exile up to two other target nonland permanents you control. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AbilityActivatedEvent",
+                    "sourceFilter": "creature"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{U}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Exile"
+                            },
+                            {
+                                "type": "CreateDelayedTrigger",
+                                "step": "END",
+                                "effect": {
+                                    "type": "MoveToZone",
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "destination": "Battlefield"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "nonland permanent ctrl:you",
+                            "excludeSelf": true
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "MYTHIC",
+        "artist": "Christina Kraus",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbcb310c-be73-46f8-8e65-8632454ccc6e.jpg?1784376948"
+    },
+    "colorIdentityOverride": [
         "BLUE"
     ]
 }
@@ -10531,6 +10798,106 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// The Queen of Dale
+{
+    "name": "The Queen of Dale",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Human Noble",
+    "oracleText": "Whenever an opponent casts their first noncreature spell each turn, you recruit. (Draw a card, then discard a card. If you discarded a nonland card, create a 1/1 white Human Soldier creature token.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthSpellCastEvent",
+                    "nthSpell": 1,
+                    "player": "EachOpponent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "recruit_hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "recruit_hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "recruit_discarded",
+                            "prompt": "Recruit — choose a card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "recruit_discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "recruit_discarded",
+                            "ifNotEmpty": {
+                                "type": "CreateToken",
+                                "power": 1,
+                                "toughness": 1,
+                                "colors": [
+                                    "WHITE"
+                                ],
+                                "creatureTypes": [
+                                    "Human",
+                                    "Soldier"
+                                ]
+                            },
+                            "filter": "nonland"
+                        }
+                    ],
+                    "descriptionOverride": "Recruit"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "MYTHIC",
+        "artist": "Magali Villeneuve",
+        "flavorText": "Dale may grow to reclaim its former glory and splendor, as in the days before the Dragon came.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c977fb5f-4436-41d0-af68-93b6d05897e5.jpg?1784376948"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -226,7 +226,17 @@ class TriggerMatcher(
                 // reaches exactly the specified threshold (e.g., 2 for "second spell").
                 if (event !is SpellCastEvent) return false
                 if (!matchesPlayer(trigger.player, event.casterId, controllerId)) return false
-                val currentCount = state.playerSpellsCastThisTurn[event.casterId] ?: 0
+                val spellFilter = trigger.spellFilter
+                val currentCount = if (spellFilter == null) {
+                    state.playerSpellsCastThisTurn[event.casterId] ?: 0
+                } else {
+                    // "their first noncreature spell each turn" — the ordinal runs over matching
+                    // spells only, so count the caster's cast records instead of the flat total.
+                    // CastSpellHandler appends the spell being cast before triggers are detected,
+                    // so this count includes it and the `== nthSpell` comparison stays the same.
+                    val records = state.spellsCastThisTurnByPlayer[event.casterId] ?: emptyList()
+                    records.count { predicateEvaluator.matchesFilter(it, spellFilter) }
+                }
                 currentCount == trigger.nthSpell
             }
             is EventPattern.CastThisSpellEvent -> {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElrondMoonReaderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElrondMoonReaderScenarioTest.kt
@@ -1,0 +1,171 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.AlongTheCrookedWay
+import com.wingedsheep.mtg.sets.definitions.hob.cards.ElrondMoonReader
+import com.wingedsheep.mtg.sets.definitions.inv.cards.Firescreamer
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Elrond, Moon-Reader (HOB #36) — {2}{U} Legendary Creature — Elf Noble 3/3.
+ *
+ * "Whenever you activate an ability of a creature, draw a card. This ability triggers only once
+ * each turn." + "{5}{U}{U}: Exile up to two other target nonland permanents you control. Return
+ * those cards to the battlefield under their owner's control at the beginning of the next end step."
+ *
+ * The trigger is the new source-filtered form of the "you activate an ability" event
+ * ([com.wingedsheep.sdk.dsl.Triggers.activatesAbilityOf]), so the interesting cases are the two
+ * ways it must *not* fire: a creature's mana ability (excluded by the shared "isn't a mana ability"
+ * gate) and a noncreature permanent's ability (excluded by the source filter).
+ */
+class ElrondMoonReaderScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(ElrondMoonReader)
+        cardRegistry.register(Firescreamer)
+        cardRegistry.register(AlongTheCrookedWay)
+
+        context("Elrond, Moon-Reader") {
+
+            test("activating a creature's non-mana ability draws, but only once each turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elrond, Moon-Reader", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Firescreamer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val screamer = game.findPermanent("Firescreamer")!!
+                val pump = Firescreamer.activatedAbilities.single().id
+                val handBefore = game.handSize(1)
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = screamer, abilityId = pump)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the first creature-ability activation this turn draws a card") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = screamer, abilityId = pump)
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("'only once each turn' suppresses the second activation's trigger") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("a creature's mana ability does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elrond, Moon-Reader", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Llanowar Elves", summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elves = game.findPermanent("Llanowar Elves")!!
+                val tapForMana = TestCards.LlanowarElves.activatedAbilities.single().id
+                val handBefore = game.handSize(1)
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = elves, abilityId = tapForMana)
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("mana abilities don't use the stack and never fire this trigger") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("a noncreature permanent's ability does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elrond, Moon-Reader", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Along the Crooked Way")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enchantment = game.findPermanent("Along the Crooked Way")!!
+                val grantMenace = AlongTheCrookedWay.activatedAbilities.single().id
+                val handBefore = game.handSize(1)
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = enchantment,
+                        abilityId = grantMenace
+                    )
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the source filter is 'a creature'; an Enchantment's ability is out of scope") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("the blink ability exiles two permanents and returns them at the next end step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Elrond, Moon-Reader", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Savannah Lions")
+                    .withLandsOnBattlefield(1, "Island", 7)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val lions = game.findPermanent("Savannah Lions")!!
+                val blink = ElrondMoonReader.activatedAbilities.single().id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = game.findPermanent("Elrond, Moon-Reader")!!,
+                        abilityId = blink,
+                        targets = listOf(ChosenTarget.Permanent(bears), ChosenTarget.Permanent(lions))
+                    )
+                ).error shouldBe null
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("both chosen permanents are exiled") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isOnBattlefield("Savannah Lions") shouldBe false
+                    game.isInExile(1, "Grizzly Bears") shouldBe true
+                    game.isInExile(1, "Savannah Lions") shouldBe true
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("each exiled card gets its own delayed return at the next end step") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Savannah Lions") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheQueenOfDaleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheQueenOfDaleScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.TheQueenOfDale
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Queen of Dale (HOB #24) — {1}{W} Legendary Creature — Human Noble 2/1.
+ *
+ * "Whenever an opponent casts their first noncreature spell each turn, you recruit."
+ *
+ * The point of interest is the new `spellFilter` on the Nth-spell-cast event: the ordinal has to
+ * run over the opponent's *noncreature* casts alone, so a creature spell cast first must neither
+ * trigger it nor consume the window, and a second noncreature spell in the same turn must not
+ * trigger it again.
+ */
+class TheQueenOfDaleScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(TheQueenOfDale)
+
+        context("The Queen of Dale") {
+
+            test("an opponent's first noncreature spell recruits") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Queen of Dale")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 3)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("recruit pauses for the discard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(game.findCardsInHand(1, "Grizzly Bears"))
+                game.resolveStack()
+
+                withClue("recruit drew the Forest") { game.isInHand(1, "Forest") shouldBe true }
+                withClue("the nonland discard mints one Human Soldier token") {
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 1
+                }
+            }
+
+            test("a creature spell neither triggers it nor consumes the turn's window") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Queen of Dale")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInHand(2, "Goblin Guide")
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 6)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Goblin Guide").error shouldBe null
+                game.resolveStack()
+
+                withClue("a creature spell is outside the filter, so nothing triggers") {
+                    game.hasPendingDecision() shouldBe false
+                }
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("the noncreature spell is still the opponent's *first* one, so it triggers") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(game.findCardsInHand(1, "Grizzly Bears"))
+                game.resolveStack()
+                game.findAllPermanents("Human Soldier Token").size shouldBe 1
+            }
+
+            test("a second noncreature spell in the same turn does not trigger it again") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Queen of Dale")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardsInHand(2, "Lightning Bolt", 2)
+                    .withLandsOnBattlefield(2, "Mountain", 6)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+                game.selectCards(game.findCardsInHand(1, "Grizzly Bears"))
+                game.resolveStack()
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("the window closed with the turn's first noncreature spell") {
+                    game.hasPendingDecision() shouldBe false
+                    game.findAllPermanents("Human Soldier Token").size shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three more HOB cards: **Bard's Company**, **Elrond, Moon-Reader**, and **The Queen of Dale** (166 → 169 of 193).

This is three rather than a bigger batch because HOB's remaining tail is nearly exhausted — of the 27 that were missing, 9 are gated on the unimplemented **storied** keyword and 2 on **hone counters**, and most of the rest need genuine engine design (last-known card types for Tom, Bert, and William; a zone *exclusion* for Bilbo's cost reduction; an information-asymmetric face-down pile for Riddles in the Dark). These three were the tractable remainder.

## The cards

| Card | Modelling |
|---|---|
| **Bard's Company** {2}{W}{U} | Entirely existing primitives — card-level `conditionalFlash`, a `ModifyStats` anthem, and two `recruit()` triggers for "enters or attacks" |
| **Elrond, Moon-Reader** {2}{U} | New `Triggers.activatesAbilityOf` + `oncePerTurn`; blink via `TargetPermanent(count = 2, optional = true)` → `ForEachTargetEffect(exileUntilEndStep)` |
| **The Queen of Dale** {1}{W} | New `spellFilter` on `NthSpellCastEvent` |

Bard's Company's flash clause is card-level `conditionalFlash` rather than a battlefield `GrantFlashToSpellType` deliberately: the permission has to be readable while the card is still in hand, and a static on the permanent can't see its own spell on the stack.

## SDK / engine changes

**`Triggers.activatesAbilityOf(sourceFilter, player)`** — the source-scoped sibling of `YouActivateAbility`, over the existing `AbilityActivatedEvent(player, sourceFilter)` (no new event type, no new matcher branch). It keeps the "isn't a mana ability" gate rather than `activatesAbilityWithoutTap`'s literal `{T}`-in-cost wording, so a creature's tap-for-mana never fires it while a `{T}`-costed non-mana ability does.

**`NthSpellCastEvent.spellFilter`** — makes the ordinal per-kind instead of over every spell. With a filter set, `TriggerMatcher` counts the caster's `spellsCastThisTurnByPlayer` records rather than the flat `playerSpellsCastThisTurn` total. That's the same history `CostGating.NthOfTypePerTurn` and the `nthOfTypePerTurn` flash gate already read, and it inherits the same convention: it counts **casts, not resolutions**, so a countered noncreature spell still closes the opponent's window for that turn. `null` (the default) is the old flat behaviour, so no existing card's serialized tree moves.

This also fixes the ordinal wording for `n = 1`, which previously rendered as "1th spell each turn". The description is a computed `val`, not a constructor property, so it isn't serialized and the goldens are unaffected.

`docs/card-sdk-language-reference.md` updated for both.

## Verification

- `just build` — green (`:mtg-sets:test` and `:rules-engine:test` both clean)
- `just rebless-cards` — HOB golden is **367 pure insertions**, exactly three `"name"` entries, no other card moved
- `ElrondMoonReaderScenarioTest` (4 tests) + `TheQueenOfDaleScenarioTest` (3 tests) — green

The scenario tests deliberately cover the cases that must **not** fire: for Elrond, a creature's mana ability and a noncreature permanent's ability; for the Queen, a leading creature spell (which neither triggers it nor consumes the turn's window) and a second noncreature spell in the same turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
