### PR TITLE
Gate every controller-grant marker behind its condition

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5133,6 +5133,17 @@ staticAbility {
   enchanted permanent is a land, it has '{T}: Add two mana of any one color'" is a
   `ConditionalStaticAbility(GrantActivatedAbility({T}: AddAnyColorMana(2)), EnchantedPermanentMatches(Land))` — the
   granted mana ability switches on/off continuously with the host's type.
+  The same holds for the **player-level controller grants** — `GrantShroudToController`,
+  `GrantHexproofToController`, `GrantProtectionToController`, `OpponentsCantMakeYouSacrifice`,
+  `GrantCantLoseGame`, `GrantOpponentsCantWinGame`, `GrantCantLoseGameFromLife`, `StationUsingToughness`,
+  `CantBeTargetedByOpponentAbilities`. Those are stamped as marker components once, as the permanent
+  enters, rather than projected each pass, so the gate travels on the marker and every reader
+  re-evaluates it against current state via `ControllerGrants` (Captain America, Super-Soldier:
+  `ConditionalStaticAbility(GrantHexproofToController, Conditions.SourceHasCounter(Named(Counters.SHIELD)))`).
+  Adding a new marker of this kind means stamping it through `StaticAbilityHandler.controllerGrant<A>()`
+  and reading it through `ControllerGrants` — a bare `any { it is A }` at the stamp makes the gated form
+  *silently inert*, and a bare `has<M>()` at the read leaves it stuck on. `ConditionalControllerGrantsTest`
+  enforces both.
 - `CompositeStaticAbility(abilities)` — bundles several component static abilities into **one** printed static ability
   whose single continuous effect spans multiple Rule 613 layers (CR 613.6). Use it when one printed ability grants a
   *combination* of type/subtype/color/keyword/P/T changes to the same objects — e.g. Bello, Bard of the Brambles: "each
@@ -5671,7 +5682,9 @@ staticAbility {
   [scope]" while this permanent is on the battlefield (Absolute Virtue: "You have protection from each
   of your opponents."). The continuous, static counterpart of the one-shot `GrantPlayerProtection`
   (The One Ring) — for a player only the **D**amage and **T**argeting legs of DEBT apply. Projected to
-  `GrantsControllerProtectionComponent(scopes)`; `PlayerProtectionRules.isProtectedFromSource` unions
+  `GrantsControllerProtectionComponent(grants)` — a list of `ProtectionGrant(scope, condition)`, gated
+  **per scope**, so one permanent can carry several of these abilities and wrap only some in a
+  `ConditionalStaticAbility`. `PlayerProtectionRules.isProtectedFromSource` unions
   these battlefield-sourced scopes with any one-shot `PlayerProtectionComponent` on the player, so the
   protection appears/disappears with the permanent (no cleanup). General over any `ProtectionScope`
   (single color, `Everything`, `EachOpponent`, …), mirroring the controller-grant statics

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.handlers.effects.LkiPolicy
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.handlers.effects.lkiPolicyFor
 import com.wingedsheep.engine.handlers.effects.lkiSnapshotFor
+import com.wingedsheep.engine.mechanics.ControllerGrants
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -1128,10 +1129,12 @@ class DynamicAmountEvaluator(
     ): Boolean {
         val projected = state.projectedState
         val controller = projected.getController(entityId) ?: fallbackControllerId ?: return false
+        // Scanned here rather than through ControllerGrants.grantedTo so the controller match
+        // stays on the *projected* controller, as it always has — a control-change effect
+        // re-points the grant. The gate still goes through ControllerGrants.
         return state.getBattlefield().any { permanentId ->
-            val perm = state.getEntity(permanentId) ?: return@any false
-            perm.has<GrantsStationUsingToughnessComponent>() &&
-                projected.getController(permanentId) == controller
+            projected.getController(permanentId) == controller &&
+                ControllerGrants.isActiveOn<GrantsStationUsingToughnessComponent>(state, permanentId)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -1127,15 +1127,10 @@ class DynamicAmountEvaluator(
         entityId: EntityId,
         fallbackControllerId: EntityId? = null
     ): Boolean {
-        val projected = state.projectedState
-        val controller = projected.getController(entityId) ?: fallbackControllerId ?: return false
-        // Scanned here rather than through ControllerGrants.grantedTo so the controller match
-        // stays on the *projected* controller, as it always has — a control-change effect
-        // re-points the grant. The gate still goes through ControllerGrants.
-        return state.getBattlefield().any { permanentId ->
-            projected.getController(permanentId) == controller &&
-                ControllerGrants.isActiveOn<GrantsStationUsingToughnessComponent>(state, permanentId)
-        }
+        val controller = state.projectedState.getController(entityId)
+            ?: fallbackControllerId
+            ?: return false
+        return ControllerGrants.grantedTo<GrantsStationUsingToughnessComponent>(state, controller)
     }
 
     // =========================================================================

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -4,12 +4,12 @@ import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOpponentAbilitiesComponent
-import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
-import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.mechanics.ControllerGrants
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.targeting.ControllerHexproof
+import com.wingedsheep.engine.mechanics.targeting.ControllerShroud
 import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
@@ -172,13 +172,10 @@ class TargetFinder(
         if (entityController == controllerId) return false  // own permanents are never restricted
         if (targetingSourceType == TargetingSourceType.SPELL) return false  // spells bypass this restriction
 
-        val container = state.getEntity(entityId) ?: return false
-        if (container.has<CantBeTargetedByOpponentAbilitiesComponent>()) {
-            // For ABILITY source type, always blocked
-            // For ANY (unknown), conservatively block since we don't know the source type
-            return true
-        }
-        return false
+        // For ABILITY source type, always blocked. For ANY (unknown), conservatively block since
+        // we don't know the source type. Read through ControllerGrants so a gated form of the
+        // ability switches off with its condition instead of sticking on.
+        return ControllerGrants.isActiveOn<CantBeTargetedByOpponentAbilitiesComponent>(state, entityId)
     }
 
     private fun findOpponentOrPlaneswalkerTargets(
@@ -568,22 +565,9 @@ class TargetFinder(
     /**
      * Check if a player has shroud (e.g., from True Believer's "You have shroud"
      * or Gilded Light's "You gain shroud until end of turn").
-     * A player has shroud if:
-     * - Any permanent on the battlefield controlled by that player has GrantsControllerShroudComponent, OR
-     * - The player entity has PlayerShroudComponent (from a spell effect)
      */
-    private fun playerHasShroud(state: GameState, playerId: EntityId): Boolean {
-        // Check for temporary player shroud (e.g., Gilded Light)
-        val playerEntity = state.getEntity(playerId)
-        if (playerEntity?.has<PlayerShroudComponent>() == true) return true
-
-        // Check for permanent-based shroud (e.g., True Believer)
-        return state.getBattlefield().any { entityId ->
-            val container = state.getEntity(entityId) ?: return@any false
-            container.get<GrantsControllerShroudComponent>() != null &&
-                container.get<ControllerComponent>()?.playerId == playerId
-        }
-    }
+    private fun playerHasShroud(state: GameState, playerId: EntityId): Boolean =
+        ControllerShroud.appliesTo(state, playerId)
 
     /**
      * Check if a player has hexproof (from a permanent like Shalai, Voice of Plenty).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawCardPrimitive.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawCardPrimitive.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.core.GameEvent
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
-import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
+import com.wingedsheep.engine.mechanics.sba.player.playerCantLoseGame
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.CardsDrawnThisTurnComponent
@@ -24,8 +24,7 @@ import com.wingedsheep.sdk.scripting.RevealFirstDrawEachTurn
  * [CardRevealedFromDrawEvent] if this is the first draw of the turn and the
  * player controls a permanent with [RevealFirstDrawEachTurn].
  *
- * Handles empty-library loss (Rule 704.5c) respecting
- * [GrantsCantLoseGameComponent] (Platinum Angel).
+ * Handles empty-library loss (Rule 704.5c) respecting [playerCantLoseGame] (Platinum Angel).
  *
  * Does **not** emit [com.wingedsheep.engine.core.CardsDrawnEvent] — the driver
  * aggregates drawn cards across multiple calls and emits a single
@@ -77,11 +76,9 @@ class DrawCardPrimitive(
         if (library.isEmpty()) {
             // Rule 704.5c: failed to draw from an empty library → lose the game,
             // unless a controlled permanent grants "can't lose the game" (Platinum Angel).
-            val cantLose = state.getBattlefield().any { entityId ->
-                val c = state.getEntity(entityId) ?: return@any false
-                c.has<GrantsCantLoseGameComponent>() &&
-                    c.get<ControllerComponent>()?.playerId == playerId
-            }
+            // Shared with the 704.5a/b checks so the gate on a conditional grant and the
+            // CR 810.8a team reach are applied identically wherever a player would lose.
+            val cantLose = playerCantLoseGame(state, playerId)
             val lostState = if (cantLose) {
                 state
             } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawCardPrimitive.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/drawing/DrawCardPrimitive.kt
@@ -24,7 +24,7 @@ import com.wingedsheep.sdk.scripting.RevealFirstDrawEachTurn
  * [CardRevealedFromDrawEvent] if this is the first draw of the turn and the
  * player controls a permanent with [RevealFirstDrawEachTurn].
  *
- * Handles empty-library loss (Rule 704.5c) respecting [playerCantLoseGame] (Platinum Angel).
+ * Handles empty-library loss (Rule 704.5b) respecting [playerCantLoseGame] (Platinum Angel).
  *
  * Does **not** emit [com.wingedsheep.engine.core.CardsDrawnEvent] — the driver
  * aggregates drawn cards across multiple calls and emits a single
@@ -74,9 +74,9 @@ class DrawCardPrimitive(
         val library = state.getZone(libraryZone)
 
         if (library.isEmpty()) {
-            // Rule 704.5c: failed to draw from an empty library → lose the game,
+            // Rule 704.5b: failed to draw from an empty library → lose the game,
             // unless a controlled permanent grants "can't lose the game" (Platinum Angel).
-            // Shared with the 704.5a/b checks so the gate on a conditional grant and the
+            // Shared with the other loss checks so the gate on a conditional grant and the
             // CR 810.8a team reach are applied identically wherever a player would lose.
             val cantLose = playerCantLoseGame(state, playerId)
             val lostState = if (cantLose) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/LoseGameExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/LoseGameExecutor.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.core.PlayerLostEvent
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
+import com.wingedsheep.engine.mechanics.sba.player.playerCantLoseGame
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.LossReason
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
@@ -36,13 +36,10 @@ class LoseGameExecutor : EffectExecutor<LoseGameEffect> {
             return EffectResult.success(state)
         }
 
-        // Check if player can't lose the game
-        val cantLose = state.getBattlefield().any { entityId ->
-            val c = state.getEntity(entityId) ?: return@any false
-            c.has<GrantsCantLoseGameComponent>() &&
-                c.get<ControllerComponent>()?.playerId == targetId
-        }
-        if (cantLose) {
+        // Check if player can't lose the game. Shared with the state-based-action checks so the
+        // gate on a conditional grant and the CR 810.8a team reach are applied identically
+        // wherever a player would lose.
+        if (playerCantLoseGame(state, targetId)) {
             return EffectResult.success(state)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -6,15 +6,14 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.legalactions.TargetInfo
 import com.wingedsheep.engine.mechanics.targeting.ControllerHexproof
+import com.wingedsheep.engine.mechanics.targeting.ControllerShroud
 import com.wingedsheep.engine.mechanics.targeting.HexproofSuppression
 import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
-import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
-import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -414,15 +413,8 @@ class TargetEnumerationUtils(
 
     // Player protection checks
 
-    fun playerHasShroud(state: GameState, playerId: EntityId): Boolean {
-        val playerEntity = state.getEntity(playerId)
-        if (playerEntity?.has<PlayerShroudComponent>() == true) return true
-        return state.getBattlefield().any { entityId ->
-            val container = state.getEntity(entityId) ?: return@any false
-            container.get<GrantsControllerShroudComponent>() != null &&
-                container.get<ControllerComponent>()?.playerId == playerId
-        }
-    }
+    fun playerHasShroud(state: GameState, playerId: EntityId): Boolean =
+        ControllerShroud.appliesTo(state, playerId)
 
     fun playerHasHexproof(state: GameState, playerId: EntityId): Boolean =
         ControllerHexproof.appliesTo(state, playerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ControllerGrants.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ControllerGrants.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.Component
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ControllerGrantMarker
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.conditions.Condition
+
+/**
+ * The single place a [ControllerGrantMarker]'s "as long as …" gate is evaluated.
+ *
+ * Player-level grants ("you have shroud", "you can't lose the game") sit outside the Rule 613
+ * layer system: `StaticAbilityHandler` stamps a marker component once, as the permanent enters,
+ * and readers scan the battlefield for it. A grant written behind a
+ * [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] therefore can't be resolved at stamp
+ * time — the gate flips later — so the condition rides on the marker and is re-evaluated here
+ * against current state on every read.
+ *
+ * Reading a gated marker with a bare `container.has<M>()` leaves the grant permanently on. Every
+ * reader goes through this object (or a mechanic-specific facade over it, like
+ * [com.wingedsheep.engine.mechanics.targeting.ControllerHexproof]) so that can't happen.
+ */
+object ControllerGrants {
+
+    private val conditionEvaluator = ConditionEvaluator()
+
+    /**
+     * Whether a gate held by the permanent [entityId] is satisfied right now. A `null` [condition]
+     * is an unconditional grant and is always active.
+     *
+     * The condition is evaluated with [entityId] as the source and its *projected* controller as
+     * "you", so a control-change effect (Layer 2) correctly re-points a "you control …" gate at
+     * the permanent's current controller.
+     */
+    fun isActive(state: GameState, entityId: EntityId, condition: Condition?): Boolean {
+        if (condition == null) return true
+        val controllerId = state.projectedState.getController(entityId)
+            ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
+            ?: return false
+        return conditionEvaluator.evaluate(
+            state,
+            condition,
+            EffectContext(sourceId = entityId, controllerId = controllerId),
+        )
+    }
+
+    /** Whether [marker], carried by [entityId], is granting right now. */
+    fun isGrantingNow(state: GameState, entityId: EntityId, marker: ControllerGrantMarker): Boolean =
+        isActive(state, entityId, marker.condition)
+
+    /**
+     * Whether any permanent on the battlefield currently grants [M] and has a controller
+     * satisfying [controllerMatches].
+     *
+     * [controllerMatches] takes the controller rather than being a plain player id so callers can
+     * widen the scope — the CR 810.8a team reach on "can't lose the game", for one, matches any
+     * teammate rather than one player.
+     */
+    inline fun <reified M> anyGranting(
+        state: GameState,
+        crossinline controllerMatches: (EntityId) -> Boolean,
+    ): Boolean where M : Component, M : ControllerGrantMarker =
+        state.getBattlefield().any { entityId ->
+            val container = state.getEntity(entityId) ?: return@any false
+            val marker = container.get<M>() ?: return@any false
+            val controllerId = container.get<ControllerComponent>()?.playerId ?: return@any false
+            controllerMatches(controllerId) && isGrantingNow(state, entityId, marker)
+        }
+
+    /** Whether [playerId] controls a permanent currently granting [M]. */
+    inline fun <reified M> grantedTo(
+        state: GameState,
+        playerId: EntityId,
+    ): Boolean where M : Component, M : ControllerGrantMarker =
+        anyGranting<M>(state) { it == playerId }
+
+    /**
+     * Whether the permanent [entityId] itself carries [M] and its gate holds right now — for the
+     * self-scoped markers, where the effect lands on the permanent rather than on its controller
+     * ([com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOpponentAbilitiesComponent]).
+     */
+    inline fun <reified M> isActiveOn(
+        state: GameState,
+        entityId: EntityId,
+    ): Boolean where M : Component, M : ControllerGrantMarker {
+        val marker = state.getEntity(entityId)?.get<M>() ?: return false
+        return isGrantingNow(state, entityId, marker)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ControllerGrants.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/ControllerGrants.kt
@@ -52,6 +52,16 @@ object ControllerGrants {
         isActive(state, entityId, marker.condition)
 
     /**
+     * Who [entityId] currently grants to — its projected controller, since control change is a
+     * Layer 2 floating effect that never writes back to [ControllerComponent]. Reading the base
+     * component instead would leave a stolen Sigarda protecting the player it was taken from, and
+     * would disagree with [isActive], which resolves "you" the same way when evaluating the gate.
+     */
+    fun granterController(state: GameState, entityId: EntityId): EntityId? =
+        state.projectedState.getController(entityId)
+            ?: state.getEntity(entityId)?.get<ControllerComponent>()?.playerId
+
+    /**
      * Whether any permanent on the battlefield currently grants [M] and has a controller
      * satisfying [controllerMatches].
      *
@@ -66,7 +76,7 @@ object ControllerGrants {
         state.getBattlefield().any { entityId ->
             val container = state.getEntity(entityId) ?: return@any false
             val marker = container.get<M>() ?: return@any false
-            val controllerId = container.get<ControllerComponent>()?.playerId ?: return@any false
+            val controllerId = granterController(state, entityId) ?: return@any false
             controllerMatches(controllerId) && isGrantingNow(state, entityId, marker)
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SacrificeImmunity.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/SacrificeImmunity.kt
@@ -2,7 +2,6 @@ package com.wingedsheep.engine.mechanics
 
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.GrantsSacrificeImmunityComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.model.EntityId
 
 /**
@@ -40,10 +39,6 @@ object SacrificeImmunity {
     ): Boolean {
         if (effectControllerId == null || effectControllerId == sacrificingPlayerId) return false
         if (effectControllerId !in state.getOpponents(sacrificingPlayerId)) return false
-        return state.getBattlefield().any { entityId ->
-            val container = state.getEntity(entityId) ?: return@any false
-            container.has<GrantsSacrificeImmunityComponent>() &&
-                container.get<ControllerComponent>()?.playerId == sacrificingPlayerId
-        }
+        return ControllerGrants.grantedTo<GrantsSacrificeImmunityComponent>(state, sacrificingPlayerId)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexpr
 import com.wingedsheep.engine.state.components.battlefield.GrantsSacrificeImmunityComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerProtectionComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsStationUsingToughnessComponent
+import com.wingedsheep.engine.state.components.battlefield.ProtectionGrant
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
 import com.wingedsheep.engine.state.components.battlefield.SuppressesHexproofForGroupComponent
@@ -75,9 +76,12 @@ import com.wingedsheep.sdk.scripting.CantBeTargetedBySourceTypeAbilities
 import com.wingedsheep.sdk.scripting.CantBeTargetedByOpponentAbilities
 import com.wingedsheep.sdk.scripting.CantBeSacrificed
 import com.wingedsheep.sdk.scripting.CantReceiveCounters
+import com.wingedsheep.sdk.scripting.GrantCantLoseGameFromLife
 import com.wingedsheep.sdk.scripting.GrantHexproofToController
+import com.wingedsheep.sdk.scripting.GrantOpponentsCantWinGame
 import com.wingedsheep.sdk.scripting.GrantProtectionToController
 import com.wingedsheep.sdk.scripting.GrantShroudToController
+import com.wingedsheep.sdk.scripting.OpponentsCantMakeYouSacrifice
 import com.wingedsheep.sdk.scripting.StationUsingToughness
 import com.wingedsheep.sdk.scripting.AdditionalAttackTriggers
 import com.wingedsheep.sdk.scripting.AdditionalDeathTriggers
@@ -242,51 +246,43 @@ class StaticAbilityHandler(
             result = result.with(ContinuousEffectSourceComponent(effectsData))
         }
 
-        // Add tag component for abilities that grant controller-level effects
-        if (allStaticAbilities.any { it is GrantShroudToController }) {
-            result = result.with(GrantsControllerShroudComponent)
+        // Marker components for the grants that live outside the layer system (see
+        // [ControllerGrantMarker]). Every one of these goes through controllerGrant<A>(), which
+        // matches the ability bare *or* behind an "as long as …" gate and carries the condition
+        // onto the marker for readers to re-evaluate. A bare `any { it is A }` here would make a
+        // gated grant silently inert.
+        allStaticAbilities.controllerGrant<GrantShroudToController>()?.let {
+            result = result.with(GrantsControllerShroudComponent(it.condition))
         }
-        // "You have hexproof", bare or behind an "as long as …" gate (Captain America,
-        // Super-Soldier). The gate rides along on the marker so every reader re-evaluates it
-        // against current state — see [ControllerHexproof].
         allStaticAbilities.controllerGrant<GrantHexproofToController>()?.let {
             result = result.with(GrantsControllerHexproofComponent(it.condition))
         }
-        val controllerProtectionScopes = allStaticAbilities
-            .filterIsInstance<GrantProtectionToController>()
-            .map { it.scope }
-        if (controllerProtectionScopes.isNotEmpty()) {
-            result = result.with(GrantsControllerProtectionComponent(controllerProtectionScopes))
+        allStaticAbilities.controllerGrant<OpponentsCantMakeYouSacrifice>()?.let {
+            result = result.with(GrantsSacrificeImmunityComponent(it.condition))
+        }
+        allStaticAbilities.controllerGrant<GrantCantLoseGame>()?.let {
+            result = result.with(GrantsCantLoseGameComponent(it.condition))
+        }
+        allStaticAbilities.controllerGrant<GrantOpponentsCantWinGame>()?.let {
+            result = result.with(GrantsOpponentsCantWinGameComponent(it.condition))
+        }
+        allStaticAbilities.controllerGrant<GrantCantLoseGameFromLife>()?.let {
+            result = result.with(GrantsCantLoseGameFromLifeComponent(it.condition))
+        }
+        allStaticAbilities.controllerGrant<StationUsingToughness>()?.let {
+            result = result.with(GrantsStationUsingToughnessComponent(it.condition))
+        }
+        allStaticAbilities.controllerGrant<CantBeTargetedByOpponentAbilities>()?.let {
+            result = result.with(CantBeTargetedByOpponentAbilitiesComponent(it.condition))
         }
 
-        // Add tag component for "opponents' spells and abilities can't make you sacrifice"
-        if (allStaticAbilities.any { it is com.wingedsheep.sdk.scripting.OpponentsCantMakeYouSacrifice }) {
-            result = result.with(GrantsSacrificeImmunityComponent)
-        }
-
-        // Add tag component for "you can't lose the game"
-        if (allStaticAbilities.any { it is com.wingedsheep.sdk.scripting.GrantCantLoseGame }) {
-            result = result.with(GrantsCantLoseGameComponent)
-        }
-
-        // Add tag component for "your opponents can't win the game" (Herald of Eternal Dawn)
-        if (allStaticAbilities.any { it is com.wingedsheep.sdk.scripting.GrantOpponentsCantWinGame }) {
-            result = result.with(GrantsOpponentsCantWinGameComponent)
-        }
-
-        // Add tag component for the narrow "you don't lose for 0 or less life" (Marina's Grimoire)
-        if (allStaticAbilities.any { it is com.wingedsheep.sdk.scripting.GrantCantLoseGameFromLife }) {
-            result = result.with(GrantsCantLoseGameFromLifeComponent)
-        }
-
-        // Add tag component for "station using toughness"
-        if (allStaticAbilities.any { it is StationUsingToughness }) {
-            result = result.with(GrantsStationUsingToughnessComponent)
-        }
-
-        // Add tag component for "can't be the target of abilities your opponents control"
-        if (allStaticAbilities.any { it is CantBeTargetedByOpponentAbilities }) {
-            result = result.with(CantBeTargetedByOpponentAbilitiesComponent)
+        // Player-level protection is the one grant gated *per scope* rather than per permanent: a
+        // card may carry several GrantProtectionToController abilities and gate them
+        // independently, so each keeps its own condition rather than collapsing to one marker.
+        val protectionGrants = allStaticAbilities.controllerGrants<GrantProtectionToController>()
+            .map { (ability, condition) -> ProtectionGrant(ability.scope, condition) }
+        if (protectionGrants.isNotEmpty()) {
+            result = result.with(GrantsControllerProtectionComponent(protectionGrants))
         }
 
         // Add component for the power/toughness-gated evasion (Tetsuko Umezawa's "creatures you
@@ -357,13 +353,12 @@ class StaticAbilityHandler(
      *
      * A bare grant wins over a gated one if a card somehow carries both, and only the first gated
      * grant is taken — no printed card has two, and a second would need a different condition to
-     * mean anything.
+     * mean anything. Use [controllerGrants] instead for the grants where a card legitimately
+     * carries several, each with its own gate.
      *
-     * Only the hexproof marker carries a condition today. The sibling grants below it
-     * ([GrantShroudToController], [GrantProtectionToController], `OpponentsCantMakeYouSacrifice`,
-     * `GrantCantLoseGame`, …) still match the bare type only, so wrapping one of *those* in a
-     * `ConditionalStaticAbility` reproduces the same silent no-op. Route them through here and give
-     * their marker components a `condition` when a card first needs it.
+     * **Every** [com.wingedsheep.engine.state.components.battlefield.ControllerGrantMarker] is
+     * stamped through this helper (or [controllerGrants]); `ConditionalControllerGrantsTest` fails
+     * the build if a new one regresses to a bare type check.
      */
     private inline fun <reified A : StaticAbility> List<StaticAbility>.controllerGrant(): ControllerGrant? =
         when {
@@ -371,6 +366,23 @@ class StaticAbilityHandler(
             else -> filterIsInstance<ConditionalStaticAbility>()
                 .firstOrNull { it.ability is A }
                 ?.let { ControllerGrant(it.condition) }
+        }
+
+    /**
+     * Every static ability of type [A] the permanent carries, each paired with the gate it sits
+     * behind (`null` when written bare) — the many-per-card counterpart of [controllerGrant], for
+     * grants that stack rather than collapsing into a single marker
+     * ([GrantProtectionToController]: "you have protection from red, and from blue as long as you
+     * control an Island" is two abilities with two different gates).
+     */
+    private inline fun <reified A : StaticAbility> List<StaticAbility>.controllerGrants(): List<Pair<A, Condition?>> =
+        mapNotNull { ability ->
+            when {
+                ability is A -> ability to null
+                ability is ConditionalStaticAbility ->
+                    (ability.ability as? A)?.let { it to ability.condition }
+                else -> null
+            }
         }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
@@ -3,13 +3,13 @@ package com.wingedsheep.engine.mechanics.sba.player
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.GameEndReason
 import com.wingedsheep.engine.core.PlayerLostEvent
+import com.wingedsheep.engine.mechanics.ControllerGrants
 import com.wingedsheep.engine.mechanics.sba.SbaOrder
 import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameFromLifeComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsOpponentsCantWinGameComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.player.LossReason
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
@@ -58,11 +58,7 @@ internal fun playerCantLoseGame(state: GameState, playerId: EntityId): Boolean {
     // games the grant protects only its own controller.
     val team = (if (state.format.playersWinLoseAsTeam) state.teamOf(playerId) else listOf(playerId))
         .toHashSet()
-    return state.getBattlefield().any { entityId ->
-        val container = state.getEntity(entityId) ?: return@any false
-        container.has<GrantsCantLoseGameComponent>() &&
-            container.get<ControllerComponent>()?.playerId in team
-    }
+    return ControllerGrants.anyGranting<GrantsCantLoseGameComponent>(state) { it in team }
 }
 
 /**
@@ -72,11 +68,7 @@ internal fun playerCantLoseGame(state: GameState, playerId: EntityId): Boolean {
  * to the controller itself — it is not a team-wide "can't lose" grant.
  */
 internal fun playerCantLoseGameFromLife(state: GameState, playerId: EntityId): Boolean =
-    state.getBattlefield().any { entityId ->
-        val container = state.getEntity(entityId) ?: return@any false
-        container.has<GrantsCantLoseGameFromLifeComponent>() &&
-            container.get<ControllerComponent>()?.playerId == playerId
-    }
+    ControllerGrants.grantedTo<GrantsCantLoseGameFromLifeComponent>(state, playerId)
 
 /**
  * True when [playerId] can't win the game because one of its opponents controls a permanent
@@ -86,9 +78,5 @@ internal fun playerCantLoseGameFromLife(state: GameState, playerId: EntityId): B
  */
 internal fun playerCantWinGame(state: GameState, playerId: EntityId): Boolean {
     val opponents = state.getOpponents(playerId).toHashSet()
-    return state.getBattlefield().any { entityId ->
-        val container = state.getEntity(entityId) ?: return@any false
-        container.has<GrantsOpponentsCantWinGameComponent>() &&
-            container.get<ControllerComponent>()?.playerId in opponents
-    }
+    return ControllerGrants.anyGranting<GrantsOpponentsCantWinGameComponent>(state) { it in opponents }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.EffectHandler
 import com.wingedsheep.engine.handlers.effects.composite.PreTargetedEffectContext
 import com.wingedsheep.engine.handlers.effects.composite.processPreTargetedEffectQueue
+import com.wingedsheep.engine.mechanics.ControllerGrants
 import com.wingedsheep.engine.mechanics.FlashbackGrants
 import com.wingedsheep.engine.mechanics.HarmonizeGrants
 import com.wingedsheep.engine.mechanics.SpliceCasts
@@ -3289,8 +3290,11 @@ class StackResolver(
 
                     // Check can't-be-targeted-by-abilities (Shanna, Sisay's Legacy)
                     if (targetingSourceType != TargetingSourceType.SPELL && entityController != controllerId) {
-                        val container = state.getEntity(target.entityId)
-                        if (container?.has<CantBeTargetedByOpponentAbilitiesComponent>() == true) {
+                        if (ControllerGrants.isActiveOn<CantBeTargetedByOpponentAbilitiesComponent>(
+                                state,
+                                target.entityId,
+                            )
+                        ) {
                             return@filterIndexed false
                         }
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/ControllerHexproof.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/ControllerHexproof.kt
@@ -12,8 +12,9 @@ import com.wingedsheep.sdk.model.EntityId
  *
  * Single home for the question so the four readers that ask it — [TargetValidator],
  * `TargetEnumerationUtils`, `TargetFinder` and `ClientStateTransformer` — can't drift. They had
- * four copies of the same battlefield scan, and a gated grant would otherwise have had to be
- * special-cased in each.
+ * four copies of the same battlefield scan, each matching on the base `ControllerComponent` (so a
+ * stolen granter kept protecting the player it was taken from), and a gated grant would otherwise
+ * have had to be special-cased in each.
  *
  * The gate is the reason this exists rather than a bare component check.
  * [GrantsControllerHexproofComponent] is stamped once by `StaticAbilityHandler` as the permanent
@@ -23,15 +24,6 @@ import com.wingedsheep.sdk.model.EntityId
  * component and is evaluated here, against current state, on every read.
  */
 object ControllerHexproof {
-
-    /**
-     * Whether [entityId] is *currently* granting hexproof to its controller — it carries the
-     * marker, and either the grant is unconditional or its "as long as" gate holds right now.
-     */
-    fun isGrantingNow(state: GameState, entityId: EntityId): Boolean {
-        val marker = state.getEntity(entityId)?.get<GrantsControllerHexproofComponent>() ?: return false
-        return ControllerGrants.isGrantingNow(state, entityId, marker)
-    }
 
     /**
      * Whether [playerId] has hexproof — either directly ([PlayerHexproofComponent], from a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/ControllerHexproof.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/ControllerHexproof.kt
@@ -1,10 +1,8 @@
 package com.wingedsheep.engine.mechanics.targeting
 
-import com.wingedsheep.engine.handlers.ConditionEvaluator
-import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.mechanics.ControllerGrants
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexproofComponent
-import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
 import com.wingedsheep.sdk.model.EntityId
 
@@ -26,24 +24,13 @@ import com.wingedsheep.sdk.model.EntityId
  */
 object ControllerHexproof {
 
-    private val conditionEvaluator = ConditionEvaluator()
-
     /**
      * Whether [entityId] is *currently* granting hexproof to its controller — it carries the
      * marker, and either the grant is unconditional or its "as long as" gate holds right now.
      */
     fun isGrantingNow(state: GameState, entityId: EntityId): Boolean {
-        val container = state.getEntity(entityId) ?: return false
-        val marker = container.get<GrantsControllerHexproofComponent>() ?: return false
-        val condition = marker.condition ?: return true
-        val controllerId = state.projectedState.getController(entityId)
-            ?: container.get<ControllerComponent>()?.playerId
-            ?: return false
-        return conditionEvaluator.evaluate(
-            state,
-            condition,
-            EffectContext(sourceId = entityId, controllerId = controllerId),
-        )
+        val marker = state.getEntity(entityId)?.get<GrantsControllerHexproofComponent>() ?: return false
+        return ControllerGrants.isGrantingNow(state, entityId, marker)
     }
 
     /**
@@ -56,12 +43,7 @@ object ControllerHexproof {
      */
     fun appliesTo(state: GameState, playerId: EntityId): Boolean {
         if (state.getEntity(playerId)?.has<PlayerHexproofComponent>() == true) return true
-
-        return state.getBattlefield().any { entityId ->
-            val container = state.getEntity(entityId) ?: return@any false
-            container.get<ControllerComponent>()?.playerId == playerId &&
-                isGrantingNow(state, entityId)
-        }
+        return ControllerGrants.grantedTo<GrantsControllerHexproofComponent>(state, playerId)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/ControllerShroud.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/ControllerShroud.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.engine.mechanics.targeting
+
+import com.wingedsheep.engine.mechanics.ControllerGrants
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
+import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Player-level shroud granted by a permanent ("You have shroud" — True Believer).
+ *
+ * The shroud counterpart of [ControllerHexproof], and it exists for the same two reasons. First,
+ * three readers — [TargetValidator], `TargetEnumerationUtils` and `TargetFinder` — each held their
+ * own copy of the same battlefield scan and could drift apart. Second, and load-bearing: the grant
+ * can be gated. [GrantsControllerShroudComponent] is stamped once by `StaticAbilityHandler` as the
+ * permanent enters, so an "as long as …" wrapper can't be resolved at stamp time; the condition
+ * travels on the marker and is re-evaluated here, against current state, on every read.
+ *
+ * Shroud is stricter than hexproof: it stops the controller's *own* spells and abilities too
+ * (CR 702.18), so there is no `appliesAgainst` counterpart — the caster is irrelevant.
+ */
+object ControllerShroud {
+
+    /**
+     * Whether [playerId] has shroud — either directly ([PlayerShroudComponent], from a
+     * resolution-time effect like Gilded Light) or from a permanent they control that grants it.
+     */
+    fun appliesTo(state: GameState, playerId: EntityId): Boolean {
+        if (state.getEntity(playerId)?.has<PlayerShroudComponent>() == true) return true
+        return ControllerGrants.grantedTo<GrantsControllerShroudComponent>(state, playerId)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerProtectionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerProtectionRules.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.mechanics.targeting
 
+import com.wingedsheep.engine.mechanics.ControllerGrants
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerProtectionComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
@@ -41,8 +42,13 @@ object PlayerProtectionRules {
         return state.getBattlefield().any { entityId ->
             val container = state.getEntity(entityId) ?: return@any false
             if (container.get<ControllerComponent>()?.playerId != playerId) return@any false
-            container.get<GrantsControllerProtectionComponent>()?.scopes
-                ?.any { scopeMatchesSource(state, playerId, it, sourceId, casterId) } == true
+            container.get<GrantsControllerProtectionComponent>()?.grants
+                // Each scope carries its own "as long as …" gate, re-evaluated here on every read
+                // because the marker was stamped once, on entry — see [ControllerGrantMarker].
+                ?.any {
+                    ControllerGrants.isActive(state, entityId, it.condition) &&
+                        scopeMatchesSource(state, playerId, it.scope, sourceId, casterId)
+                } == true
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerProtectionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerProtectionRules.kt
@@ -41,7 +41,9 @@ object PlayerProtectionRules {
 
         return state.getBattlefield().any { entityId ->
             val container = state.getEntity(entityId) ?: return@any false
-            if (container.get<ControllerComponent>()?.playerId != playerId) return@any false
+            // Projected controller: a stolen Absolute Virtue protects its thief, not the player it
+            // was taken from — see [ControllerGrants.granterController].
+            if (ControllerGrants.granterController(state, entityId) != playerId) return@any false
             container.get<GrantsControllerProtectionComponent>()?.grants
                 // Each scope carries its own "as long as …" gate, re-evaluated here on every read
                 // because the marker was stamped once, on entry — see [ControllerGrantMarker].

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -8,9 +8,6 @@ import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.TargetingSourceType
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
-import com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOpponentAbilitiesComponent
-import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
-import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
@@ -987,16 +984,8 @@ class TargetValidator {
      * Check if a player has shroud (e.g., from True Believer's "You have shroud"
      * or Gilded Light's "You gain shroud until end of turn").
      */
-    private fun playerHasShroud(state: GameState, playerId: EntityId): Boolean {
-        val playerEntity = state.getEntity(playerId)
-        if (playerEntity?.has<PlayerShroudComponent>() == true) return true
-
-        return state.getBattlefield().any { entityId ->
-            val container = state.getEntity(entityId) ?: return@any false
-            container.get<GrantsControllerShroudComponent>() != null &&
-                container.get<ControllerComponent>()?.playerId == playerId
-        }
-    }
+    private fun playerHasShroud(state: GameState, playerId: EntityId): Boolean =
+        ControllerShroud.appliesTo(state, playerId)
 
     private fun playerHasHexproof(state: GameState, playerId: EntityId): Boolean =
         ControllerHexproof.appliesTo(state, playerId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -5,7 +5,9 @@ import com.wingedsheep.engine.state.Component
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ProtectionScope
 import com.wingedsheep.sdk.scripting.ReplacementEffect
+import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import kotlinx.serialization.Serializable
 
@@ -874,12 +876,48 @@ data class GraveyardPlayPermissionUsedComponent(
 }
 
 /**
+ * A marker component stamped on a permanent from one of its static abilities, carrying that
+ * ability's "as long as …" gate. Almost all of these hand a *player-level* effect to the
+ * permanent's controller — "you have shroud", "you can't lose the game", "opponents can't make you
+ * sacrifice"; [CantBeTargetedByOpponentAbilitiesComponent] is the self-scoped exception.
+ *
+ * These grants are deliberately outside the Rule 613 layer system: they are stamped **once**, by
+ * `StaticAbilityHandler` as the permanent enters, and readers later scan the battlefield for the
+ * marker rather than re-deriving it each projection pass.
+ *
+ * That stamp-once design is exactly why [condition] exists. A grant written behind an "as long as
+ * …" gate ([com.wingedsheep.sdk.scripting.ConditionalStaticAbility]) cannot be resolved at stamp
+ * time — the gate flips later in the game — so the condition rides along on the marker and is
+ * re-evaluated against current state on **every** read, via
+ * [com.wingedsheep.engine.mechanics.ControllerGrants]. `null` means an unconditional grant.
+ *
+ * Two rules for anything implementing this interface:
+ *  1. Stamp it through `StaticAbilityHandler.controllerGrant<A>()`, never a bare `any { it is A }`
+ *     — a bare type check misses a `ConditionalStaticAbility` wrapper, and the ability then does
+ *     nothing *at all* rather than switching on and off. That silent no-op is the bug this
+ *     interface exists to make unrepresentable.
+ *  2. Read it through [com.wingedsheep.engine.mechanics.ControllerGrants], never a bare
+ *     `container.has<M>()` — the latter ignores the gate and leaves the grant permanently on.
+ *
+ * `ConditionalControllerGrantsTest` holds every implementor to both rules.
+ */
+interface ControllerGrantMarker {
+    /** The "as long as …" gate this grant sits behind, or `null` when it is unconditional. */
+    val condition: Condition?
+}
+
+/**
  * Marks a permanent as granting shroud to its controller.
  * Used for True Believer: "You have shroud."
  * When the permanent leaves the battlefield, the component goes with it — no cleanup needed.
+ *
+ * See [ControllerGrantMarker] for why [condition] travels on the marker; read through
+ * [com.wingedsheep.engine.mechanics.targeting.ControllerShroud].
  */
 @Serializable
-data object GrantsControllerShroudComponent : Component
+data class GrantsControllerShroudComponent(
+    override val condition: Condition? = null
+) : Component, ControllerGrantMarker
 
 /**
  * Marks a permanent as granting hexproof to its controller.
@@ -889,16 +927,14 @@ data object GrantsControllerShroudComponent : Component
  *
  * [condition] is set when the grant is gated behind a
  * [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] ("As long as Captain America has a
- * shield counter on him, you … have hexproof"). The marker is stamped once, as the permanent
- * enters, so the gate **must** be re-evaluated on every read rather than baked in here — otherwise
- * the grant would freeze at whatever the condition said on entry. Every reader goes through
- * [com.wingedsheep.engine.mechanics.targeting.ControllerHexproof], which does exactly that; `null`
- * means an unconditional grant.
+ * shield counter on him, you … have hexproof"). See [ControllerGrantMarker] for why it travels on
+ * the marker; every reader goes through
+ * [com.wingedsheep.engine.mechanics.targeting.ControllerHexproof].
  */
 @Serializable
 data class GrantsControllerHexproofComponent(
-    val condition: com.wingedsheep.sdk.scripting.conditions.Condition? = null
-) : Component
+    override val condition: Condition? = null
+) : Component, ControllerGrantMarker
 
 /**
  * Marks a permanent as granting its controller player-level protection from one or more
@@ -909,11 +945,28 @@ data class GrantsControllerHexproofComponent(
  * read by [com.wingedsheep.engine.mechanics.targeting.PlayerProtectionRules], which scans the
  * battlefield for permanents carrying this component under the queried player's control. When the
  * permanent leaves the battlefield the component goes with it — no cleanup needed.
+ *
+ * The gate is **per scope**, not per component: one permanent can carry several
+ * `GrantProtectionToController` abilities and gate them independently ("you have protection from
+ * red" unconditionally, "and from blue as long as you control an Island"). That is why this is a
+ * list of [ProtectionGrant] rather than a [ControllerGrantMarker] with one condition — see that
+ * interface for the stamp-once reasoning the gate exists to work around.
  */
 @Serializable
 data class GrantsControllerProtectionComponent(
-    val scopes: List<com.wingedsheep.sdk.scripting.ProtectionScope>
+    val grants: List<ProtectionGrant>
 ) : Component
+
+/**
+ * One player-level protection scope, together with the "as long as …" gate it sits behind
+ * (`null` when unconditional). Evaluated on every read by
+ * [com.wingedsheep.engine.mechanics.targeting.PlayerProtectionRules].
+ */
+@Serializable
+data class ProtectionGrant(
+    val scope: ProtectionScope,
+    val condition: Condition? = null
+)
 
 /**
  * Marks a permanent as granting "spells and abilities your opponents control can't cause you to
@@ -923,17 +976,26 @@ data class GrantsControllerProtectionComponent(
  * [com.wingedsheep.engine.mechanics.SacrificeImmunity], which every sacrifice site consults
  * before moving a permanent to the graveyard. When the permanent leaves the battlefield the
  * component goes with it — no cleanup needed.
+ *
+ * See [ControllerGrantMarker] for why [condition] travels on the marker.
  */
 @Serializable
-data object GrantsSacrificeImmunityComponent : Component
+data class GrantsSacrificeImmunityComponent(
+    override val condition: Condition? = null
+) : Component, ControllerGrantMarker
 
 /**
  * Marks a permanent as granting "can't lose the game" to its controller.
  * Used for Lich's Mastery: "You can't lose the game."
  * When the permanent leaves the battlefield, the component goes with it — no cleanup needed.
+ *
+ * See [ControllerGrantMarker] for why [condition] travels on the marker; read through
+ * `playerCantLoseGame`, which also applies the CR 810.8a team reach.
  */
 @Serializable
-data object GrantsCantLoseGameComponent : Component
+data class GrantsCantLoseGameComponent(
+    override val condition: Condition? = null
+) : Component, ControllerGrantMarker
 
 /**
  * Marks a permanent as granting "your opponents can't win the game" from its controller.
@@ -942,18 +1004,26 @@ data object GrantsCantLoseGameComponent : Component
  * [com.wingedsheep.engine.mechanics.sba.player.playerCantWinGame]): an effect that would make an
  * opponent of this permanent's controller win the game does nothing.
  * When the permanent leaves the battlefield, the component goes with it — no cleanup needed.
+ *
+ * See [ControllerGrantMarker] for why [condition] travels on the marker.
  */
 @Serializable
-data object GrantsOpponentsCantWinGameComponent : Component
+data class GrantsOpponentsCantWinGameComponent(
+    override val condition: Condition? = null
+) : Component, ControllerGrantMarker
 
 /**
  * Marks a permanent as granting "you don't lose the game for having 0 or less life" to its
  * controller — the narrow sibling of [GrantsCantLoseGameComponent]. Read only by the 704.5a
  * life-loss state-based action (Marina Vendrell's Grimoire); poison / empty-library / effect
  * losses are unaffected. Leaves with the permanent — no cleanup needed.
+ *
+ * See [ControllerGrantMarker] for why [condition] travels on the marker.
  */
 @Serializable
-data object GrantsCantLoseGameFromLifeComponent : Component
+data class GrantsCantLoseGameFromLifeComponent(
+    override val condition: Condition? = null
+) : Component, ControllerGrantMarker
 
 /**
  * Marks a permanent as granting the Station-using-toughness effect to creatures its
@@ -961,17 +1031,29 @@ data object GrantsCantLoseGameFromLifeComponent : Component
  * Station ability and its toughness > power, it contributes toughness instead of power.
  *
  * Created by [StaticAbilityHandler] from [StationUsingToughness] static abilities.
+ *
+ * See [ControllerGrantMarker] for why [condition] travels on the marker.
  */
 @Serializable
-data object GrantsStationUsingToughnessComponent : Component
+data class GrantsStationUsingToughnessComponent(
+    override val condition: Condition? = null
+) : Component, ControllerGrantMarker
 
 /**
  * Marks a permanent as unable to be targeted by abilities opponents control.
  * Unlike hexproof, spells can still target this permanent.
  * Used for Shanna, Sisay's Legacy: "Shanna can't be the target of abilities your opponents control."
+ *
+ * The self-scoped outlier among [ControllerGrantMarker]s — the effect lands on this permanent
+ * rather than on its controller. It implements the interface anyway because the hazard is
+ * identical: stamped once on entry, so a gated form has to carry its condition here and be read
+ * through [com.wingedsheep.engine.mechanics.ControllerGrants.isActive] rather than a bare
+ * `has<…>()`. Readers pass this permanent's own id, not its controller's.
  */
 @Serializable
-data object CantBeTargetedByOpponentAbilitiesComponent : Component
+data class CantBeTargetedByOpponentAbilitiesComponent(
+    override val condition: Condition? = null
+) : Component, ControllerGrantMarker
 
 /**
  * Marks a permanent as granting "can't be blocked" to the creatures [affects] resolves to, while

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -45,6 +45,7 @@ import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.imageOverrideFor
 import com.wingedsheep.engine.mechanics.targeting.ControllerHexproof
+import com.wingedsheep.engine.mechanics.targeting.ControllerShroud
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.model.CardDefinition
 import kotlinx.serialization.json.JsonArray
@@ -2177,8 +2178,10 @@ class ClientStateTransformer(
             )
         }
 
-        // Check for PlayerShroudComponent (e.g., Gilded Light)
-        if (container.has<PlayerShroudComponent>()) {
+        // Shroud, from a resolution-time effect (Gilded Light) or from a permanent that grants it
+        // (True Believer). [ControllerShroud] unions the two and re-evaluates any "as long as …"
+        // gate the grant sits behind, so the badge tracks the gate instead of freezing on entry.
+        if (ControllerShroud.appliesTo(state, playerId)) {
             effects.add(
                 ClientPlayerEffect(
                     effectId = "player_shroud",
@@ -2224,25 +2227,11 @@ class ClientStateTransformer(
             )
         }
 
-        // Check for PlayerHexproofComponent (e.g., Dawn's Truce)
-        if (container.has<PlayerHexproofComponent>()) {
-            effects.add(
-                ClientPlayerEffect(
-                    effectId = "player_hexproof",
-                    name = "Hexproof",
-                    description = "You have hexproof (you can't be the target of spells or abilities your opponents control)",
-                    icon = "shield"
-                )
-            )
-        }
-
-        // Check for permanent-based player hexproof (e.g., Shalai, Voice of Plenty)
-        val hasHexproof = !container.has<PlayerHexproofComponent>() && state.getBattlefield().any { entityId ->
-            val entityContainer = state.getEntity(entityId) ?: return@any false
-            entityContainer.get<ControllerComponent>()?.playerId == playerId &&
-                ControllerHexproof.isGrantingNow(state, entityId)
-        }
-        if (hasHexproof) {
+        // Hexproof, from a resolution-time effect (Dawn's Truce) or from a permanent that grants it
+        // (Shalai, Voice of Plenty). Same union-and-re-evaluate as shroud above; this used to be
+        // two blocks, the second scanning the battlefield on the *base* controller so a stolen
+        // Shalai badged the wrong player.
+        if (ControllerHexproof.appliesTo(state, playerId)) {
             effects.add(
                 ClientPlayerEffect(
                     effectId = "player_hexproof",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ConditionalControllerGrantsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/layers/ConditionalControllerGrantsTest.kt
@@ -1,0 +1,319 @@
+package com.wingedsheep.engine.mechanics.layers
+
+import com.wingedsheep.engine.mechanics.ControllerGrants
+import com.wingedsheep.engine.mechanics.targeting.ControllerHexproof
+import com.wingedsheep.engine.mechanics.targeting.ControllerShroud
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOpponentAbilitiesComponent
+import com.wingedsheep.engine.state.components.battlefield.ControllerGrantMarker
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameFromLifeComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexproofComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsControllerProtectionComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsOpponentsCantWinGameComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsSacrificeImmunityComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsStationUsingToughnessComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CantBeTargetedByOpponentAbilities
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantCantLoseGame
+import com.wingedsheep.sdk.scripting.GrantCantLoseGameFromLife
+import com.wingedsheep.sdk.scripting.GrantHexproofToController
+import com.wingedsheep.sdk.scripting.GrantOpponentsCantWinGame
+import com.wingedsheep.sdk.scripting.GrantProtectionToController
+import com.wingedsheep.sdk.scripting.GrantShroudToController
+import com.wingedsheep.sdk.scripting.OpponentsCantMakeYouSacrifice
+import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.StationUsingToughness
+import com.wingedsheep.sdk.scripting.StaticAbility
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Every [ControllerGrantMarker] must survive being wrapped in a [ConditionalStaticAbility].
+ *
+ * These grants sit outside the Rule 613 layer system: `StaticAbilityHandler` stamps a marker
+ * component **once**, as the permanent enters, and readers later scan the battlefield for it.
+ * Because the stamp happens once, a gate can't be resolved at stamp time — it has to travel on the
+ * marker and be re-evaluated on every read.
+ *
+ * Two ways to get that wrong, and this file exists to fail the build on both:
+ *
+ *  1. **Stamping with a bare `any { it is A }`.** A wrapped ability is a `ConditionalStaticAbility`,
+ *     not an `A`, so the marker is never stamped and the ability does *nothing at all* — not
+ *     "always on", not "always off", simply absent. No compile error, no warning, and the obvious
+ *     half of a hand-written scenario test ("condition false → no grant") passes trivially. This is
+ *     the silent no-op that shipped for hexproof until Captain America, Super-Soldier hit it.
+ *  2. **Reading with a bare `container.has<M>()`.** The marker is stamped but the gate is ignored,
+ *     so the grant is stuck permanently on.
+ *
+ * `grantCases` is the roster. When you add a `ControllerGrantMarker`, add it here too — the
+ * roster-completeness test at the bottom fails if you don't.
+ */
+class ConditionalControllerGrantsTest : FunSpec({
+
+    val handler = StaticAbilityHandler(CardRegistry())
+    val player = EntityId.generate()
+
+    /** Cheap, easy-to-flip gate: "as long as this permanent has a shield counter on it". */
+    val gate: Condition = Conditions.SourceHasCounter(CounterTypeFilter.Named(Counters.SHIELD))
+
+    /**
+     * One marker under test: the SDK ability that produces it, and how to read the stamped
+     * component's gate back off a container ([conditionOf] returns `null` both when the marker is
+     * absent and when it carries no gate — [stamped] separates those two cases).
+     */
+    data class GrantCase(
+        val label: String,
+        val ability: StaticAbility,
+        val marker: Class<out ControllerGrantMarker>,
+        val stamped: (ComponentContainer) -> Boolean,
+        val conditionOf: (ComponentContainer) -> Condition?,
+    )
+
+    val grantCases = listOf(
+        GrantCase(
+            "GrantShroudToController", GrantShroudToController,
+            GrantsControllerShroudComponent::class.java,
+            { it.get<GrantsControllerShroudComponent>() != null },
+            { it.get<GrantsControllerShroudComponent>()?.condition },
+        ),
+        GrantCase(
+            "GrantHexproofToController", GrantHexproofToController,
+            GrantsControllerHexproofComponent::class.java,
+            { it.get<GrantsControllerHexproofComponent>() != null },
+            { it.get<GrantsControllerHexproofComponent>()?.condition },
+        ),
+        GrantCase(
+            "OpponentsCantMakeYouSacrifice", OpponentsCantMakeYouSacrifice,
+            GrantsSacrificeImmunityComponent::class.java,
+            { it.get<GrantsSacrificeImmunityComponent>() != null },
+            { it.get<GrantsSacrificeImmunityComponent>()?.condition },
+        ),
+        GrantCase(
+            "GrantCantLoseGame", GrantCantLoseGame,
+            GrantsCantLoseGameComponent::class.java,
+            { it.get<GrantsCantLoseGameComponent>() != null },
+            { it.get<GrantsCantLoseGameComponent>()?.condition },
+        ),
+        GrantCase(
+            "GrantOpponentsCantWinGame", GrantOpponentsCantWinGame,
+            GrantsOpponentsCantWinGameComponent::class.java,
+            { it.get<GrantsOpponentsCantWinGameComponent>() != null },
+            { it.get<GrantsOpponentsCantWinGameComponent>()?.condition },
+        ),
+        GrantCase(
+            "GrantCantLoseGameFromLife", GrantCantLoseGameFromLife,
+            GrantsCantLoseGameFromLifeComponent::class.java,
+            { it.get<GrantsCantLoseGameFromLifeComponent>() != null },
+            { it.get<GrantsCantLoseGameFromLifeComponent>()?.condition },
+        ),
+        GrantCase(
+            "StationUsingToughness", StationUsingToughness,
+            GrantsStationUsingToughnessComponent::class.java,
+            { it.get<GrantsStationUsingToughnessComponent>() != null },
+            { it.get<GrantsStationUsingToughnessComponent>()?.condition },
+        ),
+        GrantCase(
+            "CantBeTargetedByOpponentAbilities", CantBeTargetedByOpponentAbilities,
+            CantBeTargetedByOpponentAbilitiesComponent::class.java,
+            { it.get<CantBeTargetedByOpponentAbilitiesComponent>() != null },
+            { it.get<CantBeTargetedByOpponentAbilitiesComponent>()?.condition },
+        ),
+    )
+
+    fun cardWith(vararg statics: StaticAbility) = CardDefinition(
+        name = "Test Grant Source",
+        manaCost = ManaCost(emptyList()),
+        typeLine = TypeLine(cardTypes = setOf(CardType.CREATURE)),
+        creatureStats = CreatureStats(1, 1),
+        script = CardScript(staticAbilities = statics.toList()),
+    )
+
+    fun stamp(vararg statics: StaticAbility): ComponentContainer =
+        handler.addContinuousEffectComponent(ComponentContainer(), cardWith(*statics))
+
+    // =========================================================================
+    // Stamping — the silent no-op
+    // =========================================================================
+
+    context("a bare grant stamps its marker with no gate") {
+        grantCases.forEach { case ->
+            test(case.label) {
+                val container = stamp(case.ability)
+                withClue("marker must be stamped for the bare form") {
+                    case.stamped(container) shouldBe true
+                }
+                withClue("a bare grant is unconditional, so it carries no condition") {
+                    case.conditionOf(container) shouldBe null
+                }
+            }
+        }
+    }
+
+    context("a gated grant stamps its marker AND carries the gate") {
+        grantCases.forEach { case ->
+            test(case.label) {
+                val container = stamp(ConditionalStaticAbility(ability = case.ability, condition = gate))
+                withClue(
+                    "${case.label} wrapped in ConditionalStaticAbility stamped no marker — the " +
+                        "ability is silently inert. StaticAbilityHandler is matching the bare " +
+                        "type instead of going through controllerGrant<A>()."
+                ) {
+                    case.stamped(container) shouldBe true
+                }
+                withClue("the gate must travel on the marker so readers can re-evaluate it") {
+                    case.conditionOf(container) shouldBe gate
+                }
+            }
+        }
+    }
+
+    test("player-level protection gates per scope, not per permanent") {
+        // One permanent, two GrantProtectionToController abilities, only one of them gated —
+        // the reason this marker holds a list of ProtectionGrant rather than one condition.
+        val container = stamp(
+            GrantProtectionToController(ProtectionScope.EachOpponent),
+            ConditionalStaticAbility(
+                ability = GrantProtectionToController(ProtectionScope.Everything),
+                condition = gate,
+            ),
+        )
+        val grants = container.get<GrantsControllerProtectionComponent>()?.grants
+        grants.shouldNotBeNull()
+        withClue("both abilities must be stamped, gated or not") { grants.size shouldBe 2 }
+        grants.single { it.scope == ProtectionScope.EachOpponent }.condition shouldBe null
+        grants.single { it.scope == ProtectionScope.Everything }.condition shouldBe gate
+    }
+
+    // =========================================================================
+    // Reading — the gate has to actually flip
+    // =========================================================================
+
+    /** A battlefield holding one permanent controlled by [player], carrying [components]. */
+    fun battlefieldWith(
+        permanentId: EntityId,
+        container: ComponentContainer,
+        shieldCounters: Int,
+    ): GameState {
+        var withCounters = container
+            .with(
+                CardComponent(
+                    cardDefinitionId = "Test Grant Source",
+                    name = "Test Grant Source",
+                    manaCost = ManaCost(emptyList()),
+                    typeLine = TypeLine(cardTypes = setOf(CardType.CREATURE)),
+                    ownerId = player,
+                    baseStats = CreatureStats(1, 1),
+                )
+            )
+            .with(OwnerComponent(player))
+            .with(ControllerComponent(player))
+        if (shieldCounters > 0) {
+            withCounters = withCounters.with(
+                CountersComponent(mapOf(CounterType.SHIELD to shieldCounters))
+            )
+        }
+        return GameState()
+            .withEntity(player, ComponentContainer())
+            .withEntity(permanentId, withCounters)
+            .addToZone(ZoneKey(player, Zone.BATTLEFIELD), permanentId)
+    }
+
+    test("ControllerGrants.isActive is false without the counter and true with it") {
+        val permanentId = EntityId.generate()
+        val stamped = stamp(ConditionalStaticAbility(GrantShroudToController, gate))
+
+        withClue("gate open: no shield counter, so the grant is off") {
+            val state = battlefieldWith(permanentId, stamped, shieldCounters = 0)
+            ControllerGrants.isActive(state, permanentId, gate) shouldBe false
+        }
+        withClue("gate closed: a shield counter switches the grant on") {
+            val state = battlefieldWith(permanentId, stamped, shieldCounters = 1)
+            ControllerGrants.isActive(state, permanentId, gate) shouldBe true
+        }
+    }
+
+    test("an unconditional grant is always active") {
+        val permanentId = EntityId.generate()
+        val state = battlefieldWith(permanentId, stamp(GrantShroudToController), shieldCounters = 0)
+        ControllerGrants.isActive(state, permanentId, condition = null) shouldBe true
+    }
+
+    context("the facade readers honour the gate") {
+        test("ControllerShroud") {
+            val permanentId = EntityId.generate()
+            val stamped = stamp(ConditionalStaticAbility(GrantShroudToController, gate))
+            ControllerShroud.appliesTo(
+                battlefieldWith(permanentId, stamped, shieldCounters = 0), player
+            ) shouldBe false
+            ControllerShroud.appliesTo(
+                battlefieldWith(permanentId, stamped, shieldCounters = 1), player
+            ) shouldBe true
+        }
+
+        test("ControllerHexproof") {
+            val permanentId = EntityId.generate()
+            val stamped = stamp(ConditionalStaticAbility(GrantHexproofToController, gate))
+            ControllerHexproof.appliesTo(
+                battlefieldWith(permanentId, stamped, shieldCounters = 0), player
+            ) shouldBe false
+            ControllerHexproof.appliesTo(
+                battlefieldWith(permanentId, stamped, shieldCounters = 1), player
+            ) shouldBe true
+        }
+
+        test("an ungated grant still reads as on") {
+            val permanentId = EntityId.generate()
+            val stamped = stamp(GrantShroudToController)
+            ControllerShroud.appliesTo(
+                battlefieldWith(permanentId, stamped, shieldCounters = 0), player
+            ) shouldBe true
+        }
+    }
+
+    // =========================================================================
+    // Roster completeness
+    // =========================================================================
+
+    test("every ControllerGrantMarker is covered by this file") {
+        // Reflection would need classpath scanning the engine doesn't otherwise do, so this is a
+        // hand-maintained list checked against the roster above. Adding a marker without adding a
+        // GrantCase leaves it untested — and the bug this file guards is invisible without a test.
+        val knownMarkers = setOf<Class<out ControllerGrantMarker>>(
+            GrantsControllerShroudComponent::class.java,
+            GrantsControllerHexproofComponent::class.java,
+            GrantsSacrificeImmunityComponent::class.java,
+            GrantsCantLoseGameComponent::class.java,
+            GrantsOpponentsCantWinGameComponent::class.java,
+            GrantsCantLoseGameFromLifeComponent::class.java,
+            GrantsStationUsingToughnessComponent::class.java,
+            CantBeTargetedByOpponentAbilitiesComponent::class.java,
+        )
+        withClue("grantCases must cover every marker in knownMarkers") {
+            grantCases.map { it.marker }.toSet() shouldBe knownMarkers
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TeamVsTeamTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TeamVsTeamTest.kt
@@ -158,7 +158,7 @@ class TeamVsTeamTest : FunSpec({
         // Put a "can't lose the game" permanent under p1's control (teammate of p0).
         val (permId, withId) = state.newEntity()
         val protectedState = withId
-            .withEntity(permId, ComponentContainer.of(ControllerComponent(p[1]), GrantsCantLoseGameComponent))
+            .withEntity(permId, ComponentContainer.of(ControllerComponent(p[1]), GrantsCantLoseGameComponent()))
             .addToZone(ZoneKey(p[1], Zone.BATTLEFIELD), permId)
         // Drop p0 (who does NOT control the grant) to 0 life.
         val zeroed = DamageUtils.loseLife(protectedState, p[0], 20, LifeChangeReason.LIFE_LOSS).first

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamLossTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/TwoHeadedGiantTeamLossTest.kt
@@ -140,7 +140,7 @@ class TwoHeadedGiantTeamLossTest : FunSpec({
         val protectedState = withId
             .withEntity(
                 permId,
-                ComponentContainer.of(ControllerComponent(p[1]), GrantsCantLoseGameComponent)
+                ComponentContainer.of(ControllerComponent(p[1]), GrantsCantLoseGameComponent())
             )
             .addToZone(ZoneKey(p[1], Zone.BATTLEFIELD), permId)
         // Now drop team 0 to 0 life.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ControllerGrantFollowsProjectedControllerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ControllerGrantFollowsProjectedControllerTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.targeting.ControllerShroud
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GrantShroudToController
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * A controller grant ("You have shroud") follows whoever *currently* controls the permanent.
+ *
+ * Control change is a layer-2 continuous effect (`EffectApplicator`'s `ChangeController` branch
+ * writes `projectedValues[..].controllerId`), so a stolen permanent's base `ControllerComponent`
+ * still names its original controller for as long as the theft lasts. `ControllerGrants` therefore
+ * resolves the granting permanent's controller through the projection — the same way it already
+ * resolved "you" when evaluating an "as long as …" gate, and the same rule
+ * [ReplacementFollowsProjectedControllerTest] pins for replacement effects.
+ *
+ * Reading the base component instead is silent and inverted rather than merely absent: the grant
+ * keeps protecting the player who lost the permanent and never protects the one who gained it.
+ * Both halves are asserted, because a fix that only stops the first would leave a stolen True
+ * Believer granting shroud to nobody.
+ *
+ * Shroud stands in for all nine markers here — they share the one battlefield scan in
+ * `ControllerGrants.anyGranting`, so the controller resolution is proven once for the family.
+ * `ConditionalControllerGrantsTest` covers the gate; this covers who the gate is resolved for.
+ */
+class ControllerGrantFollowsProjectedControllerTest : FunSpec({
+
+    val trueBeliever = card("True Believer") {
+        manaCost = "{W}{W}"
+        typeLine = "Creature — Human Cleric"
+        oracleText = "You have shroud."
+        power = 2
+        toughness = 2
+        staticAbility {
+            ability = GrantShroudToController
+        }
+    }
+
+    test("a stolen True Believer grants shroud to its thief, not to its owner") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(trueBeliever)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+
+        val owner = driver.player1
+        val thief = driver.getOpponent(owner)
+
+        val believer = driver.putCreatureOnBattlefield(owner, "True Believer")
+
+        withClue("Control: before the theft the grant protects its owner") {
+            ControllerShroud.appliesTo(driver.state, owner) shouldBe true
+            ControllerShroud.appliesTo(driver.state, thief) shouldBe false
+        }
+
+        // Advance to the thief's precombat main so they can cast a sorcery-speed aura.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        withClue("Setup: the thief should be the active player") {
+            (driver.state.activePlayerId == thief) shouldBe true
+        }
+
+        driver.giveMana(thief, Color.BLUE, 4)
+        val controlMagic = driver.putCardInHand(thief, "Control Magic")
+        val cast = driver.castSpell(thief, controlMagic, targets = listOf(believer))
+        withClue("Control Magic should resolve: ${cast.error}") { cast.error shouldBe null }
+        driver.bothPass()
+
+        withClue("Setup: the theft is a projection-only change, so the base component is stale") {
+            driver.state.projectedState.getController(believer) shouldBe thief
+            driver.state.getEntity(believer)?.get<ControllerComponent>()?.playerId shouldBe owner
+        }
+
+        withClue("The grant moved with the permanent, so it must stop protecting its owner") {
+            ControllerShroud.appliesTo(driver.state, owner) shouldBe false
+        }
+        withClue("...and must start protecting whoever controls it now") {
+            ControllerShroud.appliesTo(driver.state, thief) shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/PlayerGrantVisibilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/view/PlayerGrantVisibilityTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.engine.view
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantHexproofToController
+import com.wingedsheep.sdk.scripting.GrantShroudToController
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Player-level shroud and hexproof have to show up as badges on the player, whether they came from
+ * a resolution-time effect (Gilded Light, Dawn's Truce) or from a permanent that grants them
+ * (True Believer, Shalai).
+ *
+ * Shroud only ever had the first half: the transformer checked `PlayerShroudComponent` and nothing
+ * else, so a True Believer's controller was untargetable but shown as plain. That is the badge
+ * that matters most — shroud stops the player's *own* spells too (CR 702.18), so without it the
+ * client offers a self-target the server then rejects.
+ *
+ * Both now read through `ControllerShroud` / `ControllerHexproof`, which union the two sources and
+ * re-evaluate any "as long as …" gate on every read, so the badge tracks the gate rather than
+ * freezing at whatever it said when the permanent entered.
+ */
+class PlayerGrantVisibilityTest : FunSpec({
+
+    val trueBeliever = card("Test True Believer") {
+        manaCost = "{W}{W}"
+        typeLine = "Creature — Human Cleric"
+        oracleText = "You have shroud."
+        power = 2
+        toughness = 2
+        staticAbility { ability = GrantShroudToController }
+    }
+
+    val shalai = card("Test Angel of Plenty") {
+        manaCost = "{3}{W}"
+        typeLine = "Creature — Angel"
+        oracleText = "You have hexproof."
+        power = 3
+        toughness = 4
+        staticAbility { ability = GrantHexproofToController }
+    }
+
+    // The gated form, as Captain America, Super-Soldier writes it.
+    val gatedBeliever = card("Test Conditional Believer") {
+        manaCost = "{W}{W}"
+        typeLine = "Creature — Human Cleric"
+        oracleText = "As long as you control two or more creatures, you have shroud."
+        power = 2
+        toughness = 2
+        staticAbility {
+            ability = ConditionalStaticAbility(
+                ability = GrantShroudToController,
+                condition = Conditions.YouControlAtLeast(2, Filters.Creature),
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + trueBeliever + shalai + gatedBeliever)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun badges(driver: GameTestDriver, playerId: EntityId): List<String> =
+        ClientStateTransformer(cardRegistry = driver.cardRegistry)
+            .transform(driver.state, viewingPlayerId = playerId)
+            .players.single { it.playerId == playerId }
+            .activeEffects.map { it.effectId }
+
+    test("a permanent granting shroud badges its controller") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        withClue("no grant yet, so no badge") {
+            badges(driver, player).contains("player_shroud") shouldBe false
+        }
+
+        driver.putCreatureOnBattlefield(player, "Test True Believer")
+
+        withClue("True Believer's controller has shroud and must be told so") {
+            badges(driver, player).contains("player_shroud") shouldBe true
+        }
+        withClue("the opponent gains nothing from it") {
+            badges(driver, opponent).contains("player_shroud") shouldBe false
+        }
+    }
+
+    test("a permanent granting hexproof badges its controller") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        badges(driver, player).contains("player_hexproof") shouldBe false
+        driver.putCreatureOnBattlefield(player, "Test Angel of Plenty")
+        badges(driver, player).contains("player_hexproof") shouldBe true
+    }
+
+    test("the badge leaves with the permanent") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val believer = driver.putCreatureOnBattlefield(player, "Test True Believer")
+        badges(driver, player).contains("player_shroud") shouldBe true
+
+        driver.moveToGraveyard(believer)
+        withClue("the marker leaves with the permanent, so the badge must too") {
+            badges(driver, player).contains("player_shroud") shouldBe false
+        }
+    }
+
+    test("a gated grant badges only while its gate holds") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(player, "Test Conditional Believer")
+        withClue("one creature, so the gate is open and the badge must be absent") {
+            badges(driver, player).contains("player_shroud") shouldBe false
+        }
+
+        driver.putCreatureOnBattlefield(player, "Savannah Lions")
+        withClue("the gate closed, so the badge must appear without the granter re-entering") {
+            badges(driver, player).contains("player_shroud") shouldBe true
+        }
+    }
+
+    test("two granting permanents still produce one badge") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(player, "Test True Believer")
+        driver.putCreatureOnBattlefield(player, "Test True Believer")
+
+        badges(driver, player).count { it == "player_shroud" } shouldBe 1
+    }
+})


### PR DESCRIPTION
# Gate every controller-grant marker behind its condition

Player-level grants ("you have shroud", "you can't lose the game") sit outside the Rule 613 layer
system: `StaticAbilityHandler` stamps a marker component **once**, as the permanent enters, and
readers later scan the battlefield for it. Because the stamp happens once, an "as long as …" gate
can't be resolved at stamp time — it has to travel on the marker and be re-evaluated on every read.

Only hexproof did that. The eight siblings matched the bare type, so wrapping one in a
`ConditionalStaticAbility` stamped **no marker at all** and the ability was *silently inert* — not
stuck on, not stuck off, simply absent, with no compile error or warning. That is the bug Captain
America, Super-Soldier hit for hexproof, and it was waiting for the next card to hit for any of the
other eight.

## What changed

- **`ControllerGrantMarker`** — one interface carrying the condition, with the stamp/read rules that
  make the silent no-op unrepresentable.
- **`ControllerGrants`** — the single place a gate is evaluated. `ControllerHexproof` delegates to
  it; `ControllerShroud` is new and collapses the duplicated battlefield scans in `TargetValidator`,
  `TargetEnumerationUtils`, `TargetFinder` and `ClientStateTransformer`.
- **`StaticAbilityHandler`** routes all nine grants through `controllerGrant<A>()`. Protection gates
  per *scope*, so `GrantsControllerProtectionComponent` now holds `List<ProtectionGrant>` rather than
  `List<ProtectionScope>` — one card can carry several `GrantProtectionToController` abilities and
  gate them independently.

## Fixes found along the way

**Controller grants now follow the projected controller.** Control change is a Layer 2 floating
effect that never writes back to `ControllerComponent` (`EffectApplicator`'s `ChangeController`
branch), so every one of these scans was matching on a stale base controller: steal a True Believer,
Sigarda or Platinum Angel and the grant kept protecting the player it was taken from, while its gate
was evaluated as the thief. `ControllerGrants.granterController` resolves it through the projection
now — the same rule `ReplacementEffectProcessor` already follows for `Player.You` replacements.

**Empty-library and effect-driven losses are team-aware.** `DrawCardPrimitive` and `LoseGameExecutor`
each had their own can't-lose scan and neither was team-aware, so in Two-Headed Giant a teammate's
Platinum Angel stopped the 704.5a life SBA but not an empty-library draw or a `LoseGameEffect`.
CR 810.8a makes it team-wide; both now call the shared `playerCantLoseGame`.

**Player shroud is visible in the client.** `ClientStateTransformer` only ever checked
`PlayerShroudComponent`, so a True Believer's controller was untargetable but shown as plain — the
badge that matters most, since shroud stops the player's *own* spells (CR 702.18) and the client
would otherwise offer a self-target the server then rejects. Shroud and hexproof both read through
the facades now, which also removes the transformer's own battlefield scan.

## Tests

- **`ConditionalControllerGrantsTest`** covers all nine grants bare and gated, asserts the gate flips
  at read time, and fails if a new marker is added without a case.
- **`ControllerGrantFollowsProjectedControllerTest`** steals a True Believer with Control Magic and
  asserts shroud both leaves the owner *and* reaches the thief — a half-fix would leave it granting
  to nobody.
- **`PlayerGrantVisibilityTest`** covers the badge appearing, staying controller-only, leaving with
  the permanent, tracking a gate that flips without the granter re-entering, and not duplicating.

## Verification

`just test` — BUILD SUCCESSFUL across all modules, 0 failures. `game-server` is included because
`ClientStateTransformer` changed. The suites this touches all pass: `ConditionalControllerGrantsTest`,
`CaptainAmericaSuperSoldierScenarioTest`, `TrueBelieverTest`, `SigardaHostOfHeronsScenarioTest`,
`TwoHeadedGiantTeamLossTest`, `TeamVsTeamTest` and `ReplacementFollowsProjectedControllerTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
