### PR TITLE
Add four Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7828,6 +7828,16 @@ default to "you" so card authors don't need to pass it explicitly.
   `DynamicAmounts.permanentsSacrificedThisTurn()` amount for "that much" damage (Sawblade Skinripper:
   "At the beginning of your end step, if you sacrificed one or more permanents this turn, this creature
   deals that much damage to any target").
+- `SacrificedArtifactThisTurn` — you sacrificed at least one artifact this turn. Composes through
+  `Compare(DynamicAmount.TurnTracking(Player.You, TurnTracker.ARTIFACT_SACRIFICED), GTE, Fixed(1))`,
+  the card-type sibling of `SacrificedFoodThisTurn`. Backed by the per-player marker
+  `SacrificedArtifactThisTurnComponent`, set in `ZoneTransitionService.trackPermanentSacrifice` off
+  the *projected* type line (an animated artifact counts) and cleared by `CleanupPhaseManager`. Turn
+  history, not a graveyard scan — the artifact having since left the graveyard doesn't clear it, and
+  it's controller-scoped, so an opponent cracking their own Clue never sets yours. Both MKM readings
+  of "if you've sacrificed an artifact this turn" ride it: the cost reduction via
+  `ModifySpellCost(SelfCast, ReduceGeneric(3), CostGating.OnlyIf(...))` (Suspicious Detonation) and
+  the "as long as" evasion via `ConditionalStaticAbility` (Furtive Courier).
 - `DynamicAmounts.cardsDiscardedThisTurn(player)` / `TurnTracker.CARDS_DISCARDED` — the number of cards
   `player` has discarded this turn (CR 701.8). Backed by the per-player `CardsDiscardedThisTurnComponent`
   id list, recorded at **every** discard site (cost, effect, cycling, CR 514.1 hand-size cleanup) via
@@ -8708,6 +8718,9 @@ this turn").
   `Conditions.CreaturesEnteredThisTurn` — Spider-UK's "two or more creatures entered the
   battlefield under your control this turn."
 - `FOOD_SACRIFICED` — Food tokens sacrificed.
+- `ARTIFACT_SACRIFICED` — indicator (0 or 1) that the player sacrificed an artifact this turn, read
+  off the projected type line at sacrifice time. Backs `Conditions.SacrificedArtifactThisTurn`
+  (Suspicious Detonation, Furtive Courier).
 - `CARDS_LEFT_GRAVEYARD` — cards leaving your graveyard.
 - `DESCENDED` — number of times a player has descended this turn (CR 700.11) — i.e.
   count of nontoken permanent cards put into that player's graveyard from any zone.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1622,6 +1622,17 @@ object Conditions {
         trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.FOOD_SACRIFICED)
 
     /**
+     * If you've sacrificed an artifact this turn — Murders at Karlov Manor's artifact-sacrifice
+     * payoffs (Suspicious Detonation's cost reduction, Furtive Courier's evasion).
+     *
+     * Controller-scoped turn history, not a graveyard scan: the artifact having since left the
+     * graveyard doesn't clear it, and an opponent sacrificing their own artifact never sets it.
+     * The card-type sibling of [SacrificedFoodThisTurn].
+     */
+    val SacrificedArtifactThisTurn: ConditionInterface =
+        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.ARTIFACT_SACRIFICED)
+
+    /**
      * If you descended this turn (CR 700.11) — i.e. at least one nontoken permanent
      * card was put into your graveyard from any zone this turn. Tokens do not count;
      * non-permanent cards (instants, sorceries) do not count.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -104,6 +104,18 @@ enum class TurnTracker {
     CREATURES_ENTERED_UNDER_CONTROL,
     /** Indicator (0 or 1) that the player sacrificed at least one Food this turn. */
     FOOD_SACRIFICED,
+    /**
+     * Indicator (0 or 1) that the player sacrificed at least one artifact this turn — the
+     * card-type sibling of [FOOD_SACRIFICED], recorded by the same central sacrifice hook and
+     * read off the projected type line, so a permanent that was only an artifact through a
+     * continuous effect still counts.
+     *
+     * Backs Murders at Karlov Manor's "if you've sacrificed an artifact this turn" wording
+     * (Suspicious Detonation's cost reduction, Furtive Courier's evasion). Turn history, not a
+     * board scan: it stays set for the rest of the turn even once the artifact has left the
+     * graveyard.
+     */
+    ARTIFACT_SACRIFICED,
     /** Total cards that left the player's graveyard this turn (Bonecache Overseer). */
     CARDS_LEFT_GRAVEYARD,
     /**
@@ -180,6 +192,7 @@ enum class TurnTracker {
         NONLAND_PERMANENTS_ENTERED -> "the number of nonland permanents that entered the battlefield under ${player.possessive} control this turn"
         CREATURES_ENTERED_UNDER_CONTROL -> "the number of creatures that entered the battlefield under ${player.possessive} control this turn"
         FOOD_SACRIFICED -> "whether ${player.description} sacrificed a Food this turn"
+        ARTIFACT_SACRIFICED -> "whether ${player.description} sacrificed an artifact this turn"
         CARDS_LEFT_GRAVEYARD -> "the number of cards that left ${player.possessive} graveyard this turn"
         DESCENDED -> "the number of times ${player.description} descended this turn"
         CARDS_DRAWN -> "the number of cards ${player.description} have drawn this turn"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BreakOut.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BreakOut.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Break Out {R}{G}
+ * Sorcery
+ *
+ * Look at the top six cards of your library. You may reveal a creature card from among them. If
+ * that card has mana value 2 or less, you may put it onto the battlefield and it gains haste until
+ * end of turn. If you didn't put the revealed card onto the battlefield this way, put it into your
+ * hand. Put the rest on the bottom of your library in a random order.
+ *
+ * Two nested "may"s over one revealed card, so the pipeline partitions rather than branches:
+ *
+ *  1. `chooseUpToSplit` of 1 creature card — the optional reveal. Declining leaves `revealed`
+ *     empty and every later step is a no-op over an empty slot, so all six cards fall through to
+ *     the bottom-of-library move.
+ *  2. `filterSplit` on [CollectionFilter.ManaValueAtMost] splits the revealed card into the
+ *     battlefield-eligible `cheap` slot and `tooExpensive`. The mana-value test is *not* a player
+ *     choice, matching the card: only "you may put it onto the battlefield" is optional.
+ *  3. A second `chooseUpToSplit` over `cheap` is that second "may". What the player declines lands
+ *     in `declined` and joins `tooExpensive` on the way to hand — which is exactly the card's "if
+ *     you didn't put the revealed card onto the battlefield this way, put it into your hand",
+ *     covering both reasons it might not have been put there.
+ *
+ * Haste is granted per entered card via [ForEachInCollectionEffect] over the tracked move, so it
+ * attaches to the permanent that actually entered rather than to the spell's controller, and
+ * [Duration.EndOfTurn] expires it with the generic cleanup.
+ *
+ * The `reveal` step sits right after the selection rather than riding the later moves, so the card
+ * becomes public when the player reveals it — before it's known whether it ends up on the
+ * battlefield or in hand. `revealToSelf = false` skips the overlay for the controller, who just
+ * looked at all six.
+ */
+val BreakOut = card("Break Out") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top six cards of your library. You may reveal a creature card from " +
+        "among them. If that card has mana value 2 or less, you may put it onto the battlefield " +
+        "and it gains haste until end of turn. If you didn't put the revealed card onto the " +
+        "battlefield this way, put it into your hand. Put the rest on the bottom of your library " +
+        "in a random order."
+
+    spell {
+        effect = Effects.Pipeline {
+            val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(6)))
+            val (revealed, rest) = chooseUpToSplit(
+                count = 1,
+                from = looked,
+                filter = GameObjectFilter.Creature,
+                prompt = "You may reveal a creature card",
+                showAllCards = true
+            )
+            reveal(revealed, revealToSelf = false)
+            val (cheap, tooExpensive) = filterSplit(
+                from = revealed,
+                filter = CollectionFilter.ManaValueAtMost(DynamicAmount.Fixed(2))
+            )
+            val (toBattlefield, declined) = chooseUpToSplit(
+                count = 1,
+                from = cheap,
+                prompt = "You may put it onto the battlefield with haste"
+            )
+            val entered = moveTracked(
+                from = toBattlefield,
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+            )
+            run(
+                ForEachInCollectionEffect(
+                    collection = entered.key,
+                    effect = Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn)
+                )
+            )
+            toHand(tooExpensive)
+            toHand(declined)
+            toLibraryBottom(rest, order = CardOrder.Random)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Daniel Correia"
+        flavorText = "\"Hey, kiddo. Your ride's here.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c628476-0987-47d4-8d2a-cfc3977b2357.jpg?1783912863"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ExtractAConfession.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ExtractAConfession.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.collectEvidence
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Extract a Confession {1}{B}
+ * Sorcery
+ *
+ * As an additional cost to cast this spell, you may collect evidence 6.
+ * Each opponent sacrifices a creature of their choice. If evidence was collected, instead each
+ * opponent sacrifices a creature with the greatest power among creatures they control.
+ *
+ * The "instead" is a resolution-time branch on the linked declaration, not two separate spells:
+ * [collectEvidence] stamps `ChoiceSlot.EVIDENCE_COLLECTED` on the spell at cast time and
+ * [Conditions.WasEvidenceCollected] reads it back here (CR 701.59c / CR 607 — linked abilities).
+ * Both branches are the same edict shape and differ only in the filter, so the greatest-power
+ * variant is [GameObjectFilter.Creature] narrowed by `hasGreatestPower()`, which scopes to
+ * creatures *that permanent's controller* controls — per-opponent, exactly as the card reads.
+ *
+ * Each branch resolves through `Player.EachOpponent`, so the engine walks the opponents in turn
+ * order and each picks their own creature before all of them are sacrificed simultaneously. A tie
+ * for greatest power leaves several creatures matching the filter, and the choice among them
+ * falls to that opponent — which is what the second ruling below asks for.
+ */
+val ExtractAConfession = card("Extract a Confession") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, you may collect evidence 6. (Exile " +
+        "cards with total mana value 6 or greater from your graveyard.)\n" +
+        "Each opponent sacrifices a creature of their choice. If evidence was collected, instead " +
+        "each opponent sacrifices a creature with the greatest power among creatures they control."
+
+    collectEvidence(6)
+
+    spell {
+        effect = ConditionalEffect(
+            condition = Conditions.WasEvidenceCollected,
+            effect = Effects.Sacrifice(
+                GameObjectFilter.Creature.hasGreatestPower(),
+                target = EffectTarget.PlayerRef(Player.EachOpponent)
+            ),
+            elseEffect = Effects.Sacrifice(
+                GameObjectFilter.Creature,
+                target = EffectTarget.PlayerRef(Player.EachOpponent)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Peter Polach"
+        imageUri = "https://cards.scryfall.io/normal/front/2/5/256c8b6e-4031-458b-8eb9-bbfe58405a0c.jpg?1783912899"
+        ruling(
+            "2024-02-02",
+            "Starting with the next opponent in turn order (or, if you cast Extract a Confession " +
+                "on an opponent's turn, starting with the opponent whose turn it is) and " +
+                "proceeding in turn order, each opponent chooses a creature they control to " +
+                "sacrifice. Then those creatures are sacrificed at the same time."
+        )
+        ruling(
+            "2024-02-02",
+            "If evidence was collected and an opponent has multiple creatures tied for the " +
+                "greatest power, that player chooses which one to sacrifice."
+        )
+        ruling(
+            "2024-02-02",
+            "If you can't exile enough cards to meet or exceed the required mana value, you can't " +
+                "choose to collect evidence at all."
+        )
+        ruling(
+            "2024-02-02",
+            "Once you've announced that you're casting a spell, players can't take actions until " +
+                "you've finished doing so. Notably, opponents can't try to remove cards from your " +
+                "graveyard to stop you from collecting evidence."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FurtiveCourier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FurtiveCourier.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Furtive Courier {2}{U}
+ * Creature — Merfolk Advisor
+ * 3/2
+ *
+ * This creature can't be blocked as long as you've sacrificed an artifact this turn.
+ * Whenever this creature attacks, draw a card, then discard a card.
+ *
+ * The evasion is a [ConditionalStaticAbility], not an attack trigger: "as long as" is a
+ * continuous ability re-evaluated every time the projection is rebuilt, which is what makes the
+ * card's ruling fall out for free — sacrificing an artifact after blockers are declared doesn't
+ * unblock it, because CR 509 has already locked the block in. Conversely, sacrificing an artifact
+ * before blockers are declared makes it unblockable even though it was already attacking.
+ *
+ * [Conditions.SacrificedArtifactThisTurn] is controller-scoped, so the *defending* player cracking
+ * a Clue never turns this on.
+ */
+val FurtiveCourier = card("Furtive Courier") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Advisor"
+    power = 3
+    toughness = 2
+    oracleText = "This creature can't be blocked as long as you've sacrificed an artifact this turn.\n" +
+        "Whenever this creature attacks, draw a card, then discard a card."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(AbilityFlag.CANT_BE_BLOCKED.name, GroupFilter.source()),
+            condition = Conditions.SacrificedArtifactThisTurn
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Hand.loot()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "59"
+        artist = "Mark Behm"
+        flavorText = "\"Glad to see you made it in one piece. Next time, try not looking so " +
+            "obviously nervous.\"\n—Linghu of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f359fc2-b9e4-4a01-9d04-442bb160b01e.jpg?1783912908"
+        ruling(
+            "2024-02-02",
+            "Sacrificing an artifact after Furtive Courier has been blocked won't cause it to " +
+                "become unblocked."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SuspiciousDetonation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SuspiciousDetonation.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Suspicious Detonation {4}{R}
+ * Sorcery
+ *
+ * This spell costs {3} less to cast if you've sacrificed an artifact this turn.
+ * This spell can't be countered.
+ * Suspicious Detonation deals 4 damage to target creature.
+ *
+ * The reduction rides the generic gated-reduction rail ([ModifySpellCost] +
+ * [CostGating.OnlyIf]) rather than a bespoke `CostReductionSource`, the same way Bite Down on
+ * Crime gates its {2} on evidence. [Conditions.SacrificedArtifactThisTurn] is controller-scoped
+ * turn history, so an opponent cracking their own Clue never discounts this, and the artifact
+ * having since left the graveyard doesn't undo the discount.
+ *
+ * `cantBeCountered` covers the parenthetical "(This includes by the ward ability.)": ward's
+ * counter-unless-you-pay is a countering effect, so it simply fails to counter this spell — the
+ * ward cost is still *offered*, and declining it no longer counters the spell.
+ */
+val SuspiciousDetonation = card("Suspicious Detonation") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "This spell costs {3} less to cast if you've sacrificed an artifact this turn.\n" +
+        "This spell can't be countered. (This includes by the ward ability.)\n" +
+        "Suspicious Detonation deals 4 damage to target creature."
+
+    cantBeCountered = true
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(3),
+            gating = CostGating.OnlyIf(Conditions.SacrificedArtifactThisTurn),
+        )
+    }
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(4, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "145"
+        artist = "Joe Slucher"
+        flavorText = "\"Clearly someone wanted us to find this.\"\n—Runubi of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6e280482-ed7e-4011-899e-096ff7bd4c41.jpg?1783912874"
+        ruling(
+            "2024-02-02",
+            "If you target a creature or planeswalker with ward, you may still pay the ward cost, " +
+                "but Suspicious Detonation won't be countered even if you don't."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -780,6 +780,138 @@
     ]
 }
 
+// Break Out
+{
+    "name": "Break Out",
+    "manaCost": "{R}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top six cards of your library. You may reveal a creature card from among them. If that card has mana value 2 or less, you may put it onto the battlefield and it gains haste until end of turn. If you didn't put the revealed card onto the battlefield this way, put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 6
+                        }
+                    },
+                    "storeAs": "gathered0"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "gathered0",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "creature",
+                    "storeSelected": "selected1",
+                    "storeRemainder": "remainder1",
+                    "prompt": "You may reveal a creature card",
+                    "showAllCards": true
+                },
+                {
+                    "type": "RevealCollection",
+                    "from": "selected1",
+                    "revealToSelf": false
+                },
+                {
+                    "type": "FilterCollection",
+                    "from": "selected1",
+                    "filter": {
+                        "type": "ManaValueAtMost",
+                        "max": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeMatching": "matching3",
+                    "storeNonMatching": "rest3"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "matching3",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "selected4",
+                    "storeRemainder": "remainder4",
+                    "prompt": "You may put it onto the battlefield with haste"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "selected4",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    },
+                    "storeMovedAs": "moved5"
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Collection",
+                        "collection": "moved5"
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HASTE",
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest3",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "remainder4",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "remainder1",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Correia",
+        "flavorText": "\"Hey, kiddo. Your ride's here.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c628476-0987-47d4-8d2a-cfc3977b2357.jpg?1783912863"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Bubble Smuggler
 {
     "name": "Bubble Smuggler",
@@ -2574,6 +2706,88 @@
     ]
 }
 
+// Extract a Confession
+{
+    "name": "Extract a Confession",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, you may collect evidence 6. (Exile cards with total mana value 6 or greater from your graveyard.)\nEach opponent sacrifices a creature of their choice. If evidence was collected, instead each opponent sacrifices a creature with the greatest power among creatures they control.",
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "additionalCost": {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomCollectEvidence",
+                    "amount": 6
+                }
+            },
+            "declaredSlot": "EVIDENCE_COLLECTED"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "CastChoiceMade",
+                    "slot": "EVIDENCE_COLLECTED"
+                }
+            },
+            "then": {
+                "type": "ForceSacrifice",
+                "filter": {
+                    "cardPredicates": [
+                        "IsCreature"
+                    ],
+                    "statePredicates": [
+                        "HasGreatestPower"
+                    ]
+                },
+                "target": {
+                    "type": "PlayerRef",
+                    "player": "EachOpponent"
+                }
+            },
+            "otherwise": {
+                "type": "ForceSacrifice",
+                "filter": "creature",
+                "target": {
+                    "type": "PlayerRef",
+                    "player": "EachOpponent"
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Peter Polach",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/5/256c8b6e-4031-458b-8eb9-bbfe58405a0c.jpg?1783912899",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Starting with the next opponent in turn order (or, if you cast Extract a Confession on an opponent's turn, starting with the opponent whose turn it is) and proceeding in turn order, each opponent chooses a creature they control to sacrifice. Then those creatures are sacrificed at the same time."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If evidence was collected and an opponent has multiple creatures tied for the greatest power, that player chooses which one to sacrifice."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Once you've announced that you're casting a spell, players can't take actions until you've finished doing so. Notably, opponents can't try to remove cards from your graveyard to stop you from collecting evidence."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Fae Flight
 {
     "name": "Fae Flight",
@@ -3112,6 +3326,115 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Furtive Courier
+{
+    "name": "Furtive Courier",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Merfolk Advisor",
+    "oracleText": "This creature can't be blocked as long as you've sacrificed an artifact this turn.\nWhenever this creature attacks, draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "ARTIFACT_SACRIFICED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Behm",
+        "flavorText": "\"Glad to see you made it in one piece. Next time, try not looking so obviously nervous.\"\n—Linghu of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f359fc2-b9e4-4a01-9d04-442bb160b01e.jpg?1783912908",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Sacrificing an artifact after Furtive Courier has been blocked won't cause it to become unblocked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -8378,6 +8701,78 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Suspicious Detonation
+{
+    "name": "Suspicious Detonation",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "This spell costs {3} less to cast if you've sacrificed an artifact this turn.\nThis spell can't be countered. (This includes by the ward ability.)\nSuspicious Detonation deals 4 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 3
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "TurnTracking",
+                            "player": "You",
+                            "tracker": "ARTIFACT_SACRIFICED"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "artist": "Joe Slucher",
+        "flavorText": "\"Clearly someone wanted us to find this.\"\n—Runubi of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6e280482-ed7e-4011-899e-096ff7bd4c41.jpg?1783912874",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you target a creature or planeswalker with ward, you may still pay the ward cost, but Suspicious Detonation won't be countered even if you don't."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -59,6 +59,7 @@ import com.wingedsheep.engine.state.components.player.LifeGainedThisTurnComponen
 import com.wingedsheep.engine.state.components.player.LifeLostAmountThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeLostThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PutCounterOnCreatureThisTurnComponent
+import com.wingedsheep.engine.state.components.player.SacrificedArtifactThisTurnComponent
 import com.wingedsheep.engine.state.components.player.SacrificedFoodThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageByLegendaryCreatureThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CombatDamageReceivedThisTurnComponent
@@ -730,6 +731,9 @@ class CleanupPhaseManager(
                 }
                 if (result.has<SacrificedFoodThisTurnComponent>()) {
                     result = result.without<SacrificedFoodThisTurnComponent>()
+                }
+                if (result.has<SacrificedArtifactThisTurnComponent>()) {
+                    result = result.without<SacrificedArtifactThisTurnComponent>()
                 }
                 if (result.has<PermanentsEnteredUnderControlThisTurnComponent>()) {
                     result = result.without<PermanentsEnteredUnderControlThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -587,6 +587,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PlayerCantPlayFromHandComponent::class)
         subclass(PlayerShroudComponent::class)
         subclass(SacrificedFoodThisTurnComponent::class)
+        subclass(SacrificedArtifactThisTurnComponent::class)
         subclass(PermanentsEnteredUnderControlThisTurnComponent::class)
         subclass(SpellsCantBeCounteredComponent::class)
         subclass(FlashGrantsThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -543,6 +543,10 @@ class DynamicAmountEvaluator(
                         state.getEntity(playerId)
                             ?.has<com.wingedsheep.engine.state.components.player.SacrificedFoodThisTurnComponent>() == true
                     }
+                    TurnTracker.ARTIFACT_SACRIFICED -> playerIds.count { playerId ->
+                        state.getEntity(playerId)
+                            ?.has<com.wingedsheep.engine.state.components.player.SacrificedArtifactThisTurnComponent>() == true
+                    }
                     TurnTracker.CARDS_LEFT_GRAVEYARD -> playerIds.sumOf { playerId ->
                         state.getEntity(playerId)
                             ?.get<com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -41,6 +41,7 @@ import com.wingedsheep.engine.state.components.player.PermanentLeftBattlefieldTh
 import com.wingedsheep.engine.state.components.player.CreatureLeftBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentsSacrificedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent
+import com.wingedsheep.engine.state.components.player.SacrificedArtifactThisTurnComponent
 import com.wingedsheep.engine.state.components.player.SacrificedFoodThisTurnComponent
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.CounterType
@@ -974,6 +975,13 @@ object ZoneTransitionService {
      *    Sawblade Skinripper).
      *  - Marks the controller with [SacrificedFoodThisTurnComponent] if any sacrificed permanent
      *    was a Food (Food-sacrifice triggers, e.g. Ygra).
+     *  - Marks the controller with [SacrificedArtifactThisTurnComponent] if any sacrificed
+     *    permanent was an artifact (backs `TurnTracker.ARTIFACT_SACRIFICED` — Suspicious
+     *    Detonation, Furtive Courier).
+     *
+     * Both markers read the *projected* characteristics, so a permanent that was only a Food or
+     * only an artifact through a continuous effect still counts, and both are checked
+     * independently — one sacrifice can set both.
      */
     fun trackPermanentSacrifice(state: GameState, permanentIds: List<EntityId>, controllerId: EntityId): GameState {
         if (permanentIds.isEmpty()) return state
@@ -988,13 +996,15 @@ object ZoneTransitionService {
             container.with(PermanentsSacrificedThisTurnComponent(prior + permanentIds.size))
         }
         val projected = state.projectedState
-        for (permId in permanentIds) {
-            newState.getEntity(permId)?.get<CardComponent>() ?: continue
-            if (projected.hasSubtype(permId, Subtype.FOOD.value)) {
-                newState = newState.updateEntity(controllerId) { container ->
-                    container.with(SacrificedFoodThisTurnComponent)
-                }
-                break // Only need to mark once
+        val sacrificedCards = permanentIds.filter { newState.getEntity(it)?.has<CardComponent>() == true }
+        if (sacrificedCards.any { projected.hasSubtype(it, Subtype.FOOD.value) }) {
+            newState = newState.updateEntity(controllerId) { container ->
+                container.with(SacrificedFoodThisTurnComponent)
+            }
+        }
+        if (sacrificedCards.any { projected.hasType(it, CardType.ARTIFACT.name) }) {
+            newState = newState.updateEntity(controllerId) { container ->
+                container.with(SacrificedArtifactThisTurnComponent)
             }
         }
         return newState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -1135,6 +1135,19 @@ data class CardsPutIntoExileThisTurnComponent(val count: Int = 0) : Component
 data object SacrificedFoodThisTurnComponent : Component
 
 /**
+ * Marker component indicating that this player has sacrificed an artifact this turn.
+ * Cleared at end of turn by CleanupPhaseManager.
+ *
+ * The card-type sibling of [SacrificedFoodThisTurnComponent], set by the same
+ * `ZoneTransitionService.trackPermanentSacrifice` hook off the *projected* type line, so an
+ * animated or type-changed permanent that was an artifact when sacrificed counts. Backs
+ * `TurnTracker.ARTIFACT_SACRIFICED` — "if you've sacrificed an artifact this turn"
+ * (Suspicious Detonation, Furtive Courier).
+ */
+@Serializable
+data object SacrificedArtifactThisTurnComponent : Component
+
+/**
  * Tracks the number of permanents this player has sacrificed this turn (controller-scoped,
  * any permanent type). Incremented by `ZoneTransitionService.trackPermanentSacrifice` on the
  * sacrificing player and cleared at end of turn by `CleanupPhaseManager`.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakOutScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreakOutScenarioTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Break Out (MKM) — {R}{G} sorcery, look at the top six, may reveal a creature card, put it onto
+ * the battlefield with haste if its mana value is 2 or less, otherwise into your hand, rest on the
+ * bottom in a random order.
+ *
+ * Break Out composes entirely from existing pipeline steps, but it stacks two independent "may"s
+ * over one card and routes three different outcomes, so these tests pin the partition rather than
+ * the primitives: cheap-and-accepted goes to the battlefield hasted, cheap-and-declined and
+ * too-expensive both go to hand, and a declined reveal leaves all six on the bottom.
+ *
+ * Each scenario seeds exactly six library cards with a single creature among five Forests, so the
+ * `filter = Creature` selection offers exactly one candidate no matter how the library is ordered.
+ */
+class BreakOutScenarioTest : ScenarioTestBase() {
+
+    private fun board(creature: String): ScenarioBuilder {
+        var builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "Break Out")
+            .withLandsOnBattlefield(1, "Mountain", 1)
+            .withLandsOnBattlefield(1, "Forest", 1)
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            .withCardInLibrary(1, creature)
+        repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+        return builder
+    }
+
+    private fun handNames(game: TestGame): List<String> =
+        game.state.getHand(game.player1Id)
+            .mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+
+    init {
+        test("a revealed mana-value-2 creature can be put onto the battlefield with haste") {
+            val game = board("Grizzly Bears").build()
+            val bears = game.findCardsInLibrary(1, "Grizzly Bears").single()
+
+            game.castSpell(1, "Break Out").error shouldBe null
+            game.resolveStack()
+
+            withClue("first decision: which creature card to reveal") {
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(listOf(bears)).error shouldBe null
+            }
+            withClue("second decision: whether to put the mana-value-2 creature onto the battlefield") {
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(listOf(bears)).error shouldBe null
+            }
+            game.resolveStack()
+
+            val onBattlefield = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+            withClue("it gains haste until end of turn") {
+                game.state.projectedState.hasKeyword(onBattlefield, "HASTE") shouldBe true
+            }
+            withClue("it went to the battlefield, not to hand") {
+                handNames(game) shouldContainExactly emptyList()
+            }
+            withClue("the other five go to the bottom of the library") {
+                game.librarySize(1) shouldBe 5
+            }
+        }
+
+        test("a revealed creature costing more than 2 goes to hand instead") {
+            val game = board("Hill Giant").build()
+            val giant = game.findCardsInLibrary(1, "Hill Giant").single()
+
+            game.castSpell(1, "Break Out").error shouldBe null
+            game.resolveStack()
+
+            withClue("the reveal is offered; mana value 4 is not") {
+                game.hasPendingDecision() shouldBe true
+                game.selectCards(listOf(giant)).error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("no battlefield option for a mana value above 2") {
+                game.findPermanent("Hill Giant") shouldBe null
+            }
+            handNames(game) shouldContainExactly listOf("Hill Giant")
+            game.librarySize(1) shouldBe 5
+        }
+
+        test("declining the battlefield option still puts the creature into your hand") {
+            val game = board("Grizzly Bears").build()
+            val bears = game.findCardsInLibrary(1, "Grizzly Bears").single()
+
+            game.castSpell(1, "Break Out").error shouldBe null
+            game.resolveStack()
+
+            game.selectCards(listOf(bears)).error shouldBe null
+            withClue("decline the second may") {
+                game.skipSelection().error shouldBe null
+            }
+            game.resolveStack()
+
+            game.findPermanent("Grizzly Bears") shouldBe null
+            handNames(game) shouldContainExactly listOf("Grizzly Bears")
+            game.librarySize(1) shouldBe 5
+        }
+
+        test("declining the reveal sends all six to the bottom") {
+            val game = board("Grizzly Bears").build()
+
+            game.castSpell(1, "Break Out").error shouldBe null
+            game.resolveStack()
+
+            withClue("decline the reveal") {
+                game.skipSelection().error shouldBe null
+            }
+            game.resolveStack()
+
+            game.findPermanent("Grizzly Bears") shouldBe null
+            handNames(game) shouldContainExactly emptyList()
+            withClue("nothing was kept — all six went back") {
+                game.librarySize(1) shouldBe 6
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExtractAConfessionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExtractAConfessionScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Extract a Confession (MKM) — {1}{B} sorcery, optional collect evidence 6, "each opponent
+ * sacrifices a creature of their choice. If evidence was collected, instead each opponent
+ * sacrifices a creature with the greatest power among creatures they control."
+ *
+ * The card composes from existing vocabulary, but the interesting claim is the *linkage*: the
+ * `ChoiceSlot.EVIDENCE_COLLECTED` stamped at cast time has to survive to resolution and pick the
+ * greatest-power branch (CR 701.59c / CR 607). These tests prove it from both sides by giving the
+ * opponent a 1/1 and a 4/4 and watching which one dies — a free choice leaves the small one on the
+ * board, evidence forces the big one.
+ *
+ * Air Elemental (mana value 5) plus Hill Giant (4) clears the evidence-6 threshold.
+ */
+class ExtractAConfessionScenarioTest : ScenarioTestBase() {
+
+    private fun board() = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, "Extract a Confession")
+        .withLandsOnBattlefield(1, "Swamp", 2)
+        .withCardInGraveyard(1, "Air Elemental")
+        .withCardInGraveyard(1, "Hill Giant")
+        .withCardOnBattlefield(2, "Grizzly Bears")
+        .withCardOnBattlefield(2, "Air Elemental")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+    init {
+        test("without evidence the opponent chooses which creature to sacrifice") {
+            val game = board().build()
+
+            game.castSpell(1, "Extract a Confession").error shouldBe null
+            game.resolveStack()
+
+            withClue("the opponent picks — the harness takes the first offered option") {
+                game.hasPendingDecision() shouldBe true
+            }
+            val decision = game.getPendingDecision()!!
+            withClue("both creatures must be on the menu when no evidence was collected") {
+                game.selectCards(
+                    listOf((decision as SelectCardsDecision).options.first())
+                ).error shouldBe null
+            }
+
+            withClue("exactly one of the two died") {
+                listOf("Grizzly Bears", "Air Elemental")
+                    .count { game.findPermanent(it) != null } shouldBe 1
+            }
+        }
+
+        test("with evidence collected the greatest-power creature is forced") {
+            val game = board().build()
+
+            game.castSpellCollectingEvidence(1, "Extract a Confession", "Air Elemental", "Hill Giant")
+                .error shouldBe null
+            game.resolveStack()
+
+            // Only the 4/4 matches `hasGreatestPower()`, so there is nothing to choose between.
+            if (game.hasPendingDecision()) {
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                withClue("the 1/1 must not be offered when evidence was collected") {
+                    decision.options.size shouldBe 1
+                }
+                game.selectCards(listOf(decision.options.first())).error shouldBe null
+            }
+
+            withClue("the 4/4 Air Elemental is the greatest power and must be the one sacrificed") {
+                game.findPermanent("Air Elemental") shouldBe null
+            }
+            withClue("the smaller creature survives — it was never a legal choice") {
+                (game.findPermanent("Grizzly Bears") != null) shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FurtiveCourierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FurtiveCourierScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.combat.BlockedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.WeldingJar
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Furtive Courier (MKM) — {2}{U} 3/2, "can't be blocked as long as you've sacrificed an artifact
+ * this turn", plus an attack-trigger loot.
+ *
+ * The evasion half is the `TurnTracker.ARTIFACT_SACRIFICED` consumer that reads through the
+ * *projection* rather than the cost rail, so it's the other side of the tracker from
+ * [SuspiciousDetonationScenarioTest]: here the condition has to reach `ConditionalStaticAbility`
+ * and land in `ProjectedState` before `BlockPhaseManager` validates a declaration.
+ *
+ * "As long as" is continuous, which is why the third test matters — sacrificing the artifact
+ * *after* blockers are declared changes nothing, because CR 509 has already locked the block in.
+ * That's the card's printed ruling, and it falls out of modelling this as a static rather than an
+ * attack trigger.
+ */
+class FurtiveCourierScenarioTest : ScenarioTestBase() {
+
+    private val weldingJarAbility = WeldingJar.activatedAbilities.first().id
+
+    /**
+     * Sacrifice one Welding Jar, pointing its regenerate at the other so the target is real.
+     *
+     * Declaring blockers hands priority to the defending player, so take it back before activating
+     * — the third test needs to sacrifice inside the declare-blockers step.
+     */
+    private fun sacrificeAWeldingJar(game: TestGame) {
+        if (game.state.priorityPlayerId != game.player1Id) game.passPriority()
+        val jars = game.findPermanents("Welding Jar")
+        withClue("the scenario must set up two Welding Jars") { jars.size shouldBe 2 }
+        game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = jars[0],
+                abilityId = weldingJarAbility,
+                targets = listOf(ChosenTarget.Permanent(jars[1])),
+            )
+        ).error shouldBe null
+        game.resolveStack()
+        withClue("the sacrifice must actually have happened") {
+            game.findPermanents("Welding Jar").size shouldBe 1
+        }
+    }
+
+    /**
+     * A scenario starts with empty libraries, and the Courier's attack trigger draws — seed both
+     * players so nobody decks out mid-test.
+     */
+    private fun board(): ScenarioBuilder {
+        var builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardOnBattlefield(1, "Furtive Courier")
+            .withCardOnBattlefield(1, "Welding Jar")
+            .withCardOnBattlefield(1, "Welding Jar")
+            .withCardOnBattlefield(2, "Grizzly Bears")
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        repeat(10) {
+            builder = builder.withCardInLibrary(1, "Island").withCardInLibrary(2, "Island")
+        }
+        return builder
+    }
+
+    init {
+        test("blockable when no artifact has been sacrificed") {
+            val game = board().build()
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Furtive Courier" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            withClue("without a sacrifice this turn the Courier has no evasion") {
+                game.declareBlockers(mapOf("Grizzly Bears" to listOf("Furtive Courier")))
+                    .error shouldBe null
+            }
+        }
+
+        test("sacrificing an artifact before blockers makes it unblockable") {
+            val game = board().build()
+
+            sacrificeAWeldingJar(game)
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Furtive Courier" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+            withClue("the block must be rejected — the Courier can't be blocked") {
+                game.declareBlockers(mapOf("Grizzly Bears" to listOf("Furtive Courier")))
+                    .error shouldNotBe null
+            }
+            withClue("declaring no blockers is the only legal declaration") {
+                game.declareNoBlockers().error shouldBe null
+            }
+        }
+
+        test("sacrificing after blockers are declared doesn't unblock it") {
+            val game = board().build()
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Furtive Courier" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Grizzly Bears" to listOf("Furtive Courier")))
+                .error shouldBe null
+
+            sacrificeAWeldingJar(game)
+
+            withClue("CR 509 already locked the block in — the Bears is still blocking") {
+                val courier = game.findPermanent("Furtive Courier").shouldNotBeNull()
+                val bears = game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                game.state.getEntity(courier)?.get<BlockedComponent>()?.blockerIds shouldBe listOf(bears)
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SuspiciousDetonationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SuspiciousDetonationScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.WeldingJar
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Suspicious Detonation (MKM) — {4}{R} sorcery, "costs {3} less to cast if you've sacrificed an
+ * artifact this turn", can't be countered, 4 damage to target creature.
+ *
+ * Covers the new `TurnTracker.ARTIFACT_SACRIFICED` end to end. The tracker is only worth anything
+ * if it survives the artifact leaving the battlefield *and* the round trip through the cost
+ * reduction rail, so these tests pin the mana actually required rather than reading the component:
+ * five lands cast it cold, two lands cast it after a sacrifice, and two lands alone can't.
+ *
+ * Welding Jar is the sacrifice outlet — a {0} artifact whose whole ability is
+ * `Costs.SacrificeSelf`, so activating it routes through `ZoneTransitionService`'s central
+ * sacrifice hook the same way cracking a Clue does. Two copies are on the battlefield so the
+ * sacrificed one has another artifact to target.
+ */
+class SuspiciousDetonationScenarioTest : ScenarioTestBase() {
+
+    private val weldingJarAbility = WeldingJar.activatedAbilities.first().id
+
+    /** Sacrifice one Welding Jar, pointing its regenerate at the other so the target is real. */
+    private fun sacrificeAWeldingJar(game: TestGame) {
+        val jars = game.findPermanents("Welding Jar")
+        withClue("the scenario must set up two Welding Jars") { jars.size shouldBe 2 }
+        game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = jars[0],
+                abilityId = weldingJarAbility,
+                targets = listOf(ChosenTarget.Permanent(jars[1])),
+            )
+        ).error shouldBe null
+        game.resolveStack()
+        withClue("the sacrifice must actually have happened") {
+            game.findPermanents("Welding Jar").size shouldBe 1
+        }
+    }
+
+    private fun toughnessDamageVictim(game: TestGame): EntityId =
+        game.findPermanent("Grizzly Bears").shouldNotBeNull()
+
+    /**
+     * Shared board: the Detonation in hand, a 2/2 to point it at, and stocked libraries so the
+     * turn-scoping test can round the table through two draw steps without decking anyone.
+     */
+    private fun board(mountains: Int, withJars: Boolean): ScenarioBuilder {
+        var builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "Suspicious Detonation")
+            .withLandsOnBattlefield(1, "Mountain", mountains)
+            .withCardOnBattlefield(2, "Grizzly Bears")
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        if (withJars) {
+            builder = builder
+                .withCardOnBattlefield(1, "Welding Jar")
+                .withCardOnBattlefield(1, "Welding Jar")
+        }
+        repeat(10) {
+            builder = builder.withCardInLibrary(1, "Island").withCardInLibrary(2, "Island")
+        }
+        return builder
+    }
+
+    init {
+        test("costs its full {4}{R} when no artifact was sacrificed") {
+            val game = board(mountains = 2, withJars = false).build()
+
+            withClue("{1}{R} can't pay {4}{R} without the reduction") {
+                game.castSpell(1, "Suspicious Detonation", toughnessDamageVictim(game))
+                    .error shouldNotBe null
+            }
+        }
+
+        test("sacrificing an artifact reduces it to {1}{R} and it deals 4 damage") {
+            val game = board(mountains = 2, withJars = true).build()
+
+            sacrificeAWeldingJar(game)
+
+            val victim = toughnessDamageVictim(game)
+            withClue("the {3} reduction must bring {4}{R} within reach of two Mountains") {
+                game.castSpell(1, "Suspicious Detonation", victim).error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("4 damage kills a 2/2") {
+                game.findPermanent("Grizzly Bears") shouldBe null
+            }
+        }
+
+        test("the reduction is gone on a later turn — the tracker is turn-scoped") {
+            val game = board(mountains = 2, withJars = true).build()
+
+            sacrificeAWeldingJar(game)
+
+            // Round the table back to player 1's next main phase. Each stop has to be a distinct
+            // (phase, step) or passUntilPhase returns immediately without advancing, so walk
+            // upkeep → main → upkeep → main across the turn boundary; cleanup clears the marker
+            // on the way.
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // player 2's upkeep
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // player 2's main
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // player 1's next upkeep
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // player 1's next main
+            withClue("we must actually be back on player 1's turn") {
+                game.state.activePlayerId shouldBe game.player1Id
+            }
+
+            withClue("a sacrifice on a previous turn must not discount this spell") {
+                game.castSpell(1, "Suspicious Detonation", toughnessDamageVictim(game))
+                    .error shouldNotBe null
+            }
+        }
+
+        test("it resolves through a counterspell") {
+            val game = board(mountains = 5, withJars = false)
+                .withCardInHand(2, "Cancel")
+                .withLandsOnBattlefield(2, "Island", 3)
+                .build()
+
+            game.castSpell(1, "Suspicious Detonation", toughnessDamageVictim(game))
+                .error shouldBe null
+            game.passPriority()
+
+            withClue("Cancel may still target it — it just won't counter it") {
+                game.castSpellTargetingStackSpell(2, "Cancel", "Suspicious Detonation")
+                    .error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("can't be countered: the damage still happens") {
+                game.findPermanent("Grizzly Bears") shouldBe null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Four Murders at Karlov Manor cards. Two compose entirely from existing primitives; two share one new piece of turn-history vocabulary.

| Card | | Approach |
|---|---|---|
| **Extract a Confession** | `{1}{B}` | `collectEvidence(6)` + a `WasEvidenceCollected`-gated branch that swaps only the edict's filter |
| **Break Out** | `{R}{G}` | Inline pipeline — gather 6, optional reveal, partition on mana value, optional battlefield put with haste |
| **Suspicious Detonation** | `{4}{R}` | New tracker via the existing `ModifySpellCost` + `CostGating.OnlyIf` rail; `cantBeCountered` |
| **Furtive Courier** | `{2}{U}` | New tracker via `ConditionalStaticAbility`; loot on attack |

## New SDK vocabulary

`TurnTracker.ARTIFACT_SACRIFICED` / `Conditions.SacrificedArtifactThisTurn` — "if you've sacrificed an artifact this turn".

A per-player marker (`SacrificedArtifactThisTurnComponent`) set by the same central `ZoneTransitionService.trackPermanentSacrifice` hook that already records Food, read off the **projected** type line so a permanent that was only an artifact through a continuous effect still counts, and cleared by `CleanupPhaseManager` at end of turn. Turn history rather than a graveyard scan: the artifact having since left the graveyard doesn't clear it, and it's controller-scoped, so an opponent cracking their own Clue never sets yours.

Both of MKM's readings ride it without a bespoke type:

- **Suspicious Detonation's cost reduction** goes through the existing gated-reduction rail, so it needs no new `CostReductionSource`.
- **Furtive Courier's "as long as" evasion** goes through `ConditionalStaticAbility`. Modelling it as a static rather than an attack trigger is what makes the card's printed ruling fall out for free — sacrificing an artifact after blockers are declared doesn't unblock it, because CR 509 has already locked the block in.

The Food branch in `trackPermanentSacrifice` was restructured from a break-on-first-match loop into two independent checks, so one sacrifice can set both markers. Food behaviour is unchanged.

## Notes on the two compositional cards

**Break Out** stacks two independent "may"s over a single revealed card, so the pipeline partitions rather than branches: `chooseUpToSplit` for the optional reveal, `filterSplit` on `ManaValueAtMost(2)`, then a second `chooseUpToSplit` for the battlefield option. Cheap-and-declined and too-expensive both flow to hand — which is exactly the card's "if you didn't put the revealed card onto the battlefield this way, put it into your hand", covering both reasons it might not have been put there.

**Extract a Confession's** "instead" is a resolution-time branch on the linked collect-evidence declaration (CR 701.59c / CR 607), switching only the edict's filter to `hasGreatestPower()` — which scopes per controller, so each opponent loses their own biggest creature.

## Not included

**Macabre Reconstruction** was a fifth candidate and is deliberately left out. Its "a creature card was put into your graveyard from anywhere this turn" needs a third, unrelated tracker. Approximating it by scanning the graveyard for a creature card stamped `putIntoGraveyardThisTurn` silently misses the case where the card later leaves the graveyard, so it seemed better to leave the card unimplemented than to ship one that looks right and resolves wrong.

## Verification

- `just test` — green (full gate, all modules).
- Card snapshot re-blessed; only the four new cards moved in `MKM.json`.
- `just check-card-printing` clean for all four (each is MKM-exclusive, so the canonical definition belongs in `mkm`).
- All mechanical fields re-verified field-by-field against Scryfall; all four `imageUri`s return HTTP 200.
- 13 scenario tests across four files, one per card — including the two that pin the rulings above: the cost reduction expiring at end of turn, and a post-blockers sacrifice not unblocking the Courier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
