### PR TITLE
Add four Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/TajNarSwordsmithReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/TajNarSwordsmithReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Taj-Nar Swordsmith reprint in C17. Canonical CardDefinition lives in its earliest set, Mirrodin.
+ */
+val TajNarSwordsmithReprint = Printing(
+    oracleId = "dcbf8d72-3367-43e1-9a71-e674e0ed52d9",
+    name = "Taj-Nar Swordsmith",
+    setCode = "C17",
+    collectorNumber = "77",
+    scryfallId = "4bcbd8bb-997a-4be0-966d-b472c31b4c73",
+    artist = "Todd Lockwood",
+    imageUri = "https://cards.scryfall.io/normal/front/4/b/4bcbd8bb-997a-4be0-966d-b472c31b4c73.jpg",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MindsEye.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MindsEye.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Mind's Eye — Mirrodin #205
+ * {5} · Artifact
+ *
+ * Whenever an opponent draws a card, you may pay {1}. If you do, draw a card.
+ *
+ * [Triggers.OpponentDraws] fires once per individual card drawn (CR 121.2), so an opponent's
+ * "draw three cards" puts three separate instances on the stack and each is paid for — or
+ * declined — on its own. The payment is a resolution-time optional cost
+ * ([MayPayManaEffect] → `Gate.MayPay`), so the {1} is only asked for as each instance
+ * resolves, and an empty mana pool with no untapped lands skips the prompt entirely rather
+ * than offering an unpayable "yes".
+ *
+ * The replacement draw is a normal draw by the Eye's controller, so it feeds their own
+ * draw triggers; it is not itself an opponent draw and can never re-trigger this ability.
+ */
+val MindsEye = card("Mind's Eye") {
+    manaCost = "{5}"
+    typeLine = "Artifact"
+    oracleText = "Whenever an opponent draws a card, you may pay {1}. If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.OpponentDraws
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "205"
+        artist = "Edward P. Beard, Jr."
+        flavorText = "\"Ideas drift like petals on the wind. I have only to lift my face to the breeze.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/0899f753-c229-4cdf-a60c-4978a6506def.jpg?1783944513"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NimDevourer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/NimDevourer.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Nim Devourer — Mirrodin #70
+ * {3}{B}{B} · Creature — Zombie · 4/1
+ *
+ * This creature gets +1/+0 for each artifact you control.
+ * {B}{B}: Return this card from your graveyard to the battlefield, then sacrifice a creature.
+ * Activate only during your upkeep.
+ *
+ * The power boost is the shared Nim continuous effect ([NimShrieker], [NimLasher]) — a
+ * [GrantDynamicStatsEffect] scoped to the source, recomputed from the live artifact count.
+ * The Devourer is not itself an artifact, so it never counts toward its own bonus.
+ *
+ * The recursion is an *activated ability that functions from the graveyard*
+ * (`activateFromZone = Zone.GRAVEYARD`), and the return and the sacrifice are both parts of the
+ * **effect**, not the cost: the {B}{B} is all you pay to put it on the stack. That ordering
+ * matters — the Devourer is back on the battlefield by the time the edict resolves, so it is a
+ * legal (and, with an otherwise empty board, the only) sacrifice, which is exactly how the
+ * printed card behaves. The sacrifice is `Player.You` choosing, not a targeted permanent, so it
+ * follows the "sacrifice a creature" template rather than "sacrifice this creature".
+ *
+ * "Activate only during your upkeep" composes the two timing gates the engine already has:
+ * `DuringStep(UPKEEP)` bounds the step and `OnlyDuringYourTurn` bounds whose upkeep it is —
+ * either alone would let it fire on an opponent's upkeep or during your own later steps.
+ */
+val NimDevourer = card("Nim Devourer") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 4
+    toughness = 1
+    oracleText = "This creature gets +1/+0 for each artifact you control.\n" +
+        "{B}{B}: Return this card from your graveyard to the battlefield, then sacrifice a creature. " +
+        "Activate only during your upkeep."
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.battlefield(Player.You, GameObjectFilter.Artifact).count(),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{B}{B}")
+        effect = Effects.Composite(
+            listOf(
+                Effects.PutOntoBattlefield(EffectTarget.Self),
+                Effects.Sacrifice(
+                    filter = GameObjectFilter.Creature,
+                    count = 1,
+                    target = EffectTarget.PlayerRef(Player.You)
+                )
+            )
+        )
+        activateFromZone = Zone.GRAVEYARD
+        restrictions = listOf(
+            ActivationRestriction.DuringStep(Step.UPKEEP),
+            ActivationRestriction.OnlyDuringYourTurn
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "70"
+        artist = "Adam Rex"
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a037ef49-8849-41aa-aa6e-3ac6ee34cdad.jpg?1783944547"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TajNarSwordsmith.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/TajNarSwordsmith.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayXForEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Taj-Nar Swordsmith — Mirrodin #27
+ * {3}{W} · Creature — Cat Soldier · 2/3
+ *
+ * When this creature enters, you may pay {X}. If you do, search your library for an Equipment
+ * card with mana value X or less, put that card onto the battlefield, then shuffle.
+ *
+ * The {X} is chosen *on resolution of the trigger*, not when the Swordsmith is cast — the number
+ * chooser [MayPayXForEffect] raises runs while the trigger resolves, so the opponent has already
+ * had the chance to respond to the creature and the payment is made with whatever mana is
+ * untapped at that moment. The chosen value is bound into the resolution context, which is how
+ * [GameObjectFilter.manaValueAtMostX] reads it while filtering the library.
+ *
+ * The search is a normal `searchLibrary`, so it is a "you may fail to find" search
+ * (`ChooseUpTo(1)`, CR 701.19c) — a library with no cheap enough Equipment is not a loss, and
+ * the shuffle happens either way.
+ *
+ * Fidelity note: the engine's X chooser treats X = 0 as declining the payment, so the strictly
+ * legal (and near-useless) "pay {0}, search for a mana value 0 Equipment" line is not offered.
+ */
+val TajNarSwordsmith = card("Taj-Nar Swordsmith") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, you may pay {X}. If you do, search your library for an " +
+        "Equipment card with mana value X or less, put that card onto the battlefield, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayPayXForEffect(
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Artifact.withSubtype("Equipment").manaValueAtMostX(),
+                count = 1,
+                destination = SearchDestination.BATTLEFIELD
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "27"
+        artist = "Todd Lockwood"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/89c24cb4-4d7d-41df-b5c2-bd967a6a5d7e.jpg?1783944557"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/VulshokBattlemaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/VulshokBattlemaster.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Vulshok Battlemaster — Mirrodin #110
+ * {4}{R} · Creature — Human Warrior · 2/2
+ *
+ * Haste
+ * When this creature enters, attach all Equipment on the battlefield to it.
+ * (Control of the Equipment doesn't change.)
+ *
+ * The trigger sweeps **every** Equipment in play, not just the controller's — the printed
+ * rulings are explicit that opponents' Equipment moves too, and that moving it changes neither
+ * who controls it nor who may activate its equip ability. So the group filter carries no
+ * `youControl()` and no `excludeSelf`; the only constraint is the Equipment subtype.
+ *
+ * `AttachTargetEquipmentToCreature` is the force-attach atom (Blacksmith's Talent, Beatrix): it
+ * detaches from the current host first, so Equipment already strapped to another creature is
+ * pulled off exactly as the ruling describes. Inside `ForEachInGroup` the pipeline rebinds
+ * [EffectTarget.Self] to the current iteration entity, which is why the Equipment side is `Self`
+ * and the Battlemaster is referenced as [EffectTarget.TriggeringEntity] — the entering permanent
+ * carried on the enters-the-battlefield `ZoneChangeEvent`.
+ *
+ * Known gap: the engine's attach atom does not re-check equip legality, so an Equipment whose
+ * own restriction excludes the Battlemaster ("equipped creature is a Human", protection from
+ * red/artifacts) is still moved onto it rather than staying put per the third printed ruling.
+ * That limitation is shared with every other card that force-attaches Equipment, not specific to
+ * this one.
+ */
+val VulshokBattlemaster = card("Vulshok Battlemaster") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Haste\n" +
+        "When this creature enters, attach all Equipment on the battlefield to it. " +
+        "(Control of the Equipment doesn't change.)"
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter(GameObjectFilter.Artifact.withSubtype("Equipment")),
+            effect = Effects.AttachTargetEquipmentToCreature(
+                equipmentTarget = EffectTarget.Self,
+                creatureTarget = EffectTarget.TriggeringEntity
+            )
+        )
+        description = "When this creature enters, attach all Equipment on the battlefield to it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "110"
+        artist = "Kev Walker"
+        flavorText = "\"I could demonstrate how the leonin sunsplicer works, but then you'd be too dead to buy one.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/083f3b83-b7d3-472f-87b2-ed247c9c937e.jpg?1783944537"
+        ruling(
+            "2004-12-01",
+            "The \"enters\" effect moves all Equipment onto the Battlemaster, regardless of whether that Equipment was attached to other creatures."
+        )
+        ruling(
+            "2004-12-01",
+            "Other players' Equipment is moved onto the Battlemaster as well as your own. This doesn't change who controls the Equipment or who can activate its equip ability to move it onto another creature."
+        )
+        ruling(
+            "2004-12-01",
+            "If an Equipment can't equip Vulshok Battlemaster, it isn't attached to the Battlemaster, and it doesn't become unattached (if it's attached to a creature)."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -4178,6 +4178,50 @@
     ]
 }
 
+// Mind's Eye
+{
+    "name": "Mind's Eye",
+    "manaCost": "{5}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever an opponent draws a card, you may pay {1}. If you do, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DrawEvent",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "RARE",
+        "artist": "Edward P. Beard, Jr.",
+        "flavorText": "\"Ideas drift like petals on the wind. I have only to lift my face to the breeze.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/0899f753-c229-4cdf-a60c-4978a6506def.jpg?1783944513"
+    }
+}
+
 // Molder Slug
 {
     "name": "Molder Slug",
@@ -4879,6 +4923,85 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Nim Devourer
+{
+    "name": "Nim Devourer",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "This creature gets +1/+0 for each artifact you control.\n{B}{B}: Return this card from your graveyard to the battlefield, then sacrifice a creature. Activate only during your upkeep.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Battlefield"
+                        },
+                        {
+                            "type": "ForceSacrifice",
+                            "filter": "creature",
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "You"
+                            }
+                        }
+                    ]
+                },
+                "restrictions": [
+                    {
+                        "type": "DuringStep",
+                        "step": "UPKEEP"
+                    },
+                    "OnlyDuringYourTurn"
+                ],
+                "activateFromZone": "Graveyard"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "artifact"
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "RARE",
+        "artist": "Adam Rex",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a037ef49-8849-41aa-aa6e-3ac6ee34cdad.jpg?1783944547"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -7052,6 +7175,87 @@
     ]
 }
 
+// Taj-Nar Swordsmith
+{
+    "name": "Taj-Nar Swordsmith",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Cat Soldier",
+    "oracleText": "When this creature enters, you may pay {X}. If you do, search your library for an Equipment card with mana value X or less, put that card onto the battlefield, then shuffle.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayPayX",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            "IsArtifact",
+                                            {
+                                                "type": "HasSubtype",
+                                                "subtype": "Equipment"
+                                            },
+                                            "ManaValueAtMostX"
+                                        ]
+                                    }
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "UNCOMMON",
+        "artist": "Todd Lockwood",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/89c24cb4-4d7d-41df-b5c2-bd967a6a5d7e.jpg?1783944557"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Talisman of Dominance
 {
     "name": "Talisman of Dominance",
@@ -8749,6 +8953,71 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/3/13e731de-32e9-4dae-804f-9b962b457cf3.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Vulshok Battlemaster
+{
+    "name": "Vulshok Battlemaster",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Haste\nWhen this creature enters, attach all Equipment on the battlefield to it. (Control of the Equipment doesn't change.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "artifact Equipment"
+                        }
+                    },
+                    "body": {
+                        "type": "AttachTargetEquipmentToCreature",
+                        "equipmentTarget": "Self",
+                        "creatureTarget": "TriggeringEntity"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, attach all Equipment on the battlefield to it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "flavorText": "\"I could demonstrate how the leonin sunsplicer works, but then you'd be too dead to buy one.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/083f3b83-b7d3-472f-87b2-ed247c9c937e.jpg?1783944537",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "The \"enters\" effect moves all Equipment onto the Battlemaster, regardless of whether that Equipment was attached to other creatures."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "Other players' Equipment is moved onto the Battlemaster as well as your own. This doesn't change who controls the Equipment or who can activate its equip ability to move it onto another creature."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "If an Equipment can't equip Vulshok Battlemaster, it isn't attached to the Battlemaster, and it doesn't become unattached (if it's attached to a creature)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Vulshok Berserker

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MindsEyeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MindsEyeScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.MindsEye
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mind's Eye (MRD #205) — {5} Artifact.
+ *
+ * "Whenever an opponent draws a card, you may pay {1}. If you do, draw a card."
+ *
+ * Pins the three things that can go wrong with this shape: paying actually draws, declining draws
+ * nothing, and the trigger fires per *individual* card the opponent draws (CR 121.2) rather than
+ * once per draw spell.
+ */
+class MindsEyeScenarioTest : FunSpec({
+
+    val drawOne = card("Test Draw One") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        spell { effect = Effects.DrawCards(1) }
+    }
+    val drawTwo = card("Test Draw Two") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        spell { effect = Effects.DrawCards(2) }
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MindsEye, drawOne, drawTwo))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Resolve everything on the stack, answering each Mind's Eye payment offer with [pay], and
+     * return how many offers were made. The optional-mana gate surfaces either as a plain yes/no
+     * (mana already floating) or as a mana-source selection, so both are handled.
+     */
+    fun GameTestDriver.settle(me: EntityId, pay: Boolean): Int {
+        var offers = 0
+        var guard = 0
+        while ((stackSize > 0 || isPaused) && guard++ < 40) {
+            when (pendingDecision) {
+                is YesNoDecision -> {
+                    submitYesNo(me, pay); offers++
+                }
+                is SelectManaSourcesDecision -> {
+                    submitManaAutoPayOrDecline(me, autoPay = pay); offers++
+                }
+                null -> bothPass()
+                else -> autoResolveDecision()
+            }
+        }
+        return offers
+    }
+
+    fun GameTestDriver.opponentCasts(spellName: String, opponent: EntityId) {
+        val spell = putCardInHand(opponent, spellName)
+        giveMana(opponent, Color.BLUE, 1)
+        castSpell(opponent, spell)
+    }
+
+    test("paying {1} on an opponent's draw draws a card") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putPermanentOnBattlefield(me, "Mind's Eye")
+        driver.giveColorlessMana(me, 1)
+        val handBefore = driver.getHandSize(me)
+
+        driver.passPriority(me)
+        driver.opponentCasts("Test Draw One", opponent)
+
+        driver.settle(me, pay = true) shouldBe 1
+        driver.getHandSize(me) shouldBe handBefore + 1
+    }
+
+    test("declining the payment draws nothing") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putPermanentOnBattlefield(me, "Mind's Eye")
+        driver.giveColorlessMana(me, 1)
+        val handBefore = driver.getHandSize(me)
+
+        driver.passPriority(me)
+        driver.opponentCasts("Test Draw One", opponent)
+
+        driver.settle(me, pay = false) shouldBe 1
+        driver.getHandSize(me) shouldBe handBefore
+    }
+
+    test("an opponent drawing two cards triggers twice, once per card") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        driver.putPermanentOnBattlefield(me, "Mind's Eye")
+        driver.giveColorlessMana(me, 2)
+        val handBefore = driver.getHandSize(me)
+
+        driver.passPriority(me)
+        driver.opponentCasts("Test Draw Two", opponent)
+
+        // Two separate trigger instances, each with its own payment offer.
+        driver.settle(me, pay = true) shouldBe 2
+        driver.getHandSize(me) shouldBe handBefore + 2
+    }
+
+    test("your own draws never trigger it") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(me, "Mind's Eye")
+        driver.giveColorlessMana(me, 2)
+        driver.giveMana(me, Color.BLUE, 1)
+        val handBefore = driver.getHandSize(me)
+
+        val spell = driver.putCardInHand(me, "Test Draw One")
+        driver.castSpell(me, spell)
+
+        // No payment offer at all. Net hand change: +1 (the spell was added), -1 (it was cast),
+        // +1 (its own draw) = handBefore + 1 — the extra Mind's Eye card is absent.
+        driver.settle(me, pay = true) shouldBe 0
+        driver.getHandSize(me) shouldBe handBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NimDevourerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NimDevourerScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.NimDevourer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Nim Devourer (MRD #70) — {3}{B}{B} Creature — Zombie, 4/1.
+ *
+ * "This creature gets +1/+0 for each artifact you control.
+ *  {B}{B}: Return this card from your graveyard to the battlefield, then sacrifice a creature.
+ *  Activate only during your upkeep."
+ *
+ * Three claims worth pinning: the artifact-count boost is live and never counts the Devourer
+ * itself, the timing rider really is "your upkeep" (both halves — right step *and* right turn),
+ * and the return-then-sacrifice ordering means the Devourer is back on the battlefield in time to
+ * be a legal sacrifice.
+ */
+class NimDevourerScenarioTest : FunSpec({
+
+    val abilityId = NimDevourer.activatedAbilities.first().id
+
+    fun newDriver(startingPlayer: Int = 0): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(NimDevourer))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20, startingPlayer = startingPlayer)
+        return driver
+    }
+
+    fun canActivate(driver: GameTestDriver, player: EntityId, devourer: EntityId): Boolean {
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        return enumerator.enumerate(driver.state, player, EnumerationMode.FULL)
+            .any { (it.action as? ActivateAbility)?.sourceId == devourer }
+    }
+
+    fun GameTestDriver.drainStack() {
+        var guard = 0
+        while (stackSize > 0 && guard++ < 50) bothPass()
+    }
+
+    test("gets +1/+0 for each artifact you control, and is not itself an artifact") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val devourer = driver.putPermanentOnBattlefield(me, "Nim Devourer")
+
+        // No artifacts yet — printed 4/1.
+        driver.state.projectedState.getPower(devourer) shouldBe 4
+        driver.state.projectedState.getToughness(devourer) shouldBe 1
+
+        driver.putPermanentOnBattlefield(me, "Frogmite")
+        driver.putPermanentOnBattlefield(me, "Frogmite")
+
+        driver.state.projectedState.getPower(devourer) shouldBe 6
+        driver.state.projectedState.getToughness(devourer) shouldBe 1
+    }
+
+    test("the boost only counts artifacts you control") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val devourer = driver.putPermanentOnBattlefield(me, "Nim Devourer")
+        driver.putPermanentOnBattlefield(opponent, "Frogmite")
+
+        driver.state.projectedState.getPower(devourer) shouldBe 4
+    }
+
+    test("can't be activated outside the upkeep step") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        val devourer = driver.putCardInGraveyard(me, "Nim Devourer")
+        driver.giveMana(me, Color.BLACK, 2)
+
+        canActivate(driver, me, devourer) shouldBe false
+    }
+
+    test("can't be activated during an opponent's upkeep") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.UPKEEP)
+        val activePlayer = driver.activePlayer!!
+        val nonActive = driver.getOpponent(activePlayer)
+
+        val devourer = driver.putCardInGraveyard(nonActive, "Nim Devourer")
+        driver.giveMana(nonActive, Color.BLACK, 2)
+
+        canActivate(driver, nonActive, devourer) shouldBe false
+    }
+
+    test("during your upkeep, returns itself and then sacrifices a creature") {
+        val driver = newDriver()
+        driver.passPriorityUntil(Step.UPKEEP)
+        val me = driver.activePlayer!!
+
+        val devourer = driver.putCardInGraveyard(me, "Nim Devourer")
+        // A second creature so the edict has a choice other than the Devourer itself.
+        driver.putPermanentOnBattlefield(me, "Savannah Lions")
+        driver.giveMana(me, Color.BLACK, 2)
+
+        canActivate(driver, me, devourer) shouldBe true
+
+        driver.submit(ActivateAbility(playerId = me, sourceId = devourer, abilityId = abilityId))
+            .isSuccess shouldBe true
+        driver.bothPass()
+
+        // The return happens before the sacrifice, so the Devourer is on the battlefield and is
+        // itself a legal choice for the edict.
+        var guard = 0
+        while (driver.isPaused && guard++ < 20) driver.autoResolveDecision()
+        driver.drainStack()
+
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(devourer) shouldBe false
+        // Exactly one creature was sacrificed: two creatures were on the battlefield, one remains.
+        driver.getCreatures(me).size shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TajNarSwordsmithScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TajNarSwordsmithScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.TajNarSwordsmith
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Taj-Nar Swordsmith (MRD #27) — {3}{W} Creature — Cat Soldier, 2/3.
+ *
+ * "When this creature enters, you may pay {X}. If you do, search your library for an Equipment
+ *  card with mana value X or less, put that card onto the battlefield, then shuffle."
+ *
+ * The interesting part is that the chosen X has to flow from the payment gate into the *library
+ * filter* — `CardPredicate.ManaValueAtMostX` reads it off the resolution context — so the tests
+ * pin both sides of the bound: an Equipment within X is offered, one above X is not.
+ *
+ * Bonesplitter is {1} (mana value 1); Fireshrieker is {3} (mana value 3).
+ */
+class TajNarSwordsmithScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TajNarSwordsmith))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Cast the Swordsmith, answer its "pay {X}" chooser with [x], and resolve everything —
+     * picking [pick] out of the library-search options when one matches. Returns the names the
+     * search actually offered, so a test can assert on what was *not* findable.
+     */
+    fun GameTestDriver.castSwordsmith(player: EntityId, x: Int, pick: String? = null): List<String> {
+        val card = putCardInHand(player, "Taj-Nar Swordsmith")
+        giveMana(player, Color.WHITE, 4 + x)
+        castSpell(player, card).isSuccess shouldBe true
+
+        val offered = mutableListOf<String>()
+        var guard = 0
+        while ((stackSize > 0 || isPaused) && guard++ < 40) {
+            when (val decision = pendingDecision) {
+                is ChooseNumberDecision ->
+                    submitDecision(player, NumberChosenResponse(decision.id, x))
+                is SelectCardsDecision -> {
+                    offered += decision.options.mapNotNull { getCardName(it) }
+                    val chosen = decision.options.firstOrNull { getCardName(it) == pick }
+                    if (chosen != null) submitCardSelection(player, listOf(chosen))
+                    else submitCardSelection(player, emptyList())
+                }
+                null -> bothPass()
+                else -> autoResolveDecision()
+            }
+        }
+        return offered
+    }
+
+    test("paying X=3 finds an Equipment with mana value 3 and puts it onto the battlefield") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(me, "Fireshrieker")
+
+        val offered = driver.castSwordsmith(me, x = 3, pick = "Fireshrieker")
+
+        offered.contains("Fireshrieker") shouldBe true
+        (driver.findPermanent(me, "Fireshrieker") != null) shouldBe true
+    }
+
+    test("X=2 does not offer an Equipment with mana value 3") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(me, "Fireshrieker")
+
+        val offered = driver.castSwordsmith(me, x = 2, pick = "Fireshrieker")
+
+        offered.contains("Fireshrieker") shouldBe false
+        driver.findPermanent(me, "Fireshrieker") shouldBe null
+    }
+
+    test("X=1 still finds a mana value 1 Equipment") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(me, "Bonesplitter")
+
+        val offered = driver.castSwordsmith(me, x = 1, pick = "Bonesplitter")
+
+        offered.contains("Bonesplitter") shouldBe true
+        (driver.findPermanent(me, "Bonesplitter") != null) shouldBe true
+    }
+
+    test("declining the payment (X = 0) searches for nothing") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(me, "Bonesplitter")
+
+        driver.castSwordsmith(me, x = 0, pick = "Bonesplitter")
+
+        driver.findPermanent(me, "Bonesplitter") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VulshokBattlemasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VulshokBattlemasterScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.VulshokBattlemaster
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vulshok Battlemaster (MRD #110) — {4}{R} Creature — Human Warrior, 2/2.
+ *
+ * "Haste
+ *  When this creature enters, attach all Equipment on the battlefield to it."
+ *
+ * The printed rulings are the test plan: unattached Equipment comes over, Equipment already
+ * strapped to another creature is *pulled off* and re-attached, and **opponents'** Equipment moves
+ * too without changing controller. That last one is the easiest to get wrong — a stray
+ * `youControl()` on the group filter would silently pass every other test here.
+ *
+ * The Battlemaster is *cast* rather than placed, because the driver's direct-placement helpers
+ * don't emit the `ZoneChangeEvent` an enters-the-battlefield trigger reads.
+ */
+class VulshokBattlemasterScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(VulshokBattlemaster))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.attachedTo(equipment: EntityId): EntityId? =
+        state.getEntity(equipment)?.get<AttachedToComponent>()?.targetId
+
+    /** Cast the Battlemaster and let the enters trigger fully resolve; returns its entity id. */
+    fun GameTestDriver.castBattlemaster(player: EntityId): EntityId {
+        val card = putCardInHand(player, "Vulshok Battlemaster")
+        giveMana(player, Color.RED, 5)
+        castSpell(player, card).isSuccess shouldBe true
+        var guard = 0
+        while ((stackSize > 0 || isPaused) && guard++ < 30) {
+            if (isPaused) autoResolveDecision() else bothPass()
+        }
+        return findPermanent(player, "Vulshok Battlemaster")!!
+    }
+
+    test("has haste") {
+        VulshokBattlemaster.keywords.contains(Keyword.HASTE) shouldBe true
+    }
+
+    test("unattached Equipment is attached on entry") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+
+        val bonesplitter = driver.putPermanentOnBattlefield(me, "Bonesplitter")
+        driver.attachedTo(bonesplitter) shouldBe null
+
+        val battlemaster = driver.castBattlemaster(me)
+
+        driver.attachedTo(bonesplitter) shouldBe battlemaster
+    }
+
+    test("Equipment already attached to another creature is pulled off and re-attached") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+
+        val lions = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        val bonesplitter = driver.putPermanentOnBattlefield(me, "Bonesplitter")
+        driver.addComponent(bonesplitter, AttachedToComponent(lions))
+        driver.attachedTo(bonesplitter) shouldBe lions
+
+        val battlemaster = driver.castBattlemaster(me)
+
+        driver.attachedTo(bonesplitter) shouldBe battlemaster
+    }
+
+    test("an opponent's Equipment moves over too, and they keep control of it") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val theirBonesplitter = driver.putPermanentOnBattlefield(opponent, "Bonesplitter")
+        driver.getController(theirBonesplitter) shouldBe opponent
+
+        val battlemaster = driver.castBattlemaster(me)
+
+        driver.attachedTo(theirBonesplitter) shouldBe battlemaster
+        // "Control of the Equipment doesn't change."
+        driver.getController(theirBonesplitter) shouldBe opponent
+    }
+
+    test("every Equipment on the battlefield comes over, not just one") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val mine = driver.putPermanentOnBattlefield(me, "Bonesplitter")
+        val theirs = driver.putPermanentOnBattlefield(opponent, "Leonin Scimitar")
+
+        val battlemaster = driver.castBattlemaster(me)
+
+        driver.attachedTo(mine) shouldBe battlemaster
+        driver.attachedTo(theirs) shouldBe battlemaster
+    }
+})


### PR DESCRIPTION
Adds four Mirrodin cards, each canonical in MRD (their earliest real printing per Scryfall). All four are pure composition over existing SDK primitives — **no new engine or SDK vocabulary**.

| Card | Shape |
|---|---|
| **Mind's Eye** {5} | `Triggers.OpponentDraws` + `MayPayManaEffect("{1}", DrawCards(1))` |
| **Nim Devourer** {3}{B}{B} | `GrantDynamicStatsEffect` artifact-count boost + graveyard-zone activated ability |
| **Taj-Nar Swordsmith** {3}{W} | `Gate.MayPayX` feeding a library search filtered by `ManaValueAtMostX` |
| **Vulshok Battlemaster** {4}{R} | haste + enters trigger looping `ForEachInGroup` over all Equipment |

### Notes on the two non-obvious ones

**Nim Devourer** — "Activate only during your upkeep" is `All(DuringStep(UPKEEP), OnlyDuringYourTurn)`; either restriction alone leaks (an opponent's upkeep, or your own later steps). The return and the sacrifice are both *effect* steps rather than costs, so the Devourer is back on the battlefield by the time the edict resolves and is itself a legal sacrifice — which is how the printed card behaves.

**Vulshok Battlemaster** — the group filter deliberately carries **no** `youControl()`: the printed rulings say opponents' Equipment moves over too, without changing who controls it or who may activate equip. Inside `ForEachInGroup` the pipeline rebinds `EffectTarget.Self` to the iteration entity, so the Equipment side is `Self` and the Battlemaster is `EffectTarget.TriggeringEntity`.

### Also included

A missing `Printing(...)` row for **Taj-Nar Swordsmith** in C17 — `just check-card-printing` reported it as drift.

### Scoped out: Sun Droplet

I started with five cards and dropped Sun Droplet after a scenario test proved it silently did nothing. "Whenever you're dealt damage" needs a *source-agnostic* player-damage trigger; the engine's only damage-to-you observer path (`DamageTriggerDetector.detectDamageToControllerTriggers`) early-returns unless the damage source is a creature — it implements the Aurification shape, "whenever a **creature** deals damage to you". A Lightning Bolt to the face therefore banked zero charge counters. That is `add-feature` work rather than `add-card`, so the card is not in this PR.

### Known limitation (pre-existing, not introduced here)

Vulshok Battlemaster's third ruling — an Equipment that *can't* legally equip the Battlemaster should stay where it is — is not honored, because the engine's attach atom doesn't re-check equip legality. That gap is shared with every other card that force-attaches Equipment (Blacksmith's Talent, Beatrix, Gilgamesh); it is documented in the card's KDoc.

### Verification

- `just build` — green (full gate: card lint, facade boundary, success-criterion validation, snapshot round-trip, rules-engine suite).
- `just rebless-cards` — only the four new cards moved in `MRD.json`.
- `just check-card-printing` — clean for all four.
- 18 new scenario tests across four files, all passing:
  - `MindsEyeScenarioTest` (4) — pay/decline, per-card triggering on a two-card draw, own draws don't trigger.
  - `NimDevourerScenarioTest` (5) — boost counts only your artifacts and not itself, can't activate outside upkeep or on an opponent's upkeep, return-then-sacrifice ordering.
  - `TajNarSwordsmithScenarioTest` (4) — both sides of the X bound (X=3 finds Fireshrieker, X=2 doesn't), X=0 declines.
  - `VulshokBattlemasterScenarioTest` (5) — unattached, already-attached, opponent-controlled, and multi-Equipment cases.

Note: the box was under heavy memory pressure and the Kotlin compile daemon was being OS-killed, so these runs used `-Pkotlin.compiler.execution.strategy=in-process` through `scripts/gradle-locked`. No shared config was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
