### PR TITLE
Add five Murders at Karlov Manor cards with face-down mana support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -8607,6 +8607,14 @@ restriction matches the spell context.
 - `ManaRestriction.UnlockDoorOnly` — only the unlock-a-door special action (CR 709.5e).
   Satisfied by `SpellPaymentContext.isUnlockDoorAction`; the unlock-room handler/enumerator pass
   that context. Creeping Peeper (inside `AnyOf`).
+- `ManaRestriction.FaceDownSpellsOnly` — only spells **cast face down** for a morph (CR 702.37a)
+  or disguise (CR 702.168a) cost. Satisfied by `SpellPaymentContext.isFaceDownCast`, which every
+  face-down cast path sets via `SpellPaymentContext.faceDownCast()` — the CR 708.2 shape (nameless
+  colorless 2/2 creature spell, mana value 0), *not* the printed card's characteristics. Does not
+  cover cloak or manifest: nothing there is cast. The turn-face-up half of "cast face-down spells
+  or turn creatures face up" is the separate `TurnPermanentsFaceUpOnly` atom (a face-down permanent
+  is always a creature, so "permanents" and "creatures" coincide). Tin Street Gossip:
+  `AnyOf(FaceDownSpellsOnly, TurnPermanentsFaceUpOnly)`.
 - `ManaRestriction.CannotCastSpellsOtherThan(cardTypes)` — the family's only **negative**
   restriction: "This mana can't be spent to cast a non[type] spell" (Hydraulic Helper —
   `CannotCastSpellsOtherThan(setOf(CardType.ARTIFACT))`). Every other variant is a whitelist

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
@@ -142,6 +142,23 @@ sealed interface ManaRestriction {
     }
 
     /**
+     * "Spend this mana only to cast face-down spells."
+     *
+     * Satisfied by casting a card face down for its morph (CR 702.37a) or disguise (CR 702.168a)
+     * cost — a spell with no name and no characteristics but "2/2 creature" (CR 708.2). Used
+     * inside [AnyOf] by Tin Street Gossip.
+     *
+     * Deliberately *not* satisfied by effects that merely put cards onto the battlefield face
+     * down: per the printed ruling on Tin Street Gossip, this mana can't pay for a spell that
+     * instructs you to cloak or manifest, because nothing there is cast face down.
+     */
+    @SerialName("FaceDownSpellsOnly")
+    @Serializable
+    data object FaceDownSpellsOnly : ManaRestriction {
+        override val description: String = "Spend this mana only to cast face-down spells"
+    }
+
+    /**
      * "Spend this mana only to unlock a door."
      *
      * Satisfied by the unlock-a-door special action (CR 709.5e), not by spell casts or ability

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EliminateTheImpossible.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/EliminateTheImpossible.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Eliminate the Impossible — Murders at Karlov Manor #54
+ * {1}{U} · Instant
+ *
+ * Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are
+ * suspected, they're no longer suspected.
+ *
+ * A combat trick pointed the wrong way: it blunts an attack *and* strips the menace / can't-block
+ * package off every suspected attacker, turning the opponent's own suspect payoffs against them.
+ *
+ * All three sentences are untargeted and resolve together, so this is one [Effects.then] chain in
+ * a single `spell`. Per the printed ruling the affected set is locked in at resolution — creatures
+ * an opponent gains control of later in the turn get neither the -2/-0 nor the absolution, which
+ * is what both the group modification and the [Effects.ForEachInGroup] sweep give: each reads the
+ * battlefield once, as the spell resolves.
+ *
+ * "If any of them are suspected" is scoped to the same set as the -2/-0, hence
+ * `Creature.opponentControls().suspected()` rather than [AbsolvingLammasu]'s symmetric sweep over
+ * every suspected creature — your own suspected attackers keep their menace.
+ *
+ * [Effects.NoLongerSuspected] (CR 701.60c) removes the whole suspect application at once: status,
+ * menace, and "this creature can't block" all hang off being suspected, so all three go together.
+ * Menace from any other source is untouched.
+ */
+val EliminateTheImpossible = card("Eliminate the Impossible") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Investigate. Creatures your opponents control get -2/-0 until end of turn. If " +
+        "any of them are suspected, they're no longer suspected. (To investigate, create a Clue " +
+        "token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        effect = Effects.Investigate()
+            .then(
+                Patterns.Group.modifyStatsForAll(
+                    power = -2,
+                    toughness = 0,
+                    filter = GroupFilter.AllCreaturesOpponentsControl
+                )
+            )
+            .then(
+                Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature.opponentControls().suspected()),
+                    Effects.NoLongerSuspected(EffectTarget.Self)
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "54"
+        artist = "Carlos Palma Cruchaga"
+        flavorText = "\"Half the city had motive. Time to narrow down who also had the means and " +
+            "opportunity.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/486f1cc2-c162-448e-91a9-577d7d796584.jpg?1783912910"
+
+        ruling(
+            "2024-02-02",
+            "Eliminate the Impossible affects only creatures your opponents control at the time " +
+                "it resolves. Creatures they begin to control later in the turn won't get -2/-0 " +
+                "and won't stop being suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until it " +
+                "leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+        ruling(
+            "2024-02-02",
+            "If a suspected creature loses all abilities, it will lose menace and \"This creature " +
+                "can't block\", but it won't stop being suspected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PersuasiveInterrogators.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PersuasiveInterrogators.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Persuasive Interrogators — Murders at Karlov Manor #98
+ * {4}{B}{B} · Creature — Gorgon Detective · 5/6
+ *
+ * When this creature enters, investigate.
+ * Whenever you sacrifice a Clue, target opponent gets two poison counters.
+ *
+ * The infect payoff in a set with no other poison: every Clue you cash in is two counters, so
+ * five Clues is a kill on their own.
+ *
+ * [Triggers.YouSacrificeA] is the per-permanent form — "whenever you sacrifice **a** Clue"
+ * triggers once per Clue (CR 603.2), so sacrificing two at once gives four counters across two
+ * separate abilities, each with its own target. It fires on *any* sacrifice, including paying a
+ * Clue's own "{2}, Sacrifice this token: Draw a card" cost, because costs are paid before the
+ * ability goes on the stack and the trigger reads the sacrifice event. Same shape as
+ * [CuriousCadaver]'s recursion trigger.
+ *
+ * Poison counters go on a player, which [Effects.AddCounters] resolves the same way it does for
+ * a permanent — the target is a player-shaped `TargetOpponent`, so an opponent who becomes an
+ * illegal target (hexproof from a player-targeting effect, or having left a multiplayer game)
+ * fizzles the whole ability.
+ */
+val PersuasiveInterrogators = card("Persuasive Interrogators") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Gorgon Detective"
+    power = 5
+    toughness = 6
+    oracleText = "When this creature enters, investigate. (Create a Clue token. It's an artifact " +
+        "with \"{2}, Sacrifice this token: Draw a card.\")\n" +
+        "Whenever you sacrifice a Clue, target opponent gets two poison counters. (A player with " +
+        "ten or more poison counters loses the game.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Investigate()
+        description = "When this creature enters, investigate."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouSacrificeA(GameObjectFilter.Artifact.withSubtype("Clue"))
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.AddCounters(Counters.POISON, 2, opponent)
+        description = "Whenever you sacrifice a Clue, target opponent gets two poison counters."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "98"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0713025-581f-451b-97a3-97d891285dcc.jpg?1783912892"
+
+        ruling(
+            "2024-02-02",
+            "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger " +
+                "whenever you sacrifice a Clue for any reason, not just to activate a Clue's " +
+                "activated ability."
+        )
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token."
+        )
+        ruling(
+            "2024-02-02",
+            "You can't sacrifice a Clue to pay multiple costs. For example, you can't sacrifice a " +
+                "Clue token to activate its own ability and also to activate another ability."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SharpEyedRookie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SharpEyedRookie.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Sharp-Eyed Rookie — Murders at Karlov Manor #176
+ * {1}{G} · Creature — Human Detective · 2/2
+ *
+ * Vigilance
+ * Whenever a creature you control enters, if its power is greater than this creature's power or
+ * its toughness is greater than this creature's toughness, put a +1/+1 counter on this creature
+ * and investigate.
+ *
+ * A self-escalating ramp payoff: every creature that out-sizes the Rookie grows it *and* draws
+ * you a Clue, until it has outgrown the rest of your board.
+ *
+ * The trigger is `ANY`-bound with a `Creature.youControl()` filter rather than
+ * [Triggers.OtherCreatureEnters] — the printed text says "a creature you control", not "another",
+ * so the Rookie's own arrival does check itself. It never fires from that, because a creature's
+ * power is never greater than its own.
+ *
+ * The "if …" clause is an intervening-if (CR 603.4): it gates whether the ability triggers at all
+ * *and* is checked again on resolution, which `triggerCondition` provides. Both re-checks are
+ * load-bearing per the printed rulings — two 3/3s entering against a 2/2 Rookie trigger twice, but
+ * the second ability finds a 3/3 Rookie and does nothing. Either axis alone is enough, and the
+ * axis may even swap between trigger and resolution (a 1/3 that gets +2/-2 in response still
+ * resolves), which is exactly what a [Conditions.Any] over the two comparisons gives.
+ *
+ * Both sides read projected power/toughness, so +1/+1 counters an entering creature brings with
+ * it, and lords on either side, count. If the entering creature has left by resolution the
+ * comparison uses last-known information (CR 608.2h) — the same [EntityReference.Triggering] read
+ * [HulklingBurgeoningBruiser] relies on.
+ *
+ * The counter and the Clue are one effect, not two abilities: they succeed or fail together.
+ */
+val SharpEyedRookie = card("Sharp-Eyed Rookie") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Detective"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance\n" +
+        "Whenever a creature you control enters, if its power is greater than this creature's " +
+        "power or its toughness is greater than this creature's toughness, put a +1/+1 counter " +
+        "on this creature and investigate. (Create a Clue token. It's an artifact with " +
+        "\"{2}, Sacrifice this token: Draw a card.\")"
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        triggerCondition = Conditions.Any(
+            Compare(
+                DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Power),
+                ComparisonOperator.GT,
+                DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power)
+            ),
+            Compare(
+                DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Toughness),
+                ComparisonOperator.GT,
+                DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Toughness)
+            )
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            .then(Effects.Investigate())
+        description = "Whenever a creature you control enters, if its power is greater than this " +
+            "creature's power or its toughness is greater than this creature's toughness, put a " +
+            "+1/+1 counter on this creature and investigate."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "176"
+        artist = "Jake Murray"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d5d4788-a970-4e09-89a1-740eca9331d9.jpg?1783912862"
+
+        ruling(
+            "2024-02-02",
+            "When a creature enters the battlefield under your control, check its power and " +
+                "toughness against Sharp-Eyed Rookie's power and toughness. If neither stat of the " +
+                "new creature is greater, Sharp-Eyed Rookie's triggered ability won't trigger at all."
+        )
+        ruling(
+            "2024-02-02",
+            "If Sharp-Eyed Rookie's triggered ability triggers, the stat comparison will happen " +
+                "again when the ability tries to resolve. If neither stat of the new creature is " +
+                "greater, the ability will do nothing. If the creature that entered the battlefield " +
+                "leaves the battlefield before the ability tries to resolve, use its power and " +
+                "toughness as it last existed on the battlefield for the purposes of the comparison."
+        )
+        ruling(
+            "2024-02-02",
+            "If a creature enters the battlefield with +1/+1 counters on it, consider those " +
+                "counters when determining if Sharp-Eyed Rookie's triggered ability will trigger."
+        )
+        ruling(
+            "2024-02-02",
+            "When comparing the stats as Sharp-Eyed Rookie's ability resolves, it's possible that " +
+                "the stat that's greater changes from power to toughness or vice versa. If this " +
+                "happens, the ability will still resolve and you'll put a +1/+1 counter on " +
+                "Sharp-Eyed Rookie and investigate."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TheyWentThisWay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TheyWentThisWay.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * They Went This Way — Murders at Karlov Manor #178
+ * {2}{G} · Sorcery
+ *
+ * Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
+ * Investigate.
+ *
+ * A green ramp spell with a Clue stapled on. Both sentences live in one spell resolution, so
+ * the two halves are a plain [Effects.then] chain rather than separate abilities.
+ *
+ * "Search your library for a basic land card" is not "up to one" — but searching never *forces*
+ * a find (CR 701.23b), which is what `searchLibrary`'s `ChooseUpTo` selection models. Declining
+ * to find still shuffles and still investigates: the Clue rides on the same resolution and has
+ * no dependency on the search succeeding.
+ */
+val TheyWentThisWay = card("They Went This Way") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for a basic land card, put it onto the battlefield tapped, " +
+        "then shuffle. Investigate. (Create a Clue token. It's an artifact with " +
+        "\"{2}, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true
+        ) then Effects.Investigate()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Andreas Zafiratos"
+        flavorText = "\"Running doesn't prove guilt, but innocent people don't typically flee " +
+            "into the North Ridge Forest.\"\n—Alst of the Foundway Associates"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4a31d4a-34bc-46b4-b20f-a5460191b35d.jpg?1783912860"
+
+        ruling(
+            "2024-02-02",
+            "Clue is an artifact type. Even though it appears on some cards with other permanent " +
+                "types, it's never a creature type, a land type, or anything but an artifact type."
+        )
+        ruling(
+            "2024-02-02",
+            "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact " +
+                "token."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TinStreetGossip.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/TinStreetGossip.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Tin Street Gossip — Murders at Karlov Manor #235
+ * {2}{R}{G} · Creature — Lizard Advisor · 4/4
+ *
+ * Vigilance
+ * {T}: Add {R}{G}. Spend this mana only to cast face-down spells or to turn creatures face up.
+ *
+ * The disguise deck's mana engine: vigilance means it can attack and still leave two mana up to
+ * flip something mid-combat.
+ *
+ * The spend clause is a two-atom [ManaRestriction.AnyOf] —
+ * [ManaRestriction.FaceDownSpellsOnly] for the cast half (added for this card) and the existing
+ * [ManaRestriction.TurnPermanentsFaceUpOnly] for the flip half. The printed wording says "turn
+ * *creatures* face up" where the atom says "permanents", which is not a gap: a face-down permanent
+ * is always a 2/2 creature (CR 708.2), so the two sets coincide.
+ *
+ * Per the printed ruling this mana can't pay for a spell that instructs you to cloak or manifest —
+ * those put cards onto the battlefield face down without anything being *cast* face down, which is
+ * why [ManaRestriction.FaceDownSpellsOnly] keys off the cast itself and not off face-down-ness in
+ * general.
+ *
+ * `{T}: Add {R}{G}` is one activation producing two mana of different colors, so the effect is a
+ * composite of two [Effects.AddMana] calls carrying the same restriction (Gruul Signet's shape).
+ * Both halves are a mana ability (CR 605.1a): no target, adds mana, doesn't use the stack.
+ */
+val TinStreetGossip = card("Tin Street Gossip") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Lizard Advisor"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "{T}: Add {R}{G}. Spend this mana only to cast face-down spells or to turn creatures face up."
+
+    keywords(Keyword.VIGILANCE)
+
+    val faceDownMana = ManaRestriction.AnyOf(
+        listOf(
+            ManaRestriction.FaceDownSpellsOnly,
+            ManaRestriction.TurnPermanentsFaceUpOnly
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.Composite(
+            Effects.AddMana(Color.RED, 1, restriction = faceDownMana),
+            Effects.AddMana(Color.GREEN, 1, restriction = faceDownMana)
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {R}{G}. Spend this mana only to cast face-down spells or to turn " +
+            "creatures face up."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "235"
+        artist = "Tony Foti"
+        flavorText = "\"The lawmages are trying to hush it up, but I'm telling you—the guard didn't " +
+            "fall off that balcony. He was pushed!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/4094b13f-28d4-48b6-8cce-3c44656745b7.jpg?1783912834"
+
+        ruling(
+            "2024-02-02",
+            "The mana produced by Tin Street Gossip can't be used to cast a spell that instructs " +
+                "you to cloak or manifest cards."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -2451,6 +2451,91 @@
     ]
 }
 
+// Eliminate the Impossible
+{
+    "name": "Eliminate the Impossible",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Investigate. Creatures your opponents control get -2/-0 until end of turn. If any of them are suspected, they're no longer suspected. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "IsSuspected"
+                                ],
+                                "controllerPredicate": "ControlledByOpponent"
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "RemoveSuspected",
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "rarity": "UNCOMMON",
+        "artist": "Carlos Palma Cruchaga",
+        "flavorText": "\"Half the city had motive. Time to narrow down who also had the means and opportunity.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/486f1cc2-c162-448e-91a9-577d7d796584.jpg?1783912910",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Eliminate the Impossible affects only creatures your opponents control at the time it resolves. Creatures they begin to control later in the turn won't get -2/-0 and won't stop being suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a suspected creature loses all abilities, it will lose menace and \"This creature can't block\", but it won't stop being suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Escape Tunnel
 {
     "name": "Escape Tunnel",
@@ -6559,6 +6644,80 @@
     ]
 }
 
+// Persuasive Interrogators
+{
+    "name": "Persuasive Interrogators",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Gorgon Detective",
+    "oracleText": "When this creature enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")\nWhenever you sacrifice a Clue, target opponent gets two poison counters. (A player with ten or more poison counters loses the game.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "descriptionOverride": "When this creature enters, investigate."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "artifact Clue",
+                    "perPermanent": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "poison",
+                    "count": 2,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "Whenever you sacrifice a Clue, target opponent gets two poison counters."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "UNCOMMON",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0713025-581f-451b-97a3-97d891285dcc.jpg?1783912892",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Some abilities trigger \"whenever you sacrifice a Clue\". Those abilities trigger whenever you sacrifice a Clue for any reason, not just to activate a Clue's activated ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You can't sacrifice a Clue to pay multiple costs. For example, you can't sacrifice a Clue token to activate its own ability and also to activate another ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Pick Your Poison
 {
     "name": "Pick Your Poison",
@@ -8261,6 +8420,110 @@
     ]
 }
 
+// Sharp-Eyed Rookie
+{
+    "name": "Sharp-Eyed Rookie",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Vigilance\nWhenever a creature you control enters, if its power is greater than this creature's power or its toughness is greater than this creature's toughness, put a +1/+1 counter on this creature and investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Clue"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "Power"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Power"
+                            }
+                        },
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "Toughness"
+                            },
+                            "operator": "GT",
+                            "right": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Toughness"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever a creature you control enters, if its power is greater than this creature's power or its toughness is greater than this creature's toughness, put a +1/+1 counter on this creature and investigate."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "RARE",
+        "artist": "Jake Murray",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d5d4788-a970-4e09-89a1-740eca9331d9.jpg?1783912862",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "When a creature enters the battlefield under your control, check its power and toughness against Sharp-Eyed Rookie's power and toughness. If neither stat of the new creature is greater, Sharp-Eyed Rookie's triggered ability won't trigger at all."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If Sharp-Eyed Rookie's triggered ability triggers, the stat comparison will happen again when the ability tries to resolve. If neither stat of the new creature is greater, the ability will do nothing. If the creature that entered the battlefield leaves the battlefield before the ability tries to resolve, use its power and toughness as it last existed on the battlefield for the purposes of the comparison."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If a creature enters the battlefield with +1/+1 counters on it, consider those counters when determining if Sharp-Eyed Rookie's triggered ability will trigger."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "When comparing the stats as Sharp-Eyed Rookie's ability resolves, it's possible that the stat that's greater changes from power to toughness or vice versa. If this happens, the ability will still resolve and you'll put a +1/+1 counter on Sharp-Eyed Rookie and investigate."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Slice from the Shadows
 {
     "name": "Slice from the Shadows",
@@ -8836,6 +9099,76 @@
     ]
 }
 
+// They Went This Way
+{
+    "name": "They Went This Way",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "basicland"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                },
+                "ShuffleLibrary",
+                "EmitLibrarySearchedEvent",
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "\"Running doesn't prove guilt, but innocent people don't typically flee into the North Ridge Forest.\"\n—Alst of the Foundway Associates",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4a31d4a-34bc-46b4-b20f-a5460191b35d.jpg?1783912860",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Clue is an artifact type. Even though it appears on some cards with other permanent types, it's never a creature type, a land type, or anything but an artifact type."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If an effect refers to a Clue, it means any Clue artifact, not just a Clue artifact token."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Thinking Cap
 {
     "name": "Thinking Cap",
@@ -8953,6 +9286,76 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Tin Street Gossip
+{
+    "name": "Tin Street Gossip",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Lizard Advisor",
+    "oracleText": "Vigilance\n{T}: Add {R}{G}. Spend this mana only to cast face-down spells or to turn creatures face up.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddMana",
+                            "color": "RED",
+                            "restriction": {
+                                "type": "AnyOf",
+                                "restrictions": [
+                                    "FaceDownSpellsOnly",
+                                    "TurnPermanentsFaceUpOnly"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "GREEN",
+                            "restriction": {
+                                "type": "AnyOf",
+                                "restrictions": [
+                                    "FaceDownSpellsOnly",
+                                    "TurnPermanentsFaceUpOnly"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {R}{G}. Spend this mana only to cast face-down spells or to turn creatures face up."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "UNCOMMON",
+        "artist": "Tony Foti",
+        "flavorText": "\"The lawmages are trying to hush it up, but I'm telling you—the guard didn't fall off that balcony. He was pushed!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/4094b13f-28d4-48b6-8cce-3c44656745b7.jpg?1783912834",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "The mana produced by Tin Street Gossip can't be used to cast a spell that instructs you to cloak or manifest cards."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1201,7 +1201,11 @@ class CastSpellHandler(
 
         // Build spell context for conditional mana validation
         val cardComponent = state.getEntity(action.cardId)?.get<CardComponent>()
-        val spellCtx = if (cardComponent != null) {
+        val spellCtx = if (action.castFaceDown) {
+            // CR 708.2 — a face-down spell has none of the printed card's characteristics, so
+            // conditional mana is judged against the nameless 2/2 creature it actually is.
+            SpellPaymentContext.faceDownCast(isFromHand = isCastFromHand(state, action.cardId))
+        } else if (cardComponent != null) {
             SpellPaymentContext(
                 isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
                 isKicked = action.declaredCostSlot == ChoiceSlot.KICKED,
@@ -3033,8 +3037,12 @@ class CastSpellHandler(
             events.add(bendEvent)
         }
 
-        // Build spell context for conditional mana restrictions
-        val spellContext = SpellPaymentContext(
+        // Build spell context for conditional mana restrictions. A face-down cast (CR 708.2) is a
+        // nameless 2/2 creature spell regardless of what the card says, so it gets its own context
+        // rather than the printed card's — see `validatePayment`.
+        val spellContext = if (action.castFaceDown) {
+            SpellPaymentContext.faceDownCast(isFromHand = isCastFromHand(currentState, action.cardId))
+        } else SpellPaymentContext(
             isInstantOrSorcery = cardComponent.typeLine.isInstant || cardComponent.typeLine.isSorcery,
             isKicked = action.declaredCostSlot == ChoiceSlot.KICKED,
             isCreature = cardComponent.typeLine.isCreature,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -43,6 +43,7 @@ import com.wingedsheep.engine.mechanics.FlashbackGrants
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.mechanics.MayhemGrants
 import com.wingedsheep.engine.mechanics.WarpGrants
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.mechanics.mana.spellPaymentContextFor
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 
@@ -359,7 +360,13 @@ class CastFromZoneEnumerator : ActionEnumerator {
                 }
                 if (castableFaceDown) {
                     val morphCost = context.costCalculator.calculateFaceDownCost(state, playerId)
-                    val canAffordMorph = context.manaSolver.canPay(state, playerId, morphCost, precomputedSources = context.availableManaSources)
+                    val canAffordMorph = context.manaSolver.canPay(
+                        state, playerId, morphCost,
+                        // CR 708.2 — nameless 2/2 creature spell, so "spend this mana only to cast
+                        // face-down spells" (Tin Street Gossip) counts here.
+                        spellContext = SpellPaymentContext.faceDownCast(isFromHand = false),
+                        precomputedSources = context.availableManaSources
+                    )
                     result.add(
                         LegalAction(
                             actionType = "CastFaceDown",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/MorphCastEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/MorphCastEnumerator.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.legalactions.ActionEnumerator
 import com.wingedsheep.engine.legalactions.EnumerationContext
 import com.wingedsheep.engine.legalactions.LegalAction
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
@@ -35,10 +36,22 @@ class MorphCastEnumerator : ActionEnumerator {
         val playerId = context.playerId
 
         val faceDownCost = context.costCalculator.calculateFaceDownCost(state, playerId)
-        val canAffordFaceDown = context.manaSolver.canPay(state, playerId, faceDownCost, precomputedSources = context.availableManaSources)
+        // CR 708.2 — the spell on the stack is a nameless 2/2 creature, whatever card it came
+        // from, so every card in hand shares one payment context. That context is what makes
+        // "spend this mana only to cast face-down spells" mana (Tin Street Gossip) count toward
+        // affordability here.
+        val faceDownContext = SpellPaymentContext.faceDownCast()
+        val canAffordFaceDown = context.manaSolver.canPay(
+            state, playerId, faceDownCost,
+            spellContext = faceDownContext,
+            precomputedSources = context.availableManaSources
+        )
         val faceDownAutoTapPreview = if (context.skipAutoTapPreview) null else {
-            context.manaSolver.solve(state, playerId, faceDownCost, precomputedSources = context.availableManaSources)
-                ?.sources?.map { it.entityId }
+            context.manaSolver.solve(
+                state, playerId, faceDownCost,
+                spellContext = faceDownContext,
+                precomputedSources = context.availableManaSources
+            )?.sources?.map { it.entityId }
         }
 
         val hand = state.getHand(playerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
@@ -59,7 +59,34 @@ data class SpellPaymentContext(
      * (Creeping Peeper).
      */
     val isUnlockDoorAction: Boolean = false,
+    /**
+     * True when the spell being cast is being cast **face down** for its morph (CR 702.37a) or
+     * disguise (CR 702.168a) cost. Lets [ManaRestriction.FaceDownSpellsOnly] recognize "spend
+     * this mana only to cast face-down spells" (Tin Street Gossip).
+     *
+     * A face-down spell has no name and no characteristics other than "2/2 creature" (CR 708.2),
+     * so [faceDownCast] is the whole context for such a cast — see its factory below.
+     */
+    val isFaceDownCast: Boolean = false,
 ) {
+    companion object {
+        /**
+         * The payment context for a face-down cast (morph / disguise). CR 708.2: the spell has no
+         * name, no mana cost, no color, and no card types or subtypes other than creature, with
+         * power and toughness 2/2. Building it from the *printed* card would let restricted mana
+         * keyed to the hidden card's characteristics (Cavern of Souls' chosen type, "creature
+         * spells with mana value 4 or greater") pay for a cast that, as far as the rules are
+         * concerned, has none of them.
+         */
+        fun faceDownCast(isFromHand: Boolean = true): SpellPaymentContext = SpellPaymentContext(
+            isCreature = true,
+            manaValue = 0,
+            cardTypes = setOf(com.wingedsheep.sdk.core.CardType.CREATURE),
+            isFromHand = isFromHand,
+            isFaceDownCast = true,
+        )
+    }
+
     /**
      * True when this payment is for *casting a spell*, as opposed to activating an ability, a
      * special action, or any other cost a player is asked to pay. Every spell has at least one
@@ -89,6 +116,7 @@ fun ManaRestriction.isSatisfiedBy(context: SpellPaymentContext): Boolean = when 
     is ManaRestriction.CastFromExileOnly -> !context.isAbilityActivation && context.isFromExile
     is ManaRestriction.CastFromNonHandOnly -> !context.isAbilityActivation && !context.isFromHand
     is ManaRestriction.TurnPermanentsFaceUpOnly -> context.isTurnFaceUpAction
+    is ManaRestriction.FaceDownSpellsOnly -> !context.isAbilityActivation && context.isFaceDownCast
     is ManaRestriction.UnlockDoorOnly -> context.isUnlockDoorAction
     is ManaRestriction.AbilityActivationOnly -> context.isAbilityActivation
     is ManaRestriction.AnyOf -> restrictions.any { it.isSatisfiedBy(context) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.legalactions.*
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.mechanics.mana.buildAbilityPaymentContext
 import com.wingedsheep.engine.mechanics.mana.isSatisfiedBy
 import com.wingedsheep.engine.mechanics.mana.spellPaymentContextFor
@@ -51,7 +52,13 @@ class LegalActionEnricher(
         restrictedMana: List<RestrictedManaEntry>
     ): List<ClientRestrictedManaEntry>? {
         val paymentContext = when (val gameAction = action.action) {
-            is CastSpell -> state.getEntity(gameAction.cardId)?.get<CardComponent>()?.let { card ->
+            // CR 708.2 — a face-down cast is a nameless 2/2 creature spell, so it never carries
+            // the printed card's characteristics into the restriction check.
+            is CastSpell -> if (gameAction.castFaceDown) {
+                SpellPaymentContext.faceDownCast(
+                    isFromHand = action.sourceZone == null || action.sourceZone == "HAND"
+                )
+            } else state.getEntity(gameAction.cardId)?.get<CardComponent>()?.let { card ->
                 spellPaymentContextFor(
                     card,
                     isKicked = gameAction.declaredCostSlot == ChoiceSlot.KICKED,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TinStreetGossipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TinStreetGossipScenarioTest.kt
@@ -1,0 +1,181 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
+import com.wingedsheep.engine.mechanics.mana.isSatisfiedBy
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.NightdrinkerMoroii
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.TinStreetGossip
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tin Street Gossip — "{T}: Add {R}{G}. Spend this mana only to cast face-down spells or to turn
+ * creatures face up."
+ *
+ * The turn-face-up half is [ManaRestriction.TurnPermanentsFaceUpOnly], already covered by Overgrown
+ * Zealot and Creeping Peeper. What is new here is [ManaRestriction.FaceDownSpellsOnly] and the
+ * face-down payment context that satisfies it, so these tests pin down three things: the atom's
+ * truth table, that the mana actually pays for a real disguise cast, and that it is *not* spendable
+ * on the same card cast normally.
+ */
+class TinStreetGossipScenarioTest : FunSpec({
+
+    val gossipRestriction = ManaRestriction.AnyOf(
+        listOf(
+            ManaRestriction.FaceDownSpellsOnly,
+            ManaRestriction.TurnPermanentsFaceUpOnly,
+        )
+    )
+
+    // A morph creature whose turn-face-up cost is the mana {1}{R}.
+    val manaMorphTester = card("Mana Morph Tester") {
+        manaCost = "{3}{R}"
+        typeLine = "Creature — Zombie"
+        power = 2
+        toughness = 2
+        morph = "{1}{R}"
+    }
+
+    val allCards = TestCards.all + listOf(TinStreetGossip, NightdrinkerMoroii, manaMorphTester)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    fun GameTestDriver.putFaceDownCreature(playerId: EntityId, cardName: String): EntityId {
+        val creatureId = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = allCards.first { it.name == cardName }
+        val morphAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Morph>().firstOrNull()
+        replaceState(
+            state.updateEntity(creatureId) { container ->
+                var c = container.with(FaceDownComponent)
+                if (morphAbility != null) {
+                    c = c.with(MorphDataComponent(morphAbility.morphCost, cardDef.name))
+                }
+                c
+            }
+        )
+        removeSummoningSickness(creatureId)
+        return creatureId
+    }
+
+    test("FaceDownSpellsOnly is satisfied by a face-down cast and nothing else") {
+        val faceDownCast = SpellPaymentContext.faceDownCast()
+        val creatureSpell = SpellPaymentContext(isCreature = true, cardTypes = setOf(CardType.CREATURE))
+        val turnFaceUp = SpellPaymentContext(isTurnFaceUpAction = true)
+        val abilityActivation = SpellPaymentContext(isAbilityActivation = true)
+
+        ManaRestriction.FaceDownSpellsOnly.isSatisfiedBy(faceDownCast) shouldBe true
+        ManaRestriction.FaceDownSpellsOnly.isSatisfiedBy(creatureSpell) shouldBe false
+        ManaRestriction.FaceDownSpellsOnly.isSatisfiedBy(turnFaceUp) shouldBe false
+        ManaRestriction.FaceDownSpellsOnly.isSatisfiedBy(abilityActivation) shouldBe false
+
+        // The AnyOf the card actually prints covers both halves of its clause.
+        gossipRestriction.isSatisfiedBy(faceDownCast) shouldBe true
+        gossipRestriction.isSatisfiedBy(turnFaceUp) shouldBe true
+        gossipRestriction.isSatisfiedBy(creatureSpell) shouldBe false
+    }
+
+    test("a face-down cast context carries the CR 708.2 characteristics, not the card's") {
+        // Nameless colorless 2/2 creature spell with mana value 0 — so restricted mana keyed to
+        // the hidden card's real characteristics can never pay for it.
+        val faceDownCast = SpellPaymentContext.faceDownCast()
+
+        faceDownCast.isCreature shouldBe true
+        faceDownCast.manaValue shouldBe 0
+        faceDownCast.cardTypes shouldBe setOf(CardType.CREATURE)
+        faceDownCast.subtypes shouldBe emptySet()
+
+        ManaRestriction.SpellsWithManaValueAtLeast(4).isSatisfiedBy(faceDownCast) shouldBe false
+        ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Vampire").isSatisfiedBy(faceDownCast) shouldBe false
+    }
+
+    test("the restricted mana pays for casting a disguise card face down") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // The face-down cast costs {3}; hand it exactly that as Tin Street Gossip mana.
+        val cardId = driver.putCardInHand(player, "Nightdrinker Moroii")
+        driver.giveRestrictedMana(player, Color.RED, 1, gossipRestriction)
+        driver.giveRestrictedMana(player, Color.GREEN, 1, gossipRestriction)
+        driver.giveRestrictedMana(player, null, 1, gossipRestriction)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = cardId,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.error shouldBe null
+        driver.stackSize shouldBe 1
+
+        val pool = driver.state.getEntity(player)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+        pool.restrictedMana.size shouldBe 0
+    }
+
+    test("the same mana cannot pay for that card cast face up") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Nightdrinker Moroii costs {3}{B}. Hand over mana that matches that cost exactly in both
+        // colour and quantity, so the only thing that can stop the cast is the spend restriction.
+        val cardId = driver.putCardInHand(player, "Nightdrinker Moroii")
+        driver.giveRestrictedMana(player, Color.BLACK, 1, gossipRestriction)
+        driver.giveRestrictedMana(player, null, 3, gossipRestriction)
+
+        val result = driver.submit(
+            CastSpell(playerId = player, cardId = cardId, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.error shouldNotBe null
+        driver.stackSize shouldBe 0
+    }
+
+    test("the restricted mana still pays to turn a face-down creature face up") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val hidden = driver.putFaceDownCreature(player, "Mana Morph Tester")
+        driver.giveRestrictedMana(player, Color.RED, 1, gossipRestriction)
+        driver.giveRestrictedMana(player, null, 1, gossipRestriction)
+
+        val result = driver.submit(
+            TurnFaceUp(playerId = player, sourceId = hidden, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.error shouldBe null
+        driver.state.getEntity(hidden)?.get<FaceDownComponent>() shouldBe null
+    }
+
+    test("card definition exposes one mana ability carrying the two-atom restriction") {
+        TinStreetGossip.activatedAbilities.size shouldBe 1
+        TinStreetGossip.activatedAbilities.single().isManaAbility shouldBe true
+    }
+})


### PR DESCRIPTION
Five MKM cards, four of them built entirely from existing primitives and one that needed a new `ManaRestriction` atom.

## Cards

| Card | Cost | Text |
|---|---|---|
| **They Went This Way** | `{2}{G}` | Search your library for a basic land card, put it onto the battlefield tapped, then shuffle. Investigate. |
| **Persuasive Interrogators** | `{4}{B}{B}` | ETB investigate. Whenever you sacrifice a Clue, target opponent gets two poison counters. |
| **Eliminate the Impossible** | `{1}{U}` | Investigate. Creatures your opponents control get -2/-0 UEOT. If any of them are suspected, they're no longer suspected. |
| **Sharp-Eyed Rookie** | `{1}{G}` | Vigilance. Whenever a creature you control enters, if its power or toughness is greater than this creature's, put a +1/+1 counter on it and investigate. |
| **Tin Street Gossip** | `{2}{R}{G}` | Vigilance. `{T}`: Add `{R}{G}`. Spend this mana only to cast face-down spells or to turn creatures face up. |

Notes on the two with rules subtlety:

- **Persuasive Interrogators** uses `Triggers.YouSacrificeA` (per-permanent), so sacrificing two Clues at once produces two separate abilities with two separate targets — CR 603.2, matching Curious Cadaver's shape in the same set.
- **Sharp-Eyed Rookie**'s "if …" clause is an intervening-if (CR 603.4), checked when the trigger would go on the stack *and* again on resolution. Both re-checks are load-bearing per the printed rulings: two 3/3s entering against a 2/2 Rookie trigger twice, but the second ability finds a 3/3 Rookie and does nothing. The trigger is `ANY`-bound rather than `OtherCreatureEnters` because the printed text says "a creature you control", not "another".

## New SDK vocabulary

`ManaRestriction.FaceDownSpellsOnly` — the cast half of Tin Street Gossip's spend clause. The turn-up half reuses the existing `TurnPermanentsFaceUpOnly` (the printed text says "creatures" where the atom says "permanents", which coincide: a face-down permanent is always a 2/2 creature, CR 708.2).

It is satisfied by `SpellPaymentContext.isFaceDownCast`, set by every face-down cast path through a new `SpellPaymentContext.faceDownCast()` factory. Per the printed ruling it deliberately does *not* cover cloak or manifest — nothing there is cast.

### Correctness gap this closes

Face-down casts previously built their payment context from the **printed** card, so restricted mana keyed to the hidden card's characteristics (Cavern of Souls' chosen type, "creature spells with mana value 4 or greater") would have paid for a spell that per CR 708.2 has none of them — it is a nameless, colorless 2/2 creature with mana value 0. Separately, `MorphCastEnumerator` and the top-of-library face-down path in `CastFromZoneEnumerator` passed **no** context at all, so restricted mana never counted toward face-down affordability in the first place.

All four consumer sites now go through the factory: both enumerators, `CastSpellHandler.validatePayment`, and the execute-path payment. `LegalActionEnricher` uses it too, so the client's own cost math sees the mana as eligible.

## Verification

- `just build` passes.
- `TinStreetGossipScenarioTest` (6 tests): the restriction's truth table, the CR 708.2 context shape, a real disguise cast paid entirely from restricted mana, the same mana failing to pay for that card cast face up, the turn-face-up half still working, and the card's ability shape.
- MKM card snapshot re-blessed — only these five cards moved in the golden.
- `just check-card-printing` clean for all five (all MKM-original, no reprint rows needed).
- Every mechanical field (name, cost, type line, P/T, rarity, collector number, artist, image URI) diffed against the Scryfall MKM printing; all image URLs return HTTP 200.
- `docs/card-sdk-language-reference.md` updated with the new restriction in the same change.

The other four cards are built purely from existing primitives, so they are covered by the snapshot and lint nets rather than by dedicated scenario tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
