### PR TITLE
Add three storied The Hobbit cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BomburGentleDreamer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BomburGentleDreamer.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.storied
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bombur, Gentle Dreamer
+ * {2}{R}
+ * Legendary Creature — Dwarf Bard
+ * 5/3
+ *
+ * Storied.
+ * Bombur doesn't untap during your untap step unless you have an enduring story.
+ *
+ * The drawback half is the *inverse* of the usual storied payoff: the restriction is printed and the
+ * enduring story turns it **off**, so the gate is `Not(YouHaveEnduringStory)` rather than the bare
+ * condition every other storied card uses. Since the designation is never lost once gained
+ * (CR 702.195a), that means Bombur untaps normally from the moment the third artifact/legendary/Saga
+ * lands and forever after — Bombur himself is legendary and counts toward his own threshold.
+ *
+ * "Doesn't untap during your untap step" is the narrow [AbilityFlag.DOESNT_UNTAP], not the stronger
+ * `CANT_BECOME_UNTAPPED`: a Twiddle still untaps Bombur even while the restriction is live. Granting
+ * it through [GrantKeyword] rather than the printed `flags(...)` is what makes it conditional at all
+ * — `flags` bakes the restriction into the card definition where no condition can reach it, whereas
+ * a static ability re-projects every time [Conditions.YouHaveEnduringStory] changes answer.
+ */
+val BomburGentleDreamer = card("Bombur, Gentle Dreamer") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dwarf Bard"
+    oracleText = "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you " +
+        "have an enduring story for the rest of the game.)\n" +
+        "Bombur doesn't untap during your untap step unless you have an enduring story."
+    power = 5
+    toughness = 3
+
+    storied()
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name, GroupFilter.source()),
+            condition = Conditions.Not(Conditions.YouHaveEnduringStory)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "88"
+        artist = "Eric Deschamps"
+        flavorText = "Bombur was always trying to recapture the beautiful dreams he had in the forest."
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63c317e7-432c-4817-8db4-3670a1d84be3.jpg?1785496185"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DainLordOfTheIronHills.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DainLordOfTheIronHills.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.storied
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AttackTax
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dáin, Lord of the Iron Hills
+ * {1}{W}
+ * Legendary Creature — Dwarf Noble
+ * 2/2
+ *
+ * Vigilance
+ * Storied.
+ * As long as you have an enduring story, creatures can't attack you unless their controller pays {1}
+ * for each of those creatures.
+ *
+ * A Ghostly Prison that only switches on with the enduring story. The gate rides [AttackTax.condition]
+ * rather than a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] wrapper: `AttackPhaseManager.
+ * calculateTotalAttackTax` scans `cardDef.staticAbilities` **raw** and only recognizes a bare
+ * [AttackTax], so a wrapped one would silently tax nothing. The field exists for exactly this shape
+ * (Archangel of Tithes gates on being untapped); it is evaluated with Dáin's controller as "you", which
+ * is the player being attacked.
+ */
+val DainLordOfTheIronHills = card("Dáin, Lord of the Iron Hills") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Dwarf Noble"
+    oracleText = "Vigilance\n" +
+        "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you have an " +
+        "enduring story for the rest of the game.)\n" +
+        "As long as you have an enduring story, creatures can't attack you unless their controller " +
+        "pays {1} for each of those creatures."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.VIGILANCE)
+    storied()
+
+    staticAbility {
+        ability = AttackTax(
+            amountPerAttacker = DynamicAmount.Fixed(1),
+            condition = Conditions.YouHaveEnduringStory
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "Tomas Duchek"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99d27749-d16c-45e9-accc-6a01351c17f9.jpg?1785496921"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/FiliThePathfinder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/FiliThePathfinder.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.storied
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Fíli the Pathfinder
+ * {3}{W}
+ * Legendary Creature — Dwarf Scout
+ * 2/2
+ *
+ * Storied.
+ * As long as you have an enduring story, creatures you control get +1/+1.
+ * Whenever Fíli or another nontoken Dwarf you control enters, create a 2/2 red Dwarf creature token.
+ *
+ * The anthem says "creatures you control", not "other creatures", so the filter carries no
+ * `excludeSelf` — Fíli pumps himself to 3/3 once the enduring story is on.
+ *
+ * "Fíli or another nontoken Dwarf you control" is the Arahbo shape: one `ANY`-bound enters trigger over
+ * `Dwarf.nontoken().youControl()` covers both halves, because Fíli is himself a nontoken Dwarf you
+ * control and so matches his own filter. The tokens it makes are Dwarves too, but `nontoken()` keeps
+ * them from re-triggering — otherwise the ability would loop.
+ */
+val FiliThePathfinder = card("Fíli the Pathfinder") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Dwarf Scout"
+    oracleText = "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you " +
+        "have an enduring story for the rest of the game.)\n" +
+        "As long as you have an enduring story, creatures you control get +1/+1.\n" +
+        "Whenever Fíli or another nontoken Dwarf you control enters, create a 2/2 red Dwarf " +
+        "creature token."
+    power = 2
+    toughness = 2
+
+    storied()
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(
+                powerBonus = 1,
+                toughnessBonus = 1,
+                filter = GroupFilter(GameObjectFilter.Creature.youControl())
+            ),
+            condition = Conditions.YouHaveEnduringStory
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.DWARF).nontoken().youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dwarf"),
+            imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "14"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b02142f3-5e55-40dc-a02c-9113fb7d763c.jpg?1785496367"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1279,6 +1279,50 @@
     ]
 }
 
+// Bombur, Gentle Dreamer
+{
+    "name": "Bombur, Gentle Dreamer",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Dwarf Bard",
+    "oracleText": "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you have an enduring story for the rest of the game.)\nBombur doesn't untap during your untap step unless you have an enduring story.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "STORIED"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOESNT_UNTAP",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Not",
+                    "condition": "PlayerHasEnduringStory"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Deschamps",
+        "flavorText": "Bombur was always trying to recapture the beautiful dreams he had in the forest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63c317e7-432c-4817-8db4-3670a1d84be3.jpg?1785496185"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Bothersome Noisemaker
 {
     "name": "Bothersome Noisemaker",
@@ -3180,6 +3224,43 @@
     ]
 }
 
+// Dáin, Lord of the Iron Hills
+{
+    "name": "Dáin, Lord of the Iron Hills",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Dwarf Noble",
+    "oracleText": "Vigilance\nStoried (If you control three or more artifacts, legendaries, and/or Sagas, you have an enduring story for the rest of the game.)\nAs long as you have an enduring story, creatures can't attack you unless their controller pays {1} for each of those creatures.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE",
+        "STORIED"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "AttackTax",
+                "amountPerAttacker": {
+                    "type": "Fixed",
+                    "amount": 1
+                },
+                "condition": "PlayerHasEnduringStory"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "UNCOMMON",
+        "artist": "Tomas Duchek",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99d27749-d16c-45e9-accc-6a01351c17f9.jpg?1785496921"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Eagle of the Great Shelf
 {
     "name": "Eagle of the Great Shelf",
@@ -3972,6 +4053,69 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Fíli the Pathfinder
+{
+    "name": "Fíli the Pathfinder",
+    "manaCost": "{3}{W}",
+    "typeLine": "Legendary Creature — Dwarf Scout",
+    "oracleText": "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you have an enduring story for the rest of the game.)\nAs long as you have an enduring story, creatures you control get +1/+1.\nWhenever Fíli or another nontoken Dwarf you control enters, create a 2/2 red Dwarf creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "STORIED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Dwarf nontoken ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Dwarf"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "condition": "PlayerHasEnduringStory"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "rarity": "RARE",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b02142f3-5e55-40dc-a02c-9113fb7d763c.jpg?1785496367"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BomburGentleDreamerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BomburGentleDreamerScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.enduringstory.EnduringStoryService
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bombur, Gentle Dreamer — "Bombur doesn't untap during your untap step unless you have an enduring
+ * story."
+ *
+ * The inverted storied gate: every other storied card grants something *while* you have the enduring
+ * story, Bombur takes a restriction away. That makes him the only card wiring
+ * `Not(YouHaveEnduringStory)` into a `ConditionalStaticAbility`, and the reason this file exists — a
+ * gate that silently evaluated the wrong way would leave the card either permanently stuck or never
+ * stuck, and both look plausible on the battlefield.
+ *
+ * The threshold rules themselves are pinned in [StoriedEnduringStoryTest]; here Bombur is one of the
+ * three qualifying permanents himself (he's legendary), so the "off" board is Bombur plus lands and
+ * the "on" board is Bombur plus two more legendaries.
+ */
+class BomburGentleDreamerScenarioTest : ScenarioTestBase() {
+
+    init {
+
+        test("without an enduring story Bombur stays tapped through his controller's untap step") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Bombur, Gentle Dreamer", tapped = true)
+                // Lands are neither artifacts, legendaries, nor Sagas — Bombur is the only one of
+                // the three, so the threshold stays unmet.
+                .withLandsOnBattlefield(1, "Mountain", 3)
+                .withCardsInHand(1, "Mountain", 3)
+                .withCardsInHand(2, "Mountain", 3)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bombur = game.findPermanent("Bombur, Gentle Dreamer")!!
+
+            withClue("no enduring story, so the printed restriction is live") {
+                EnduringStoryService.has(game.state, game.player1Id) shouldBe false
+                game.state.projectedState.hasKeyword(bombur, AbilityFlag.DOESNT_UNTAP) shouldBe true
+            }
+
+            // Round the turn cycle back to Player 1's next upkeep — their untap step runs on the
+            // boundary in between, and the untap step itself has no priority window to stop in.
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // Player 2's upkeep
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // Player 2's main
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // Player 1's next upkeep
+            game.state.activePlayerId shouldBe game.player1Id
+
+            withClue("Bombur was skipped by the untap step") {
+                game.state.getEntity(bombur)?.has<TappedComponent>() shouldBe true
+            }
+        }
+
+        test("with an enduring story Bombur untaps normally") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Bombur, Gentle Dreamer", tapped = true)
+                // Two more legendaries put Bombur's controller over the storied threshold of three.
+                .withCardOnBattlefield(1, "Ori, Keeper of Songs")
+                .withCardOnBattlefield(1, "Thorin Oakenshield")
+                .withLandsOnBattlefield(1, "Mountain", 3)
+                .withCardsInHand(1, "Mountain", 3)
+                .withCardsInHand(2, "Mountain", 3)
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withCardInLibrary(2, "Mountain")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bombur = game.findPermanent("Bombur, Gentle Dreamer")!!
+
+            withClue("three qualifying permanents, so the restriction is switched off") {
+                EnduringStoryService.has(game.state, game.player1Id) shouldBe true
+                game.state.projectedState.hasKeyword(bombur, AbilityFlag.DOESNT_UNTAP) shouldBe false
+            }
+
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.state.activePlayerId shouldBe game.player1Id
+
+            withClue("Bombur untapped with everything else") {
+                game.state.getEntity(bombur)?.has<TappedComponent>() shouldBe false
+            }
+        }
+
+        test("the restriction is the narrow untap-step one, not can't-become-untapped") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Bombur, Gentle Dreamer", tapped = true)
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bombur = game.findPermanent("Bombur, Gentle Dreamer")!!
+
+            // The two flags are trivially easy to swap and resolve differently against any untap
+            // *effect* — a Twiddle still untaps Bombur even while the storied gate is unmet.
+            withClue("DOESNT_UNTAP only, so untap effects still work on him") {
+                game.state.projectedState.hasKeyword(bombur, AbilityFlag.DOESNT_UNTAP) shouldBe true
+                game.state.projectedState
+                    .hasKeyword(bombur, AbilityFlag.CANT_BECOME_UNTAPPED) shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DainLordOfTheIronHillsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DainLordOfTheIronHillsScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.mechanics.enduringstory.EnduringStoryService
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Dáin, Lord of the Iron Hills — "As long as you have an enduring story, creatures can't attack you
+ * unless their controller pays {1} for each of those creatures."
+ *
+ * A Ghostly Prison behind the storied gate. The gate rides `AttackTax.condition` rather than a
+ * `ConditionalStaticAbility` wrapper, and that is exactly what these tests pin:
+ * `AttackPhaseManager.calculateTotalAttackTax` scans `cardDef.staticAbilities` **raw**, matching only
+ * a bare `AttackTax`, so a wrapped ability would tax nothing at all and the "off" case below would
+ * pass for the wrong reason. Asserting both directions is what separates "gate works" from "gate
+ * never fires".
+ */
+class DainLordOfTheIronHillsScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        return d
+    }
+
+    test("without an enduring story Dáin taxes nothing") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 30), skipMulligans = true)
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+
+        // Dáin is legendary and so counts toward his own threshold, but he is the only one of the
+        // three — the tax stays dormant.
+        d.putCreatureOnBattlefield(defender, "Dáin, Lord of the Iron Hills")
+        val bear = d.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        d.removeSummoningSickness(bear)
+
+        EnduringStoryService.has(d.state, defender) shouldBe false
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val result = d.declareAttackers(attacker, listOf(bear), defender)
+
+        withClue("no enduring story → no tax, so the attack goes through unpaused") {
+            result.isSuccess shouldBe true
+            (result.newState.pendingDecision is SelectManaSourcesDecision) shouldBe false
+        }
+    }
+
+    test("with an enduring story Dáin taxes each attacker {1}") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 30), skipMulligans = true)
+        val attacker = d.activePlayer!!
+        val defender = d.getOpponent(attacker)
+
+        d.putCreatureOnBattlefield(defender, "Dáin, Lord of the Iron Hills")
+        d.putCreatureOnBattlefield(defender, "Ori, Keeper of Songs")
+        d.putCreatureOnBattlefield(defender, "Thorin Oakenshield")
+        val bear = d.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        d.removeSummoningSickness(bear)
+        // A single untapped land so the attacker can actually pay the {1} they now owe.
+        d.putLandOnBattlefield(attacker, "Forest")
+
+        EnduringStoryService.has(d.state, defender) shouldBe true
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val result = d.declareAttackers(attacker, listOf(bear), defender)
+
+        withClue("the tax is owed, so declaring attackers pauses for mana") {
+            result.newState.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FiliThePathfinderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FiliThePathfinderScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.enduringstory.EnduringStoryService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fíli the Pathfinder — a conditional anthem plus "Whenever Fíli or another nontoken Dwarf you
+ * control enters, create a 2/2 red Dwarf creature token."
+ *
+ * Two things worth pinning. The anthem says "creatures you control", not "other creatures", so Fíli
+ * pumps himself — an `excludeSelf` slipped into the filter would be invisible except on his own
+ * stats. And the trigger's `nontoken()` is load-bearing in the other direction: the tokens it makes
+ * are themselves Dwarves you control, so without it every trigger would spawn a token that
+ * re-triggered, and the ability would loop forever.
+ */
+class FiliThePathfinderScenarioTest : ScenarioTestBase() {
+
+    init {
+
+        test("without an enduring story the anthem is off") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Fíli the Pathfinder")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val fili = game.findPermanent("Fíli the Pathfinder")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            EnduringStoryService.has(game.state, game.player1Id) shouldBe false
+            game.state.projectedState.getPower(fili) shouldBe 2
+            game.state.projectedState.getToughness(fili) shouldBe 2
+            game.state.projectedState.getPower(bears) shouldBe 2
+        }
+
+        test("with an enduring story every creature you control gets +1/+1 — Fíli included") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Fíli the Pathfinder")
+                .withCardOnBattlefield(1, "Óin the Brave")
+                .withCardOnBattlefield(1, "Thorin Oakenshield")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(2, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val fili = game.findPermanent("Fíli the Pathfinder")!!
+            val myBears = game.findPermanent("Grizzly Bears")!!
+            val theirGiant = game.findPermanent("Hill Giant")!!
+
+            EnduringStoryService.has(game.state, game.player1Id) shouldBe true
+
+            withClue("\"creatures you control\" has no excludeSelf — Fíli pumps himself") {
+                game.state.projectedState.getPower(fili) shouldBe 3
+                game.state.projectedState.getToughness(fili) shouldBe 3
+            }
+            game.state.projectedState.getPower(myBears) shouldBe 3
+            withClue("the opponent's 3/3 Hill Giant is untouched — it would be 4/4 if it were pumped") {
+                game.state.projectedState.getPower(theirGiant) shouldBe 3
+                game.state.projectedState.getToughness(theirGiant) shouldBe 3
+            }
+        }
+
+        test("another nontoken Dwarf entering makes a 2/2 red Dwarf token, and the token doesn't loop") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Fíli the Pathfinder")
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withCardInHand(1, "Dwarven Mauler")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Dwarven Mauler").error shouldBe null
+            game.resolveStack()
+
+            val tokens = game.findPermanents("Dwarf Token")
+            withClue("exactly one token — the token is a Dwarf too, but nontoken() stops the loop") {
+                tokens.size shouldBe 1
+            }
+            game.state.projectedState.getPower(tokens.first()) shouldBe 2
+            game.state.projectedState.getToughness(tokens.first()) shouldBe 2
+        }
+    }
+}


### PR DESCRIPTION
Three more HOB cards off the back of the storied keyword (PR #1788): **Bombur, Gentle Dreamer**, **Dáin, Lord of the Iron Hills**, and **Fíli the Pathfinder**. All built from existing SDK vocabulary — no engine or SDK changes, so `docs/card-sdk-language-reference.md` is unaffected.

Takes HOB from 172/193 to **175/193**.

### Bombur, Gentle Dreamer — {2}{R} 5/3

> Bombur doesn't untap during your untap step unless you have an enduring story.

The only storied card that *inverts* the gate: the restriction is printed and the enduring story turns it off. So it is `Not(YouHaveEnduringStory)` around a `GrantKeyword(AbilityFlag.DOESNT_UNTAP, source())`, not the printed `flags(AbilityFlag.DOESNT_UNTAP)` — `flags` bakes the restriction into the card definition where no condition can reach it, whereas a static ability re-projects whenever the condition changes answer.

`DOESNT_UNTAP`, not the stronger `CANT_BECOME_UNTAPPED`: an untap *effect* still works on Bombur while the restriction is live. The two are easy to swap and the test pins the distinction.

### Dáin, Lord of the Iron Hills — {1}{W} 2/2

> Vigilance. As long as you have an enduring story, creatures can't attack you unless their controller pays {1} for each of those creatures.

A Ghostly Prison behind the storied gate. The gate rides `AttackTax.condition` rather than a `ConditionalStaticAbility` wrapper, because `AttackPhaseManager.calculateTotalAttackTax` scans `cardDef.staticAbilities` **raw** and matches only a bare `AttackTax` — a wrapped one would silently tax nothing. The field exists for exactly this shape (Archangel of Tithes gates on being untapped).

### Fíli the Pathfinder — {3}{W} 2/2

> As long as you have an enduring story, creatures you control get +1/+1.
> Whenever Fíli or another nontoken Dwarf you control enters, create a 2/2 red Dwarf creature token.

The Arahbo, the First Fang shape: one `ANY`-bound enters trigger over `Dwarf.nontoken().youControl()` covers both halves, since Fíli is himself a nontoken Dwarf you control. `nontoken()` is load-bearing — the tokens it makes are Dwarves too, so without it the ability would loop. The anthem says "creatures you control", not "other creatures", so no `excludeSelf`: Fíli pumps himself.

## Tests

One scenario test per card (8 tests total), each covering both sides of its storied gate:

- `BomburGentleDreamerScenarioTest` — stays tapped through his own untap step without the story, untaps with it, and carries only the narrow flag.
- `DainLordOfTheIronHillsScenarioTest` — declaring attackers is unpaused without the story, pauses for `SelectManaSourcesDecision` with it.
- `FiliThePathfinderScenarioTest` — anthem off/on (including Fíli himself and *not* the opponent's creatures), and casting a Dwarven Mauler makes exactly one 2/2 token.

## Verification

- `just build` — green (full gate: compile, card linter, facade boundary, snapshots, rules-engine suite).
- `just rebless-cards` — only the three new cards moved in `snapshots/cards/HOB.json`.
- `just check-card-printing` — all three canonical in HOB, their only real printing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)