### PR TITLE
Bind {X} at cast time; make Leatherhead's counter removal a real cost

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1132,6 +1132,15 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   with `maxTotal` set, not a separate effect: one `ChooseNumber` prompt per kind, each capped at
   `min(kind's count, remaining budget)`; prompting stops once the budget is spent. Used by Heartless Act's
   "Remove up to three counters from target creature."
+- `RemoveCounterOfAnyKind(target, count = 1)` — "**remove a counter** from it": the player chooses which
+  *kind* comes off, but not *whether*. The floored form of the same effect (`minTotal = maxTotal = count`).
+  Each prompt's minimum is the share of the floor the kinds still to come can't cover, so the choice stays
+  free while the floor is reachable and is enforced on the last kind that can pay it; a prompt whose min and
+  max coincide is applied without asking, so a permanent carrying a single kind raises no prompt at all.
+  **Reach for this, not `RemoveCountersUpTo(1, …)`, whenever a payoff hangs off the removal** — `IfYouDo` /
+  `ReflexiveTriggerEffect` ("remove a counter … when you do, …", Leatherhead, Swamp Stalker). A bare ceiling
+  lets the player answer 0 to every prompt and still report success, firing the payoff for free against
+  CR 603.12. Use `RemoveCountersUpTo` only where the card really does say "up to".
 - **Player-scoped counters (CR 122.1, 107.14).** Every counter type above lives on a permanent/object. Poison,
   energy, and rad counters instead live directly on a **player entity**, reusing the same `CountersComponent` —
   no separate component or data model. `AddCountersExecutor` already resolves player-shaped targets (`that

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1762,6 +1762,24 @@ object Effects {
         com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect(target, maxTotal = maxCount)
 
     /**
+     * "Remove a counter from [target]" — the player picks *which kind*, but not *whether*. The
+     * floored form of [RemoveCountersUpTo]: exactly [count] counters come off, chosen across
+     * whatever kinds the permanent carries.
+     *
+     * Reach for this, not `RemoveCountersUpTo(1, …)`, whenever a payoff hangs off the removal
+     * ("remove a counter … when you do, …", Leatherhead, Swamp Stalker; "… if you do, draw a card",
+     * Mister Hyde, Monster Within). A bare ceiling lets the player answer 0 to every prompt and
+     * still succeed, which fires the payoff for free. Use [RemoveCountersUpTo] only where the card
+     * really does say "up to".
+     */
+    fun RemoveCounterOfAnyKind(
+        target: EffectTarget = EffectTarget.ContextTarget(0),
+        count: Int = 1
+    ): Effect = com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect(
+        target, maxTotal = count, minTotal = count
+    )
+
+    /**
      * "[player] gets N [counterType] counters" (CR 122.1 — counters placed on a player rather
      * than a permanent). Sugar for [AddCounters] targeting the player directly; no new plumbing —
      * `AddCountersExecutor` already resolves player-shaped targets the same way it does for

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
@@ -137,32 +137,51 @@ data class RemoveCountersEffect(
 
 /**
  * Remove counters from a target permanent. The controller chooses how many counters of each kind
- * to remove (0 up to the current count of that kind). With [maxTotal] set, no more than that many
- * counters may be removed in total across all kinds ("remove up to N counters"); left null, there
- * is no cap ("remove any number of counters").
+ * to remove. [maxTotal] caps the total across all kinds ("remove up to N counters"); left null,
+ * there is no cap ("remove any number of counters"). [minTotal] is the matching *floor* — the
+ * number the controller must remove in total once the effect resolves at all.
  *
  * "Remove any number of counters from target creature you control." ([maxTotal] = null.)
  * "Remove up to three counters from target creature." (Heartless Act, [maxTotal] = 3.)
+ * "Remove a counter from it." ([minTotal] = [maxTotal] = 1 — the kind is the player's choice, the
+ * count is not.)
+ *
+ * The floor matters because a bare ceiling silently makes every such removal optional: "remove a
+ * counter" modelled as `maxTotal = 1` alone lets the controller answer 0 to every prompt and still
+ * report success, which hands a free payoff to any "if you do" / "when you do" clause hanging off
+ * it (CR 603.12 — the reflexive ability triggers only when the action is actually taken).
  *
  * At resolution time, the executor enumerates each counter kind currently on the target and
- * presents a sequence of `ChooseNumberDecision`s — one per kind. When [maxTotal] is set, each
- * prompt's maximum is the smaller of that kind's count and the remaining budget, and prompting
- * stops once the budget is spent.
+ * presents a sequence of `ChooseNumberDecision`s — one per kind. Each prompt's maximum is the
+ * smaller of that kind's count and the remaining budget, and prompting stops once the budget is
+ * spent. Each prompt's *minimum* is whatever of [minTotal] the kinds still to come can't cover, so
+ * the player keeps a free choice for as long as the floor is still reachable and is held to it on
+ * the last kind that can pay it. With one kind present and `minTotal == maxTotal` the prompt
+ * collapses to a single legal answer and is auto-resolved rather than asked.
  *
  * @property target The permanent to remove counters from.
  * @property maxTotal The total budget across all kinds, or null for no cap.
+ * @property minTotal The total that must be removed across all kinds; 0 makes the removal optional.
  */
 @SerialName("RemoveAnyNumberOfCounters")
 @Serializable
 data class RemoveAnyNumberOfCountersEffect(
     val target: EffectTarget = EffectTarget.ContextTarget(0),
-    val maxTotal: Int? = null
+    val maxTotal: Int? = null,
+    val minTotal: Int = 0
 ) : Effect {
-    override val description: String =
-        if (maxTotal != null)
+    override val description: String = when {
+        minTotal > 0 && minTotal == maxTotal ->
+            "Remove $minTotal counter${if (minTotal != 1) "s" else ""} from ${target.description}"
+        minTotal > 0 && maxTotal != null ->
+            "Remove $minTotal to $maxTotal counters from ${target.description}"
+        minTotal > 0 ->
+            "Remove at least $minTotal counter${if (minTotal != 1) "s" else ""} from ${target.description}"
+        maxTotal != null ->
             "Remove up to $maxTotal counter${if (maxTotal != 1) "s" else ""} from ${target.description}"
-        else
+        else ->
             "Remove any number of counters from ${target.description}"
+    }
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/DawningPurist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/DawningPurist.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.ons.cards
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.core.Zone
@@ -17,6 +18,10 @@ import com.wingedsheep.sdk.dsl.Effects
  * Whenever Dawning Purist deals combat damage to a player, you may destroy target
  * enchantment that player controls.
  * Morph {1}{W}
+ *
+ * "That player" is the player just dealt combat damage, which is
+ * `controlledByTriggeringPlayer()` — not "any opponent". The two coincide in a two-player game
+ * and diverge the moment there's a third player at the table.
  */
 val DawningPurist = card("Dawning Purist") {
     manaCost = "{2}{W}"
@@ -28,7 +33,12 @@ val DawningPurist = card("Dawning Purist") {
 
     triggeredAbility {
         trigger = Triggers.DealsCombatDamageToPlayer
-        val t = target("target", TargetPermanent(filter = TargetFilter.Enchantment.opponentControls()))
+        val t = target(
+            "target",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.Enchantment.controlledByTriggeringPlayer())
+            )
+        )
         effect = MayEffect(Effects.Move(t, Zone.GRAVEYARD, byDestruction = true))
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeatherheadSwampStalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeatherheadSwampStalker.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
@@ -42,24 +43,32 @@ val LeatherheadSwampStalker = card("Leatherhead, Swamp Stalker") {
         )
     )
 
-    // Reflexive: removing a counter is the cost that arms the destroy — Dawning Purist's
+    // Reflexive: removing a counter is the cost that arms the destroy — Rustmouth Ogre's
     // "that player controls" combat-damage target hung off a remove-a-counter action.
     //
     // "Remove a counter" is any kind, not just the hexproof one she enters with: once anything
-    // has put +1/+1 counters on her (Ouroboroid's combat trigger, an Adapt, a bestow) the
-    // controller chooses which kind to take off, and hardcoding `Counters.HEXPROOF` silently
-    // spent her hexproof every time. [Effects.RemoveCountersUpTo]`(1, …)` is the choice-carrying
-    // primitive — it prompts per counter kind present, capped at one counter total, which is the
-    // same liberty Mister Hyde, Monster Within takes (it also permits taking off zero, already
-    // covered here by the `optional = true` decline).
+    // has put +1/+1 counters on her (Ouroboroid's combat trigger, an Adapt) the controller
+    // chooses which kind to take off, and hardcoding `Counters.HEXPROOF` silently spent her
+    // hexproof every time. [Effects.RemoveCounterOfAnyKind] is the choice-carrying primitive — it
+    // prompts per counter kind present for a total of exactly one. Not `RemoveCountersUpTo(1, …)`:
+    // a bare ceiling lets the controller say yes and then answer 0 to every prompt, which under
+    // CR 603.12 would fire "when you do" without the "you do" ever happening.
+    //
+    // "That player controls" is the player Leatherhead just damaged, so the target filter is
+    // `controlledByTriggeringPlayer()` rather than "any opponent" — the two only coincide in a
+    // two-player game.
     triggeredAbility {
         trigger = Triggers.DealsCombatDamageToPlayer
         effect = ReflexiveTriggerEffect(
-            action = Effects.RemoveCountersUpTo(1, EffectTarget.Self),
+            action = Effects.RemoveCounterOfAnyKind(EffectTarget.Self),
             optional = true,
             reflexiveEffect = Effects.Destroy(EffectTarget.ContextTarget(0)),
             reflexiveTargetRequirements = listOf(
-                TargetPermanent(filter = TargetFilter.ArtifactOrEnchantment.opponentControls())
+                TargetPermanent(
+                    filter = TargetFilter(
+                        GameObjectFilter.ArtifactOrEnchantment.controlledByTriggeringPlayer()
+                    )
+                )
             ),
             // The yes/no prompt should read as the card does, not as the composed
             // "remove up to 1 counter" primitive's own wording.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeatherheadSwampStalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeatherheadSwampStalker.kt
@@ -42,18 +42,29 @@ val LeatherheadSwampStalker = card("Leatherhead, Swamp Stalker") {
         )
     )
 
-    // Reflexive: removing a counter (the only kind she carries is hexproof) is the cost that
-    // arms the destroy — modelled like Slumbering Walker (remove-a-counter reflexive) with
-    // Dawning Purist's "that player controls" combat-damage target.
+    // Reflexive: removing a counter is the cost that arms the destroy — Dawning Purist's
+    // "that player controls" combat-damage target hung off a remove-a-counter action.
+    //
+    // "Remove a counter" is any kind, not just the hexproof one she enters with: once anything
+    // has put +1/+1 counters on her (Ouroboroid's combat trigger, an Adapt, a bestow) the
+    // controller chooses which kind to take off, and hardcoding `Counters.HEXPROOF` silently
+    // spent her hexproof every time. [Effects.RemoveCountersUpTo]`(1, …)` is the choice-carrying
+    // primitive — it prompts per counter kind present, capped at one counter total, which is the
+    // same liberty Mister Hyde, Monster Within takes (it also permits taking off zero, already
+    // covered here by the `optional = true` decline).
     triggeredAbility {
         trigger = Triggers.DealsCombatDamageToPlayer
         effect = ReflexiveTriggerEffect(
-            action = Effects.RemoveCounters(Counters.HEXPROOF, 1, EffectTarget.Self),
+            action = Effects.RemoveCountersUpTo(1, EffectTarget.Self),
             optional = true,
             reflexiveEffect = Effects.Destroy(EffectTarget.ContextTarget(0)),
             reflexiveTargetRequirements = listOf(
                 TargetPermanent(filter = TargetFilter.ArtifactOrEnchantment.opponentControls())
-            )
+            ),
+            // The yes/no prompt should read as the card does, not as the composed
+            // "remove up to 1 counter" primitive's own wording.
+            descriptionOverride = "You may remove a counter from Leatherhead. When you do, " +
+                "destroy target artifact or enchantment that player controls."
         )
         description = "Whenever Leatherhead deals combat damage to a player, you may remove a counter from her. When you do, destroy target artifact or enchantment that player controls."
     }

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -4270,7 +4270,7 @@
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
-                        "baseFilter": "enchantment ctrl:opponent"
+                        "baseFilter": "enchantment ctrl:triggering-player"
                     },
                     "id": "target"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5141,10 +5141,10 @@
                 "effect": {
                     "type": "ReflexiveTrigger",
                     "action": {
-                        "type": "RemoveCounters",
-                        "counterType": "hexproof",
-                        "count": 1,
-                        "target": "Self"
+                        "type": "RemoveAnyNumberOfCounters",
+                        "target": "Self",
+                        "maxTotal": 1,
+                        "minTotal": 1
                     },
                     "reflexiveEffect": {
                         "type": "MoveToZone",
@@ -5159,10 +5159,11 @@
                         {
                             "type": "TargetObject",
                             "filter": {
-                                "baseFilter": "artifact|enchantment ctrl:opponent"
+                                "baseFilter": "artifact|enchantment ctrl:triggering-player"
                             }
                         }
-                    ]
+                    ],
+                    "descriptionOverride": "You may remove a counter from Leatherhead. When you do, destroy target artifact or enchantment that player controls."
                 },
                 "descriptionOverride": "Whenever Leatherhead deals combat damage to a player, you may remove a counter from her. When you do, destroy target artifact or enchantment that player controls."
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -159,14 +159,17 @@ data class DistributeCountersContinuation(
  * When [remainingBudget] is non-null, a *total* cap is in force (`maxTotal` on the effect —
  * Heartless Act's "remove up to N counters"): each prompt is capped at `min(kindCount, budget)`,
  * the budget is decremented on resume, and prompting stops once it hits zero. Null means no cap
- * ("remove any number").
+ * ("remove any number"). [remainingFloor] is the mirror image — the `minTotal` still owed, which
+ * raises a later prompt's minimum once the kinds after it can no longer cover it.
  *
  * @property targetId The permanent whose counters are being removed
  * @property controllerId The player making the choices
  * @property currentCounterType The counter kind the active decision is for
- * @property currentMaxAmount Cap shown to the player (0..currentMaxAmount)
+ * @property currentMinAmount Floor shown to the player, and enforced on resume
+ * @property currentMaxAmount Cap shown to the player (currentMinAmount..currentMaxAmount)
  * @property remainingBudget Counters still removable in total after the active decision, or null for no cap
- * @property remainingCounterTypes Pending (counterType, maxAmount) prompts
+ * @property remainingFloor Counters still owed toward the effect's `minTotal`
+ * @property remainingCounterTypes Counter kinds still to be walked, in prompt order
  * @property targetName Display name for follow-up prompts
  * @property sourceId Source emitting the effect (for prompt context)
  * @property sourceName Source name for prompt context
@@ -178,11 +181,13 @@ data class RemoveAnyNumberOfCountersContinuation(
     val controllerId: EntityId,
     val currentCounterType: String,
     val currentMaxAmount: Int,
-    val remainingCounterTypes: List<Pair<String, Int>>,
+    val remainingCounterTypes: List<String>,
     val targetName: String,
     val sourceId: EntityId?,
     val sourceName: String?,
-    val remainingBudget: Int? = null
+    val remainingBudget: Int? = null,
+    val currentMinAmount: Int = 0,
+    val remainingFloor: Int = 0
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.handlers.continuations
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
+import com.wingedsheep.engine.handlers.effects.permanent.counters.RemoveAnyNumberOfCountersFlow
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.sdk.model.EntityId
 
@@ -674,96 +675,45 @@ class MiscContinuationResumer(
             return ExecutionResult.error(state, "Expected number response for remove-any-counters")
         }
 
-        val chosen = response.number.coerceIn(0, continuation.currentMaxAmount)
-        val counterType = com.wingedsheep.engine.handlers.effects.permanent.counters
-            .resolveCounterType(continuation.currentCounterType)
+        // Coerce into the prompt's own bounds, not just its ceiling: `currentMinAmount` is the
+        // share of the effect's `minTotal` that the kinds after this one can no longer cover, so
+        // honoring it here is what actually makes "remove a counter" mandatory. A client that sends
+        // 0 under a floor of 1 must not be able to talk its way out of the removal.
+        val chosen = response.number.coerceIn(continuation.currentMinAmount, continuation.currentMaxAmount)
 
         var newState = state
         val events = mutableListOf<GameEvent>()
 
-        if (chosen > 0) {
-            val current = newState.getEntity(continuation.targetId)
-                ?.get<com.wingedsheep.engine.state.components.battlefield.CountersComponent>()
-                ?: com.wingedsheep.engine.state.components.battlefield.CountersComponent()
-            newState = newState.updateEntity(continuation.targetId) { container ->
-                container.with(current.withRemoved(counterType, chosen))
-            }
-            events.add(
-                CountersRemovedEvent(
-                    continuation.targetId,
-                    continuation.currentCounterType,
-                    chosen,
-                    continuation.targetName
-                )
-            )
-        }
-
-        // Decrement the total budget when one is in force; stop entirely once it is exhausted.
-        val remainingBudget = continuation.remainingBudget?.minus(chosen)
-        if (remainingBudget != null && remainingBudget <= 0) {
-            return checkForMore(newState, events)
-        }
-
-        // If more counter kinds remain, prompt for the next one. Re-read live counts so a
-        // counter kind that was removed by an interaction during this resolution is skipped.
-        val live = newState.getEntity(continuation.targetId)
-            ?.get<com.wingedsheep.engine.state.components.battlefield.CountersComponent>()
-        val nextPrompt = continuation.remainingCounterTypes
-            .map { (type, _) ->
-                type to (live?.getCount(
-                    com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType(type)
-                ) ?: 0)
-            }
-            .firstOrNull { it.second > 0 }
-
-        if (nextPrompt == null) {
-            return checkForMore(newState, events)
-        }
-
-        val (nextType, nextCount) = nextPrompt
-        // Cap the next prompt at the remaining budget when one is in force.
-        val nextMax = remainingBudget?.let { minOf(nextCount, it) } ?: nextCount
-        val remainingAfter = continuation.remainingCounterTypes
-            .dropWhile { it.first != nextType }
-            .drop(1)
-
-        val decisionId = java.util.UUID.randomUUID().toString()
-        val decision = ChooseNumberDecision(
-            id = decisionId,
-            playerId = continuation.controllerId,
-            prompt = "Remove how many $nextType counters from ${continuation.targetName}? (0-$nextMax)",
-            context = DecisionContext(
-                sourceId = continuation.sourceId,
-                sourceName = continuation.sourceName,
-                phase = DecisionPhase.RESOLUTION
-            ),
-            minValue = 0,
-            maxValue = nextMax
+        val (afterRemoval, removalEvent) = RemoveAnyNumberOfCountersFlow.removeCounters(
+            newState,
+            continuation.targetId,
+            continuation.currentCounterType,
+            chosen,
+            continuation.targetName
         )
-        val nextContinuation = RemoveAnyNumberOfCountersContinuation(
-            decisionId = decisionId,
+        newState = afterRemoval
+        removalEvent?.let { events.add(it) }
+
+        // Carry the walk on over the kinds still to come, with the budget and the floor both
+        // decremented by what just came off.
+        val outcome = RemoveAnyNumberOfCountersFlow.advance(
+            state = newState,
             targetId = continuation.targetId,
             controllerId = continuation.controllerId,
-            currentCounterType = nextType,
-            currentMaxAmount = nextMax,
-            remainingCounterTypes = remainingAfter,
             targetName = continuation.targetName,
             sourceId = continuation.sourceId,
             sourceName = continuation.sourceName,
-            remainingBudget = remainingBudget
+            order = continuation.remainingCounterTypes,
+            budget = continuation.remainingBudget?.minus(chosen),
+            floor = (continuation.remainingFloor - chosen).coerceAtLeast(0),
+            priorEvents = events
         )
-        events.add(
-            DecisionRequestedEvent(
-                decisionId = decisionId,
-                playerId = continuation.controllerId,
-                decisionType = "CHOOSE_NUMBER",
-                prompt = decision.prompt
-            )
-        )
-        val pausedState = newState
-            .withPendingDecision(decision)
-            .pushContinuation(nextContinuation)
-        return ExecutionResult.paused(pausedState, decision, events)
+        return when (outcome) {
+            is RemoveAnyNumberOfCountersFlow.Outcome.Done ->
+                checkForMore(outcome.state, outcome.events)
+            is RemoveAnyNumberOfCountersFlow.Outcome.Prompt ->
+                ExecutionResult.paused(outcome.state, outcome.decision, outcome.events)
+        }
     }
 
     private fun resumeMoveChosenCountersToTarget(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -217,6 +217,15 @@ class ReflexiveTriggerEffectExecutor(
                 ?: 0
             current >= action.amount
         }
+        // "You may remove a counter from ~" (Leatherhead, Swamp Stalker) — with no counters left
+        // there is nothing to remove, so the may-clause must be absent. Both removal executors
+        // no-op on an empty permanent and report *success*, which would otherwise arm the "when you
+        // do" payoff for free: Leatherhead would keep destroying an artifact each combat long after
+        // her last counter was spent.
+        is com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect ->
+            countersOn(state, context, action.target) > 0
+        is com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect ->
+            countersOn(state, context, action.target, kind = action.counterType) >= action.count
         // "You may collect evidence 3" (Sample Collector) — CR 701.59b is explicit that a player
         // unable to exile cards totalling N *can't choose to collect evidence*, so the option must
         // be absent rather than offered and refused. Without this branch the `else -> true` below
@@ -228,6 +237,30 @@ class ReflexiveTriggerEffectExecutor(
                 .canCollect(state, playerId, action.amount)
         }
         else -> true
+    }
+
+    /**
+     * How many counters the permanent [target] resolves to currently carries — of every kind, or
+     * of [kind] alone when one is named. Zero when the target doesn't resolve or isn't a permanent
+     * that tracks counters, which is the fail-closed answer the callers above want.
+     */
+    private fun countersOn(
+        state: GameState,
+        context: EffectContext,
+        target: com.wingedsheep.sdk.scripting.targets.EffectTarget,
+        kind: String? = null
+    ): Int {
+        val targetId = context.resolveTarget(target) ?: return 0
+        val counters = state.getEntity(targetId)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.CountersComponent>()
+            ?: return 0
+        return if (kind == null) {
+            counters.counters.values.sum()
+        } else {
+            counters.getCount(
+                com.wingedsheep.engine.handlers.effects.permanent.counters.resolveCounterType(kind)
+            )
+        }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -221,11 +221,14 @@ class ReflexiveTriggerEffectExecutor(
         // there is nothing to remove, so the may-clause must be absent. Both removal executors
         // no-op on an empty permanent and report *success*, which would otherwise arm the "when you
         // do" payoff for free: Leatherhead would keep destroying an artifact each combat long after
-        // her last counter was spent.
+        // her last counter was spent. A `minTotal` floor raises the bar to the whole floor — an
+        // action that can't pay it in full can't be performed at all.
         is com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect ->
-            countersOn(state, context, action.target) > 0
+            countersOn(state, context, action.target)
+                ?.let { it >= action.minTotal.coerceAtLeast(1) } ?: true
         is com.wingedsheep.sdk.scripting.effects.RemoveCountersEffect ->
-            countersOn(state, context, action.target, kind = action.counterType) >= action.count
+            countersOn(state, context, action.target, kind = action.counterType)
+                ?.let { it >= action.count } ?: true
         // "You may collect evidence 3" (Sample Collector) — CR 701.59b is explicit that a player
         // unable to exile cards totalling N *can't choose to collect evidence*, so the option must
         // be absent rather than offered and refused. Without this branch the `else -> true` below
@@ -241,16 +244,24 @@ class ReflexiveTriggerEffectExecutor(
 
     /**
      * How many counters the permanent [target] resolves to currently carries — of every kind, or
-     * of [kind] alone when one is named. Zero when the target doesn't resolve or isn't a permanent
-     * that tracks counters, which is the fail-closed answer the callers above want.
+     * of [kind] alone when one is named. Zero for an entity that is gone or tracks no counters,
+     * which is the fail-*closed* answer the callers want: nothing to remove means no may-clause.
+     *
+     * `null` means the target shape couldn't be resolved at all, which is a different question and
+     * gets the opposite answer. Feasibility runs before the action does, so a `PipelineTarget`
+     * filled in by an earlier step of the same composite isn't stored yet, and `state` is consulted
+     * for the relational shapes ([EffectTarget.EnchantedCreature], `EquippedCreature`,
+     * `ChosenCreature`, …) that the stateless overload can't reach. Treating "don't know" as zero
+     * would silently delete the whole ability, so callers fail open on it — the same policy as this
+     * method's `else -> true`.
      */
     private fun countersOn(
         state: GameState,
         context: EffectContext,
         target: com.wingedsheep.sdk.scripting.targets.EffectTarget,
         kind: String? = null
-    ): Int {
-        val targetId = context.resolveTarget(target) ?: return 0
+    ): Int? {
+        val targetId = context.resolveTarget(target, state) ?: return null
         val counters = state.getEntity(targetId)
             ?.get<com.wingedsheep.engine.state.components.battlefield.CountersComponent>()
             ?: return 0

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAnyNumberOfCountersExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAnyNumberOfCountersExecutor.kt
@@ -1,31 +1,25 @@
 package com.wingedsheep.engine.handlers.effects.permanent.counters
 
-import com.wingedsheep.engine.core.ChooseNumberDecision
-import com.wingedsheep.engine.core.DecisionContext
-import com.wingedsheep.engine.core.DecisionPhase
-import com.wingedsheep.engine.core.DecisionRequestedEvent
 import com.wingedsheep.engine.core.EffectResult
-import com.wingedsheep.engine.core.RemoveAnyNumberOfCountersContinuation
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
  * Executor for [RemoveAnyNumberOfCountersEffect].
  *
- * "Remove any number of counters from target creature you control." — and, with the effect's
- * `maxTotal` set, its budget-capped form "Remove up to N counters from target creature"
- * (Heartless Act).
+ * "Remove any number of counters from target creature you control." — with the effect's `maxTotal`
+ * set, its budget-capped form "Remove up to N counters from target creature" (Heartless Act), and
+ * with `minTotal` set too, its mandatory form "Remove a counter from it" (Leatherhead, Swamp
+ * Stalker), where the player picks the kind but not whether.
  *
- * Enumerates each counter kind currently on the target and prompts the controller with a
- * [ChooseNumberDecision] per kind, sequentially. Each prompt's cap is that kind's count, further
- * clamped to the remaining `maxTotal` budget when one is set. The continuation applies each chosen
- * amount, decrements the budget, and queues the next prompt while counters (and budget) remain.
+ * The prompt-per-kind walk itself — the budget cap, the floor, and the forced steps that are
+ * applied rather than asked — lives in [RemoveAnyNumberOfCountersFlow], shared with the
+ * continuation resumer that carries it on after each answer.
  */
 class RemoveAnyNumberOfCountersExecutor : EffectExecutor<RemoveAnyNumberOfCountersEffect> {
 
@@ -48,58 +42,38 @@ class RemoveAnyNumberOfCountersExecutor : EffectExecutor<RemoveAnyNumberOfCounte
         val counters = targetEntity.get<CountersComponent>() ?: return EffectResult.success(state, emptyList())
         val present = counters.counters.entries
             .filter { it.value > 0 }
-            .map { counterTypeToString(it.key) to it.value }
+            .map { counterTypeToString(it.key) }
 
         if (present.isEmpty()) return EffectResult.success(state, emptyList())
 
         val targetName = targetEntity.get<CardComponent>()?.name ?: ""
         val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
 
-        val (firstType, firstCount) = present.first()
-        val remaining = present.drop(1)
-        // Clamp the first prompt to the total budget when one is in force.
-        val firstMax = maxTotal?.let { minOf(firstCount, it) } ?: firstCount
+        // The floor can't exceed the budget or what's actually there — a permanent carrying one
+        // counter satisfies "remove a counter" by losing it, and can't be asked for more.
+        val available = counters.counters.values.sum()
+        val floor = effect.minTotal
+            .coerceAtMost(maxTotal ?: Int.MAX_VALUE)
+            .coerceAtMost(available)
+            .coerceAtLeast(0)
 
-        val decisionId = UUID.randomUUID().toString()
-        val decision = ChooseNumberDecision(
-            id = decisionId,
-            playerId = context.controllerId,
-            prompt = "Remove how many $firstType counters from $targetName? (0-$firstMax)",
-            context = DecisionContext(
+        return when (
+            val outcome = RemoveAnyNumberOfCountersFlow.advance(
+                state = state,
+                targetId = targetId,
+                controllerId = context.controllerId,
+                targetName = targetName,
                 sourceId = context.sourceId,
                 sourceName = sourceName,
-                phase = DecisionPhase.RESOLUTION
-            ),
-            minValue = 0,
-            maxValue = firstMax
-        )
-
-        val continuation = RemoveAnyNumberOfCountersContinuation(
-            decisionId = decisionId,
-            targetId = targetId,
-            controllerId = context.controllerId,
-            currentCounterType = firstType,
-            currentMaxAmount = firstMax,
-            remainingCounterTypes = remaining,
-            targetName = targetName,
-            sourceId = context.sourceId,
-            sourceName = sourceName,
-            remainingBudget = maxTotal
-        )
-
-        val newState = state
-            .withPendingDecision(decision)
-            .pushContinuation(continuation)
-
-        val events = listOf(
-            DecisionRequestedEvent(
-                decisionId = decisionId,
-                playerId = context.controllerId,
-                decisionType = "CHOOSE_NUMBER",
-                prompt = decision.prompt
+                order = present,
+                budget = maxTotal,
+                floor = floor
             )
-        )
-
-        return EffectResult.paused(newState, decision, events)
+        ) {
+            is RemoveAnyNumberOfCountersFlow.Outcome.Done ->
+                EffectResult.success(outcome.state, outcome.events)
+            is RemoveAnyNumberOfCountersFlow.Outcome.Prompt ->
+                EffectResult.paused(outcome.state, outcome.decision, outcome.events)
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAnyNumberOfCountersFlow.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/RemoveAnyNumberOfCountersFlow.kt
@@ -1,0 +1,172 @@
+package com.wingedsheep.engine.handlers.effects.permanent.counters
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.CountersRemovedEvent
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DecisionRequestedEvent
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.RemoveAnyNumberOfCountersContinuation
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.sdk.model.EntityId
+import java.util.UUID
+
+/**
+ * The prompt-per-counter-kind walk behind
+ * [com.wingedsheep.sdk.scripting.effects.RemoveAnyNumberOfCountersEffect], shared by
+ * [RemoveAnyNumberOfCountersExecutor] (which starts it) and
+ * [com.wingedsheep.engine.handlers.continuations.MiscContinuationResumer] (which continues it after
+ * each answer) so the budget and floor arithmetic lives in exactly one place.
+ *
+ * Each kind currently on the target gets a `ChooseNumberDecision` in turn, bounded by:
+ *  - **maximum** — that kind's live count, further clamped to the remaining `maxTotal` budget.
+ *  - **minimum** — whatever of the remaining `minTotal` floor the *later* kinds can't cover. While
+ *    the floor is still reachable from what's left the player chooses freely (0 is legal); on the
+ *    last kind that can pay it the minimum rises to the shortfall. This is what makes "remove a
+ *    counter" mandatory-once-resolved without dictating which kind comes off.
+ *
+ * A kind whose minimum and maximum coincide has no decision left to make, so it is applied
+ * silently rather than asked — "remove a counter" from a permanent carrying only one kind never
+ * raises a prompt at all.
+ */
+object RemoveAnyNumberOfCountersFlow {
+
+    /** Where the walk ended: either everything is applied, or a player owes us an answer. */
+    sealed interface Outcome {
+        /** No prompt left to raise; [state] has every forced removal applied. */
+        data class Done(val state: GameState, val events: List<GameEvent>) : Outcome
+
+        /** [decision] is pending; [state] already carries it and the frame holding the rest of the walk. */
+        data class Prompt(
+            val state: GameState,
+            val decision: ChooseNumberDecision,
+            val events: List<GameEvent>
+        ) : Outcome
+    }
+
+    /**
+     * Walk [order] (counter kinds, in prompt order) applying forced removals until a genuine choice
+     * is reached or the kinds run out.
+     *
+     * @param budget counters still removable in total, or null for no cap
+     * @param floor counters that still *must* be removed in total
+     */
+    fun advance(
+        state: GameState,
+        targetId: EntityId,
+        controllerId: EntityId,
+        targetName: String,
+        sourceId: EntityId?,
+        sourceName: String?,
+        order: List<String>,
+        budget: Int?,
+        floor: Int,
+        priorEvents: List<GameEvent> = emptyList()
+    ): Outcome {
+        var currentState = state
+        var remaining = order
+        var remainingBudget = budget
+        var remainingFloor = floor
+        val events = priorEvents.toMutableList()
+
+        while (remaining.isNotEmpty()) {
+            if (remainingBudget != null && remainingBudget <= 0) break
+
+            val kind = remaining.first()
+            val rest = remaining.drop(1)
+            val live = countOf(currentState, targetId, kind)
+            if (live <= 0) {
+                remaining = rest
+                continue
+            }
+
+            val maxHere = remainingBudget?.let { minOf(live, it) } ?: live
+            if (maxHere <= 0) break
+
+            // What the kinds after this one could still supply toward the floor. Clamped to the
+            // budget, since the budget bounds the total however it's spread across kinds.
+            val othersRaw = rest.sumOf { countOf(currentState, targetId, it) }
+            val others = remainingBudget?.let { minOf(othersRaw, it) } ?: othersRaw
+            val minHere = (remainingFloor - others).coerceIn(0, maxHere)
+
+            if (minHere == maxHere) {
+                // Nothing left to decide — apply it rather than asking a question with one answer.
+                val (applied, event) = removeCounters(currentState, targetId, kind, minHere, targetName)
+                currentState = applied
+                event?.let { events.add(it) }
+                remainingBudget = remainingBudget?.minus(minHere)
+                remainingFloor = (remainingFloor - minHere).coerceAtLeast(0)
+                remaining = rest
+                continue
+            }
+
+            val decisionId = UUID.randomUUID().toString()
+            val decision = ChooseNumberDecision(
+                id = decisionId,
+                playerId = controllerId,
+                prompt = "Remove how many $kind counters from $targetName? ($minHere-$maxHere)",
+                context = DecisionContext(
+                    sourceId = sourceId,
+                    sourceName = sourceName,
+                    phase = DecisionPhase.RESOLUTION
+                ),
+                minValue = minHere,
+                maxValue = maxHere
+            )
+            val continuation = RemoveAnyNumberOfCountersContinuation(
+                decisionId = decisionId,
+                targetId = targetId,
+                controllerId = controllerId,
+                currentCounterType = kind,
+                currentMinAmount = minHere,
+                currentMaxAmount = maxHere,
+                remainingCounterTypes = rest,
+                targetName = targetName,
+                sourceId = sourceId,
+                sourceName = sourceName,
+                remainingBudget = remainingBudget,
+                remainingFloor = remainingFloor
+            )
+            events.add(
+                DecisionRequestedEvent(
+                    decisionId = decisionId,
+                    playerId = controllerId,
+                    decisionType = "CHOOSE_NUMBER",
+                    prompt = decision.prompt
+                )
+            )
+            return Outcome.Prompt(
+                state = currentState.withPendingDecision(decision).pushContinuation(continuation),
+                decision = decision,
+                events = events
+            )
+        }
+
+        return Outcome.Done(currentState, events)
+    }
+
+    /** Live count of [kind] on [targetId]; 0 when the entity is gone or tracks no counters. */
+    fun countOf(state: GameState, targetId: EntityId, kind: String): Int =
+        state.getEntity(targetId)
+            ?.get<CountersComponent>()
+            ?.getCount(resolveCounterType(kind))
+            ?: 0
+
+    /** Apply a removal, paired with the event to emit (null when [count] is 0). */
+    fun removeCounters(
+        state: GameState,
+        targetId: EntityId,
+        kind: String,
+        count: Int,
+        targetName: String
+    ): Pair<GameState, CountersRemovedEvent?> {
+        if (count <= 0) return state to null
+        val counterType = resolveCounterType(kind)
+        val current = state.getEntity(targetId)?.get<CountersComponent>() ?: return state to null
+        val updated = state.updateEntity(targetId) { container ->
+            container.with(current.withRemoved(counterType, count))
+        }
+        return updated to CountersRemovedEvent(targetId, kind, count, targetName)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -258,6 +258,25 @@ class StackResolver(
             ?: transformedBackDef?.manaCost?.cmc
             ?: cardComponent.manaValue
 
+        // CR 601.2b — a spell with `{X}` in its cost has X *chosen as it is cast*; there is no such
+        // thing as a spell on the stack whose X is undetermined. A caller that announced nothing
+        // (the AI's CastSpell carries no xValue, and a synthesized free cast never picks one) paid
+        // nothing for X, so X is 0.
+        //
+        // Binding it here rather than leaving null is load-bearing, not cosmetic: the resolution-time
+        // `CardPredicate.ManaValueAtMostX` fails *open* on an unbound X — deliberately, so an X spell
+        // is still offered during legal-action enumeration, which runs before X is chosen. Left null
+        // all the way to resolution, "each creature with mana value X or less" matches *every*
+        // creature, and Day of Black Sun cast for X=0 wipes the board. It is also what puts the
+        // "(X=0)" in the game log's cast line, which is otherwise silently absent.
+        val boundXValue = xValue ?: run {
+            val castCost = faceIndex
+                ?.let { cardRegistry.getCard(cardComponent.cardDefinitionId)?.cardFaces?.getOrNull(it)?.manaCost }
+                ?: transformedBackDef?.manaCost
+                ?: cardComponent.manaCost
+            if (castCost.hasX) 0 else null
+        }
+
         // Build the flat target union for choose-N modal spells (Rule 700.2 / 601.2c).
         // TargetsComponent holds the union so existing target-arrow rendering and resolution-time
         // re-validation keep working; per-mode breakdown lives on SpellOnStackComponent.
@@ -287,7 +306,7 @@ class StackResolver(
         newState = newState.updateEntity(cardId) { c ->
             var updated = c.with(SpellOnStackComponent(
                 casterId = casterId,
-                xValue = xValue,
+                xValue = boundXValue,
                 declaredCostSlot = declaredCostSlot,
                 wasBlightPaid = wasBlightPaid,
                 wasWaterbendPaid = wasWaterbendPaid,
@@ -473,7 +492,7 @@ class StackResolver(
                 cardName = eventName,
                 casterId = casterId,
                 targetNames = targetNames,
-                xValue = xValue,
+                xValue = boundXValue,
                 declaredCostSlot = declaredCostSlot,
                 totalManaSpent = totalManaSpent,
                 distinctColorsSpent =

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -258,10 +258,11 @@ class StackResolver(
             ?: transformedBackDef?.manaCost?.cmc
             ?: cardComponent.manaValue
 
-        // CR 601.2b — a spell with `{X}` in its cost has X *chosen as it is cast*; there is no such
-        // thing as a spell on the stack whose X is undetermined. A caller that announced nothing
-        // (the AI's CastSpell carries no xValue, and a synthesized free cast never picks one) paid
-        // nothing for X, so X is 0.
+        // CR 601.2b — a spell with `{X}` in its cost has X *announced as it is cast*; there is no
+        // such thing as a spell on the stack whose X is undetermined. A caller that announced
+        // nothing (the AI's CastSpell carries no xValue) paid nothing for X, so X is 0. For the
+        // other caller — a synthesized cast that pays no mana cost at all — CR 107.3b is directly
+        // on point: "the only legal choice for X is 0."
         //
         // Binding it here rather than leaving null is load-bearing, not cosmetic: the resolution-time
         // `CardPredicate.ManaValueAtMostX` fails *open* on an unbound X — deliberately, so an X spell

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DayOfBlackSunScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DayOfBlackSunScenarioTest.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SpellCastEvent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Day of Black Sun (TLA #94) — {X}{B}{B} Sorcery.
+ *
+ * "Each creature with mana value X or less loses all abilities until end of turn.
+ *  Destroy those creatures."
+ *
+ * The interesting case is the *undeclared* X. A caster that announces nothing — the AI's
+ * `CastSpell` carries no `xValue`, and a synthesized free cast never picks one — pays nothing for
+ * X, so X is 0 (CR 601.2b). Left null all the way to resolution it hit
+ * [com.wingedsheep.sdk.scripting.predicates.CardPredicate.ManaValueAtMostX], which fails *open* on
+ * an unbound X — deliberately, so an X spell is still enumerated as a legal action before X is
+ * chosen — and "mana value X or less" then matched every creature on the board.
+ */
+class DayOfBlackSunScenarioTest : FunSpec({
+
+    fun GameTestDriver.resolveStack() {
+        var safety = 0
+        while (stackSize > 0 && !isPaused && safety < 20) {
+            bothPass(); safety++
+        }
+    }
+
+    fun setup(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return Triple(driver, player, opponent)
+    }
+
+    fun GameTestDriver.castEvent(name: String): SpellCastEvent =
+        events.filterIsInstance<SpellCastEvent>().single { it.cardName == name }
+
+    test("cast with no declared X resolves as X=0: only mana value 0 creatures die") {
+        val (driver, player, opponent) = setup()
+
+        driver.putCreatureOnBattlefield(opponent, "Ornithopter")     // MV 0 — dies
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")   // MV 2 — survives
+        driver.putCreatureOnBattlefield(opponent, "Hill Giant")      // MV 4 — survives
+
+        repeat(2) { driver.putLandOnBattlefield(player, "Swamp") }
+
+        val wipe = driver.putCardInHand(player, "Day of Black Sun")
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = wipe,
+                paymentStrategy = PaymentStrategy.AutoPay
+                // xValue deliberately omitted — this is the AI / synthesized-cast shape.
+            )
+        )
+        driver.resolveStack()
+
+        driver.findPermanent(opponent, "Ornithopter") shouldBe null
+        (driver.findPermanent(opponent, "Grizzly Bears") != null) shouldBe true
+        (driver.findPermanent(opponent, "Hill Giant") != null) shouldBe true
+    }
+
+    test("an undeclared X is reported as 0 on the cast event, so the log line can show it") {
+        val (driver, player, _) = setup()
+
+        repeat(2) { driver.putLandOnBattlefield(player, "Swamp") }
+
+        val wipe = driver.putCardInHand(player, "Day of Black Sun")
+        driver.submitSuccess(
+            CastSpell(playerId = player, cardId = wipe, paymentStrategy = PaymentStrategy.AutoPay)
+        )
+
+        driver.castEvent("Day of Black Sun").xValue shouldBe 0
+    }
+
+    test("X=2 destroys creatures with mana value 2 or less and spares larger ones") {
+        val (driver, player, opponent) = setup()
+
+        driver.putCreatureOnBattlefield(opponent, "Ornithopter")     // MV 0 — dies
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")   // MV 2 — dies
+        driver.putCreatureOnBattlefield(opponent, "Hill Giant")      // MV 4 — survives
+
+        repeat(4) { driver.putLandOnBattlefield(player, "Swamp") }
+
+        val wipe = driver.putCardInHand(player, "Day of Black Sun")
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = wipe,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                xValue = 2
+            )
+        )
+        driver.resolveStack()
+
+        driver.findPermanent(opponent, "Ornithopter") shouldBe null
+        driver.findPermanent(opponent, "Grizzly Bears") shouldBe null
+        (driver.findPermanent(opponent, "Hill Giant") != null) shouldBe true
+
+        driver.castEvent("Day of Black Sun").xValue shouldBe 2
+    }
+
+    test("a spell with no {X} in its cost still reports no X, so its log line stays clean") {
+        val (driver, player, opponent) = setup()
+
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        repeat(3) { driver.putLandOnBattlefield(player, "Swamp") }
+
+        val bears = driver.findPermanent(opponent, "Grizzly Bears")!!
+        val removal = driver.putCardInHand(player, "Doom Blade")
+        driver.submitSuccess(
+            CastSpell(
+                playerId = player,
+                cardId = removal,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                targets = listOf(ChosenTarget.Permanent(bears))
+            )
+        )
+
+        driver.castEvent("Doom Blade").xValue shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeatherheadSwampStalkerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeatherheadSwampStalkerScenarioTest.kt
@@ -23,10 +23,17 @@ import io.kotest.matchers.shouldBe
  *  Whenever Leatherhead deals combat damage to a player, you may remove a counter from her.
  *  When you do, destroy target artifact or enchantment that player controls."
  *
- * "A counter" is any kind, not the hexproof one specifically. Once something has put +1/+1
- * counters on her (Ouroboroid's begin-combat trigger is the common case) the controller chooses
- * which kind comes off — the implementation used to hardcode the hexproof counter and spend it
- * with no prompt at all.
+ * Two things the wording pins down, and both have been wrong here:
+ *
+ *  - **"A counter" is any kind**, not the hexproof one specifically. Once something has put +1/+1
+ *    counters on her (Ouroboroid's begin-combat trigger is the common case) the controller chooses
+ *    which kind comes off — the implementation used to hardcode the hexproof counter and spend it
+ *    with no prompt at all.
+ *  - **The choice is which kind, not whether.** Once you accept the "you may", a counter comes off;
+ *    CR 603.12's "when you do" is what arms the destroy, so a controller who takes off nothing must
+ *    get nothing. Modelling this as `RemoveCountersUpTo(1, …)` — a ceiling with no floor — let the
+ *    controller say yes and then answer 0 at every prompt, destroying an artifact every combat
+ *    without ever spending a counter.
  */
 class LeatherheadSwampStalkerScenarioTest : FunSpec({
 
@@ -166,5 +173,69 @@ class LeatherheadSwampStalkerScenarioTest : FunSpec({
         val after = counts(driver, leatherhead)
         (after[CounterType.HEXPROOF] ?: 0) shouldBe 0
         after[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 3
+    }
+
+    test("answering zero at every prompt still spends a counter — the destroy is never free") {
+        val (driver, leatherhead, defender) = attackAndAccept(plusOnes = 3)
+
+        // Try to take nothing: answer 0 to every prompt, including any the floor has already
+        // narrowed to a single legal answer. The engine holds the controller to the minimum.
+        var safety = 0
+        while (safety++ < 10) {
+            val decision = driver.pendingDecision as? ChooseNumberDecision ?: break
+            driver.submitDecision(decision.playerId, NumberChosenResponse(decision.id, 0))
+        }
+
+        // 4 counters went in; "remove a counter" means exactly one comes off, controller's pick.
+        counts(driver, leatherhead).values.sum() shouldBe 3
+
+        // And the payoff is genuinely earned, so it does resolve.
+        val chooseTargets = driver.advanceToChooseTargets()
+        val enchantment = driver.findPermanent(defender, "Test Enchantment")!!
+        driver.submitTargetSelection(chooseTargets.playerId, listOf(enchantment))
+        safety = 0
+        while (driver.findPermanent(defender, "Test Enchantment") != null && safety++ < 6) {
+            driver.bothPass()
+        }
+        driver.findPermanent(defender, "Test Enchantment") shouldBe null
+    }
+
+    test("with a single kind of counter there is nothing to ask, so no prompt is raised") {
+        val (driver, leatherhead, _) = attackAndAccept(plusOnes = 0)
+
+        // One kind, floor and ceiling both 1: the only legal answer is applied rather than asked.
+        (driver.pendingDecision is ChooseNumberDecision) shouldBe false
+        counts(driver, leatherhead).values.sum() shouldBe 0
+    }
+
+    test("no counters left: the may-clause is never offered and nothing is destroyed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Swamp" to 20), startingLife = 20)
+
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        // Straight onto the battlefield, so the enters-with-a-hexproof-counter replacement never
+        // runs — this is Leatherhead a combat after her last counter was spent.
+        val leatherhead = driver.putCreatureOnBattlefield(attacker, "Leatherhead, Swamp Stalker")
+        driver.removeSummoningSickness(leatherhead)
+        counts(driver, leatherhead).values.sum() shouldBe 0
+
+        driver.putPermanentOnBattlefield(defender, "Test Enchantment")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(leatherhead), defender)
+        driver.bothPass()
+        driver.declareNoBlockers(defender)
+
+        var safety = 0
+        var asked = false
+        while (safety++ < 12) {
+            if (driver.pendingDecision is YesNoDecision) { asked = true; break }
+            driver.bothPass()
+        }
+
+        asked shouldBe false
+        (driver.findPermanent(defender, "Test Enchantment") != null) shouldBe true
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeatherheadSwampStalkerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeatherheadSwampStalkerScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.core.PendingDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Leatherhead, Swamp Stalker (TMT #117) — {2}{G}{G} 5/4 Legendary Crocodile.
+ *
+ * "Trample
+ *  Leatherhead enters with a hexproof counter on her.
+ *  Whenever Leatherhead deals combat damage to a player, you may remove a counter from her.
+ *  When you do, destroy target artifact or enchantment that player controls."
+ *
+ * "A counter" is any kind, not the hexproof one specifically. Once something has put +1/+1
+ * counters on her (Ouroboroid's begin-combat trigger is the common case) the controller chooses
+ * which kind comes off — the implementation used to hardcode the hexproof counter and spend it
+ * with no prompt at all.
+ */
+class LeatherheadSwampStalkerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun addCounters(driver: GameTestDriver, entityId: EntityId, type: CounterType, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(type, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    fun counts(driver: GameTestDriver, entityId: EntityId): Map<CounterType, Int> =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.counters ?: emptyMap()
+
+    /**
+     * Pass priority until the pending decision satisfies [matches], so the tests don't have to know
+     * how many stack objects sit between combat damage and each prompt (the combat-damage trigger,
+     * then the separate CR 603.12 reflexive trigger).
+     */
+    fun GameTestDriver.advanceUntil(what: String, matches: (Any?) -> Boolean): PendingDecision {
+        var safety = 0
+        while (!matches(pendingDecision) && safety++ < 12) bothPass()
+        return pendingDecision?.takeIf { matches(it) }
+            ?: error("expected $what, got ${pendingDecision?.let { it::class.simpleName }}")
+    }
+
+    fun GameTestDriver.advanceToYesNo(): YesNoDecision =
+        advanceUntil("a YesNoDecision") { it is YesNoDecision } as YesNoDecision
+
+    fun GameTestDriver.advanceToChooseTargets(): ChooseTargetsDecision =
+        advanceUntil("a ChooseTargetsDecision") { it is ChooseTargetsDecision } as ChooseTargetsDecision
+
+    /**
+     * Attack unblocked with a Leatherhead carrying a hexproof counter and [plusOnes] +1/+1
+     * counters, then say yes to the "you may remove a counter" prompt. Returns the driver
+     * parked on whatever decision comes next (the counter-kind prompts).
+     */
+    fun attackAndAccept(plusOnes: Int): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Swamp" to 20), startingLife = 20)
+
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val leatherhead = driver.putCreatureOnBattlefield(attacker, "Leatherhead, Swamp Stalker")
+        driver.removeSummoningSickness(leatherhead)
+        addCounters(driver, leatherhead, CounterType.HEXPROOF, 1)
+        if (plusOnes > 0) addCounters(driver, leatherhead, CounterType.PLUS_ONE_PLUS_ONE, plusOnes)
+
+        driver.putPermanentOnBattlefield(defender, "Test Enchantment")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(leatherhead), defender)
+        driver.bothPass()
+        driver.declareNoBlockers(defender)
+
+        val yesNo = driver.advanceToYesNo()
+        driver.submitYesNo(yesNo.playerId, true)
+
+        return Triple(driver, leatherhead, defender)
+    }
+
+    /**
+     * Answer the sequence of per-kind counter prompts, taking one counter off [take] and zero off
+     * every other kind. Stops when the prompts run out.
+     */
+    fun answerCounterPrompts(driver: GameTestDriver, take: CounterType) {
+        val wanted = when (take) {
+            CounterType.HEXPROOF -> "hexproof"
+            CounterType.PLUS_ONE_PLUS_ONE -> "+1/+1"
+            else -> error("unsupported counter kind for this test: $take")
+        }
+        var safety = 0
+        while (safety++ < 10) {
+            val decision = driver.pendingDecision as? ChooseNumberDecision ?: return
+            val amount = if (decision.prompt.contains(wanted)) 1 else 0
+            driver.submitDecision(decision.playerId, NumberChosenResponse(decision.id, amount))
+        }
+    }
+
+    test("with only the hexproof counter, that is the counter removed") {
+        val (driver, leatherhead, defender) = attackAndAccept(plusOnes = 0)
+
+        answerCounterPrompts(driver, take = CounterType.HEXPROOF)
+
+        (counts(driver, leatherhead)[CounterType.HEXPROOF] ?: 0) shouldBe 0
+
+        val chooseTargets = driver.advanceToChooseTargets()
+        val enchantment = driver.findPermanent(defender, "Test Enchantment")!!
+        driver.submitTargetSelection(chooseTargets.playerId, listOf(enchantment))
+        var safety = 0
+        while (driver.findPermanent(defender, "Test Enchantment") != null && safety++ < 6) {
+            driver.bothPass()
+        }
+
+        driver.findPermanent(defender, "Test Enchantment") shouldBe null
+    }
+
+    test("with +1/+1 counters too, the controller is prompted for which kind to remove") {
+        val (driver, _, _) = attackAndAccept(plusOnes = 3)
+
+        // The bug was that no prompt appeared at all — the hexproof counter was spent silently.
+        (driver.pendingDecision is ChooseNumberDecision) shouldBe true
+    }
+
+    test("keeping hexproof: a +1/+1 counter comes off instead and the destroy still happens") {
+        val (driver, leatherhead, defender) = attackAndAccept(plusOnes = 3)
+
+        answerCounterPrompts(driver, take = CounterType.PLUS_ONE_PLUS_ONE)
+
+        val after = counts(driver, leatherhead)
+        after[CounterType.HEXPROOF] shouldBe 1
+        after[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 2
+
+        val chooseTargets = driver.advanceToChooseTargets()
+        val enchantment = driver.findPermanent(defender, "Test Enchantment")!!
+        driver.submitTargetSelection(chooseTargets.playerId, listOf(enchantment))
+        var safety = 0
+        while (driver.findPermanent(defender, "Test Enchantment") != null && safety++ < 6) {
+            driver.bothPass()
+        }
+
+        driver.findPermanent(defender, "Test Enchantment") shouldBe null
+    }
+
+    test("spending hexproof leaves the +1/+1 counters alone") {
+        val (driver, leatherhead, _) = attackAndAccept(plusOnes = 3)
+
+        answerCounterPrompts(driver, take = CounterType.HEXPROOF)
+
+        val after = counts(driver, leatherhead)
+        (after[CounterType.HEXPROOF] ?: 0) shouldBe 0
+        after[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReflexiveTriggerFeasibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReflexiveTriggerFeasibilityTest.kt
@@ -1,19 +1,26 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -41,6 +48,13 @@ import io.kotest.matchers.shouldBe
  *
  * The mandatory (`optional = false`) case is here too: it shares the same gate, so a vacuous action
  * must not pay out even when there was never a yes/no question to skip.
+ *
+ * Counter removal is the other family with the same "no-ops and reports success" hazard, and it
+ * pins the boundary between the walker's two answers. **Zero counters** is knowledge — the removal
+ * is impossible, so the prompt must be absent (Leatherhead, Swamp Stalker would otherwise keep
+ * destroying an artifact each combat after her last counter was gone). **An unresolvable target**
+ * is not: feasibility runs before the action does, so a pipeline slot the same composite fills a
+ * step earlier is simply not stored yet, and reading that as zero would delete a working ability.
  */
 class ReflexiveTriggerFeasibilityTest : FunSpec({
 
@@ -96,6 +110,73 @@ class ReflexiveTriggerFeasibilityTest : FunSpec({
         }
     }
 
+    /**
+     * "Whenever you attack, you may remove a counter from a creature you control. When you do, gain
+     * 3 life." — the removal target is a pipeline slot the *same composite* fills a step earlier
+     * (Mister Hyde, Monster Within's shape), so at feasibility time it is not yet stored. That is a
+     * "don't know", not a "no counters", and must be offered rather than silently suppressed.
+     */
+    val RemoveFromSelectedCreature = card("Feasibility Test Remove From Selected") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever you attack, you may remove a counter from a creature you control. " +
+            "When you do, you gain 3 life."
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            effect = ReflexiveTriggerEffect(
+                action = Effects.Composite(
+                    Effects.SelectTarget(Targets.CreatureYouControl, storeAs = "counterSource"),
+                    Effects.RemoveCounterOfAnyKind(EffectTarget.PipelineTarget("counterSource", 0))
+                ),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(3)
+            )
+        }
+    }
+
+    /**
+     * "Whenever you attack, you may remove a -1/-1 counter from this. When you do, gain 3 life."
+     *
+     * 3/3 rather than 1/1 like its siblings: the tests put a -1/-1 counter on it, and a 1/1 would
+     * be a 0/0 that dies to state-based actions before it ever attacks.
+     */
+    val RemoveNamedCounter = card("Feasibility Test Remove Named Counter") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Soldier"
+        power = 3
+        toughness = 3
+        oracleText = "Whenever you attack, you may remove a -1/-1 counter from this creature. " +
+            "When you do, you gain 3 life."
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            effect = ReflexiveTriggerEffect(
+                action = Effects.RemoveCounters(Counters.MINUS_ONE_MINUS_ONE, 1, EffectTarget.Self),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(3)
+            )
+        }
+    }
+
+    /** "Whenever you attack, you may remove a counter from this. When you do, gain 3 life." */
+    val RemoveAnyCounter = card("Feasibility Test Remove Any Counter") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "Whenever you attack, you may remove a counter from this creature. " +
+            "When you do, you gain 3 life."
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            effect = ReflexiveTriggerEffect(
+                action = Effects.RemoveCounterOfAnyKind(EffectTarget.Self),
+                optional = true,
+                reflexiveEffect = Effects.GainLife(3)
+            )
+        }
+    }
+
     /** "Whenever you attack, discard a card. When you do, you gain 3 life." (mandatory) */
     val MandatoryDiscard = card("Feasibility Test Mandatory Discard") {
         manaCost = "{1}"
@@ -114,7 +195,12 @@ class ReflexiveTriggerFeasibilityTest : FunSpec({
     }
 
     fun driver(): GameTestDriver = GameTestDriver().apply {
-        registerCards(TestCards.all + listOf(Prompter, DrawThenDiscard, DiscardTwo, MandatoryDiscard))
+        registerCards(
+            TestCards.all + listOf(
+                Prompter, DrawThenDiscard, DiscardTwo, MandatoryDiscard,
+                RemoveNamedCounter, RemoveAnyCounter, RemoveFromSelectedCreature
+            )
+        )
         initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
     }
 
@@ -134,6 +220,10 @@ class ReflexiveTriggerFeasibilityTest : FunSpec({
                 is YesNoDecision -> { asked = true; submitYesNo(you, accept) }
                 is SelectCardsDecision ->
                     submitCardSelection(you, dec.options.take(dec.minSelections.coerceAtLeast(1)))
+                // Answer counter-kind prompts with the least the floor allows — a gate that only
+                // fires because the test over-paid would prove nothing.
+                is ChooseNumberDecision ->
+                    submitDecision(you, NumberChosenResponse(dec.id, dec.minValue))
                 else -> if (state.stack.isNotEmpty()) bothPass() else return asked
             }
         }
@@ -151,6 +241,31 @@ class ReflexiveTriggerFeasibilityTest : FunSpec({
         d.declareAttackers(you, listOf(attacker), d.getOpponent(you))
         return d
     }
+
+    /** Attack with a freshly-made [cardName] carrying [counters]. Returns the driver and attacker. */
+    fun attackWithCounters(
+        cardName: String,
+        counters: Map<CounterType, Int>
+    ): Pair<GameTestDriver, EntityId> {
+        val d = driver()
+        val you = d.activePlayer!!
+        val attacker = d.putCreatureOnBattlefield(you, cardName)
+        d.removeSummoningSickness(attacker)
+        counters.forEach { (type, count) ->
+            d.replaceState(
+                d.state.updateEntity(attacker) { container ->
+                    val existing = container.get<CountersComponent>() ?: CountersComponent()
+                    container.with(existing.withAdded(type, count))
+                }
+            )
+        }
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(you, listOf(attacker), d.getOpponent(you))
+        return d to attacker
+    }
+
+    fun GameTestDriver.counterTotal(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<CountersComponent>()?.counters?.values?.sum() ?: 0
 
     test("an empty hand is never asked to discard, and never pays out") {
         val d = attackWith("Feasibility Test Prompter") { emptyHand(it) }
@@ -195,5 +310,76 @@ class ReflexiveTriggerFeasibilityTest : FunSpec({
         d.getLifeTotal(you) shouldBe 23
         d.getHandSize(you) shouldBe 0
         d.getGraveyard(you).size shouldBe 1
+    }
+
+    test("a permanent with no counters is never asked to remove a named one") {
+        val (d, _) = attackWithCounters("Feasibility Test Remove Named Counter", emptyMap())
+        val you = d.activePlayer!!
+
+        // Both removal executors no-op on an empty permanent and report success, so without the
+        // gate the payoff fires for a removal that never happened.
+        d.resolveAttackTriggers(you, accept = true) shouldBe false
+        d.getLifeTotal(you) shouldBe 20
+    }
+
+    test("a permanent with no counters is never asked to remove one of any kind") {
+        val (d, _) = attackWithCounters("Feasibility Test Remove Any Counter", emptyMap())
+        val you = d.activePlayer!!
+
+        d.resolveAttackTriggers(you, accept = true) shouldBe false
+        d.getLifeTotal(you) shouldBe 20
+    }
+
+    test("one -1/-1 counter is enough to be offered, and paying it earns the payoff") {
+        val (d, attacker) = attackWithCounters(
+            "Feasibility Test Remove Named Counter",
+            mapOf(CounterType.MINUS_ONE_MINUS_ONE to 1)
+        )
+        val you = d.activePlayer!!
+
+        d.resolveAttackTriggers(you, accept = true) shouldBe true
+        d.getLifeTotal(you) shouldBe 23
+        d.counterTotal(attacker) shouldBe 0
+    }
+
+    test("a named removal is not offered when the permanent is short of the full count") {
+        // "Remove a -1/-1 counter" on a permanent carrying only +1/+1 counters: the kind that would
+        // pay isn't there, so the count check must look at that kind, not the total.
+        val (d, attacker) = attackWithCounters(
+            "Feasibility Test Remove Named Counter",
+            mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)
+        )
+        val you = d.activePlayer!!
+
+        d.resolveAttackTriggers(you, accept = true) shouldBe false
+        d.getLifeTotal(you) shouldBe 20
+        d.counterTotal(attacker) shouldBe 2
+    }
+
+    test("an any-kind removal takes whichever counter is there and earns the payoff") {
+        val (d, attacker) = attackWithCounters(
+            "Feasibility Test Remove Any Counter",
+            mapOf(CounterType.PLUS_ONE_PLUS_ONE to 2)
+        )
+        val you = d.activePlayer!!
+
+        d.resolveAttackTriggers(you, accept = true) shouldBe true
+        d.getLifeTotal(you) shouldBe 23
+        d.counterTotal(attacker) shouldBe 1
+    }
+
+    test("a not-yet-stored pipeline target fails open — the ability is still offered") {
+        // The removal points at a slot the composite's own earlier step fills, so at feasibility
+        // time it resolves to nothing. Reading that as "zero counters" would delete the whole
+        // ability; "don't know" has to mean "offer it".
+        val (d, attacker) = attackWithCounters(
+            "Feasibility Test Remove From Selected",
+            mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)
+        )
+        val you = d.activePlayer!!
+
+        d.resolveAttackTriggers(you, accept = true) shouldBe true
+        d.getLifeTotal(you) shouldBe 23
+        d.counterTotal(attacker) shouldBe 0
     }
 })


### PR DESCRIPTION
Two playtest bugs, plus the fixes from reviewing them.

## Day of Black Sun destroyed every creature

A caster that announced no X — the AI's `CastSpell` carries none, and a synthesized free cast never picks one — left `SpellOnStackComponent.xValue` null all the way to resolution, where `CardPredicate.ManaValueAtMostX` fails *open*. That fail-open is deliberate: legal-action enumeration runs before X is chosen, so an X spell must still be offered, which is why the resolution-only siblings `ToughnessAtMostX` / `PowerAtLeastX` fail closed instead. So the fix binds X rather than touching the predicate.

Per CR 601.2b a spell with `{X}` in its cost has X announced as it is cast, and a caster who paid nothing for X cast it for 0; for the free-cast path CR 107.3b is explicit that 0 is the only legal choice. `StackResolver` resolves that at cast time and feeds it to both `SpellOnStackComponent` and `SpellCastEvent`, so the board wipe filters correctly and the game log's cast line carries `(X=0)` — previously absent for the same reason. Spells with no `{X}` still report null, so their log lines are unchanged.

Guarded against the two paths that share the X slot: mana payment already computes `action.xValue ?: 0`, so X=0 matches what was actually paid, and a `PayXLife` additional cost can never co-exist with an `{X}` mana cost (`Costs.kt`).

## Leatherhead, Swamp Stalker spent her hexproof counter every time

"You may remove a counter from her" hardcoded `Counters.HEXPROOF`, so once anything had put +1/+1 counters on her (Ouroboroid's begin-combat trigger) there was no prompt at all and her hexproof went every time. The card wants any kind, controller's choice.

It also closes an adjacent hole in the same path: both counter-removal executors no-op on a permanent with no counters and report success, which armed the "when you do" payoff for free — Leatherhead would have kept destroying an artifact every combat after her last counter was gone. `ReflexiveTriggerEffectExecutor.isActionFeasible` now gates on the counters actually being there, alongside the existing sacrifice/discard/evidence gates.

## Review follow-ups (second commit)

**The removal needed a floor, not just a ceiling.** Modelled as `RemoveCountersUpTo(1, …)`, accepting the "may" and then answering 0 at every prompt removed nothing and still reported success — so CR 603.12's reflexive "when you do" fired for a "you do" that never happened. That is the same free-payoff hole the feasibility gate closes, one step further in. `RemoveAnyNumberOfCountersEffect` gains `minTotal` to match its `maxTotal`, exposed as `Effects.RemoveCounterOfAnyKind`. Each prompt's minimum is the share of the floor the kinds still to come can't cover, so the controller keeps a free choice of *which* kind while the floor is reachable and is held to it on the last kind that can pay; the resumer coerces into `[min, max]`, so enforcement is server-side. A prompt whose bounds coincide is applied rather than asked, so a permanent with one kind of counter raises no prompt at all.

**The feasibility gate failed closed on targets it couldn't resolve.** It read counters through the stateless resolver and scored an unresolvable target as zero. Feasibility runs before the action, so a pipeline slot the same composite fills a step earlier isn't stored yet — treating that as "no counters" silently deleted the whole ability. It now uses the state-aware resolver and fails open on "don't know", matching the walker's own `else -> true` policy.

**"That player controls" was filtered as "an opponent controls."** Leatherhead and Dawning Purist both print the damaged player, but filtered on any opponent — the two coincide only in a two-player game. Both now use `controlledByTriggeringPlayer()`, the primitive Rustmouth Ogre already uses for the identical template.

Also re-blesses the ONS and TMT card snapshots. TMT was stale as of the first commit, which changed Leatherhead's definition without updating the golden — `CardDefinitionSnapshotTest` was failing on the branch until now.

## Tests

`DayOfBlackSunScenarioTest` (4) covers the undeclared-X wipe, an explicit X=2, the cast event's reported X, and a no-`{X}` control case. `LeatherheadSwampStalkerScenarioTest` (7) covers kind selection, the zero-answer floor, the single-kind no-prompt path, and the no-counters-left case. `ReflexiveTriggerFeasibilityTest` (+5) covers both new `isActionFeasible` branches, present and absent, plus the fail-open pipeline-target case.

Verified with `:rules-engine:test` over the seven affected classes (37 passed) and `:mtg-sets:test --rerun-tasks` (`CardDefinitionSnapshotTest` 308/308). A full `test` gate ran 10,637/10,638; the one failure was `ConniveTargetingTest` timing out after 120s under parallel-module contention on a memory-limited box — it passes in isolation, its sibling `ConniveTest` passed in the same run, and it touches none of the changed code paths.

The fail-open branch was confirmed load-bearing by temporarily reverting it: exactly one test failed, that one.

**Not covered:** the multiplayer half of the "that player controls" fix. `GameTestDriver.initGame` hard-codes two `PlayerConfig`s, and two players is exactly where `controlledByTriggeringPlayer()` and `opponentControls()` agree. The swap is proven correct-by-precedent and proven not to regress two-player play, but the divergence it fixes has no test; extending the driver to three players is a larger change than this warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
