### PR TITLE
Block for survival when the AI is facing lethal

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
@@ -194,7 +194,7 @@ class CombatAdvisor(
         )
 
         // ── Phase 2: Improve via local search (if not nested) ──
-        val bestMap = if (useSimulation) {
+        var bestMap = if (useSimulation) {
             improveViaLocalSearch(
                 state, projected, playerId, attackers, validBlockers,
                 mandatoryBlockerIds, seedMap, budget, trace
@@ -212,21 +212,7 @@ class CombatAdvisor(
             val unblockedAttackers = attackers
                 .filter { attacker -> bestMap.values.none { attacker in it } }
 
-            // Sort by damage actually prevented by a chump block: non-tramplers first
-            // (chump blocks all damage) then tramplers (only prevents blocker toughness).
-            // Among each group, prefer blocking higher-power attackers.
-            val sortedUnblocked = unblockedAttackers.sortedByDescending { attacker ->
-                val aKeywords = projected.getKeywords(attacker)
-                val aPower = projected.getPower(attacker) ?: 0
-                if (Keyword.TRAMPLE.name in aKeywords) {
-                    // Trample: chump only prevents ~1-2 damage (blocker toughness)
-                    // Use negative power so tramplers sort after non-tramplers
-                    aPower * -1
-                } else {
-                    // Non-trampler: chump prevents ALL damage
-                    aPower * 1000
-                }
-            }
+            val sortedUnblocked = unblockedAttackers.sortedByDescending { chumpPriority(projected, it) }
 
             for (attacker in sortedUnblocked) {
                 val available = availableBlockersFor(state, projected, attacker, validBlockers, assignedBlockers)
@@ -234,6 +220,23 @@ class CombatAdvisor(
                 val cheapest = available.firstOrNull() ?: continue
                 bestMap[cheapest] = listOf(attacker)
                 assignedBlockers.add(cheapest)
+            }
+
+            // ── Survival pass: a plan that still lets lethal through is not a plan ──
+            // Everything above prices a block by what it *wins* — a favourable trade, a gang block
+            // that eats the best attacker — which is the right currency only if we get another turn
+            // to spend the board on. When the leftovers are lethal we do not, and two blockers
+            // standing in front of one creature while a bigger one walks in unblocked is a loss
+            // however good the trade reads. So rebuild the assignment for damage *prevented*, and
+            // adopt it only when it genuinely saves us: positions the AI already survives keep the
+            // plan they had.
+            if (calculateIncomingDamage(state, projected, attackers, bestMap) >= myLife) {
+                val survival = damageMinimisingPlan(state, projected, attackers, validBlockers, mandatoryMap)
+                if (calculateIncomingDamage(state, projected, attackers, survival) < myLife) {
+                    bestMap = survival
+                    assignedBlockers.clear()
+                    assignedBlockers.addAll(survival.keys)
+                }
             }
         }
 
@@ -244,11 +247,7 @@ class CombatAdvisor(
             if (inDanger) {
                 val unblockedAttackers = attackers
                     .filter { attacker -> bestMap.values.none { attacker in it } }
-                    .sortedByDescending { attacker ->
-                        val aKeywords = projected.getKeywords(attacker)
-                        val aPower = projected.getPower(attacker) ?: 0
-                        if (Keyword.TRAMPLE.name in aKeywords) aPower * -1 else aPower * 1000
-                    }
+                    .sortedByDescending { chumpPriority(projected, it) }
 
                 for (attacker in unblockedAttackers) {
                     val available = availableBlockersFor(state, projected, attacker, validBlockers, assignedBlockers)
@@ -838,6 +837,68 @@ class CombatAdvisor(
         return sides.opponents.maxOf { team ->
             team.sumOf { CombatMath.estimateNextTurnDamage(state, projected, it, myBlockers) }
         }
+    }
+
+    /**
+     * How much a chump block on [attacker] is worth, as a sort key: the damage it takes off the
+     * table, biggest first.
+     *
+     * A trampler keeps hitting us for everything the blocker cannot soak, so a chump in front of
+     * one buys a point or two; a chump in front of anything else buys the whole hit. Scaling
+     * separates the two groups outright rather than trying to price them on one scale — no
+     * trampler is ever worth chumping ahead of a non-trampler.
+     */
+    private fun chumpPriority(projected: ProjectedState, attacker: EntityId): Int {
+        val power = projected.getPower(attacker) ?: 0
+        return if (Keyword.TRAMPLE.name in projected.getKeywords(attacker)) -power else power * 1000
+    }
+
+    /**
+     * Assign blockers for damage prevented rather than for value: the biggest hits first, paid for
+     * with the cheapest legal body that can stand in front of each.
+     *
+     * Only [mandatoryMap] is carried over — every other blocker is put back in the pool, which is
+     * the point. This is the plan for a turn we do not survive otherwise, so a blocker committed to
+     * a trade or to the second half of a gang block is a blocker standing in the wrong place.
+     */
+    private fun damageMinimisingPlan(
+        state: GameState,
+        projected: ProjectedState,
+        attackers: List<EntityId>,
+        validBlockers: List<EntityId>,
+        mandatoryMap: Map<EntityId, List<EntityId>>,
+    ): MutableMap<EntityId, List<EntityId>> {
+        val plan = mandatoryMap.toMutableMap()
+        val assigned = plan.keys.toMutableSet()
+        val alreadyBlocked = plan.values.flatten().toSet()
+
+        val byDamage = attackers
+            .filter { it !in alreadyBlocked }
+            .sortedByDescending { chumpPriority(projected, it) }
+
+        for (attacker in byDamage) {
+            val keywords = projected.getKeywords(attacker)
+            // Menace wants two bodies or none — a lone blocker on it is an illegal plan that
+            // `fixMenaceAssignments` would strip right back out, damage and all.
+            val needed = if (Keyword.MENACE.name in keywords) 2 else 1
+            val available = availableBlockersFor(state, projected, attacker, validBlockers, assigned)
+                .sortedWith(
+                    if (Keyword.TRAMPLE.name in keywords) {
+                        // Trample spills whatever the blockers cannot soak, so here the wall is
+                        // worth more than the cheap body.
+                        compareByDescending<EntityId> { projected.getToughness(it) ?: 0 }
+                            .thenBy { CombatMath.creatureValue(state, projected, it) }
+                    } else {
+                        compareBy { CombatMath.creatureValue(state, projected, it) }
+                    }
+                )
+            if (available.size < needed) continue
+            available.take(needed).forEach { blocker ->
+                plan[blocker] = listOf(attacker)
+                assigned.add(blocker)
+            }
+        }
+        return plan
     }
 
     /**

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/BlockSurvivalPropertyTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/BlockSurvivalPropertyTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.ai.puzzles
+
+import com.wingedsheep.ai.engine.AIPlayer
+import com.wingedsheep.ai.engine.AiProfile
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.matchers.collections.shouldBeEmpty
+
+/**
+ * One property, swept over ~900 randomly generated combats: **when some legal set of blocks
+ * survives the turn, the AI declares one.**
+ *
+ * A curated puzzle asks whether the AI makes the move a good player makes; this asks the much
+ * weaker question of whether it stays alive when staying alive was on offer, and it asks it of
+ * boards nobody chose. That is the difference that mattered here — `blocking-07` and `blocking-08`
+ * are two positions this sweep found, and neither is a shape anyone would have thought to write
+ * down. Both had the AI spending its blockers on the trades that read best (a gang block that eats
+ * the biggest attacker, a free kill on a 2/2) while a creature it could have covered walked in for
+ * exactly lethal.
+ *
+ * **Vanilla creatures only**, which is what makes the oracle trustworthy: with no trample, flying,
+ * menace or deathtouch in the pool every blocker can block every attacker and each one it blocks
+ * absorbs that attacker's whole hit. So the least damage any legal plan can take is
+ * `total power − the N biggest powers`, N = our creature count, and the check needs no search of
+ * its own to be sure it is right. Keywords are the puzzles' job.
+ *
+ * Seeds are pinned: a CI gate cannot be seeded from the clock.
+ */
+class BlockSurvivalPropertyTest : ScenarioTestBase() {
+
+    private companion object {
+        /** `ScenarioBuilder` seeds itself from the clock otherwise; a gate cannot. */
+        const val SCENARIO_SEED = 20260727L
+    }
+
+    init {
+        val pool = listOf("Grizzly Bears", "Hill Giant", "Craw Wurm", "Ordinary Bear")
+        val seeds = listOf(20260811L, 4242L, 777L)
+        val positionsPerSeed = 300
+
+        test("the AI survives every combat that a legal block could survive") {
+            val deaths = mutableListOf<String>()
+            var survivable = 0
+
+            for (seed in seeds) {
+                val rng = kotlin.random.Random(seed)
+                repeat(positionsPerSeed) { index ->
+                    val attackerNames = List(rng.nextInt(2, 5)) { pool.random(rng) }
+                    val blockerNames = List(rng.nextInt(1, 4)) { pool.random(rng) }
+                    val life = rng.nextInt(3, 12)
+
+                    var builder = scenario().withRngSeed(SCENARIO_SEED).withPlayers()
+                    attackerNames.forEach { builder = builder.withCardOnBattlefield(1, it) }
+                    blockerNames.forEach { builder = builder.withCardOnBattlefield(2, it) }
+                    val game = builder.withLifeTotal(2, life).build()
+                        .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                        .also { g -> g.declareAttackers(attackerNames.distinct().associateWith { 2 }) }
+                        .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+
+                    val state = game.state
+                    val aiId = game.seatId(2)
+                    // A mis-built position scores as a pass otherwise. Skip rather than measure it.
+                    if (state.pendingDecision != null || state.priorityPlayerId != aiId) return@repeat
+
+                    val projected = state.projectedState
+                    val attackers = state.getBattlefield()
+                        .filter { state.getEntity(it)?.has<AttackingComponent>() == true }
+                    val powers = attackers.map { projected.getPower(it) ?: 0 }
+                    val unavoidable = powers.sum() - powers.sortedDescending().take(blockerNames.size).sum()
+                    if (unavoidable >= life) return@repeat // dead whatever we do; not this test's business
+                    survivable++
+
+                    val action = AIPlayer.create(cardRegistry, aiId, AiProfile.PRODUCTION).chooseAction(state)
+                    val blocks = (action as? DeclareBlockers)?.blockers.orEmpty()
+                    val blocked = blocks.values.flatten().toSet()
+                    val taken = attackers.filter { it !in blocked }.sumOf { projected.getPower(it) ?: 0 }
+                    if (taken < life) return@repeat
+
+                    val name = { id: EntityId -> state.getEntity(id)?.get<CardComponent>()?.name ?: id.value }
+                    deaths += "seed=$seed[$index] at $life life, took $taken (could have taken $unavoidable) — " +
+                        "attackers ${attackers.joinToString { "${name(it)} ${projected.getPower(it)}/${projected.getToughness(it)}" }}; " +
+                        "blockers $blockerNames; " +
+                        "chose ${blocks.entries.joinToString { (b, a) -> "${name(b)} → ${a.joinToString { at -> name(at) }}" }}"
+                }
+            }
+
+            println("block-survival sweep: $survivable survivable positions, ${deaths.size} avoidable deaths")
+            deaths.shouldBeEmpty()
+        }
+    }
+}

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/PuzzleSuiteTest.kt
@@ -36,7 +36,7 @@ class PuzzleSuiteTest : ScenarioTestBase() {
                     PuzzleCatalog.byCategory(category).size shouldBeGreaterThanOrEqual 6
                 }
             }
-            PuzzleCatalog.all.size shouldBe 96
+            PuzzleCatalog.all.size shouldBe 98
         }
 
         test("every KNOWN_FAILURES id names a real puzzle") {

--- a/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/BlockingPuzzles.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/puzzles/categories/BlockingPuzzles.kt
@@ -119,5 +119,69 @@ object BlockingPuzzles {
             },
             check = { shouldBlock("Hill Giant", "Craw Wurm") },
         ),
+
+        // The two below are the same mistake from two directions: a block chosen for what it *wins*
+        // in a turn that does not come. Both were found by a randomised sweep over vanilla boards
+        // that asked one question — "was there a legal set of blocks that survives, and did the AI
+        // find one?" — and both killed the AI at three life with the answer sitting on the table.
+        AiPuzzle(
+            id = "blocking-07",
+            category = PuzzleCategory.BLOCKING,
+            expectation = "Three attackers, three blockers, 3 life: one body in front of each, " +
+                "not two on the Wurm while the Giant walks in for exact lethal",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Craw Wurm")        // 6/4
+                    .withCardOnBattlefield(1, "Hill Giant")       // 3/3
+                    .withCardOnBattlefield(1, "Ordinary Bear")    // 4/5
+                    .withCardOnBattlefield(2, "Trained Armodon")  // 3/3
+                    .withCardOnBattlefield(2, "Grizzly Bears")    // 2/2
+                    .withCardOnBattlefield(2, "Alpha Myr")        // 2/1
+                    .withLifeTotal(2, 3)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also {
+                        it.declareAttackers(
+                            mapOf("Craw Wurm" to 2, "Hill Giant" to 2, "Ordinary Bear" to 2)
+                        )
+                    }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            check = {
+                shouldBlockWithAtLeast(1, "Craw Wurm")
+                shouldBlockWithAtLeast(1, "Hill Giant")
+                shouldBlockWithAtLeast(1, "Ordinary Bear")
+            },
+        ),
+
+        AiPuzzle(
+            id = "blocking-08",
+            category = PuzzleCategory.BLOCKING,
+            expectation = "At 3 life the free kill on the 2/2 is a luxury: the two blockers belong " +
+                "in front of the 6/4 and the 4/5, taking 2 instead of 4",
+            aiSeat = 2,
+            position = { scenario ->
+                scenario.withPlayers()
+                    .withCardOnBattlefield(1, "Craw Wurm")        // 6/4
+                    .withCardOnBattlefield(1, "Grizzly Bears")    // 2/2
+                    .withCardOnBattlefield(1, "Ordinary Bear")    // 4/5
+                    .withCardOnBattlefield(2, "Trained Armodon")  // 3/3
+                    .withCardOnBattlefield(2, "Alpha Myr")        // 2/1
+                    .withLifeTotal(2, 3)
+                    .build()
+                    .advanceToDeclaration(1, Step.DECLARE_ATTACKERS)
+                    .also {
+                        it.declareAttackers(
+                            mapOf("Craw Wurm" to 2, "Grizzly Bears" to 2, "Ordinary Bear" to 2)
+                        )
+                    }
+                    .advanceToDeclaration(2, Step.DECLARE_BLOCKERS)
+            },
+            check = {
+                shouldBlockWithAtLeast(1, "Craw Wurm")
+                shouldBlockWithAtLeast(1, "Ordinary Bear")
+            },
+        ),
     )
 }


### PR DESCRIPTION
## The bug

Every blocking pass in `CombatAdvisor` prices a block by what it **wins** — a free kill, a
favourable trade, a gang block that eats the biggest attacker. That is the right currency only if
there is another turn to spend the resulting board on. When the unblocked leftovers are lethal there
isn't, and the AI was reliably picking the best-reading trade while a creature it could have covered
walked in for exactly the damage that killed it.

Two positions the sweep found, both at 3 life, both with a legal set of blocks that survives:

| Attacking | AI blockers | AI chose | Result |
|---|---|---|---|
| Craw Wurm 6/4, Hill Giant 3/3, Ordinary Bear 4/5 | Trained Armodon 3/3, Grizzly Bears 2/2, Alpha Myr 2/1 | Myr **and** Bears gang the Wurm, Armodon on the Bear | Hill Giant unblocked → dead. One body on each → 0 through |
| Craw Wurm 6/4, Grizzly Bears 2/2, Ordinary Bear 4/5 | Trained Armodon 3/3, Alpha Myr 2/1 | Armodon takes the free kill on the 2/2, Myr chumps the Wurm | Ordinary Bear unblocked → dead. Cover the 6/4 and the 4/5 → take 2, live at 1 |

The existing chump-block pass could not save either, because it only hands out blockers that are
still **unassigned**. Once the value passes had committed every body there was nothing left to chump
with — and local search's single "move one blocker" mutation can't climb out of that in one step,
because moving any single blocker still leaves someone lethal.

## The fix

A survival pass at the end of the chump branch: when the plan on the table is still lethal, rebuild
the assignment for damage **prevented** — biggest hits first, paid for with the cheapest legal body
that can stand in front of each — and adopt it **only when it actually brings damage below our life
total**. Positions the AI already survives keep the plan they had, so this is a floor under the
existing policy rather than a change of it.

Details worth knowing:
- Only mandatory assignments carry over into the rebuild; every other blocker goes back in the pool.
  That is the point — a blocker committed to a trade is a blocker standing in the wrong place.
- Menace attackers take two bodies or none, so `fixMenaceAssignments` doesn't strip the plan (and
  the damage with it) right back out afterwards.
- Tramplers are picked up by highest toughness rather than lowest value, since that's what actually
  reduces the spill.
- The chump-priority sort key had been copy-pasted into two passes and was about to be copied into a
  third; it's now one helper.

## Measurement

`BlockSurvivalPropertyTest` — new — sweeps ~900 randomly generated combats over vanilla creatures
across three pinned seeds and asks one weak question: *was there a legal set of blocks that survives
the turn, and did the AI declare one?* Vanilla-only is what makes the oracle exact — every blocker
can block every attacker and absorbs its whole hit, so the floor is `total power − the N biggest`.

| | avoidable deaths | survivable positions |
|---|---|---|
| before | **13** | 823 |
| after | **0** | 823 |

The two table positions above ship as `blocking-07` and `blocking-08`. `PuzzleSuiteTest` is
otherwise untouched: same `KNOWN_FAILURES`, blocking category now 8/8, `production` at 83/98.
Full `:ai:test` is green.

## Notes / what I did not do

- **The exported frame in the report is not itself fixable.** At 5 life against a 4/4, a 4/5 and a
  2/3, the AI had exactly one legal blocker (its other creature is Gollum the Abandoned, which can't
  block), so 6 damage gets through whichever attacker it covers. It blocked. The general failure the
  report describes is real, though, and it's what's fixed here.
- **No arena run.** The eval-promotion protocol (flag on `AiProfile`, two profile ids,
  `just arena <live> <candidate> 300`) is written for evaluator changes; this is a defect in shared
  plan construction that applies to every profile and can only convert a modelled loss into a
  modelled survival. Happy to gate it behind a flag and run 300 games if you'd rather have the
  number before this goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
