### PR TITLE
Add five Mirrodin cards: Thoughtcast, Broodstar, Domineer, Sculpting Steel, Rust Elemental

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/SculptingSteel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/SculptingSteel.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sculpting Steel reprint in 10E.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in MRD's `cards/` package
+ * (Mirrodin is the card's earliest real printing). This file contributes only the 10E-specific
+ * presentation row — set, collector number, art.
+ */
+val SculptingSteelReprint = Printing(
+    oracleId = "6c85271c-c711-49b0-a72e-9e576c33714d",
+    name = "Sculpting Steel",
+    setCode = "10E",
+    collectorNumber = "342",
+    scryfallId = "41368983-14f8-4efa-bb60-b0a7ceb3d021",
+    artist = "Heather Hudson",
+    imageUri = "https://cards.scryfall.io/normal/front/4/1/41368983-14f8-4efa-bb60-b0a7ceb3d021.jpg?1783942978",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Broodstar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Broodstar.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Broodstar — Mirrodin #31
+ * {8}{U}{U} · Creature — Beast · star/star
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Flying
+ * Broodstar's power and toughness are each equal to the number of artifacts you control.
+ *
+ * The affinity top-end: eight artifacts makes it {U}{U} for an 8/8 flier. Affinity only shaves
+ * generic mana, so the {U}{U} is never reduced away.
+ *
+ * `dynamicStats` is the characteristic-defining ability (CR 604.3) behind the printed star/star:
+ * base power and toughness are both set in Layer 7b from the count of artifacts you control, re-read
+ * continuously rather than snapshotted. Broodstar is not itself an artifact, so it never counts
+ * toward its own size — a lone Broodstar on an empty board is 0/0 and dies to the SBA.
+ */
+val Broodstar = card("Broodstar") {
+    manaCost = "{8}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Beast"
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Flying\n" +
+        "Broodstar's power and toughness are each equal to the number of artifacts you control."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+    keywords(Keyword.FLYING)
+
+    dynamicStats(DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).count())
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "31"
+        artist = "Glen Angus"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/07a194cb-53c9-4690-ba63-79beecaebe0e.jpg?1783944557"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Domineer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Domineer.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ControlEnchantedPermanent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Domineer — Mirrodin #33
+ * {1}{U}{U} · Enchantment — Aura
+ *
+ * Enchant artifact creature
+ * You control enchanted artifact creature.
+ *
+ * Mirrodin's artifact-only Control Magic — three mana instead of Confiscate's five, paid for by
+ * the narrower enchant restriction.
+ *
+ * The enchant restriction is checked continuously, not just on resolution (CR 704.5m): if the
+ * stolen permanent stops being an artifact creature — an Unnatural Selection-style type change,
+ * or an artifact creature animated only temporarily — Domineer is put into its owner's graveyard
+ * as a state-based action and control snaps back. That's why the restriction is the aura target
+ * filter rather than a one-shot condition.
+ *
+ * There is no `Targets.ArtifactCreature` facade; this is the first card here to need one, so the
+ * filter is inlined rather than promoted.
+ */
+val Domineer = card("Domineer") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant artifact creature\nYou control enchanted artifact creature."
+
+    auraTarget = TargetCreature(filter = TargetFilter(GameObjectFilter.ArtifactCreature))
+
+    staticAbility {
+        ability = ControlEnchantedPermanent
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Jon Foster"
+        flavorText = "Since they haven't seen their original master for millennia, golems are eager to take orders from anyone."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0010b89-afc4-4dee-bda3-2f34e552cba5.jpg?1783944556"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RustElemental.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/RustElemental.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rust Elemental — Mirrodin #234
+ * {4} · Artifact Creature — Elemental · 4/4
+ *
+ * Flying
+ * At the beginning of your upkeep, sacrifice another artifact. If you can't, tap this creature
+ * and you lose 4 life.
+ *
+ * A four-mana 4/4 flier that eats your board. The "if you can't" clause is the whole card, so it
+ * is modelled as an explicit [ConditionalEffect] rather than leaning on the sacrifice silently
+ * fizzling: the condition asks whether you control an artifact *other than* Rust Elemental, and
+ * only the failing branch taps it and drains 4.
+ *
+ * Both `excludeSelf`/`excludeSource` flags are load-bearing — Rust Elemental is itself an artifact,
+ * so without them it would satisfy its own requirement and happily sacrifice itself every upkeep.
+ *
+ * The sacrifice is mandatory when it's possible (no "may"), and the penalty branch taps rather than
+ * requiring the creature to be untapped: if Rust Elemental is already tapped, the tap does nothing
+ * and you still lose 4 life.
+ */
+val RustElemental = card("Rust Elemental") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Elemental"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "At the beginning of your upkeep, sacrifice another artifact. If you can't, tap this " +
+        "creature and you lose 4 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = ConditionalEffect(
+            condition = Conditions.YouControl(GameObjectFilter.Artifact, excludeSelf = true),
+            effect = SacrificeEffect(GameObjectFilter.Artifact, excludeSource = true),
+            elseEffect = Effects.Composite(
+                Effects.Tap(EffectTarget.Self),
+                Effects.LoseLife(4, EffectTarget.PlayerRef(Player.You))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "234"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/967a08cd-72b3-4b3f-9f23-15697704acb3.jpg?1783944506"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SculptingSteel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SculptingSteel.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersAsCopy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sculpting Steel — Mirrodin #238
+ * {3} · Artifact
+ *
+ * You may have this artifact enter as a copy of any artifact on the battlefield.
+ *
+ * Clone for artifacts. Same [EntersAsCopy] replacement effect as [
+ * com.wingedsheep.mtg.sets.definitions.ktk.cards.CleverImpersonator], narrowed to artifacts —
+ * "any artifact", so an opponent's is fair game, and so is another Sculpting Steel.
+ *
+ * `optional = true` because the copy is a "may": declining leaves a plain colorless {3} artifact
+ * with no abilities on the battlefield, which is a real (if bad) choice, not a no-op. The choice
+ * is made as the permanent enters (CR 706.2), so it never uses the stack and can't be responded to.
+ */
+val SculptingSteel = card("Sculpting Steel") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "You may have this artifact enter as a copy of any artifact on the battlefield."
+
+    replacementEffect(EntersAsCopy(optional = true, copyFilter = GameObjectFilter.Artifact))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "238"
+        artist = "Heather Hudson"
+        flavorText = "An artificer once dropped one in a vault full of coins. She has yet to find it."
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3aac5f6f-97c1-4546-94ed-016292e98c9d.jpg?1783944505"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Thoughtcast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Thoughtcast.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Thoughtcast — Mirrodin #54
+ * {4}{U} · Sorcery
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Draw two cards.
+ *
+ * The affinity payoff common: five mana on an empty board, one blue with four artifacts out.
+ * Affinity shaves generic mana only, so the {U} is never reduced away — the floor is {U}, not free.
+ *
+ * Affinity is a cost reduction, not an alternative cost: mana value stays 5 in every zone
+ * regardless of how cheaply the spell was actually cast.
+ */
+val Thoughtcast = card("Thoughtcast") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Draw two cards."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Greg Hildebrandt"
+        flavorText = "Vedalken eyes don't see the beauty in things. They see only what those things can teach."
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efb965a7-877a-4302-b507-25b0a9e32d9b.jpg?1783944550"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -509,6 +509,51 @@
     "colorIdentityOverride": []
 }
 
+// Broodstar
+{
+    "name": "Broodstar",
+    "manaCost": "{8}{U}{U}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nFlying\nBroodstar's power and toughness are each equal to the number of artifacts you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "artifact"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "artifact"
+            }
+        }
+    },
+    "keywords": [
+        "FLYING",
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "31",
+        "rarity": "RARE",
+        "artist": "Glen Angus",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/07a194cb-53c9-4690-ba63-79beecaebe0e.jpg?1783944557"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Chimney Imp
 {
     "name": "Chimney Imp",
@@ -1334,6 +1379,35 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Domineer
+{
+    "name": "Domineer",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant artifact creature\nYou control enchanted artifact creature.",
+    "script": {
+        "staticAbilities": [
+            "ControlEnchantedPermanent"
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "artifact creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Jon Foster",
+        "flavorText": "Since they haven't seen their original master for millennia, golems are eager to take orders from anyone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0010b89-afc4-4dee-bda3-2f34e552cba5.jpg?1783944556"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -5516,6 +5590,78 @@
     ]
 }
 
+// Rust Elemental
+{
+    "name": "Rust Elemental",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Elemental",
+    "oracleText": "Flying\nAt the beginning of your upkeep, sacrifice another artifact. If you can't, tap this creature and you lose 4 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "artifact",
+                            "excludeSelf": true
+                        }
+                    },
+                    "then": {
+                        "type": "Sacrifice",
+                        "filter": "artifact",
+                        "excludeSource": true
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "TapUntap",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "You"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "UNCOMMON",
+        "artist": "Arnie Swekel",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/967a08cd-72b3-4b3f-9f23-15697704acb3.jpg?1783944506"
+    },
+    "colorIdentityOverride": []
+}
+
 // Rustmouth Ogre
 {
     "name": "Rustmouth Ogre",
@@ -5787,6 +5933,34 @@
         "rarity": "UNCOMMON",
         "artist": "Thomas M. Baxa",
         "imageUri": "https://cards.scryfall.io/normal/front/4/1/415027f8-ccef-4b38-ace2-db4e94f066fe.jpg?1783944505"
+    },
+    "colorIdentityOverride": []
+}
+
+// Sculpting Steel
+{
+    "name": "Sculpting Steel",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "You may have this artifact enter as a copy of any artifact on the battlefield.",
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersAsCopy",
+                "copyFilter": {
+                    "cardPredicates": [
+                        "IsArtifact"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "RARE",
+        "artist": "Heather Hudson",
+        "flavorText": "An artificer once dropped one in a vault full of coins. She has yet to find it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3aac5f6f-97c1-4546-94ed-016292e98c9d.jpg?1783944505"
     },
     "colorIdentityOverride": []
 }
@@ -7603,6 +7777,41 @@
         "artist": "Ben Thompson",
         "flavorText": "Lymph, the fluid essence of blinkmoths, is prized by wizards for the rush of intellect it provides.",
         "imageUri": "https://cards.scryfall.io/normal/front/0/f/0ff1f608-203e-4413-8753-37fc49731c87.jpg?1783944550"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Thoughtcast
+{
+    "name": "Thoughtcast",
+    "manaCost": "{4}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nDraw two cards.",
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Greg Hildebrandt",
+        "flavorText": "Vedalken eyes don't see the beauty in things. They see only what those things can teach.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efb965a7-877a-4302-b507-25b0a9e32d9b.jpg?1783944550"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BroodstarScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BroodstarScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for Broodstar (MRD #31).
+ *
+ * {8}{U}{U} Creature — Beast star/star
+ * "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ *  Flying
+ *  Broodstar's power and toughness are each equal to the number of artifacts you control."
+ *
+ * Both halves read the same number, which is the trap worth pinning: the characteristic-defining
+ * ability is re-read continuously (not snapshotted on entry), Broodstar is not itself an artifact
+ * so it never counts toward its own size, and only artifacts *you* control count for either half.
+ */
+class BroodstarScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+    private val costCalculator by lazy { CostCalculator(cardRegistry) }
+
+    init {
+        fun board(yourArtifacts: Int, opponentArtifacts: Int = 0) = run {
+            var builder = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Broodstar")
+            repeat(yourArtifacts) { builder = builder.withCardOnBattlefield(1, "Bonesplitter") }
+            repeat(opponentArtifacts) { builder = builder.withCardOnBattlefield(2, "Bonesplitter") }
+            builder
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+        }
+
+        context("Broodstar") {
+
+            test("power and toughness both track the artifacts you control") {
+                val game = board(yourArtifacts = 3)
+                val broodstar = game.findPermanent("Broodstar")!!
+
+                val projected = projector.project(game.state)
+                withClue("three artifacts, and Broodstar itself is not one of them") {
+                    projected.getPower(broodstar) shouldBe 3
+                    projected.getToughness(broodstar) shouldBe 3
+                }
+                projected.hasKeyword(broodstar, Keyword.FLYING) shouldBe true
+            }
+
+            test("it shrinks when an artifact leaves — the ability is re-read, not snapshotted") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Broodstar")
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withCardOnBattlefield(1, "Leonin Scimitar")
+                    .withCardOnBattlefield(1, "Serum Tank")
+                    .withCardInHand(1, "Shatter")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val broodstar = game.findPermanent("Broodstar")!!
+                val doomed = game.findPermanent("Serum Tank")!!
+
+                projector.project(game.state).getPower(broodstar) shouldBe 3
+
+                game.castSpell(1, "Shatter", targetId = doomed).error shouldBe null
+                game.resolveStack()
+
+                withClue("two artifacts left, so Broodstar is a 2/2") {
+                    game.findPermanent("Serum Tank") shouldBe null
+                    val after = projector.project(game.state)
+                    after.getPower(broodstar) shouldBe 2
+                    after.getToughness(broodstar) shouldBe 2
+                }
+            }
+
+            test("an opponent's artifacts count for neither the size nor the discount") {
+                val game = board(yourArtifacts = 1, opponentArtifacts = 4)
+                val broodstar = game.findPermanent("Broodstar")!!
+
+                withClue("only your one artifact sizes it") {
+                    projector.project(game.state).getPower(broodstar) shouldBe 1
+                }
+                withClue("affinity counts artifacts you control, so {8} drops to {7}") {
+                    costCalculator.calculateEffectiveCost(
+                        game.state,
+                        cardRegistry.requireCard("Broodstar"),
+                        game.player1Id
+                    ).genericAmount shouldBe 7
+                }
+            }
+
+            test("with no artifacts it is a 0/0 and dies to state-based actions") {
+                val game = board(yourArtifacts = 0)
+                val broodstar = game.findPermanent("Broodstar")!!
+
+                projector.project(game.state).getToughness(broodstar) shouldBe 0
+
+                game.checkStateBasedActions()
+
+                withClue("0 toughness is lethal (CR 704.5f)") {
+                    game.findPermanent("Broodstar") shouldBe null
+                    game.findCardsInGraveyard(1, "Broodstar").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DomineerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DomineerScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario coverage for Domineer (MRD #33).
+ *
+ * {1}{U}{U} Enchantment — Aura
+ * "Enchant artifact creature
+ *  You control enchanted artifact creature."
+ *
+ * Mirrodin's narrow Control Magic. The claims worth pinning: the enchant restriction really is
+ * *artifact* creature (a plain creature can't be targeted), control moves while the Aura is on the
+ * battlefield, and it snaps back the moment the Aura leaves.
+ */
+class DomineerScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Domineer") {
+
+            test("stealing an opponent's artifact creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(2, "Alpha Myr")
+                    .withCardInHand(1, "Domineer")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myr = game.findPermanent("Alpha Myr")!!
+                withClue("it starts under the opponent's control") {
+                    projector.project(game.state).getController(myr) shouldBe game.player2Id
+                }
+
+                game.castSpell(1, "Domineer", targetId = myr).error shouldBe null
+                game.resolveStack()
+
+                withClue("the Aura resolved and moved control to its controller") {
+                    game.findPermanent("Domineer") shouldNotBe null
+                    projector.project(game.state).getController(myr) shouldBe game.player1Id
+                }
+            }
+
+            test("cannot enchant a creature that is not an artifact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardInHand(1, "Domineer")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                withClue("'enchant artifact creature' is a targeting restriction, not flavor") {
+                    game.castSpell(1, "Domineer", targetId = giant).error shouldNotBe null
+                    projector.project(game.state).getController(giant) shouldBe game.player2Id
+                }
+            }
+
+            test("control reverts as soon as the Aura leaves the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(2, "Alpha Myr")
+                    .withCardOnBattlefield(1, "Domineer")
+                    .withCardAttachedTo(1, "Domineer", "Alpha Myr")
+                    .withCardInHand(1, "Altar's Light")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myr = game.findPermanent("Alpha Myr")!!
+                val domineer = game.findPermanent("Domineer")!!
+
+                withClue("the pre-attached Aura already has control") {
+                    projector.project(game.state).getController(myr) shouldBe game.player1Id
+                }
+
+                game.castSpell(1, "Altar's Light", targetId = domineer).error shouldBe null
+                game.resolveStack()
+
+                withClue("no Aura, no control effect — the Myr goes home") {
+                    game.findPermanent("Domineer") shouldBe null
+                    projector.project(game.state).getController(myr) shouldBe game.player2Id
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RustElementalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RustElementalScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario coverage for Rust Elemental (MRD #234).
+ *
+ * {4} Artifact Creature — Elemental 4/4
+ * "Flying
+ *  At the beginning of your upkeep, sacrifice another artifact. If you can't, tap this creature
+ *  and you lose 4 life."
+ *
+ * The claims pinned down here are the ones the "if you can't" clause turns on:
+ *  - with another artifact around, the sacrifice happens and no life is lost;
+ *  - Rust Elemental never counts as its own fodder, even though it *is* an artifact — a lone
+ *    Rust Elemental takes the penalty instead of eating itself;
+ *  - with several artifacts out the controller chooses which one goes;
+ *  - the penalty branch fires on the controller's upkeep only, not on the opponent's.
+ */
+class RustElementalScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun TestGame.isTapped(id: EntityId): Boolean =
+            state.getEntity(id)?.has<TappedComponent>() == true
+
+        /** Board with Rust Elemental on player 1's side, parked at the opponent's end step. */
+        fun board(vararg otherArtifacts: String): TestGame {
+            var builder = scenario()
+                .withPlayers("Player", "Opponent")
+                .withLifeTotal(1, 20)
+                .withCardOnBattlefield(1, "Rust Elemental")
+            otherArtifacts.forEach { builder = builder.withCardOnBattlefield(1, it) }
+            return builder
+                .withActivePlayer(2)
+                .withPriorityPlayer(2)
+                .inPhase(Phase.ENDING, Step.END)
+                .build()
+        }
+
+        context("Rust Elemental") {
+
+            test("sacrifices the only other artifact and pays nothing else") {
+                val game = board("Bonesplitter")
+                val rust = game.findPermanent("Rust Elemental")!!
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("exactly one legal choice, so it is sacrificed without a prompt") {
+                    game.findPermanent("Bonesplitter") shouldBe null
+                    game.findCardsInGraveyard(1, "Bonesplitter").size shouldBe 1
+                }
+                withClue("the sacrifice succeeded, so the penalty branch never runs") {
+                    game.getLifeTotal(1) shouldBe 20
+                    game.isTapped(rust) shouldBe false
+                    game.findPermanent("Rust Elemental") shouldNotBe null
+                }
+            }
+
+            test("alone on the battlefield it taps itself and drains 4 — it is not its own fodder") {
+                val game = board()
+                val rust = game.findPermanent("Rust Elemental")!!
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("Rust Elemental is an artifact, but 'another' excludes it") {
+                    game.findPermanent("Rust Elemental") shouldNotBe null
+                    game.isTapped(rust) shouldBe true
+                    game.getLifeTotal(1) shouldBe 16
+                }
+            }
+
+            test("with two other artifacts the controller picks which one to sacrifice") {
+                val game = board("Bonesplitter", "Leonin Scimitar")
+                val rust = game.findPermanent("Rust Elemental")!!
+                val scimitar = game.findPermanent("Leonin Scimitar")!!
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                val decision = game.state.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("both other artifacts are offered; Rust Elemental itself is not") {
+                    decision.options shouldContain scimitar
+                    decision.options shouldContain game.findPermanent("Bonesplitter")!!
+                    decision.options.contains(rust) shouldBe false
+                }
+
+                game.selectCards(listOf(scimitar))
+
+                withClue("the chosen artifact dies and the penalty branch is skipped") {
+                    game.findPermanent("Leonin Scimitar") shouldBe null
+                    game.findPermanent("Bonesplitter") shouldNotBe null
+                    game.getLifeTotal(1) shouldBe 20
+                    game.isTapped(rust) shouldBe false
+                }
+            }
+
+            test("does nothing on the opponent's upkeep") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withLifeTotal(1, 20)
+                    .withCardOnBattlefield(1, "Rust Elemental")
+                    .withActivePlayer(1)
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.ENDING, Step.END)
+                    .build()
+                val rust = game.findPermanent("Rust Elemental")!!
+
+                // Passing from player 1's end step lands in player 2's upkeep.
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("'your upkeep' is the controller's upkeep only") {
+                    game.state.activePlayerId shouldBe game.player2Id
+                    game.isTapped(rust) shouldBe false
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SculptingSteelScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SculptingSteelScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.CopyOfComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario coverage for Sculpting Steel (MRD #238).
+ *
+ * {3} Artifact
+ * "You may have this artifact enter as a copy of any artifact on the battlefield."
+ *
+ * Clone narrowed to artifacts. What's worth proving: "any artifact" reaches across the table,
+ * non-artifacts are not on the menu, and the "may" is a real decline that leaves a vanilla {3}
+ * artifact behind rather than fizzling the permanent out of existence.
+ */
+class SculptingSteelScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sculpting Steel") {
+
+            test("copies an opponent's artifact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(2, "Gilded Lotus")
+                    .withCardInHand(1, "Sculpting Steel")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lotus = game.findPermanent("Gilded Lotus")!!
+                val steel = game.findCardsInHand(1, "Sculpting Steel").single()
+
+                game.castSpell(1, "Sculpting Steel").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.state.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("'any artifact on the battlefield' includes the opponent's") {
+                    decision.options shouldContain lotus
+                }
+                game.selectCards(listOf(lotus))
+
+                val card = game.state.getEntity(steel)?.get<CardComponent>()
+                withClue("the copy takes on the copied artifact's characteristics") {
+                    card shouldNotBe null
+                    card!!.name shouldBe "Gilded Lotus"
+                    card.typeLine.isArtifact shouldBe true
+                }
+                val copyOf = game.state.getEntity(steel)?.get<CopyOfComponent>()
+                copyOf shouldNotBe null
+                copyOf!!.originalCardDefinitionId shouldBe "Sculpting Steel"
+                copyOf.copiedCardDefinitionId shouldBe "Gilded Lotus"
+            }
+
+            test("non-artifacts are never offered") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardInHand(1, "Sculpting Steel")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bonesplitter = game.findPermanent("Bonesplitter")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Sculpting Steel").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.state.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                decision.options shouldContain bonesplitter
+                withClue("Hill Giant is a creature, not an artifact") {
+                    decision.options shouldNotContain giant
+                }
+            }
+
+            test("declining the copy leaves a plain {3} artifact on the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(2, "Gilded Lotus")
+                    .withCardInHand(1, "Sculpting Steel")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val steel = game.findCardsInHand(1, "Sculpting Steel").single()
+
+                game.castSpell(1, "Sculpting Steel").error shouldBe null
+                game.resolveStack()
+
+                game.state.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+                game.skipSelection()
+
+                withClue("the 'may' is declinable — it still enters, just as itself") {
+                    game.findPermanent("Sculpting Steel") shouldBe steel
+                    game.state.getEntity(steel)?.get<CopyOfComponent>() shouldBe null
+                    game.findPermanents("Gilded Lotus").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThoughtcastScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThoughtcastScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario coverage for Thoughtcast (MRD #54).
+ *
+ * {4}{U} Sorcery
+ * "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ *  Draw two cards."
+ *
+ * Affinity shaves generic mana only, so the interesting claims are about the floor: four artifacts
+ * take it to a bare {U}, and a fifth can't push it below that.
+ */
+class ThoughtcastScenarioTest : ScenarioTestBase() {
+
+    private val costCalculator by lazy { CostCalculator(cardRegistry) }
+
+    init {
+        fun boardWithArtifacts(count: Int) = run {
+            var builder = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardInHand(1, "Thoughtcast")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Mountain")
+            repeat(count) { builder = builder.withCardOnBattlefield(1, "Bonesplitter") }
+            builder.inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+        }
+
+        fun TestGame.genericCost(): Int = costCalculator.calculateEffectiveCost(
+            state,
+            cardRegistry.requireCard("Thoughtcast"),
+            player1Id
+        ).genericAmount
+
+        context("Thoughtcast") {
+
+            test("each artifact you control shaves {1} off the generic cost") {
+                withClue("no artifacts — full {4}{U}") {
+                    boardWithArtifacts(0).genericCost() shouldBe 4
+                }
+                withClue("three artifacts — {1}{U}") {
+                    boardWithArtifacts(3).genericCost() shouldBe 1
+                }
+            }
+
+            test("the {U} is never reduced away — extra artifacts stop mattering at four") {
+                withClue("four artifacts take the generic to zero") {
+                    boardWithArtifacts(4).genericCost() shouldBe 0
+                }
+                withClue("a sixth artifact can't push the generic below zero") {
+                    boardWithArtifacts(6).genericCost() shouldBe 0
+                }
+            }
+
+            test("cast off a single Island with four artifacts out, and draw two") {
+                val game = boardWithArtifacts(4)
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Thoughtcast").error shouldBe null
+                game.resolveStack()
+
+                withClue("Thoughtcast left hand, two cards came in: net +1") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+                game.findCardsInGraveyard(1, "Thoughtcast").size shouldBe 1
+            }
+
+            test("one Island is not enough without artifacts") {
+                val game = boardWithArtifacts(0)
+
+                withClue("{4}{U} off a single Island is unpayable") {
+                    game.castSpell(1, "Thoughtcast").error shouldNotBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five Mirrodin cards, all composed from existing SDK vocabulary — no new effects, triggers, statics or replacement effects, so `docs/card-sdk-language-reference.md` is unchanged.

## Cards

| Card | Cost | What it needed |
|---|---|---|
| **Thoughtcast** | `{4}{U}` Sorcery | `KeywordAbility.Affinity(ARTIFACT)` + `Effects.DrawCards(2)` |
| **Broodstar** | `{8}{U}{U}` Creature — Beast | Affinity, flying, and `dynamicStats` over artifacts you control |
| **Domineer** | `{1}{U}{U}` Aura | `ControlEnchantedPermanent` behind an artifact-creature `auraTarget` |
| **Sculpting Steel** | `{3}` Artifact | `EntersAsCopy(optional = true, copyFilter = Artifact)` |
| **Rust Elemental** | `{4}` Artifact Creature — Elemental 4/4 | `ConditionalEffect` around `SacrificeEffect` on an upkeep trigger |

## Notes on the fiddly bits

- **Broodstar's `*/*`** is a characteristic-defining ability (CR 604.3), so it's `dynamicStats`, re-read continuously rather than snapshotted on entry. Broodstar is *not* an artifact, so it never counts toward its own size — alone on an empty board it's a 0/0 and dies to the SBA. A test pins that.
- **Domineer's "enchant artifact creature"** is the aura target filter, not a one-shot resolution check, so CR 704.5m re-checks it continuously and control snaps back the instant the Aura leaves. There is no `Targets.ArtifactCreature` facade yet and this is the first card here to want one, so the filter is inlined rather than promoted.
- **Rust Elemental's "if you can't"** is modelled explicitly rather than leaning on the sacrifice silently fizzling — the condition asks whether you control an artifact *other than* Rust Elemental, and only the failing branch taps it and drains 4. Both `excludeSelf` and `excludeSource` are load-bearing: Rust Elemental is itself an artifact and would otherwise happily eat itself every upkeep.
- **Sculpting Steel's `optional = true`** because declining is a real (bad) choice — you keep a vanilla colorless `{3}` artifact — not a no-op.

## Placement

Mirrodin is the earliest real-expansion printing for all five (`just check-card-printing` clean on each). Sculpting Steel is also in 10E, which is scaffolded, so it gets a `Printing(...)` row there. The MRD card snapshot golden was reblessed; only these five cards moved.

## Verification

- `just build` — green.
- 18 new scenario tests across **five files, one per card**:
  - `ThoughtcastScenarioTest` — the discount per artifact, the `{U}` floor that a fifth artifact can't push past, a real cast off a single Island, and the unpayable no-artifact case.
  - `BroodstarScenarioTest` — P/T tracking, shrinking when an artifact is Shattered (proving the re-read), opponents' artifacts counting for neither size nor discount, and the 0/0 SBA death.
  - `DomineerScenarioTest` — stealing an artifact creature, the non-artifact creature being an illegal target, and control reverting when the Aura is exiled.
  - `SculptingSteelScenarioTest` — copying across the table, non-artifacts absent from the menu, and the decline leaving a plain artifact.
  - `RustElementalScenarioTest` — the auto-sacrifice, the lone-Elemental penalty branch, the multi-artifact choice prompt (with Rust Elemental itself absent from the options), and nothing happening on the opponent's upkeep.

No new decision types, so no `DecisionUI` routing changes and no e2e test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)