### PR TITLE
Add an ability-source predicate for stack targets: CardPredicate.AbilitySourceMatches (+2 MSH cards)

### DIFF
--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -27,9 +27,26 @@
 
 ## Gate
 
-`just test` — BUILD SUCCESSFUL in 15m 46s, 12200 PASSED / 0 FAILED (`build/pr/loop-msh-u08-gate.log`).
-Plus `just rebless-cards` (only MSH.json moved, +150/−0), `just check-card-printing` ok for both
-cards, `just check-backlog` in sync.
+Three trees, because two review rounds landed as new commits after the first gate. **Only the last
+block describes the code as it stands.**
+
+1. **`5df00a8467`** (original, superseded) — `just test` BUILD SUCCESSFUL in 15m 46s, 12200 PASSED /
+   0 FAILED (`build/pr/loop-msh-u08-gate.log`). Does not cover the merged code: `daec416da0` went on
+   to rewrite `PredicateEvaluator`, `ActivateAbilityHandler`, `EntitySnapshot` and
+   `ZoneTransitionService` and add two scenario tests.
+2. **`daec416da0`** (after round-3 corrections) — `just test-class ScientistSupremeOfAimScenarioTest`
+   6/6 PASSED (`-gate-correction-targeted.log`); `just test` 0 failures across every module *except*
+   `:rules-engine`, where the run ended in the documented shared-box daemon OOM at ~146 MiB available
+   (`-gate-correction.log`, environmental, not a test failure); re-run at reduced footprint,
+   `:rules-engine:test` BUILD SUCCESSFUL 12m 27s / 0 failures (`-gate-correction-rules.log`) and
+   `:mtg-sets:test` BUILD SUCCESSFUL 1m 12s / 0 failures (`-gate-correction-sets.log`). The three
+   runs together cover every module.
+3. **`HEAD`** (after round-4 review) — one behaviour-neutral plumbing change in
+   `ActivateAbilityHandler` (switch to the existing state-aware `captureEntitySnapshots` overload)
+   plus comment-only fixes. **Re-gate pending** — see `build/pr/loop-msh-u08-round4-correction.md`.
+
+Unaffected by the tree: `just rebless-cards` (only MSH.json moved, +150/−0),
+`just check-card-printing` ok for both cards, `just check-backlog` in sync.
 
 ## Things I'm unsure about — please look
 

--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -41,9 +41,13 @@ block describes the code as it stands.**
    `:rules-engine:test` BUILD SUCCESSFUL 12m 27s / 0 failures (`-gate-correction-rules.log`) and
    `:mtg-sets:test` BUILD SUCCESSFUL 1m 12s / 0 failures (`-gate-correction-sets.log`). The three
    runs together cover every module.
-3. **`HEAD`** (after round-4 review) — one behaviour-neutral plumbing change in
-   `ActivateAbilityHandler` (switch to the existing state-aware `captureEntitySnapshots` overload)
-   plus comment-only fixes. **Re-gate pending** — see `build/pr/loop-msh-u08-round4-correction.md`.
+3. **`c6d333a27e`** (after round-4 review, the code as it stands) — one behaviour-neutral plumbing
+   change in `ActivateAbilityHandler` (switch to the existing state-aware `captureEntitySnapshots`
+   overload) plus comment-only fixes. `:rules-engine:test` at reduced footprint **BUILD SUCCESSFUL
+   in 4m 34s, 10765 PASSED / 0 failures** (`build/pr/loop-msh-u08-gate-round4-rules.log`), all 15 of
+   this unit's tests green. Only `:rules-engine` was touched and no signature moved, so downstream
+   modules were not re-run — tree 2 covers them. Accounting in
+   `build/pr/loop-msh-u08-round4-correction.md`.
 
 Unaffected by the tree: `just rebless-cards` (only MSH.json moved, +150/−0),
 `just check-card-printing` ok for both cards, `just check-backlog` in sync.

--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -1,67 +1,51 @@
-# loop-msh-u07 — Ward with a non-listed cost
-
-Feature unit: two new `WardCost` variants plus the two MSH cards they unblock.
-
-## SDK
-
-- `WardCost.PlayerCounters(counterType, amount)` — counters placed on the **paying player**
-  (CR 122.1). Facade `KeywordAbility.wardPlayerCounters(Counters.POISON, 5)`. The only ward cost with
-  no affordability gate.
-- `WardCost.Choice(options)` — OR disjunction, sibling of `Composite`'s AND. Facades
-  `KeywordAbility.wardChoice(...)` and the named `wardDiscardOrPay("{2}")`. Modelled on
-  `AdditionalCost.Choice` / `PayCost.Choice`; the prompt follows `CostPaymentService.choicePrompt`
-  (payable options only + trailing decline, reduced list stored on the continuation).
-- `WardCost.clause` — new property: the self-contained verb phrase ("discard a card", "pay {2}") as
-  opposed to `description`'s object phrase. Only `Choice` reads it, so no existing card's rendered
-  text changes.
-
-## Engine
-
-- `WardCounterEffectExecutor`: two new branches; `canPayWardCost` is now the single source of truth
-  for "unpayable → counter without a prompt" and the four pre-existing inline can-pay checks were
-  folded into it.
-- Two continuations (`CounterUnlessPlayerCountersContinuation`, `WardCostChoiceContinuation`) in
-  `ManaContinuations.kt`, registered in `Serialization.kt`, resumed in
-  `ManaPaymentContinuationResumer`. The choice resumer routes the chosen option through the existing
-  `chargeNextWardPartOrNull`, so the spell-left-the-stack guard and composite chaining stay
-  single-sourced.
-- Counters are placed via the ordinary `AddCountersEffect` executor with the payer as controller —
-  replacement effects, `CountersAddedEvent` and the ten-poison SBA all follow for free.
+# loop-msh-u08 — Ability-source predicate on stack targets
 
 ## Cards
 
-- **The Serpent Society** [226] — deathtouch; `wardPlayerCounters(Counters.POISON, 5)`; OTHER-bound
-  dies trigger filtered by `withKeyword(DEATHTOUCH)` (matched against LKI) → `Effects.Sacrifice`
-  nontoken over `Player.EachOpponent`.
-- **Titania, Rugged Rumbler** [235] — `Costs.additional.DiscardOrPay("{2}")` +
-  `KeywordAbility.wardDiscardOrPay("{2}")`. Same printed shape on both rails, deliberately
-  matching facade names; the types stay separate because the additional cost's mana leg folds into
-  the spell's mana cost at cast time and the ward's does not.
+- **Echo, Perceptive Prodigy** (MSH 51) — vigilance + `{1}, {T}: Copy target activated or triggered
+  ability you control from a creature source.` Composes `Targets.ActivatedOrTriggeredAbilityYouControlFrom(Creature)`
+  (existing ability-on-stack target + the new `CardPredicate.AbilitySourceMatches`) with the existing
+  `Effects.CopyTargetSpellOrAbility`, plus `holdPriority`.
+- **Scientist Supreme of A.I.M.** (MSH 225) — `Pay 2 life: Copy target activated or triggered ability
+  you control from an artifact source. Activate only during your turn and only once each turn.`
+  Same pieces with `GameObjectFilter.Artifact`, `Costs.PayLife(2)` and
+  `ActivationRestriction.OnlyDuringYourTurn` + `OncePerTurn`.
 
-## Also
+## SDK / engine
 
-- `docs/card-sdk-language-reference.md` — ward section extended for both variants and the two-rail
-  note.
-- `backlog/sets/marvel-super-heroes/cards.md` — both ticked, count 239 → 241.
-- `backlog/sets/marvel-super-heroes/mechanics.md` — section rewritten as SHIPPED; blocked count
-  33 → 31.
-- `mtgish-tooling` `CardStructure.kt` — `wardKeywordLine` learned `_Cost: "Or"` via a new
-  `wardCostExpr` leg renderer; existing single-cost branches unchanged, no corpus ward uses `Or`, so
-  no golden moves. The IR has no player-counter cost tag, so `PlayerCounters` is not taught.
+- `CardPredicate.AbilitySourceMatches(subfilter)` — new stack-branch predicate, sibling of
+  `TargetsMatching`. Redirects the match onto the ability's `sourceId` (CR 113.7) and evaluates the
+  subfilter there. Builders: `GameObjectFilter.abilitySourceMatches`, `TargetFilter.abilitySourceMatches`,
+  `Targets.ActivatedOrTriggeredAbilityYouControlFrom`.
+- `StackObjectTargeting.permitsAbilities` — the "may this stack target requirement offer abilities?"
+  seam, extracted from `TargetFinder` so the enumerator can share it.
+- **Bug fixed, not part of the brief:** `TargetEnumerationUtils.findValidSpellTargets` filtered every
+  stack target down to spells unconditionally, so *no* ability-targeting card ever had an ability
+  **offered** as a legal target — Gogo, Master of Mimicry and Peter Parker's Camera included. Since
+  `ActivatedAbilityEnumerator` gates `holdPriority` on "top of stack ∈ validTargets", those cards
+  also never stopped auto-pass. Both readers now go through `StackObjectTargeting`.
 
-## Things worth a second opinion
+## Gate
 
-`WardPlayerCountersTest`, `WardCostChoiceTest` (engine-level, one per mechanic),
-`TheSerpentSocietyScenarioTest`, `TitaniaRuggedRumblerScenarioTest` (one per card).
+`just test` — BUILD SUCCESSFUL in 15m 46s, 12200 PASSED / 0 FAILED (`build/pr/loop-msh-u08-gate.log`).
+Plus `just rebless-cards` (only MSH.json moved, +150/−0), `just check-card-printing` ok for both
+cards, `just check-backlog` in sync.
 
-## Unsure / worth a reviewer's eye
+## Things I'm unsure about — please look
 
-- `WardCost.clause` duplicates information with `description`. The alternative — making `description`
-  the full clause everywhere and dropping the per-renderer verb prefixes — is cleaner but rewrites
-  the rendered text of every existing ward card and moves a lot of snapshots; I chose not to.
-- `canPayWardCost` for `Composite` is a snapshot check (all parts payable *now*). Paying an earlier
-  part could in principle make a later one unpayable; the per-part handler still counters at that
-  point, so behaviour is right, but a `Choice` over a `Composite` could offer a leg that later fails.
-  No printed card has that shape.
-- The ward `Choice` picker labels are generated from `clause` ("Discard a card" / "Pay {2}" /
-  "Counter spell"). Not seen in a running client.
+1. **Token sources are unmatchable once gone.** CR 704.5s deletes a token's entity, so a sacrificed
+   Clue's "Sacrifice this artifact: draw a card" is *not* "from an artifact source" for Scientist
+   Supreme. Non-token sources are fine (the entity survives in the graveyard with its printed types).
+   Closing it needs a general last-known store for deleted tokens, which the engine doesn't have —
+   `EntitySnapshot`/`LastKnownPermanentComponent` both die with the entity. Documented in the
+   predicate KDoc and the DSL reference rather than silently approximated.
+2. Related, smaller: a source whose *type* came from a continuous effect (animated land, crewed
+   Vehicle) and has since left reads its printed types.
+3. `ChosenTarget.Spell` gets no CR 608.2b filter re-check in `StackResolver.validateTargets` (only
+   "still on the stack"). Pre-existing, not touched here; it means the source restriction is enforced
+   at targeting time only. Arguably correct in practice (the ability can't stop being from a creature
+   source), but worth a second opinion.
+4. No client change was needed: `StackZone` already routes both the action-pipeline
+   (`targetingState`) and decision (`decisionSelectionState`) click paths for stack objects, and
+   `TargetingOverlay` only diverts to the pile picker for `Graveyard`/`Exile`. Verified by reading;
+   not exercised in a browser.

--- a/LOOP_UNIT.md
+++ b/LOOP_UNIT.md
@@ -33,18 +33,29 @@ cards, `just check-backlog` in sync.
 
 ## Things I'm unsure about — please look
 
-1. **Token sources are unmatchable once gone.** CR 704.5s deletes a token's entity, so a sacrificed
-   Clue's "Sacrifice this artifact: draw a card" is *not* "from an artifact source" for Scientist
-   Supreme. Non-token sources are fine (the entity survives in the graveyard with its printed types).
-   Closing it needs a general last-known store for deleted tokens, which the engine doesn't have —
-   `EntitySnapshot`/`LastKnownPermanentComponent` both die with the entity. Documented in the
-   predicate KDoc and the DSL reference rather than silently approximated.
-2. Related, smaller: a source whose *type* came from a continuous effect (animated land, crewed
-   Vehicle) and has since left reads its printed types.
+1. ~~**Token sources are unmatchable once gone.**~~ **Closed in review round 3.** The claim that the
+   engine had no last-known store for a deleted token was wrong:
+   `ActivatedAbilityOnStackComponent.lastKnownSourceSnapshot` already freezes an `EntitySnapshot` of
+   the source whenever the activation cost sacrifices/exiles it — exactly the Clue / Food / Blood /
+   Treasure shape. It just wasn't carrying the type line. It now does (via the shared
+   `projectedTypeLine` helper), and the `AbilitySourceMatches` branch falls back to it through
+   `PredicateEvaluator.matchesSnapshot` when `state.getEntity(sourceId)` is null. A cracked Clue's
+   draw ability is a legal, *offered* target for Scientist Supreme; scenario test added. Timing
+   nuance found while testing: SBAs run on the engine's post-resolution pass, so the token is still
+   readable the instant its ability hits the stack and only vanishes once something else resolves —
+   the test reproduces that sequence and asserts the entity is gone before checking the offer. The
+   rule is
+   **CR 704.5d** ("If a token is in a zone other than the battlefield, it ceases to exist"), not
+   704.5s (that one is the Saga final-chapter sacrifice).
+2. Related, smaller, still open: a **nontoken** source whose *type* came from a continuous effect
+   (animated land, crewed Vehicle) and has since left the battlefield some other way reads its
+   printed types — only the self-sacrifice/self-exile cost path freezes the projected type line.
 3. `ChosenTarget.Spell` gets no CR 608.2b filter re-check in `StackResolver.validateTargets` (only
    "still on the stack"). Pre-existing, not touched here; it means the source restriction is enforced
-   at targeting time only. Arguably correct in practice (the ability can't stop being from a creature
-   source), but worth a second opinion.
+   at targeting time only. Exposure is small but not zero: an artifact animated into a creature can
+   stop being a creature between targeting and resolution, at which point CR 608.2b says Echo's copy
+   ability should fizzle and it won't. Left open deliberately — fixing it is an engine change to the
+   shared resolution-time target validation, not this unit's scope.
 4. No client change was needed: `StackZone` already routes both the action-pipeline
    (`targetingState`) and decision (`decisionSelectionState`) click paths for stack objects, and
    `TargetingOverlay` only diverts to the pile picker for `Graveyard`/`Exile`. Verified by reading;

--- a/backlog/sets/marvel-super-heroes/cards.md
+++ b/backlog/sets/marvel-super-heroes/cards.md
@@ -3,7 +3,7 @@
 **Set Size:** 276 booster cards (collector numbers 1-276; basic lands 277-296 and showcase
 variants 297+ are excluded)
 **Release Date:** June 26, 2026
-**Implemented:** 245 / 276
+**Implemented:** 247 / 276
 - [x] Agent 13, Sharon Carter
 - [x] Agent Maria Hill
 - [x] Agent of Atlas
@@ -54,7 +54,7 @@ variants 297+ are excluded)
 - [x] Bold Biochemist
 - [x] Bruce Banner // The Incredible Hulk
 - [x] Depower
-- [ ] Echo, Perceptive Prodigy
+- [x] Echo, Perceptive Prodigy
 - [x] Falcon, Winged Wonder
 - [x] Falcon's Wing Harness
 - [x] Frozen in Ice
@@ -228,7 +228,7 @@ variants 297+ are excluded)
 - [x] The Mighty Thor, Jane Foster
 - [x] Moon Girl and Devil Dinosaur
 - [x] The Ruinous Wrecking Crew
-- [ ] Scientist Supreme of A.I.M.
+- [x] Scientist Supreme of A.I.M.
 - [x] The Serpent Society
 - [x] Speedball, New Warrior
 - [x] Spider-Man, To the Rescue

--- a/backlog/sets/marvel-super-heroes/mechanics.md
+++ b/backlog/sets/marvel-super-heroes/mechanics.md
@@ -6,9 +6,9 @@ keyword, or engine capability) — not pure card authoring.
 
 Scope: the 276 booster cards (collector numbers 1–276). Triaged against the SDK on 2026-08-04,
 updated 2026-08-07 after **power-up** and the **per-turn effect budget** shipped, 2026-08-08
-after **teamwork** shipped in full, and 2026-08-10 after **copy-with-exceptions** and
-**ward with a non-listed cost** shipped.
-**27 of the 276 are blocked**; every other card is buildable from existing primitives.
+after **teamwork** shipped in full, and 2026-08-10 after **copy-with-exceptions**,
+**ward with a non-listed cost** and the **ability-source predicate on stack targets** shipped.
+**25 of the 276 are blocked**; every other card is buildable from existing primitives.
 
 Supported today and *not* a blocker despite looking like one: **power-up** (see the first section
 below — the keyword, its once-only limit and its pip-wise cost reduction all ship), **harness / ∞ abilities**
@@ -282,18 +282,30 @@ Blocked cards: **Ironheart, Clever Champion** [60] · **Arc Reactor** [243]. Iro
 `SpellStaticAbilities.GrantsKeywordToSpells` is built for exactly this and already handles
 cost-modifying keywords.
 
-## Ability-source predicate on stack targets — 2 cards ⛔
+## Ability-source predicate on stack targets — SHIPPED ✅ (2 of 2 cards unblocked)
 
-Abilities on the stack carry no `CardComponent`, and `PredicateEvaluator.matchesCardPredicate`
-(`rules-engine/.../handlers/PredicateEvaluator.kt`) bails out on them, so `GameObjectFilter.Artifact`
-is always false for an ability. `Targets.ActivatedOrTriggeredAbilityYouControl` and
-`Effects.CopyTargetSpellOrAbility` both exist (precedent `fin/cards/GogoMasterOfMimicry.kt`) — what is
-missing is restricting the target by its **source**. Needed: a `CardPredicate.AbilitySourceMatches(filter)`
-resolved in the evaluator's stack branch against the ability's `sourceEntityId`, matched with
-last-known information since the source may have left. The concept already exists engine-side as the
-static `CantBeTargetedBySourceTypeAbilities`.
+Shipped 2026-08-10. An ability on the stack is its own object with none of its source's
+characteristics (CR 113.3b/c), so a type predicate applied to the ability entity is never true.
+`CardPredicate.AbilitySourceMatches(subfilter)` redirects the match onto the ability's **source**
+(CR 113.7) — `ActivatedAbilityOnStackComponent.sourceId` / `TriggeredAbilityOnStackComponent.sourceId`
+— and evaluates the subfilter there, in the evaluator's stack branch alongside
+`CardPredicate.TargetsMatching`. The source is read from the projection while it is on the
+battlefield and from its printed characteristics once it has left, so a dead creature's dies trigger
+is still "from a creature source" (CR 113.7a, and CR 608.2b for the resolution-time re-check) — the
+same source resolution `CantBeTargetedBySourceTypeAbilities` uses.
 
-Blocked cards: **Echo, Perceptive Prodigy** [51] (creature source) · **Scientist Supreme of A.I.M.**
+Authoring: `Targets.ActivatedOrTriggeredAbilityYouControlFrom(GameObjectFilter.Creature)`, or the
+`.abilitySourceMatches(...)` chain on `GameObjectFilter` / `TargetFilter`. See
+`docs/card-sdk-language-reference.md`.
+
+Shipped alongside, because the cards were unplayable without it: the legal-action enumerator
+(`TargetEnumerationUtils.findValidSpellTargets`) filtered *every* stack target down to spells, so no
+ability-targeting card — including the already-shipped Gogo, Master of Mimicry and Peter Parker's
+Camera — was ever **offered** an ability as a legal target, even though `TargetFinder` accepted one
+when the action was submitted. Both readers now go through the single
+`StackObjectTargeting.permitsAbilities` seam.
+
+**Unblocked (2):** Echo, Perceptive Prodigy [51] (creature source) · Scientist Supreme of A.I.M.
 [225] (artifact source).
 
 ## Ward with a non-listed cost — SHIPPED ✅ (both cards implemented)

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2900,9 +2900,10 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `Targets.CreatureSpellYouControl` — a creature spell on the stack you control (Choreographed Sparks' "Copy target creature spell you control").
 - `Targets.ActivatedOrTriggeredAbility` / `Targets.ActivatedAbility` — an ability on the stack (Stifle).
 - `Targets.ActivatedOrTriggeredAbilityYouControl` — an activated or triggered ability **you control** on the stack (`TargetFilter.ActivatedOrTriggeredAbilityOnStack.youControl()`). Mana abilities never use the stack, so they're excluded automatically. Pair with `Effects.CopyTargetSpellOrAbility` — **Gogo, Master of Mimicry**.
+- `Targets.ActivatedOrTriggeredAbilityYouControlFrom(sourceFilter)` — the same, narrowed to abilities whose **source** matches `sourceFilter` (`CardPredicate.AbilitySourceMatches`): "copy target activated or triggered ability you control **from a creature source**" (**Echo, Perceptive Prodigy**, `GameObjectFilter.Creature`) / "**from an artifact source**" (**Scientist Supreme of A.I.M.**, `GameObjectFilter.Artifact`). The restriction is on the ability's source per CR 113.7, matched with last known information when the source has already left the battlefield (CR 113.7a), so a dead creature's dies trigger still qualifies.
 - `Targets.SpellOrAbilityWithSingleTarget` — a spell or ability whose single target is changed (Willbender; pair with `Effects.ChangeTarget()`).
 - `Targets.SpellOrAbility` — any spell, activated ability, or triggered ability on the stack (`TargetFilter.SpellOrAbilityOnStack` = any object in the stack zone; mana abilities never use the stack). Pair with `Effects.CounterSpellOrAbility()` — "counter target spell, activated ability, or triggered ability" (Overcharged Amalgam).
-- `Targets.InstantSorcerySpellOrAbility` — one requirement admitting an instant spell, sorcery spell, activated ability, or triggered ability on the stack (`TargetFilter.InstantSorcerySpellOrAbilityOnStack`, a single `CardPredicate.Or`). Pair with `Effects.CopyTargetSpellOrAbility()` — Return the Favor. **Note:** the STACK targeting enumeration (`TargetFinder.findSpellTargets`) offers an ability as a legal target only when the requirement's filter *explicitly names an ability predicate* (anywhere inside `Or`/`And`/`Not`); plain "target spell" filters stay spell-only (CR 112.1 vs 113.3b/c).
+- `Targets.InstantSorcerySpellOrAbility` — one requirement admitting an instant spell, sorcery spell, activated ability, or triggered ability on the stack (`TargetFilter.InstantSorcerySpellOrAbilityOnStack`, a single `CardPredicate.Or`). Pair with `Effects.CopyTargetSpellOrAbility()` — Return the Favor. **Note:** a STACK target requirement offers an ability as a legal target only when its filter *explicitly names an ability predicate* (anywhere inside `Or`/`And`/`Not`, including `CardPredicate.AbilitySourceMatches`); plain "target spell" filters stay spell-only (CR 112.1 vs 113.3b/c). Both readers — `TargetFinder.findSpellTargets` (the authoritative target set) and `TargetEnumerationUtils.findValidSpellTargets` (the legal actions sent to clients and the AI) — ask that question through the single `StackObjectTargeting.permitsAbilities` seam, so an ability-targeting card can't end up executable-but-never-offered.
 - `Targets.InstantSorceryOrTriggeredAbility` — narrower than `Targets.InstantSorcerySpellOrAbility`: admits an instant spell, sorcery spell, or **triggered** ability on the stack, but **not** an activated ability (`TargetFilter.InstantSorcerySpellOrTriggeredAbilityOnStack`, an `Or` of `IsInstant` / `IsSorcery` / `IsTriggeredAbility`). Because the filter names `IsTriggeredAbility`, the STACK enumeration offers triggered abilities (per the note above), while activated abilities stay excluded. Pair with `Effects.CounterSpellOrAbility()` — **Spider-Sense**'s "counter target instant spell, sorcery spell, or triggered ability."
 - `Targets.Card` — any card in any zone (e.g. graveyard).
 - `Targets.CreatureOrPlaneswalker` — combined.
@@ -2915,6 +2916,10 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 `.targetsMatching(subfilter)` (a spell/ability on the stack that targets at least one object matching
 `subfilter` — `CardPredicate.TargetsMatching`; e.g. `GameObjectFilter.InstantOrSorcery.targetsMatching(GameObjectFilter.Creature)`
 for "an instant or sorcery spell that targets a creature" — Forum Necroscribe, Lecturing Scornmage);
+`.abilitySourceMatches(subfilter)` (an activated/triggered ability on the stack whose *source* matches
+`subfilter` — `CardPredicate.AbilitySourceMatches`; e.g.
+`TargetFilter.ActivatedOrTriggeredAbilityOnStack.youControl().abilitySourceMatches(GameObjectFilter.Creature)`
+for "from a creature source" — Echo, Perceptive Prodigy);
 `.castFromZone(zone)` / `.notCastFromZone(zone)` (a spell on the stack that was / wasn't cast from a
 specific zone — `StatePredicate.WasCastFromZone`, reading `SpellOnStackComponent.castFromZone`; e.g.
 `TargetFilter.SpellOnStack.notCastFromZone(Zone.HAND)` for "target spell that wasn't cast from its
@@ -3503,6 +3508,25 @@ work for abilities-on-stack (which carry no `CardComponent`).
   includes at least one chosen target matching `subfilter`. Player targets are skipped. The
   subfilter inherits the outer `PredicateContext`, so `Land.youControl()` inside the subfilter
   resolves against the outer chooser. Used by Teferi's Response.
+- `CardPredicate.AbilitySourceMatches(subfilter)` — true when the stack object is an **activated or
+  triggered ability** whose *source* (CR 113.7 — the object that generated it) matches `subfilter`.
+  The "from a creature source" / "from an artifact source" clause: **Echo, Perceptive Prodigy**,
+  **Scientist Supreme of A.I.M.** An ability on the stack is its own object with none of its
+  source's characteristics (CR 113.3b/c), so a type predicate on the ability entity is never true;
+  this predicate redirects the match onto `ActivatedAbilityOnStackComponent.sourceId` /
+  `TriggeredAbilityOnStackComponent.sourceId` and evaluates `subfilter` there, inheriting the outer
+  `PredicateContext`. **Last known information:** the source is read from the projection while it is
+  on the battlefield and from its printed characteristics once it has left, so a dead creature's
+  dies trigger still counts as "from a creature source" (CR 113.7a; CR 608.2b for the
+  resolution-time re-check) — the same source resolution `CantBeTargetedBySourceTypeAbilities` uses.
+  Never matches a spell. Build it with `GameObjectFilter.abilitySourceMatches(...)` /
+  `TargetFilter.abilitySourceMatches(...)`, or the ready-made
+  `Targets.ActivatedOrTriggeredAbilityYouControlFrom(sourceFilter)`.
+  Two limits of the last-known read, both inherited from how the engine stores last-known
+  information: a source whose type came from a continuous effect (animated land, crewed Vehicle) and
+  has since left reads its *printed* types; and a **token** source is unmatchable once it has left
+  the battlefield, because CR 704.5s cleanup deletes the entity and no snapshot survives where the
+  predicate can reach it (a sacrificed Clue's draw ability is missed by "from an artifact source").
 - `CardPredicate.HasNonManaActivatedAbility` — matches a permanent whose printed activated abilities
   include at least one that isn't a mana ability and isn't a loyalty ability (battlefield-activatable).
   Backed by the precomputed `CardComponent.hasNonManaActivatedAbility` flag (set at entity creation from

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2902,7 +2902,7 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `Targets.ActivatedOrTriggeredAbilityYouControl` — an activated or triggered ability **you control** on the stack (`TargetFilter.ActivatedOrTriggeredAbilityOnStack.youControl()`). Mana abilities never use the stack, so they're excluded automatically. Pair with `Effects.CopyTargetSpellOrAbility` — **Gogo, Master of Mimicry**.
 - `Targets.ActivatedOrTriggeredAbilityYouControlFrom(sourceFilter)` — the same, narrowed to abilities whose **source** matches `sourceFilter` (`CardPredicate.AbilitySourceMatches`): "copy target activated or triggered ability you control **from a creature source**" (**Echo, Perceptive Prodigy**, `GameObjectFilter.Creature`) / "**from an artifact source**" (**Scientist Supreme of A.I.M.**, `GameObjectFilter.Artifact`). The restriction is on the ability's source per CR 113.7, matched with last known information when the source has already left the battlefield (CR 113.7a), so a dead creature's dies trigger still qualifies.
 - `Targets.SpellOrAbilityWithSingleTarget` — a spell or ability whose single target is changed (Willbender; pair with `Effects.ChangeTarget()`).
-- `Targets.SpellOrAbility` — any spell, activated ability, or triggered ability on the stack (`TargetFilter.SpellOrAbilityOnStack` = any object in the stack zone; mana abilities never use the stack). Pair with `Effects.CounterSpellOrAbility()` — "counter target spell, activated ability, or triggered ability" (Overcharged Amalgam).
+- `Targets.SpellOrAbility` — written for "counter target spell, activated ability, or triggered ability" (Overcharged Amalgam, Grip of Chaos); pair with `Effects.CounterSpellOrAbility()`. **Caveat:** `TargetFilter.SpellOrAbilityOnStack` is `GameObjectFilter.Any` in the stack zone and so names *no* ability predicate, which by the rule in the next bullet means the targeting seam offers **spells only** — the ability half of the wording doesn't reach abilities today, in either `TargetFinder` or the enumerator. Closing it needs an explicit ability predicate on the filter (an `Or` mirroring `TargetFilter.InstantSorcerySpellOrAbilityOnStack`); until then prefer `Targets.InstantSorcerySpellOrAbility` or a filter that names the ability kinds it means.
 - `Targets.InstantSorcerySpellOrAbility` — one requirement admitting an instant spell, sorcery spell, activated ability, or triggered ability on the stack (`TargetFilter.InstantSorcerySpellOrAbilityOnStack`, a single `CardPredicate.Or`). Pair with `Effects.CopyTargetSpellOrAbility()` — Return the Favor. **Note:** a STACK target requirement offers an ability as a legal target only when its filter *explicitly names an ability predicate* (anywhere inside `Or`/`And`/`Not`, including `CardPredicate.AbilitySourceMatches`); plain "target spell" filters stay spell-only (CR 112.1 vs 113.3b/c). Both readers — `TargetFinder.findSpellTargets` (the authoritative target set) and `TargetEnumerationUtils.findValidSpellTargets` (the legal actions sent to clients and the AI) — ask that question through the single `StackObjectTargeting.permitsAbilities` seam, so an ability-targeting card can't end up executable-but-never-offered.
 - `Targets.InstantSorceryOrTriggeredAbility` — narrower than `Targets.InstantSorcerySpellOrAbility`: admits an instant spell, sorcery spell, or **triggered** ability on the stack, but **not** an activated ability (`TargetFilter.InstantSorcerySpellOrTriggeredAbilityOnStack`, an `Or` of `IsInstant` / `IsSorcery` / `IsTriggeredAbility`). Because the filter names `IsTriggeredAbility`, the STACK enumeration offers triggered abilities (per the note above), while activated abilities stay excluded. Pair with `Effects.CounterSpellOrAbility()` — **Spider-Sense**'s "counter target instant spell, sorcery spell, or triggered ability."
 - `Targets.Card` — any card in any zone (e.g. graveyard).
@@ -3518,15 +3518,23 @@ work for abilities-on-stack (which carry no `CardComponent`).
   `PredicateContext`. **Last known information:** the source is read from the projection while it is
   on the battlefield and from its printed characteristics once it has left, so a dead creature's
   dies trigger still counts as "from a creature source" (CR 113.7a; CR 608.2b for the
-  resolution-time re-check) — the same source resolution `CantBeTargetedBySourceTypeAbilities` uses.
+  resolution-time re-check) — equivalent source resolution to what
+  `CantBeTargetedBySourceTypeAbilities` uses (a parallel implementation, not shared code). When the
+  source entity is *gone entirely* — a **token** swept by CR 704.5d — the predicate falls back to
+  `ActivatedAbilityOnStackComponent.lastKnownSourceSnapshot`, the `EntitySnapshot` frozen when the
+  ability's self-sacrifice/self-exile cost was paid, and evaluates the subfilter against it via
+  `PredicateEvaluator.matchesSnapshot`. That is what makes a cracked **Clue**/**Food**/**Blood**
+  token's ability a legal target for "from an artifact source".
   Never matches a spell. Build it with `GameObjectFilter.abilitySourceMatches(...)` /
   `TargetFilter.abilitySourceMatches(...)`, or the ready-made
   `Targets.ActivatedOrTriggeredAbilityYouControlFrom(sourceFilter)`.
-  Two limits of the last-known read, both inherited from how the engine stores last-known
-  information: a source whose type came from a continuous effect (animated land, crewed Vehicle) and
-  has since left reads its *printed* types; and a **token** source is unmatchable once it has left
-  the battlefield, because CR 704.5s cleanup deletes the entity and no snapshot survives where the
-  predicate can reach it (a sacrificed Clue's draw ability is missed by "from an artifact source").
+  Remaining limits, inherited from where the engine captures snapshots: a **nontoken** source that
+  left the battlefield some other way is read off the card in its new zone, so a type a continuous
+  effect had granted it (animated land, crewed Vehicle) is no longer visible — its *printed* types
+  answer; a deleted **token** source is only recoverable for an *activated* ability whose cost
+  sacrificed/exiled it, not for a triggered ability; and the snapshot arm answers only card types,
+  sub/supertypes, keywords, token-ness and controller, so a subfilter asking for a mana value, a
+  color or a P/T comparison does not match a deleted-token source.
 - `CardPredicate.HasNonManaActivatedAbility` — matches a permanent whose printed activated abilities
   include at least one that isn't a mana ability and isn't a loyalty ability (battlefield-activatable).
   Backed by the precomputed `CardComponent.hasNonManaActivatedAbility` flag (set at entity creation from

--- a/manual-scenarios/sets/msh/loop-msh-u08-new-cards-castable.json
+++ b/manual-scenarios/sets/msh/loop-msh-u08-new-cards-castable.json
@@ -1,0 +1,119 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Echo, Perceptive Prodigy",
+      "Scientist Supreme of A.I.M."
+    ],
+    "battlefield": [
+      {
+        "name": "Prodigal Sorcerer"
+      },
+      {
+        "name": "Rod of Ruin"
+      },
+      {
+        "name": "Lifespark Spellbomb"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Island"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      },
+      {
+        "name": "Swamp"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Island",
+      "Swamp",
+      "Island",
+      "Swamp"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Shock",
+      "Grizzly Bears",
+      "Hill Giant"
+    ],
+    "battlefield": [
+      {
+        "name": "Grizzly Bears"
+      },
+      {
+        "name": "Hill Giant"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      },
+      {
+        "name": "Mountain"
+      }
+    ],
+    "graveyard": [],
+    "library": [
+      "Mountain",
+      "Mountain",
+      "Mountain",
+      "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "DECLARE_ATTACKERS",
+    "DECLARE_BLOCKERS",
+    "COMBAT_DAMAGE",
+    "POSTCOMBAT_MAIN"
+  ],
+  "player2StopAtSteps": [
+    "PRECOMBAT_MAIN"
+  ],
+  "player1OpponentStopAtSteps": [
+    "PRECOMBAT_MAIN"
+  ],
+  "player2OpponentStopAtSteps": [
+    "PRECOMBAT_MAIN",
+    "DECLARE_BLOCKERS",
+    "POSTCOMBAT_MAIN"
+  ],
+  "mode": "SELF"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
@@ -406,6 +406,25 @@ object Targets {
     )
 
     /**
+     * Target activated or triggered ability you control on the stack **from a source matching
+     * [sourceFilter]** — the "from a creature source" (Echo, Perceptive Prodigy) / "from an
+     * artifact source" (Scientist Supreme of A.I.M.) narrowing of
+     * [ActivatedOrTriggeredAbilityYouControl].
+     *
+     * The restriction is on the ability's source per CR 113.7, not on the ability object itself
+     * (which has no characteristics of its own), and is matched with last known information when
+     * the source has already left the battlefield — a dead creature's dies trigger is still "from a
+     * creature source". See [com.wingedsheep.sdk.scripting.predicates.CardPredicate.AbilitySourceMatches].
+     * Pair with [com.wingedsheep.sdk.dsl.Effects.CopyTargetSpellOrAbility].
+     */
+    fun ActivatedOrTriggeredAbilityYouControlFrom(sourceFilter: GameObjectFilter): TargetRequirement =
+        TargetObject(
+            filter = TargetFilter.ActivatedOrTriggeredAbilityOnStack
+                .youControl()
+                .abilitySourceMatches(sourceFilter)
+        )
+
+    /**
      * Target spell or ability with a single target.
      * The single-target restriction is enforced at resolution time by the executor.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -330,6 +330,16 @@ data class GameObjectFilter(
     )
 
     /**
+     * Restrict to activated/triggered abilities on the stack whose *source* (CR 113.7) matches
+     * [subfilter] — "from a creature source" (Echo, Perceptive Prodigy), "from an artifact source"
+     * (Scientist Supreme of A.I.M.). Read with last known information when the source has already
+     * left the battlefield. See [CardPredicate.AbilitySourceMatches].
+     */
+    fun abilitySourceMatches(subfilter: GameObjectFilter) = copy(
+        cardPredicates = cardPredicates + CardPredicate.AbilitySourceMatches(subfilter)
+    )
+
+    /**
      * Add an arbitrary [CardPredicate] requirement. General-purpose combinator for predicates that
      * don't have a dedicated helper — e.g. `GameObjectFilter.Nonland.withCardPredicate(
      * CardPredicate.HasActivatedAbility)` for The Enigma Jewel's craft materials.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -433,6 +433,13 @@ data class TargetFilter(
     /** Must be controlled by you */
     fun youControl() = copy(baseFilter = baseFilter.youControl())
 
+    /**
+     * Narrow a stack-ability target by its *source* (CR 113.7): "…from a creature source",
+     * "…from an artifact source". See [CardPredicate.AbilitySourceMatches].
+     */
+    fun abilitySourceMatches(subfilter: GameObjectFilter) =
+        copy(baseFilter = baseFilter.abilitySourceMatches(subfilter))
+
     /** Must not be legendary */
     fun nonlegendary() = copy(baseFilter = baseFilter.nonlegendary())
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -1060,23 +1060,31 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
      * **Last known information.** Once an ability is on the stack it exists independently of its
      * source, and the source is routinely gone by the time the ability is targeted — a dies trigger's
      * source is already in the graveyard, a self-sacrifice ability's source is already sacrificed
-     * (CR 113.7a, and CR 608.2b for the resolution-time re-check). The engine therefore reads the
-     * source's *projected* characteristics while it is on the battlefield and falls back to its
+     * (CR 113.7a, and CR 608.2b for the resolution-time re-check). The engine reads the source in
+     * two steps: its *projected* characteristics while it is on the battlefield, falling back to its
      * printed ones once it has left, so "from a creature source" still matches a dead creature's
-     * dies trigger. Same source-characteristic resolution as
-     * `CantBeTargetedBySourceTypeAbilities` / protection-from-card-type.
+     * dies trigger; and, when the source entity no longer exists at all — a **token** swept by
+     * CR 704.5d — the frozen `EntitySnapshot` the activation captured before the self-sacrifice cost
+     * took it, so "from an artifact source" matches a cracked Clue's draw ability. Equivalent
+     * source-characteristic resolution to `CantBeTargetedBySourceTypeAbilities` /
+     * protection-from-card-type (a parallel implementation, not shared code).
      *
      * Applied to a spell on the stack, or to any object that is not an ability, this is false — a
      * spell is its own source and the clause deliberately does not reach it.
      *
-     * **Known limits of that last-known read**, both inherited from how the engine stores
-     * last-known information rather than from this predicate:
-     *  - a source whose *type* came from a continuous effect (an animated land, a crewed Vehicle)
-     *    and has since left the battlefield reads its printed types, not the projected ones;
-     *  - a **token** source is unmatchable once it has left the battlefield, because CR 704.5s
-     *    cleanup deletes the entity outright and no snapshot of it survives anywhere the predicate
-     *    can reach (so "from an artifact source" misses a sacrificed Clue's draw ability). Closing
-     *    that needs a general last-known store for deleted tokens, which the engine does not have.
+     * **Known limits of that last-known read**, inherited from where the engine captures snapshots
+     * rather than from this predicate:
+     *  - a **nontoken** source that left the battlefield some other way (it died, it was exiled)
+     *    is read from the card sitting in that zone, so a type a continuous effect had granted it
+     *    (an animated land, a crewed Vehicle) is no longer visible — its *printed* types answer.
+     *    Only the self-sacrifice/self-exile cost path freezes the projected type line;
+     *  - a deleted-token source is only recoverable for an **activated** ability whose cost
+     *    sacrificed/exiled it (the Clue / Food / Blood / Treasure shape, which is where the clause
+     *    actually comes up). A *triggered* ability whose token source has since ceased to exist has
+     *    no equivalent snapshot on its stack object and stays unmatchable;
+     *  - the snapshot arm answers only card types, sub/supertypes, keywords, token-ness and
+     *    controller. A subfilter asking for anything else (mana value, color, a P/T comparison)
+     *    does not match a deleted-token source.
      */
     @SerialName("AbilitySourceMatches")
     @Serializable

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -1043,6 +1043,52 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
         }
     }
 
+    /**
+     * Matches an **activated or triggered ability on the stack** whose *source* (CR 113.7 — the
+     * object that generated it) matches [subfilter]. The "from a creature source" / "from an
+     * artifact source" clause: Echo, Perceptive Prodigy and Scientist Supreme of A.I.M.
+     *
+     * An ability on the stack is its own object (CR 113.3b/c) and carries none of its source's
+     * characteristics, so a plain type predicate applied to the ability entity can never be true.
+     * This predicate is the redirection: it re-points the match at the ability's source and
+     * evaluates [subfilter] there, which is why the restriction is a `CardPredicate` composed into
+     * the ordinary ability filter rather than a bespoke `TargetRequirement`. It composes with
+     * everything else the same way — `and`/`or`/`not`, controller predicates, any subfilter the SDK
+     * can express (`Creature`, `Artifact`, `Creature.youControl()`, a subtype, …) — instead of
+     * forcing a new target type per source category.
+     *
+     * **Last known information.** Once an ability is on the stack it exists independently of its
+     * source, and the source is routinely gone by the time the ability is targeted — a dies trigger's
+     * source is already in the graveyard, a self-sacrifice ability's source is already sacrificed
+     * (CR 113.7a, and CR 608.2b for the resolution-time re-check). The engine therefore reads the
+     * source's *projected* characteristics while it is on the battlefield and falls back to its
+     * printed ones once it has left, so "from a creature source" still matches a dead creature's
+     * dies trigger. Same source-characteristic resolution as
+     * `CantBeTargetedBySourceTypeAbilities` / protection-from-card-type.
+     *
+     * Applied to a spell on the stack, or to any object that is not an ability, this is false — a
+     * spell is its own source and the clause deliberately does not reach it.
+     *
+     * **Known limits of that last-known read**, both inherited from how the engine stores
+     * last-known information rather than from this predicate:
+     *  - a source whose *type* came from a continuous effect (an animated land, a crewed Vehicle)
+     *    and has since left the battlefield reads its printed types, not the projected ones;
+     *  - a **token** source is unmatchable once it has left the battlefield, because CR 704.5s
+     *    cleanup deletes the entity outright and no snapshot of it survives anywhere the predicate
+     *    can reach (so "from an artifact source" misses a sacrificed Clue's draw ability). Closing
+     *    that needs a general last-known store for deleted tokens, which the engine does not have.
+     */
+    @SerialName("AbilitySourceMatches")
+    @Serializable
+    data class AbilitySourceMatches(val subfilter: GameObjectFilter) : CardPredicate {
+        override val description: String =
+            "from ${subfilter.indefiniteArticle} ${subfilter.description} source"
+        override fun applyTextReplacement(replacer: TextReplacer): CardPredicate {
+            val newSubfilter = subfilter.applyTextReplacement(replacer)
+            return if (newSubfilter !== subfilter) copy(subfilter = newSubfilter) else this
+        }
+    }
+
     // =============================================================================
     // Composite Predicates
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/EchoPerceptiveProdigy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/EchoPerceptiveProdigy.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Echo, Perceptive Prodigy — Marvel Super Heroes #51 (uncommon)
+ * {2}{U} · Legendary Creature — Human Hero · 1/4
+ *
+ * Vigilance
+ * {1}, {T}: Copy target activated or triggered ability you control from a creature source. You may
+ * choose new targets for the copy. (Mana abilities can't be targeted.)
+ *
+ * Composed entirely from existing primitives plus one new predicate:
+ *  - [Targets.ActivatedOrTriggeredAbilityYouControlFrom]`(Creature)` — the existing
+ *    "target activated or triggered ability you control" filter (Gogo, Master of Mimicry;
+ *    Peter Parker's Camera) narrowed by `CardPredicate.AbilitySourceMatches(Creature)`. The
+ *    restriction is on the ability's *source* (CR 113.7), not on the ability object, which has no
+ *    characteristics of its own; the source is read with last known information, so a creature's
+ *    dies trigger — whose source is already in the graveyard when the trigger is on the stack —
+ *    is still "from a creature source" (CR 113.7a). Mana abilities never use the stack, so the
+ *    reminder text needs no modelling.
+ *  - [Effects.CopyTargetSpellOrAbility] — copies the chosen ability on the stack and reprompts for
+ *    new targets per CR 707.10c (the copy has the same source as the original, CR 707.10b).
+ *  - `holdPriority` keeps auto-pass from resolving your own ability before you get the chance to
+ *    copy it; the enumerator only surfaces the hint when a legal ability is actually on the stack.
+ */
+val EchoPerceptiveProdigy = card("Echo, Perceptive Prodigy") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Hero"
+    power = 1
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "{1}, {T}: Copy target activated or triggered ability you control from a creature source. " +
+        "You may choose new targets for the copy. (Mana abilities can't be targeted.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        val ability = target(
+            "activated or triggered ability you control from a creature source",
+            Targets.ActivatedOrTriggeredAbilityYouControlFrom(GameObjectFilter.Creature)
+        )
+        effect = Effects.CopyTargetSpellOrAbility(ability)
+        holdPriority = true
+        description = "{1}, {T}: Copy target activated or triggered ability you control from a " +
+            "creature source. You may choose new targets for the copy."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Jurijus Chitrovas"
+        flavorText = "\"I've seen the fighting techniques of some of the best. Now their strengths " +
+            "are mine.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd9b9be6-0143-467c-8a2a-937ecafe0473.jpg?1783902961"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/ScientistSupremeOfAim.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/ScientistSupremeOfAim.kt
@@ -19,10 +19,13 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
  * The artifact-source twin of Echo, Perceptive Prodigy, built from the same pieces:
  *  - [Targets.ActivatedOrTriggeredAbilityYouControlFrom]`(Artifact)` — the existing ability-on-stack
  *    target narrowed by `CardPredicate.AbilitySourceMatches(Artifact)`, which matches the ability's
- *    *source* (CR 113.7) rather than the ability object. An artifact that was animated into a
- *    creature still counts (the source's projected types are read while it is on the battlefield),
- *    and an artifact that has already been sacrificed to its own ability still counts too, because
- *    the source is read with last known information (CR 113.7a).
+ *    *source* (CR 113.7) rather than the ability object. An artifact that has already sacrificed
+ *    itself to pay for its own ability still counts, because the source is read with last known
+ *    information (CR 113.7a) — that holds for a plain artifact card (which is sitting in the
+ *    graveyard) and for an artifact **token** alike, even though CR 704.5d has deleted the token
+ *    outright, because the activation froze an `EntitySnapshot` of it. Cracking a Clue or a Food is
+ *    the line this card is printed for, and MSH makes both (Agent 13, Panther Pounce; Ant-Man's
+ *    Army, Heroic Feast).
  *  - [Effects.CopyTargetSpellOrAbility] — the copy, with the CR 707.10c retarget prompt.
  *  - Cost is a bare [Costs.PayLife] — no mana, no tap, so it works the turn Scientist Supreme
  *    enters. The two activation clauses are the existing restrictions

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/ScientistSupremeOfAim.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msh/cards/ScientistSupremeOfAim.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.msh.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Scientist Supreme of A.I.M. — Marvel Super Heroes #225 (rare)
+ * {U}{B} · Legendary Creature — Human Scientist Villain · 2/2
+ *
+ * Pay 2 life: Copy target activated or triggered ability you control from an artifact source. You
+ * may choose new targets for the copy. Activate only during your turn and only once each turn.
+ * (Mana abilities can't be targeted.)
+ *
+ * The artifact-source twin of Echo, Perceptive Prodigy, built from the same pieces:
+ *  - [Targets.ActivatedOrTriggeredAbilityYouControlFrom]`(Artifact)` — the existing ability-on-stack
+ *    target narrowed by `CardPredicate.AbilitySourceMatches(Artifact)`, which matches the ability's
+ *    *source* (CR 113.7) rather than the ability object. An artifact that was animated into a
+ *    creature still counts (the source's projected types are read while it is on the battlefield),
+ *    and an artifact that has already been sacrificed to its own ability still counts too, because
+ *    the source is read with last known information (CR 113.7a).
+ *  - [Effects.CopyTargetSpellOrAbility] — the copy, with the CR 707.10c retarget prompt.
+ *  - Cost is a bare [Costs.PayLife] — no mana, no tap, so it works the turn Scientist Supreme
+ *    enters. The two activation clauses are the existing restrictions
+ *    [ActivationRestriction.OnlyDuringYourTurn] and [ActivationRestriction.OncePerTurn].
+ *  - `holdPriority` keeps auto-pass from resolving your own artifact's ability before you can copy it.
+ */
+val ScientistSupremeOfAim = card("Scientist Supreme of A.I.M.") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human Scientist Villain"
+    power = 2
+    toughness = 2
+    oracleText = "Pay 2 life: Copy target activated or triggered ability you control from an " +
+        "artifact source. You may choose new targets for the copy. Activate only during your turn " +
+        "and only once each turn. (Mana abilities can't be targeted.)"
+
+    activatedAbility {
+        cost = Costs.PayLife(2)
+        val ability = target(
+            "activated or triggered ability you control from an artifact source",
+            Targets.ActivatedOrTriggeredAbilityYouControlFrom(GameObjectFilter.Artifact)
+        )
+        effect = Effects.CopyTargetSpellOrAbility(ability)
+        restrictions = listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.OncePerTurn
+        )
+        holdPriority = true
+        description = "Pay 2 life: Copy target activated or triggered ability you control from an " +
+            "artifact source. You may choose new targets for the copy. Activate only during your " +
+            "turn and only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "225"
+        artist = "Gal Or"
+        flavorText = "\"A weapon to kill a god? A.I.M. can do that, if you have the money.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/0473a990-88c4-4921-a492-377d9171318a.jpg?1783902899"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -4696,6 +4696,83 @@
     ]
 }
 
+// Echo, Perceptive Prodigy
+{
+    "name": "Echo, Perceptive Prodigy",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Human Hero",
+    "oracleText": "Vigilance\n{1}, {T}: Copy target activated or triggered ability you control from a creature source. You may choose new targets for the copy. (Mana abilities can't be targeted.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CopyTargetSpellOrAbility",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "activated or triggered ability you control from a creature source"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsActivatedOrTriggeredAbility",
+                                    {
+                                        "type": "AbilitySourceMatches",
+                                        "subfilter": {
+                                            "cardPredicates": [
+                                                "IsCreature"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            },
+                            "zone": "Stack"
+                        },
+                        "id": "activated or triggered ability you control from a creature source"
+                    }
+                ],
+                "descriptionOverride": "{1}, {T}: Copy target activated or triggered ability you control from a creature source. You may choose new targets for the copy.",
+                "holdPriority": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Jurijus Chitrovas",
+        "flavorText": "\"I've seen the fighting techniques of some of the best. Now their strengths are mine.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd9b9be6-0143-467c-8a2a-937ecafe0473.jpg?1783902961"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Elektra, Daughter of the Hand
 {
     "name": "Elektra, Daughter of the Hand",
@@ -12215,6 +12292,79 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Scientist Supreme of A.I.M.
+{
+    "name": "Scientist Supreme of A.I.M.",
+    "manaCost": "{U}{B}",
+    "typeLine": "Legendary Creature — Human Scientist Villain",
+    "oracleText": "Pay 2 life: Copy target activated or triggered ability you control from an artifact source. You may choose new targets for the copy. Activate only during your turn and only once each turn. (Mana abilities can't be targeted.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 2
+                    }
+                },
+                "effect": {
+                    "type": "CopyTargetSpellOrAbility",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "activated or triggered ability you control from an artifact source"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsActivatedOrTriggeredAbility",
+                                    {
+                                        "type": "AbilitySourceMatches",
+                                        "subfilter": {
+                                            "cardPredicates": [
+                                                "IsArtifact"
+                                            ]
+                                        }
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            },
+                            "zone": "Stack"
+                        },
+                        "id": "activated or triggered ability you control from an artifact source"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn",
+                    "OncePerTurn"
+                ],
+                "descriptionOverride": "Pay 2 life: Copy target activated or triggered ability you control from an artifact source. You may choose new targets for the copy. Activate only during your turn and only once each turn.",
+                "holdPriority": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "RARE",
+        "artist": "Gal Or",
+        "flavorText": "\"A weapon to kill a god? A.I.M. can do that, if you have the money.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/0473a990-88c4-4921-a492-377d9171318a.jpg?1783902899"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -224,6 +224,26 @@ class PredicateEvaluator {
                 matches(state, projected, targetEntityId, predicate.subfilter, subContext)
             }
         }
+        // Ability-source predicate ("copy target ability ... from a creature source"): an ability on
+        // the stack is its own object with no characteristics of its own (CR 113.3b/c), so the match
+        // is redirected onto the ability's source (CR 113.7) and evaluated there. Handled before the
+        // CardComponent null-check for the same reason the ability predicates above are — the
+        // ability entity has no CardComponent.
+        //
+        // Last known information: the source is routinely gone by the time the ability is on the
+        // stack (a dies trigger's source is in the graveyard; a self-sacrifice ability's source is
+        // already sacrificed). `matches` reads the source's projected characteristics while it is on
+        // the battlefield and falls back to its printed ones once it has left — the same resolution
+        // `SourceTypeTargeting.sourceCardTypes` uses for Artifact Ward, and what CR 113.7a /
+        // CR 608.2b call for. A spell on the stack is deliberately not matched: it has no
+        // ability-on-stack component, and the clause only ever speaks of abilities.
+        if (predicate is CardPredicate.AbilitySourceMatches) {
+            val sourceId = container.get<ActivatedAbilityOnStackComponent>()?.sourceId
+                ?: container.get<TriggeredAbilityOnStackComponent>()?.sourceId
+                ?: return false
+            val subContext = context ?: return false
+            return matches(state, projected, sourceId, predicate.subfilter, subContext)
+        }
 
         val card = container.get<CardComponent>() ?: return false
         val projectedValues = projected.getProjectedValues(entityId)
@@ -811,6 +831,7 @@ class PredicateEvaluator {
             CardPredicate.IsTriggeredAbility -> false
             CardPredicate.IsActivatedAbility -> false
             is CardPredicate.TargetsMatching -> false
+            is CardPredicate.AbilitySourceMatches -> false
         }
     }
 
@@ -1617,6 +1638,10 @@ class PredicateEvaluator {
             // Stack-relative targeting predicate — historical cast records have no
             // chosen-target snapshot, so this always returns false here.
             is CardPredicate.TargetsMatching -> false
+
+            // Ability-source predicate — a cast-spell record is not an ability and has no source
+            // object to inspect.
+            is CardPredicate.AbilitySourceMatches -> false
 
             // Composite predicates
             is CardPredicate.And -> predicate.predicates.all { matchesRecordPredicate(record, it) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -145,6 +145,18 @@ class PredicateEvaluator {
      * predicate makes the whole filter fail to match, which is the same answer the caller got before
      * any snapshot existed. State predicates (tapped, attacking, …) describe a battlefield presence
      * the object no longer has, so a filter carrying one never matches a snapshot.
+     *
+     * **Caller invariant: pass a snapshot captured with the state-aware
+     * [com.wingedsheep.engine.state.components.stack.captureEntitySnapshots] overload** (the
+     * `(ids, state)` one), and populate [EntitySnapshot.typeLine] and [EntitySnapshot.keywords] on
+     * top of it. The unanswerable-reports-null discipline above cannot cover
+     * [EntitySnapshot.wasToken] or [EntitySnapshot.keywords]: both default to a *legitimate* value
+     * (`false` / empty) with no "was never captured" state, so a snapshot taken by the projection-
+     * only overload answers `IsToken` false, `IsNontoken` true and every `HasKeyword` false with
+     * full confidence rather than reporting unknown. There is one caller today
+     * ([CardPredicate.AbilitySourceMatches] against
+     * [com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent.lastKnownSourceSnapshot],
+     * which does exactly that); a second one must too.
      */
     fun matchesSnapshot(
         state: GameState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -32,9 +32,11 @@ import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.engine.state.components.identity.PutIntoGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
+import com.wingedsheep.engine.state.components.stack.EntitySnapshot
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.sdk.core.Keyword
@@ -124,6 +126,122 @@ class PredicateEvaluator {
         }
 
         return true
+    }
+
+    /**
+     * Evaluate [filter] against **frozen last-known information** instead of a live entity — the
+     * arm of [matches] for an object the engine can no longer look up at all. Today that means a
+     * *token*: CR 704.5d sweeps a token out of any non-battlefield zone as a state-based action and
+     * the entity is deleted, so a Clue that sacrificed itself to pay for its own draw ability has no
+     * `getEntity` row left while that ability sits on the stack (CR 113.7a — the ability exists
+     * independently of its source, and the source's last known information is what answers
+     * questions about it).
+     *
+     * **Partial by construction**, and deliberately so: what is answered here is card types,
+     * sub/supertypes, keywords, token-ness and controller — the characteristics an "…from an X
+     * source" clause is ever written against. A predicate outside that set (mana value, colors,
+     * P/T comparisons, "has a non-mana activated ability", …) reports
+     * *unanswerable* rather than guessing — see [matchesSnapshotPredicate] — and an unanswerable
+     * predicate makes the whole filter fail to match, which is the same answer the caller got before
+     * any snapshot existed. State predicates (tapped, attacking, …) describe a battlefield presence
+     * the object no longer has, so a filter carrying one never matches a snapshot.
+     */
+    fun matchesSnapshot(
+        state: GameState,
+        snapshot: EntitySnapshot,
+        filter: GameObjectFilter,
+        context: PredicateContext
+    ): Boolean {
+        filter.controllerPredicate?.let { controllerPred ->
+            if (!matchesSnapshotController(state, snapshot, controllerPred, context)) return false
+        }
+        if (filter.statePredicates.isNotEmpty()) return false
+        if (!filter.cardPredicates.all { matchesSnapshotPredicate(snapshot, it) == true }) return false
+        if (filter.anyOf.isNotEmpty()) {
+            return filter.anyOf.any { matchesSnapshot(state, snapshot, it, context) }
+        }
+        return true
+    }
+
+    /**
+     * Tri-state evaluation of one [CardPredicate] against frozen last-known information:
+     * `true`/`false` when [EntitySnapshot] carries the characteristic, **null** when it doesn't.
+     *
+     * The null arm is what keeps [CardPredicate.Not] honest — negating "I don't know" would turn an
+     * unsupported predicate into a match — and it propagates through `And`/`Or` the way an unknown
+     * operand should: `And` is false if any operand is false, unknown if any is unknown; `Or` is
+     * true if any operand is true, unknown if any is unknown.
+     */
+    private fun matchesSnapshotPredicate(snapshot: EntitySnapshot, predicate: CardPredicate): Boolean? {
+        val typeLine = snapshot.typeLine
+        return when (predicate) {
+            CardPredicate.IsCreature -> typeLine?.isCreature
+            CardPredicate.IsLand -> typeLine?.isLand
+            CardPredicate.IsArtifact -> typeLine?.isArtifact
+            CardPredicate.IsEnchantment -> typeLine?.isEnchantment
+            CardPredicate.IsInstant -> typeLine?.isInstant
+            CardPredicate.IsSorcery -> typeLine?.isSorcery
+            CardPredicate.IsPlaneswalker -> typeLine?.cardTypes?.contains(CardType.PLANESWALKER)
+            CardPredicate.IsPermanent -> typeLine?.isPermanent
+            CardPredicate.IsLegendary -> typeLine?.isLegendary
+            CardPredicate.IsNonlegendary -> typeLine?.isLegendary?.not()
+            CardPredicate.IsToken -> snapshot.wasToken
+            CardPredicate.IsNontoken -> !snapshot.wasToken
+            is CardPredicate.HasSubtype ->
+                typeLine?.hasSubtype(predicate.subtype)
+                    ?: snapshot.subtypes.any { it.equals(predicate.subtype.value, ignoreCase = true) }
+            is CardPredicate.HasKeyword -> predicate.keyword.name in snapshot.keywords
+            is CardPredicate.Not -> matchesSnapshotPredicate(snapshot, predicate.predicate)?.not()
+            is CardPredicate.And -> {
+                val results = predicate.predicates.map { matchesSnapshotPredicate(snapshot, it) }
+                when {
+                    results.any { it == false } -> false
+                    results.any { it == null } -> null
+                    else -> true
+                }
+            }
+            is CardPredicate.Or -> {
+                val results = predicate.predicates.map { matchesSnapshotPredicate(snapshot, it) }
+                when {
+                    results.any { it == true } -> true
+                    results.any { it == null } -> null
+                    else -> false
+                }
+            }
+            else -> null
+        }
+    }
+
+    /**
+     * [ControllerPredicate] against a snapshot's frozen [EntitySnapshot.controllerId]. Only the
+     * control-based predicates can be answered — ownership isn't frozen — and an unfrozen
+     * controller (or an owner-based predicate) is a non-match, matching [matchesSnapshotPredicate]'s
+     * conservative default.
+     */
+    private fun matchesSnapshotController(
+        state: GameState,
+        snapshot: EntitySnapshot,
+        predicate: ControllerPredicate,
+        context: PredicateContext
+    ): Boolean {
+        val controllerId = snapshot.controllerId ?: return false
+        return when (predicate) {
+            is ControllerPredicate.And ->
+                predicate.predicates.all { matchesSnapshotController(state, snapshot, it, context) }
+            is ControllerPredicate.Or ->
+                predicate.predicates.any { matchesSnapshotController(state, snapshot, it, context) }
+            is ControllerPredicate.Not ->
+                !matchesSnapshotController(state, snapshot, predicate.predicate, context)
+            ControllerPredicate.ControlledByYou -> controllerId == context.controllerId
+            ControllerPredicate.ControlledByOpponent -> controllerId != context.controllerId
+            ControllerPredicate.ControlledByAny -> true
+            ControllerPredicate.ControlledByActivePlayer -> controllerId == state.activePlayerId
+            ControllerPredicate.ControlledByTargetOpponent ->
+                context.targetOpponentId?.let { controllerId == it } ?: false
+            ControllerPredicate.ControlledByTargetPlayer ->
+                context.targetPlayerId?.let { controllerId == it } ?: false
+            else -> false
+        }
     }
 
     /**
@@ -232,17 +350,35 @@ class PredicateEvaluator {
         //
         // Last known information: the source is routinely gone by the time the ability is on the
         // stack (a dies trigger's source is in the graveyard; a self-sacrifice ability's source is
-        // already sacrificed). `matches` reads the source's projected characteristics while it is on
-        // the battlefield and falls back to its printed ones once it has left — the same resolution
-        // `SourceTypeTargeting.sourceCardTypes` uses for Artifact Ward, and what CR 113.7a /
-        // CR 608.2b call for. A spell on the stack is deliberately not matched: it has no
-        // ability-on-stack component, and the clause only ever speaks of abilities.
+        // already sacrificed). Two arms, in order:
+        //  1. the source entity still exists — `matches` reads its projected characteristics while
+        //     it is on the battlefield and falls back to its printed ones once it has left, which
+        //     is equivalent resolution to what `SourceTypeTargeting.sourceCardTypes` does for
+        //     Artifact Ward, and what CR 113.7a / CR 608.2b call for;
+        //  2. the source entity is *gone* — a token swept by CR 704.5d — so fall back to the frozen
+        //     `lastKnownSourceSnapshot` the activation captured before the self-sacrifice cost took
+        //     it (a cracked Clue is still "an artifact source"). This is the same LKI value type the
+        //     rest of the engine uses (`EntitySnapshot`), read through the `EntityView` accessors,
+        //     not a parallel store.
+        // A spell on the stack is deliberately not matched: it has no ability-on-stack component,
+        // and the clause only ever speaks of abilities.
         if (predicate is CardPredicate.AbilitySourceMatches) {
-            val sourceId = container.get<ActivatedAbilityOnStackComponent>()?.sourceId
+            val activated = container.get<ActivatedAbilityOnStackComponent>()
+            val sourceId = activated?.sourceId
                 ?: container.get<TriggeredAbilityOnStackComponent>()?.sourceId
                 ?: return false
+            // A missing context is a non-match rather than a context-free evaluation of the
+            // subfilter, deliberately and in step with the `TargetsMatching` branch above: the
+            // subfilter may carry a controller predicate ("from a creature source you control")
+            // that has no answer without one, and both live call sites (TargetFinder,
+            // TargetEnumerationUtils) always supply a context.
             val subContext = context ?: return false
-            return matches(state, projected, sourceId, predicate.subfilter, subContext)
+            if (state.getEntity(sourceId) != null) {
+                return matches(state, projected, sourceId, predicate.subfilter, subContext)
+            }
+            val snapshot = activated?.lastKnownSourceSnapshot?.takeIf { it.entityId == sourceId }
+                ?: return false
+            return matchesSnapshot(state, snapshot, predicate.subfilter, subContext)
         }
 
         val card = container.get<CardComponent>() ?: return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.targeting.ControllerHexproof
 import com.wingedsheep.engine.mechanics.targeting.ControllerShroud
 import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
+import com.wingedsheep.engine.mechanics.targeting.StackObjectTargeting
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -461,32 +462,12 @@ class TargetFinder(
         // names an ability predicate (Stifle's "counter target ability", Willbender's "spell or
         // ability", Return the Favor's "spell or ability"). For spells the predicate decides as
         // before. This is the single seam where both spells and abilities become legal targets.
-        val abilitiesAllowed = filterPermitsAbilitiesOnStack(filter.baseFilter)
+        val abilitiesAllowed = StackObjectTargeting.permitsAbilities(filter.baseFilter)
         return state.stack.filter { stackId ->
             val isAbility = !state.isSpellOnStack(stackId)
             if (isAbility && !abilitiesAllowed) return@filter false
             predicateEvaluator.matches(state, state.projectedState, stackId, filter.baseFilter, predicateContext)
         }
-    }
-
-    /**
-     * Does this filter explicitly permit *abilities* on the stack (as opposed to only spells)?
-     * True iff any [CardPredicate] in the filter — including inside [CardPredicate.Or] / `And`
-     * branches and [GameObjectFilter.anyOf] sub-filters — names an ability predicate. Keeps the
-     * default "target spell" filters (base `Any`, with no ability predicate) spell-only.
-     */
-    private fun filterPermitsAbilitiesOnStack(filter: GameObjectFilter): Boolean {
-        fun predicateNamesAbility(p: CardPredicate): Boolean = when (p) {
-            CardPredicate.IsActivatedOrTriggeredAbility,
-            CardPredicate.IsTriggeredAbility,
-            CardPredicate.IsActivatedAbility -> true
-            is CardPredicate.Or -> p.predicates.any(::predicateNamesAbility)
-            is CardPredicate.And -> p.predicates.any(::predicateNamesAbility)
-            is CardPredicate.Not -> predicateNamesAbility(p.predicate)
-            else -> false
-        }
-        return filter.cardPredicates.any(::predicateNamesAbility) ||
-            filter.anyOf.any { filterPermitsAbilitiesOnStack(it) }
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1232,14 +1232,39 @@ class ActivateAbilityHandler(
                     } ?: emptyMap()
             } else emptyMap()
 
-        // Snapshot the source's projected P/T before a self-exile / self-sacrifice cost moves it
-        // off the battlefield (CR 112.7a / 608.2h), so an effect that reads its own power — e.g.
-        // "Sacrifice this creature: it deals damage equal to its power" (Ghitu Fire-Eater, Cinder
-        // Shade, Blazing Bomb's Blow Up) — sees the pre-sacrifice power rather than zero. Mirrors
-        // lastKnownSourceCounters above.
+        // Snapshot the source's projected characteristics before a self-exile / self-sacrifice cost
+        // moves it off the battlefield (CR 112.7a / 608.2h), so an effect that reads its own power —
+        // e.g. "Sacrifice this creature: it deals damage equal to its power" (Ghitu Fire-Eater,
+        // Cinder Shade, Blazing Bomb's Blow Up) — sees the pre-sacrifice power rather than zero.
+        // Mirrors lastKnownSourceCounters above.
+        //
+        // The projected *type line* and token-ness ride along because for a **token** source this
+        // snapshot is the only surviving record of the object at all: CR 704.5d sweeps a token out
+        // of any non-battlefield zone as a state-based action and the entity is deleted outright,
+        // so by the time the ability sits on the stack `state.getEntity(sourceId)` is null. That is
+        // what lets "copy target activated ability you control from an artifact source" (Scientist
+        // Supreme of A.I.M.) still see a cracked Clue as an artifact source — see
+        // `CardPredicate.AbilitySourceMatches` in PredicateEvaluator. Reading the *projected* type
+        // line here also gets the animated-artifact / crewed-Vehicle source right.
         val lastKnownSourceSnapshot: com.wingedsheep.engine.state.components.stack.EntitySnapshot? =
             if (costExilesOrSacrificesSelf(effectiveCost)) {
-                captureEntitySnapshots(listOf(action.sourceId), currentState.projectedState).firstOrNull()
+                captureEntitySnapshots(listOf(action.sourceId), currentState.projectedState)
+                    .firstOrNull()
+                    ?.copy(
+                        typeLine = com.wingedsheep.engine.state.components.stack.projectedTypeLine(
+                            currentState, action.sourceId
+                        ),
+                        keywords = currentState.projectedState.getKeywords(action.sourceId),
+                        wasToken = currentState.getEntity(action.sourceId)
+                            ?.has<com.wingedsheep.engine.state.components.identity.TokenComponent>()
+                            ?: false,
+                        cardDefinitionId = currentState.getEntity(action.sourceId)
+                            ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                            ?.cardDefinitionId,
+                        name = currentState.getEntity(action.sourceId)
+                            ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                            ?.name,
+                    )
             } else null
 
         // Snapshot the entity ids attached to the source before a self-exile / self-sacrifice cost

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1233,7 +1233,7 @@ class ActivateAbilityHandler(
             } else emptyMap()
 
         // Snapshot the source's projected characteristics before a self-exile / self-sacrifice cost
-        // moves it off the battlefield (CR 112.7a / 608.2h), so an effect that reads its own power —
+        // moves it off the battlefield (CR 113.7a / 608.2h), so an effect that reads its own power —
         // e.g. "Sacrifice this creature: it deals damage equal to its power" (Ghitu Fire-Eater,
         // Cinder Shade, Blazing Bomb's Blow Up) — sees the pre-sacrifice power rather than zero.
         // Mirrors lastKnownSourceCounters above.
@@ -1246,24 +1246,21 @@ class ActivateAbilityHandler(
         // Supreme of A.I.M.) still see a cracked Clue as an artifact source — see
         // `CardPredicate.AbilitySourceMatches` in PredicateEvaluator. Reading the *projected* type
         // line here also gets the animated-artifact / crewed-Vehicle source right.
+        //
+        // The state-aware `captureEntitySnapshots` overload already freezes token-ness and the
+        // name; only the projected type line, keywords and card-definition id are layered on top.
         val lastKnownSourceSnapshot: com.wingedsheep.engine.state.components.stack.EntitySnapshot? =
             if (costExilesOrSacrificesSelf(effectiveCost)) {
-                captureEntitySnapshots(listOf(action.sourceId), currentState.projectedState)
+                captureEntitySnapshots(listOf(action.sourceId), currentState)
                     .firstOrNull()
                     ?.copy(
                         typeLine = com.wingedsheep.engine.state.components.stack.projectedTypeLine(
                             currentState, action.sourceId
                         ),
                         keywords = currentState.projectedState.getKeywords(action.sourceId),
-                        wasToken = currentState.getEntity(action.sourceId)
-                            ?.has<com.wingedsheep.engine.state.components.identity.TokenComponent>()
-                            ?: false,
                         cardDefinitionId = currentState.getEntity(action.sourceId)
                             ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
                             ?.cardDefinitionId,
-                        name = currentState.getEntity(action.sourceId)
-                            ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
-                            ?.name,
                     )
             } else null
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -1036,6 +1036,7 @@ class CastZoneResolver(
                 is CardPredicate.DoesNotShareCreatureTypeWithPermanentYouControl,
                 is CardPredicate.DoesNotShareLandTypeWithPermanentYouControl,
                 is CardPredicate.TargetsMatching,
+                is CardPredicate.AbilitySourceMatches,
                 is CardPredicate.IsActivatedOrTriggeredAbility,
                 is CardPredicate.IsTriggeredAbility,
                 is CardPredicate.IsActivatedAbility -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -1230,25 +1230,19 @@ object ZoneTransitionService {
      * firing for creatures Ygra turned into Food artifacts).
      *
      * Falls back to the base typeLine if projection has no entry for the entity.
+     *
+     * Delegates to the shared
+     * [com.wingedsheep.engine.state.components.stack.projectedTypeLine] so the cost-time capture
+     * (`ActivateAbilityHandler`'s `lastKnownSourceSnapshot`) freezes exactly the same type line
+     * this path does — one implementation, not two that can drift.
      */
     private fun buildProjectedTypeLine(
         cardComponent: CardComponent,
         state: GameState,
         entityId: EntityId
-    ): TypeLine {
-        val baseTypeLine = cardComponent.typeLine
-        val projected = state.projectedState.getProjectedValues(entityId) ?: return baseTypeLine
-
-        val cardTypes = projected.types
-            .mapNotNull { runCatching { CardType.valueOf(it) }.getOrNull() }
-            .toSet()
-            .ifEmpty { baseTypeLine.cardTypes }
-        val subtypes = projected.subtypes.map { Subtype(it) }.toSet()
-        return baseTypeLine.copy(
-            cardTypes = cardTypes,
-            subtypes = subtypes
-        )
-    }
+    ): TypeLine = com.wingedsheep.engine.state.components.stack.projectedTypeLine(
+        state, entityId, cardComponent.typeLine
+    )
 
     /**
      * Find which zone an entity is currently in.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.mechanics.targeting.ControllerHexproof
 import com.wingedsheep.engine.mechanics.targeting.ControllerShroud
 import com.wingedsheep.engine.mechanics.targeting.HexproofSuppression
 import com.wingedsheep.engine.mechanics.targeting.PlayerTargetRestriction
+import com.wingedsheep.engine.mechanics.targeting.StackObjectTargeting
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
@@ -236,14 +237,22 @@ class TargetEnumerationUtils(
         filter: TargetFilter
     ): List<EntityId> {
         val context = PredicateContext(controllerId = playerId)
-        return state.stack.filter { spellId ->
-            // "Target spell" only matches actual spells — never triggered/activated abilities on
-            // the stack. A spell is a card on the stack (CR 112.1); an ability on the stack is an
-            // ability, not a spell (CR 113.3b/c, 113.7a). The base filter is `Any` (zone = STACK)
-            // and would otherwise pass ability entities, surfacing a castable counterspell whenever
-            // anything is on the stack — which previously left the AI in an infinite re-pick loop.
-            state.isSpellOnStack(spellId) &&
-                predicateEvaluator.matches(state, state.projectedState, spellId, filter.baseFilter, context)
+        // "Target spell" only matches actual spells — never triggered/activated abilities on the
+        // stack. A spell is a card on the stack (CR 112.1); an ability on the stack is an ability,
+        // not a spell (CR 113.3b/c, 113.7a). The base filter is `Any` (zone = STACK) and would
+        // otherwise pass ability entities, surfacing a castable counterspell whenever anything is on
+        // the stack — which previously left the AI in an infinite re-pick loop.
+        //
+        // A filter that *does* name an ability ("counter target ability", "copy target activated or
+        // triggered ability you control") must enumerate ability entities, or the card is executable
+        // but never offered: the enumeration below is what the server sends to the client and the AI
+        // as legal targets, so a blanket spells-only filter here makes every ability-targeting card
+        // unplayable through the UI even though the engine would accept the action. Same seam, same
+        // answer as the authoritative target set in `TargetFinder` — see [StackObjectTargeting].
+        val abilitiesAllowed = StackObjectTargeting.permitsAbilities(filter.baseFilter)
+        return state.stack.filter { stackId ->
+            if (!abilitiesAllowed && !state.isSpellOnStack(stackId)) return@filter false
+            predicateEvaluator.matches(state, state.projectedState, stackId, filter.baseFilter, context)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -811,6 +811,7 @@ internal class AffectsFilterResolver {
         CardPredicate.IsTriggeredAbility,
         CardPredicate.IsActivatedAbility -> false
         is CardPredicate.TargetsMatching -> false
+        is CardPredicate.AbilitySourceMatches -> false
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -1216,6 +1216,7 @@ class CostCalculator(
             CardPredicate.IsTriggeredAbility -> false
             CardPredicate.IsActivatedAbility -> false
             is CardPredicate.TargetsMatching -> false
+            is CardPredicate.AbilitySourceMatches -> false
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/StackObjectTargeting.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/StackObjectTargeting.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.engine.mechanics.targeting
+
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * The single answer to "may this stack-zone target requirement offer *abilities*, not just spells?".
+ *
+ * A spell is a card on the stack (CR 112.1); an activated or triggered ability on the stack is a
+ * different kind of object (CR 113.3b/c, 113.7a). Nearly every stack-targeting filter is the plain
+ * "target spell" shape (base filter `Any`, zone `STACK`), and offering ability entities for those
+ * would make a counterspell castable at anything on the stack. So an ability is a candidate only
+ * when the filter *explicitly* names an ability — "counter target ability" (Stifle), "spell or
+ * ability" (Willbender, Return the Favor), "copy target activated or triggered ability you control"
+ * (Gogo, Peter Parker's Camera, Echo, Scientist Supreme of A.I.M.).
+ *
+ * Two readers ask the question and must never disagree: [com.wingedsheep.engine.handlers.TargetFinder]
+ * (the authoritative legal-target set, used when a target is actually chosen) and
+ * [com.wingedsheep.engine.legalactions.utils.TargetEnumerationUtils] (the legal-action enumeration
+ * the server sends to clients and the AI). When the two drift, an ability-targeting card is
+ * *executable but not offered*: the engine accepts the action if a client somehow submits it, while
+ * the enumerator never surfaces the ability as a legal target, so the ability is unplayable through
+ * the UI and invisible to the AI. Keeping the predicate here is what stops that from recurring.
+ */
+object StackObjectTargeting {
+
+    /**
+     * True iff [filter] explicitly permits abilities on the stack — i.e. some [CardPredicate] in it,
+     * including inside [CardPredicate.Or] / `And` / `Not` branches and [GameObjectFilter.anyOf]
+     * sub-filters, names an ability. [CardPredicate.AbilitySourceMatches] counts: it reads an
+     * ability's source and can only ever be true for an ability.
+     */
+    fun permitsAbilities(filter: GameObjectFilter): Boolean {
+        fun predicateNamesAbility(p: CardPredicate): Boolean = when (p) {
+            CardPredicate.IsActivatedOrTriggeredAbility,
+            CardPredicate.IsTriggeredAbility,
+            CardPredicate.IsActivatedAbility,
+            is CardPredicate.AbilitySourceMatches -> true
+            is CardPredicate.Or -> p.predicates.any(::predicateNamesAbility)
+            is CardPredicate.And -> p.predicates.any(::predicateNamesAbility)
+            is CardPredicate.Not -> predicateNamesAbility(p.predicate)
+            else -> false
+        }
+        return filter.cardPredicates.any(::predicateNamesAbility) ||
+            filter.anyOf.any { permitsAbilities(it) }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/StackObjectTargeting.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/StackObjectTargeting.kt
@@ -38,6 +38,11 @@ object StackObjectTargeting {
             is CardPredicate.AbilitySourceMatches -> true
             is CardPredicate.Or -> p.predicates.any(::predicateNamesAbility)
             is CardPredicate.And -> p.predicates.any(::predicateNamesAbility)
+            // Negation is deliberately *not* inverted. The question this answers is "does the
+            // requirement's text mention abilities at all", not "must the object be an ability" —
+            // `Not(IsActivatedAbility)` still speaks of abilities, so the enumeration should offer
+            // ability entities and let the filter itself reject the ones that don't match. Inverting
+            // here would silently drop them before the filter ever ran.
             is CardPredicate.Not -> predicateNamesAbility(p.predicate)
             else -> false
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
@@ -96,7 +96,7 @@ data class EntitySnapshot(
     // --- battlefield-exit-only fields (no meaning for a live permanent) ---
     /** Projected type line at capture, so leaves-battlefield triggers see continuous-effect-granted types. */
     val typeLine: TypeLine? = null,
-    /** Card definition id, so dies/leaves triggers resolve for tokens after 704.5s cleanup. */
+    /** Card definition id, so dies/leaves triggers resolve for tokens after 704.5d cleanup. */
     val cardDefinitionId: String? = null,
     /**
      * The permanent's name at capture time. Frozen because a *cost* has to be describable after the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/EntitySnapshot.kt
@@ -7,6 +7,8 @@ import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.DamageSourceLki
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.TypeLine
 import com.wingedsheep.sdk.model.EntityId
 import kotlinx.serialization.Serializable
@@ -233,6 +235,36 @@ fun captureEntitySnapshots(
     snapshot.copy(
         wasToken = container?.has<TokenComponent>() ?: false,
         name = container?.get<CardComponent>()?.name,
+    )
+}
+
+/**
+ * The permanent's **projected** type line: its printed types overlaid with whatever continuous
+ * effects have granted or replaced (an animated artifact reads "Artifact Creature", a Vehicle
+ * crewed this turn reads "Artifact Creature — Vehicle"). Falls back to the printed type line when
+ * the entity has no projection entry, and returns null when it has no [CardComponent] at all.
+ *
+ * Caller must invoke this BEFORE any zone change, while the projection entry still exists. It is
+ * the single value frozen into [EntitySnapshot.typeLine], so the zone-exit path
+ * (`ZoneTransitionService`) and the cost-time path (`ActivateAbilityHandler`'s
+ * [com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent.lastKnownSourceSnapshot])
+ * capture the same thing rather than two hand-rolled copies.
+ */
+fun projectedTypeLine(state: GameState, entityId: EntityId): TypeLine? {
+    val base = state.getEntity(entityId)?.get<CardComponent>()?.typeLine ?: return null
+    return projectedTypeLine(state, entityId, base)
+}
+
+/** [projectedTypeLine] for a caller that already holds the printed [baseTypeLine]. */
+fun projectedTypeLine(state: GameState, entityId: EntityId, baseTypeLine: TypeLine): TypeLine {
+    val projected = state.projectedState.getProjectedValues(entityId) ?: return baseTypeLine
+    val cardTypes = projected.types
+        .mapNotNull { runCatching { CardType.valueOf(it) }.getOrNull() }
+        .toSet()
+        .ifEmpty { baseTypeLine.cardTypes }
+    return baseTypeLine.copy(
+        cardTypes = cardTypes,
+        subtypes = projected.subtypes.map { Subtype(it) }.toSet(),
     )
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EchoPerceptiveProdigyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EchoPerceptiveProdigyScenarioTest.kt
@@ -1,0 +1,234 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.msh.cards.EchoPerceptiveProdigy
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Echo, Perceptive Prodigy (MSH #51) — {2}{U} Legendary Creature — Human Hero, 1/4.
+ *
+ * Vigilance
+ * {1}, {T}: Copy target activated or triggered ability you control from a creature source. You may
+ * choose new targets for the copy.
+ *
+ * The new piece under test is the source restriction: `CardPredicate.AbilitySourceMatches(Creature)`
+ * narrowing the existing "target activated or triggered ability you control". Covered here:
+ *  - a creature-source activated ability is *enumerated* as a legal target and copies correctly,
+ *    with the copy retargeted (CR 707.10c);
+ *  - an artifact-source ability is neither enumerated nor accepted — the restriction actually bites;
+ *  - a dead creature's dies trigger is still "from a creature source": the source is in the
+ *    graveyard while the trigger is on the stack, so the match runs on last known information
+ *    (CR 113.7a).
+ */
+class EchoPerceptiveProdigyScenarioTest : FunSpec({
+
+    // Creature source: {T}: Target creature you control gets +1/+0 until end of turn.
+    val testPumper = card("Echo Test Pumper") {
+        manaCost = "{1}"
+        typeLine = "Creature — Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "{T}: Target creature you control gets +1/+0 until end of turn."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0))
+            target = Targets.CreatureYouControl
+            timing = TimingRule.InstantSpeed
+        }
+    }
+
+    // Artifact source: the same ability on a noncreature artifact — the negative control.
+    val testLens = card("Echo Test Lens") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = "{T}: Target creature you control gets +1/+0 until end of turn."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0))
+            target = Targets.CreatureYouControl
+            timing = TimingRule.InstantSpeed
+        }
+    }
+
+    // Creature source whose ability is a *triggered* one, and whose source is already in the
+    // graveyard by the time the trigger is on the stack — the last-known-information case.
+    val testMartyr = card("Echo Test Martyr") {
+        manaCost = "{1}"
+        typeLine = "Creature — Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "When this creature dies, draw a card."
+        triggeredAbility {
+            trigger = Triggers.Dies
+            effect = Effects.DrawCards(1)
+            description = "When this creature dies, draw a card."
+        }
+    }
+
+    val copyAbilityId = EchoPerceptiveProdigy.activatedAbilities.single().id
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(EchoPerceptiveProdigy, testPumper, testLens, testMartyr))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        return driver
+    }
+
+    /** Echo on the battlefield, untapped and able to tap for its ability. */
+    fun deployEcho(driver: GameTestDriver, me: EntityId): EntityId {
+        val echo = driver.putCreatureOnBattlefield(me, "Echo, Perceptive Prodigy")
+        driver.removeSummoningSickness(echo)
+        return echo
+    }
+
+    /** The legal targets the enumerator offers for Echo's copy ability right now. */
+    fun offeredCopyTargets(driver: GameTestDriver, me: EntityId, echo: EntityId): List<EntityId> =
+        driver.legalActions(me)
+            .filter { (it.action as? ActivateAbility)?.sourceId == echo }
+            .flatMap { it.validTargets ?: emptyList() }
+
+    test("has vigilance") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+        val echo = deployEcho(driver, me)
+        driver.state.projectedState.hasKeyword(echo, Keyword.VIGILANCE) shouldBe true
+    }
+
+    test("copies a creature-source activated ability and retargets the copy") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+
+        val echo = deployEcho(driver, me)
+        val pumper = driver.putCreatureOnBattlefield(me, "Echo Test Pumper")
+        driver.removeSummoningSickness(pumper)
+        val creatureA = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val creatureB = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val pumpAbilityId = driver.cardRegistry.requireCard("Echo Test Pumper").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = pumper, abilityId = pumpAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creatureA))
+            )
+        )
+        val pumpOnStack = driver.getTopOfStack()!!
+
+        // The server must *offer* the ability on the stack as a legal target — not merely accept it
+        // when an action is submitted. This is what makes the card clickable in the UI.
+        driver.giveColorlessMana(me, 1)
+        offeredCopyTargets(driver, me, echo) shouldContain pumpOnStack
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = echo, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(pumpOnStack))
+            )
+        )
+        driver.isTapped(echo) shouldBe true
+
+        // Resolve the copy ability → prompt for new targets for the copy; aim it at creatureB.
+        var guard = 0
+        while (driver.state.pendingDecision !is ChooseTargetsDecision && guard < 20) {
+            driver.bothPass(); guard++
+        }
+        (driver.state.pendingDecision is ChooseTargetsDecision) shouldBe true
+        driver.submitTargetSelection(me, listOf(creatureB)).isSuccess shouldBe true
+
+        guard = 0
+        while (driver.stackSize > 0 && guard < 20) { driver.bothPass(); guard++ }
+
+        driver.state.projectedState.getPower(creatureA) shouldBe 3
+        driver.state.projectedState.getPower(creatureB) shouldBe 3
+    }
+
+    test("an artifact-source ability is neither offered nor accepted as a target") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+
+        val echo = deployEcho(driver, me)
+        val lens = driver.putPermanentOnBattlefield(me, "Echo Test Lens")
+        val creatureA = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lensAbilityId = driver.cardRegistry.requireCard("Echo Test Lens").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = lens, abilityId = lensAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creatureA))
+            )
+        )
+        val lensOnStack = driver.getTopOfStack()!!
+
+        driver.giveColorlessMana(me, 1)
+        // Not offered: the only ability on the stack has an artifact source.
+        offeredCopyTargets(driver, me, echo).contains(lensOnStack) shouldBe false
+
+        // ...and hand-submitting it is rejected too, so the restriction is not merely cosmetic.
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = me, sourceId = echo, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(lensOnStack))
+            )
+        )
+    }
+
+    test("last known information: a dead creature's dies trigger is still a creature source") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+
+        val echo = deployEcho(driver, me)
+        val martyr = driver.putCreatureOnBattlefield(me, "Echo Test Martyr")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Kill the Martyr for real so its dies trigger goes on the stack with the source already in
+        // the graveyard (CR 113.7a — the ability exists independently of its source).
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, listOf(martyr)).error shouldBe null
+        var guard = 0
+        while (!driver.getGraveyard(me).contains(martyr) && guard < 20) {
+            driver.bothPass(); guard++
+        }
+        driver.getGraveyard(me).contains(martyr) shouldBe true
+
+        val diesTrigger = driver.getTopOfStack()!!
+
+        val handBefore = driver.getHandSize(me)
+        driver.giveColorlessMana(me, 1)
+        offeredCopyTargets(driver, me, echo) shouldContain diesTrigger
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = echo, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(diesTrigger))
+            )
+        )
+        guard = 0
+        while (driver.stackSize > 0 && guard < 30) { driver.bothPass(); guard++ }
+
+        // Original + copy each draw a card.
+        driver.getHandSize(me) shouldBe handBefore + 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScientistSupremeOfAimScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScientistSupremeOfAimScenarioTest.kt
@@ -6,7 +6,9 @@ import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.msh.cards.ScientistSupremeOfAim
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
@@ -28,6 +30,10 @@ import io.kotest.matchers.shouldBe
  * The artifact-source twin of Echo, Perceptive Prodigy. Covered here:
  *  - an artifact-source ability is enumerated and copied, and the copy is retargeted (CR 707.10c);
  *  - a creature-source ability is neither offered nor accepted;
+ *  - last known information (CR 113.7a): an artifact that sacrificed *itself* to pay for the
+ *    ability is still an artifact source, both as a plain card (which lands in the graveyard) and
+ *    as a **token**, whose entity CR 704.5d deletes outright — the cracked-Clue line this card is
+ *    printed for;
  *  - the cost is 2 life and the ability is once-per-turn and your-turn-only.
  */
 class ScientistSupremeOfAimScenarioTest : FunSpec({
@@ -60,11 +66,38 @@ class ScientistSupremeOfAimScenarioTest : FunSpec({
         }
     }
 
+    // Nontoken artifact that eats itself to pay for its own ability — the last-known-information
+    // case for a source that is in the graveyard by the time the ability is targeted.
+    val testCache = card("Scientist Test Cache") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = "{2}, Sacrifice this artifact: Draw a card."
+        activatedAbility {
+            cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf)
+            effect = Effects.DrawCards(1)
+            timing = TimingRule.InstantSpeed
+        }
+    }
+
+    // Sorcery that makes a Clue token, so the token-source case can be built the way a real game
+    // builds it (MSH's own Agent 13, Sharon Carter / Panther Pounce investigate).
+    val testDossier = card("Scientist Test Dossier") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        oracleText = "Investigate."
+        spell { effect = Effects.Investigate() }
+    }
+
     val copyAbilityId = ScientistSupremeOfAim.activatedAbilities.single().id
+    val clueSacAbilityId = PredefinedTokens.Clue.activatedAbilities.single().id
+    val cacheSacAbilityId = testCache.activatedAbilities.single().id
 
     fun setup(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(ScientistSupremeOfAim, testLens, testPumper))
+        driver.registerCards(
+            TestCards.all + listOf(ScientistSupremeOfAim, testLens, testPumper, testCache, testDossier)
+        )
+        driver.registerCard(PredefinedTokens.Clue)
         driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
         return driver
     }
@@ -150,6 +183,93 @@ class ScientistSupremeOfAimScenarioTest : FunSpec({
                 targets = listOf(ChosenTarget.Spell(pumpOnStack))
             )
         )
+    }
+
+    test("an artifact that sacrificed itself to pay for its own ability is still an artifact source") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+
+        val scientist = driver.putCreatureOnBattlefield(me, "Scientist Supreme of A.I.M.")
+        val cache = driver.putPermanentOnBattlefield(me, "Scientist Test Cache")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val handBefore = driver.getHandSize(me)
+        driver.giveColorlessMana(me, 2)
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = cache, abilityId = cacheSacAbilityId))
+
+        // The source paid for itself; it is in the graveyard, not on the battlefield (CR 113.7a).
+        driver.findPermanent(me, "Scientist Test Cache") shouldBe null
+        val drawOnStack = driver.getTopOfStack()!!
+
+        offeredCopyTargets(driver, me, scientist) shouldContain drawOnStack
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = scientist, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(drawOnStack))
+            )
+        )
+
+        var guard = 0
+        while (driver.stackSize > 0 && guard < 20) { driver.bothPass(); guard++ }
+
+        // The copy plus the original: two cards drawn.
+        driver.getHandSize(me) shouldBe handBefore + 2
+    }
+
+    test("a Clue token's draw ability is still an artifact source after CR 704.5d deletes the token") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+
+        val scientist = driver.putCreatureOnBattlefield(me, "Scientist Supreme of A.I.M.")
+        // A second, unrelated ability to stack on top of the Clue's, purely so *it* is what
+        // resolves first (see below) and the draw ability outlives the token's cleanup.
+        val lens = driver.putPermanentOnBattlefield(me, "Scientist Test Lens")
+        val bear = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val dossier = driver.putCardInHand(me, "Scientist Test Dossier")
+        driver.giveColorlessMana(me, 1)
+        driver.castSpell(me, dossier).isSuccess shouldBe true
+        driver.bothPass() // Investigate resolves
+        val clue = driver.findPermanent(me, "Clue")!!
+
+        val handBefore = driver.getHandSize(me)
+        driver.giveColorlessMana(me, 2)
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = clue, abilityId = clueSacAbilityId))
+        val drawOnStack = driver.getTopOfStack()!!
+
+        // State-based actions (CR 117.5, CR 704.5d) are applied on the engine's post-resolution
+        // pass, so the token entity is still readable at the instant of activation. Reproduce the
+        // ordinary table sequence that outlives it: put a second ability on top of the draw, let
+        // *that* resolve — the SBA pass sweeps the sacrificed token then — and the Clue's draw
+        // ability is still sitting on the stack with no source entity behind it.
+        val lensAbilityId = driver.cardRegistry.requireCard("Scientist Test Lens").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = lens, abilityId = lensAbilityId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        )
+        driver.bothPass() // the pump ability resolves; the sacrificed token ceases to exist
+
+        // CR 704.5d has now swept the sacrificed token out of the graveyard: there is no entity
+        // left to read, only the EntitySnapshot the activation froze.
+        driver.state.getEntity(clue) shouldBe null
+
+        offeredCopyTargets(driver, me, scientist) shouldContain drawOnStack
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = scientist, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(drawOnStack))
+            )
+        )
+
+        var guard = 0
+        while (driver.stackSize > 0 && guard < 20) { driver.bothPass(); guard++ }
+
+        driver.getHandSize(me) shouldBe handBefore + 2
     }
 
     test("activate only once each turn") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScientistSupremeOfAimScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScientistSupremeOfAimScenarioTest.kt
@@ -1,0 +1,229 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.msh.cards.ScientistSupremeOfAim
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scientist Supreme of A.I.M. (MSH #225) — {U}{B} Legendary Creature — Human Scientist Villain, 2/2.
+ *
+ * Pay 2 life: Copy target activated or triggered ability you control from an artifact source. You
+ * may choose new targets for the copy. Activate only during your turn and only once each turn.
+ *
+ * The artifact-source twin of Echo, Perceptive Prodigy. Covered here:
+ *  - an artifact-source ability is enumerated and copied, and the copy is retargeted (CR 707.10c);
+ *  - a creature-source ability is neither offered nor accepted;
+ *  - the cost is 2 life and the ability is once-per-turn and your-turn-only.
+ */
+class ScientistSupremeOfAimScenarioTest : FunSpec({
+
+    // Artifact source: {T}: Target creature you control gets +1/+0 until end of turn.
+    val testLens = card("Scientist Test Lens") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = "{T}: Target creature you control gets +1/+0 until end of turn."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0))
+            target = Targets.CreatureYouControl
+            timing = TimingRule.InstantSpeed
+        }
+    }
+
+    // Creature source: the negative control.
+    val testPumper = card("Scientist Test Pumper") {
+        manaCost = "{1}"
+        typeLine = "Creature — Soldier"
+        power = 1
+        toughness = 1
+        oracleText = "{T}: Target creature you control gets +1/+0 until end of turn."
+        activatedAbility {
+            cost = AbilityCost.Tap
+            effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0))
+            target = Targets.CreatureYouControl
+            timing = TimingRule.InstantSpeed
+        }
+    }
+
+    val copyAbilityId = ScientistSupremeOfAim.activatedAbilities.single().id
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ScientistSupremeOfAim, testLens, testPumper))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        return driver
+    }
+
+    /** The legal targets the enumerator offers for the Scientist's copy ability right now. */
+    fun offeredCopyTargets(driver: GameTestDriver, me: EntityId, scientist: EntityId): List<EntityId> =
+        driver.legalActions(me)
+            .filter { (it.action as? ActivateAbility)?.sourceId == scientist }
+            .flatMap { it.validTargets ?: emptyList() }
+
+    test("copies an artifact-source ability, retargets the copy, and costs 2 life") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+
+        // No tap in the cost, so summoning sickness is irrelevant — deliberately not cleared.
+        val scientist = driver.putCreatureOnBattlefield(me, "Scientist Supreme of A.I.M.")
+        val lens = driver.putPermanentOnBattlefield(me, "Scientist Test Lens")
+        val creatureA = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val creatureB = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lensAbilityId = driver.cardRegistry.requireCard("Scientist Test Lens").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = lens, abilityId = lensAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creatureA))
+            )
+        )
+        val lensOnStack = driver.getTopOfStack()!!
+
+        // Enumerated as a legal target, not merely accepted on submit.
+        offeredCopyTargets(driver, me, scientist) shouldContain lensOnStack
+
+        val lifeBefore = driver.getLifeTotal(me)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = scientist, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(lensOnStack))
+            )
+        )
+        driver.getLifeTotal(me) shouldBe lifeBefore - 2
+
+        var guard = 0
+        while (driver.state.pendingDecision !is ChooseTargetsDecision && guard < 20) {
+            driver.bothPass(); guard++
+        }
+        (driver.state.pendingDecision is ChooseTargetsDecision) shouldBe true
+        driver.submitTargetSelection(me, listOf(creatureB)).isSuccess shouldBe true
+
+        guard = 0
+        while (driver.stackSize > 0 && guard < 20) { driver.bothPass(); guard++ }
+
+        driver.state.projectedState.getPower(creatureA) shouldBe 3
+        driver.state.projectedState.getPower(creatureB) shouldBe 3
+    }
+
+    test("a creature-source ability is neither offered nor accepted as a target") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+
+        val scientist = driver.putCreatureOnBattlefield(me, "Scientist Supreme of A.I.M.")
+        val pumper = driver.putCreatureOnBattlefield(me, "Scientist Test Pumper")
+        driver.removeSummoningSickness(pumper)
+        val creatureA = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val pumpAbilityId = driver.cardRegistry.requireCard("Scientist Test Pumper").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = pumper, abilityId = pumpAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creatureA))
+            )
+        )
+        val pumpOnStack = driver.getTopOfStack()!!
+
+        offeredCopyTargets(driver, me, scientist).contains(pumpOnStack) shouldBe false
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = me, sourceId = scientist, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(pumpOnStack))
+            )
+        )
+    }
+
+    test("activate only once each turn") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+
+        val scientist = driver.putCreatureOnBattlefield(me, "Scientist Supreme of A.I.M.")
+        val lens = driver.putPermanentOnBattlefield(me, "Scientist Test Lens")
+        val lens2 = driver.putPermanentOnBattlefield(me, "Scientist Test Lens")
+        val creatureA = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lensAbilityId = driver.cardRegistry.requireCard("Scientist Test Lens").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = lens, abilityId = lensAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creatureA))
+            )
+        )
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = scientist, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(driver.getTopOfStack()!!))
+            )
+        )
+
+        // Second artifact ability on the stack, but the Scientist is spent for the turn.
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me, sourceId = lens2, abilityId = lensAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creatureA))
+            )
+        )
+        val secondLensOnStack = driver.getTopOfStack()!!
+
+        offeredCopyTargets(driver, me, scientist).contains(secondLensOnStack) shouldBe false
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = me, sourceId = scientist, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(secondLensOnStack))
+            )
+        )
+    }
+
+    test("can't be activated during an opponent's turn") {
+        val driver = setup()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val scientist = driver.putCreatureOnBattlefield(opponent, "Scientist Supreme of A.I.M.")
+        val lens = driver.putPermanentOnBattlefield(opponent, "Scientist Test Lens")
+        val creatureA = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // Hand priority to the non-active player so they can use their own artifact at instant speed.
+        driver.passPriority(me)
+
+        val lensAbilityId = driver.cardRegistry.requireCard("Scientist Test Lens").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = opponent, sourceId = lens, abilityId = lensAbilityId,
+                targets = listOf(ChosenTarget.Permanent(creatureA))
+            )
+        )
+        val lensOnStack = driver.getTopOfStack()!!
+
+        // It is `me`'s turn, so the Scientist's controller may not activate it.
+        offeredCopyTargets(driver, opponent, scientist).contains(lensOnStack) shouldBe false
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = opponent, sourceId = scientist, abilityId = copyAbilityId,
+                targets = listOf(ChosenTarget.Spell(lensOnStack))
+            )
+        )
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/targeting/AbilitySourceTargetingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/targeting/AbilitySourceTargetingTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.targeting
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.targeting.StackObjectTargeting
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine-level coverage of targeting an **ability on the stack by its source** — the mechanic behind
+ * Echo, Perceptive Prodigy and Scientist Supreme of A.I.M.
+ *
+ * Two halves:
+ *
+ * 1. [StackObjectTargeting.permitsAbilities] — the single seam deciding whether a stack-zone target
+ *    requirement may offer abilities at all. "Target spell" must stay spell-only (the
+ *    `TargetSpellExcludesAbilitiesTest` regression); an ability-naming filter, including the new
+ *    [CardPredicate.AbilitySourceMatches], must not.
+ *
+ * 2. Enumeration parity. The legal-action enumerator and the authoritative target finder ask that
+ *    question separately, and the enumerator used to answer "spells only" unconditionally — so an
+ *    ability-targeting card was accepted when executed but never *offered*, i.e. unplayable through
+ *    the UI and invisible to the AI. That is asserted here on a plain
+ *    `Targets.ActivatedOrTriggeredAbilityYouControl` card, independent of the source predicate.
+ */
+class AbilitySourceTargetingTest : FunSpec({
+
+    context("StackObjectTargeting.permitsAbilities") {
+        test("plain 'target spell' filters stay spell-only") {
+            StackObjectTargeting.permitsAbilities(TargetFilter.SpellOnStack.baseFilter) shouldBe false
+            StackObjectTargeting.permitsAbilities(TargetFilter.CreatureSpellOnStack.baseFilter) shouldBe false
+        }
+
+        test("filters naming an ability permit abilities") {
+            StackObjectTargeting.permitsAbilities(
+                TargetFilter.ActivatedOrTriggeredAbilityOnStack.baseFilter
+            ) shouldBe true
+            StackObjectTargeting.permitsAbilities(
+                TargetFilter.InstantSorcerySpellOrAbilityOnStack.baseFilter
+            ) shouldBe true
+        }
+
+        test("an ability-source predicate alone permits abilities") {
+            // It can only ever be true for an ability, so it must not be treated as spell-only.
+            StackObjectTargeting.permitsAbilities(
+                GameObjectFilter(
+                    cardPredicates = listOf(CardPredicate.AbilitySourceMatches(GameObjectFilter.Creature))
+                )
+            ) shouldBe true
+        }
+
+        test("the Echo/Scientist target filter permits abilities") {
+            val echoLike = (
+                Targets.ActivatedOrTriggeredAbilityYouControlFrom(GameObjectFilter.Artifact)
+                    as TargetObject
+                ).filter
+            StackObjectTargeting.permitsAbilities(echoLike.baseFilter) shouldBe true
+        }
+    }
+
+    context("enumeration offers abilities on the stack") {
+        // {T}: Target creature you control gets +1/+0 until end of turn.
+        val pumper = card("Stack Target Test Pumper") {
+            manaCost = "{1}"
+            typeLine = "Creature — Soldier"
+            power = 1
+            toughness = 1
+            oracleText = "{T}: Target creature you control gets +1/+0 until end of turn."
+            activatedAbility {
+                cost = AbilityCost.Tap
+                effect = Effects.ModifyStats(1, 0, EffectTarget.ContextTarget(0))
+                target = Targets.CreatureYouControl
+                timing = TimingRule.InstantSpeed
+            }
+        }
+
+        // The unnarrowed "copy target activated or triggered ability you control" shape shared by
+        // Gogo, Master of Mimicry and Peter Parker's Camera.
+        val copier = card("Stack Target Test Copier") {
+            manaCost = "{1}"
+            typeLine = "Artifact"
+            oracleText = "{T}: Copy target activated or triggered ability you control."
+            activatedAbility {
+                cost = AbilityCost.Tap
+                val ability = target(
+                    "target activated or triggered ability you control",
+                    Targets.ActivatedOrTriggeredAbilityYouControl
+                )
+                effect = Effects.CopyTargetSpellOrAbility(ability)
+                timing = TimingRule.InstantSpeed
+            }
+        }
+
+        test("an activated ability on the stack is enumerated as a legal target for a copy ability") {
+            val driver = GameTestDriver()
+            driver.registerCards(TestCards.all + listOf(pumper, copier))
+            driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+            val me = driver.activePlayer!!
+
+            val pumperId = driver.putCreatureOnBattlefield(me, "Stack Target Test Pumper")
+            driver.removeSummoningSickness(pumperId)
+            val copierId = driver.putPermanentOnBattlefield(me, "Stack Target Test Copier")
+            val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            val pumpAbilityId =
+                driver.cardRegistry.requireCard("Stack Target Test Pumper").activatedAbilities[0].id
+            driver.submitSuccess(
+                ActivateAbility(
+                    playerId = me, sourceId = pumperId, abilityId = pumpAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(bears))
+                )
+            )
+            val pumpOnStack = driver.getTopOfStack()!!
+
+            val offered = driver.legalActions(me)
+                .filter { (it.action as? ActivateAbility)?.sourceId == copierId }
+                .flatMap { it.validTargets ?: emptyList() }
+            offered shouldContain pumpOnStack
+        }
+    }
+})


### PR DESCRIPTION
# Add an ability-source predicate for stack targets (Echo, Perceptive Prodigy · Scientist Supreme of A.I.M.)

Marvel Super Heroes has two cards that copy an ability on the stack, restricted by what *kind of
object* produced it:

- **Echo, Perceptive Prodigy** [51] — "Copy target activated or triggered ability you control **from
  a creature source**."
- **Scientist Supreme of A.I.M.** [225] — "…**from an artifact source**."

Everything else about them already shipped: `Targets.ActivatedOrTriggeredAbilityYouControl` and
`Effects.CopyTargetSpellOrAbility` back Gogo, Master of Mimicry and Peter Parker's Camera today.

## The gap

An ability on the stack is its own object and carries none of its source's characteristics
(CR 113.3b/c); it has no `CardComponent` at all. `PredicateEvaluator.matchesCardPredicate` bails at
that missing component, so `GameObjectFilter.Artifact` applied to an ability entity is
unconditionally false. There was no way to express "the ability's source is a creature".

## The design

`CardPredicate.AbilitySourceMatches(subfilter: GameObjectFilter)` — resolved in the evaluator's
stack branch, immediately alongside its sibling `CardPredicate.TargetsMatching`, *before* the
`CardComponent` null-check. It reads `ActivatedAbilityOnStackComponent.sourceId` /
`TriggeredAbilityOnStackComponent.sourceId` — the source per **CR 113.7** — and re-runs the ordinary
filter machinery against that entity, inheriting the outer `PredicateContext`.

**Why a `CardPredicate` rather than a one-off target type.** The clause is a *narrowing of an
existing target*, not a new kind of target: the requirement is still "activated or triggered ability
you control", with one more condition on it. Modelling it as a predicate means it composes with
everything the SDK already has — `And`/`Or`/`Not`, controller predicates, and any subfilter at all
(`Creature`, `Artifact`, `Creature.youControl()`, a subtype, an `anyOf` union) — so the next card
that says "from an enchantment source" or "from a Villain source" is a filter argument, not another
`TargetRequirement`. `TargetsMatching` set exactly this precedent for "spell that targets a
creature"; this is the same shape pointed at the source instead of the targets.
`CantBeTargetedBySourceTypeAbilities` (Artifact Ward) is the engine-side precedent for keying a
restriction off an ability's source, and the source-characteristic resolution here matches its
`SourceTypeTargeting.sourceCardTypes` exactly.

Surface added: `GameObjectFilter.abilitySourceMatches(...)`, `TargetFilter.abilitySourceMatches(...)`,
and the ready-made `Targets.ActivatedOrTriggeredAbilityYouControlFrom(sourceFilter)`.

## Last known information

Once an ability is on the stack it exists independently of its source, and by the time it can be
targeted the source is routinely gone — a dies trigger's source is already in the graveyard. The
match therefore reads the source's **projected** characteristics while it is on the battlefield and
falls back to its **printed** ones once it has left, which is what CR 113.7a ("if the source is no
longer in the zone it's expected to be in at that time, its last known information is used") and
CR 608.2b ("if the source of an ability has left the zone it was in, its last known information is
used during this process") call for. That is equivalent resolution to what `SourceTypeTargeting` does
for Artifact Ward (a parallel implementation, not shared code). A scenario test kills a creature with
Lightning Bolt and proves Echo can still copy the resulting dies trigger.

### Deleted tokens — the Clue/Food case

A **token** source is a harder case: CR 704.5d ("If a token is in a zone other than the battlefield,
it ceases to exist") makes `TokensInWrongZonesCheck` delete the entity outright, so once a Clue has
sacrificed itself to pay for its own draw ability there is no `getEntity(sourceId)` row left to read.
That is not a corner case for this card — MSH itself prints four Clue/Food makers (Agent 13, Sharon
Carter; Panther Pounce; Ant-Man's Army; Heroic Feast), and cracking a Clue is the line Scientist
Supreme of A.I.M. is printed for.

The timing is worth stating precisely, because it makes the bug look intermittent from the table:
state-based actions are applied on the engine's post-resolution pass, so the token is still a
readable graveyard entity the instant its ability hits the stack, and only ceases to exist once
something else resolves — an opponent's response, a second ability of yours. Copy it immediately and
it worked; let one thing resolve first and the ability silently stopped being offered.

It is handled, using the store the engine already has rather than a new one:
`ActivatedAbilityOnStackComponent.lastKnownSourceSnapshot` is an `EntitySnapshot` frozen at
activation whenever the cost sacrifices or exiles the source (`costExilesOrSacrificesSelf`) — the
Clue / Food / Blood / Treasure shape verbatim. It now also carries the source's **projected type
line**, keywords and token-ness, captured through a `projectedTypeLine` helper shared with
`ZoneTransitionService` so the two capture sites can't drift. When `state.getEntity(sourceId)` is
null, the `AbilitySourceMatches` branch evaluates the subfilter against that snapshot via
`PredicateEvaluator.matchesSnapshot`. Reading the *projected* type line also gets an
animated-artifact / crewed-Vehicle source right on that path.

`matchesSnapshot` is deliberately **partial**: a snapshot freezes card types, sub/supertypes,
keywords, P/T, controller and token-ness, and a predicate it cannot answer reports *unanswerable*
(tri-state) rather than guessing — which keeps `Not`/`And`/`Or` honest and degrades to the
pre-existing "no match" answer.

**Remaining limits**, documented in the predicate KDoc, the DSL reference and `LOOP_UNIT.md`:

1. A **nontoken** source that left the battlefield some other way (it died, it was exiled) is read
   off the card in its new zone, so a type a continuous effect had granted it is no longer visible —
   its printed types answer.
2. A deleted **token** source is recoverable only for an *activated* ability whose cost sacrificed or
   exiled it; a triggered ability whose token source has ceased to exist has no equivalent snapshot
   on its stack object.
3. A snapshot answers only the characteristics it freezes, so a subfilter asking for a mana value or
   a color does not match a deleted-token source.

## Player-facing verification — and a bug it turned up

Scenario tests drive `GameAction`s directly, so they prove nothing about whether a card is
*playable*. Checking that here found a real defect that predates this unit:

`TargetEnumerationUtils.findValidSpellTargets` — the enumeration behind the legal actions the server
sends to clients and the AI — filtered **every** stack-zone target down to `state.isSpellOnStack(...)`
unconditionally. The authoritative `TargetFinder.findSpellTargets` has a seam for this
(`filterPermitsAbilitiesOnStack`); the enumerator did not. Consequences:

- No ability-targeting card ever had an ability **offered** as a legal target — not Echo, and not the
  already-shipped **Gogo, Master of Mimicry** or **Peter Parker's Camera**. The engine accepted the
  action if it was submitted; the UI had nothing to click.
- `ActivatedAbilityEnumerator` gates `holdPriority` on "top of stack ∈ `validTargets`", so those
  cards also never stopped auto-pass — the ability you meant to copy resolved before you got priority.

Fixed by extracting the question into one shared `StackObjectTargeting.permitsAbilities(filter)`
consulted by **both** readers, with `AbilitySourceMatches` counted as an ability-naming predicate.
"Target spell" filters stay spell-only (CR 112.1 vs 113.3b/c) — the existing
`TargetSpellExcludesAbilitiesTest` regression still passes and is re-asserted directly against the
new seam.

Both new cards also set `holdPriority = true` so auto-pass stops while a copyable ability of yours is
on top.

**Client:** no change was needed, verified by reading the two paths. `StackZone.handleStackItemClick`
already routes *both* the action-pipeline (`targetingState.validTargets`) and decision-path
(`decisionSelectionState.validOptions`) clicks for stack objects, and force-expands any collapsed
pile containing a targetable item; `TargetingOverlay` only diverts to the pile picker for
`Graveyard`/`Exile`, so a `Stack` requirement falls through to the click-the-board banner;
`ClientStateTransformer.transformAbilityOnStack` gives every ability on the stack a `ClientCard`, and
`useStackCards` includes it. Not exercised in a browser — see "Not done" below.

## Verified CR citations

Every rule number below was grepped out of the local Comprehensive Rules
(`MagicCompRules_20260619.txt`) and read before being written down; nothing is cited from memory.

- **113.3b / 113.3c** — activated and triggered abilities exist on the stack as their own objects.
- **113.7** — "The source of an activated ability on the stack is the object whose ability was
  activated… of a triggered ability… the object whose ability triggered."
- **113.7a** — "Once activated or triggered, an ability exists on the stack independently of its
  source… if the source is no longer in the zone it's expected to be in at that time, its last known
  information is used."
- **608.2b** — "If the source of an ability has left the zone it was in, its last known information
  is used during this process."
- **707.10 / 707.10b / 707.10c** — copying an ability; the copy has the same source; "you may choose
  new targets for the copy".
- **112.1** — a spell is a card on the stack (the spell-vs-ability distinction the enumeration seam
  turns on).
- **117.5** — "Each time a player would get priority, the game first performs all applicable
  state-based actions…" (why the deleted-token window opens only after something resolves).
- **704.5d** — "If a token is in a zone other than the battlefield, it ceases to exist" (the
  deleted-token case above; **111.7** states the same rule from the token's side). An earlier draft of
  this PR cited 704.5s for it — that number is the Saga final-chapter sacrifice and was wrong. Note
  the repo has four *pre-existing* wrong 704.5s citations for the token rule
  (`TokensInWrongZonesCheck.kt`, `DeathAndLeaveTriggerDetector.kt`, `TriggerDetector.kt`); they are
  left alone as out of scope for this unit, but worth a sweep so the next agent doesn't copy them.

## Files

| Area | Change |
|---|---|
| `mtg-sdk` | `CardPredicate.AbilitySourceMatches`; `GameObjectFilter.abilitySourceMatches`; `TargetFilter.abilitySourceMatches`; `Targets.ActivatedOrTriggeredAbilityYouControlFrom` |
| `rules-engine` | `PredicateEvaluator` stack branch + snapshot fallback (`matchesSnapshot`) + 4 exhaustive-`when` arms; new `StackObjectTargeting`; `TargetFinder` uses it; `TargetEnumerationUtils.findValidSpellTargets` fixed; `EntitySnapshot.projectedTypeLine` shared with `ZoneTransitionService`; `ActivateAbilityHandler` freezes the source's type line/keywords/token-ness |
| `mtg-sets` | `msh/cards/EchoPerceptiveProdigy.kt`, `msh/cards/ScientistSupremeOfAim.kt` |
| tests | `EchoPerceptiveProdigyScenarioTest`, `ScientistSupremeOfAimScenarioTest`, `AbilitySourceTargetingTest` (mechanic-level: the seam + the enumeration regression) |
| docs | `docs/card-sdk-language-reference.md` — predicate, chained builder, target facade, enumeration note |
| backlog | `cards.md` both ticked, header 239 → 241; `mechanics.md` section marked SHIPPED, 33 → 31 blocked |

## Verification

The branch was gated three times, on three different trees, because two rounds of review findings
landed as new commits after the first gate. Reading the table top-down gives the history; **the
bottom block is the one that describes the code being merged.**

**Tree 1 — `5df00a8467`, the original implementation (superseded).**

| Command | Result |
|---|---|
| `just test` | BUILD SUCCESSFUL in 15m 46s — 12200 tests PASSED, 0 FAILED (`build/pr/loop-msh-u08-gate.log`) |
| `just test-rules` (earlier iteration) | BUILD SUCCESSFUL in 15m 8s, 0 failed (`build/pr/loop-msh-u08-gate-rules.log`) |

This run does **not** cover the merged code: the round-3 correction (`daec416da0`) went on to rewrite
`PredicateEvaluator` (+161 lines, `matchesSnapshot`), `ActivateAbilityHandler`, `EntitySnapshot` and
`ZoneTransitionService`, and added two scenario tests.

**Tree 2 — `daec416da0`, after the round-3 corrections.**

| Command | Result |
|---|---|
| `just test-class ScientistSupremeOfAimScenarioTest` | **6/6 PASSED** (`build/pr/loop-msh-u08-gate-correction-targeted.log`) — includes both new last-known-information cases; the token test asserts `state.getEntity(clue) == null` before checking the offer, so it fails on the pre-fix code |
| `just test` | **0 test failures** across `mtg-sdk`, `mtg-sets`, `ai`, `game-server`, `gym`, `gym-server`, `gym-trainer`, `mtg-search`, `mtgish-tooling` — but the run ended with *"Gradle build daemon disappeared unexpectedly"* while `:rules-engine:test` was still in flight, at ~146 MiB available RAM (`build/pr/loop-msh-u08-gate-correction.log`). That is the documented shared-box OOM (`rules-engine` starves first), **not** a test failure. No `clean`, no retry loop — the two uncovered modules were re-run separately below |
| `:rules-engine:test` (reduced footprint) | **BUILD SUCCESSFUL in 12m 27s, 0 failures** (`build/pr/loop-msh-u08-gate-correction-rules.log`) — the module carrying every behavioural change |
| `:mtg-sets:test` (reduced footprint) | **BUILD SUCCESSFUL in 1m 12s, 0 failures** (`build/pr/loop-msh-u08-gate-correction-sets.log`) — the card-snapshot golden, so `MSH.json` is confirmed unmoved |

Together those three runs cover every module. Three comment-only edits (two KDoc blocks, one doc
paragraph) landed while the `just test` run was executing; they change no bytecode, and the two
reduced-footprint runs were started after them.

**Tree 3 — `c6d333a27e`, after the round-4 review — the code being merged.**

| Command | Result |
|---|---|
| `:rules-engine:test` (reduced footprint) | **BUILD SUCCESSFUL in 4m 34s — 10765 tests PASSED, 0 failures** (`build/pr/loop-msh-u08-gate-round4-rules.log`). All 15 of this unit's tests green, including both last-known-information cases and the enumeration-parity assertions |

Round 4 changed one line of behaviour-neutral plumbing in `ActivateAbilityHandler`
(`captureEntitySnapshots(ids, projectedState)` + a hand-rolled `wasToken`/`name` copy → the existing
`captureEntitySnapshots(ids, state)` overload, which fills exactly those two fields the same way),
plus three comment-only fixes. `manual-scenarios/…/loop-msh-u08-new-cards-castable.json` was also
added; nothing compiles or loads it under test.

`:rules-engine` is the only module round 4 touched, and the change is inside a function body — no
signature moved — so the downstream modules (`ai`, `game-server`, `gym*`) can't be affected at
compile or behaviour level and were not re-run; tree 2's runs still cover them.

**Everything below is unaffected by which tree it ran on.**

| Command | Result |
|---|---|
| `just rebless-cards` | exit 0. `git diff --stat` on the snapshots: **only** `mtg-sets/src/test/resources/snapshots/cards/MSH.json`, +150 / −0 — the two new cards and nothing else moved |
| `just check-card-printing "Echo, Perceptive Prodigy"` | `ok: canonical is in the card's earliest real printing and all scaffolded reprints have rows.` (msh 51 canonical; pw26 promo not scaffolded) |
| `just check-card-printing "Scientist Supreme of A.I.M."` | `ok: canonical is in the card's earliest real printing and all scaffolded reprints have rows.` (msh 225 canonical) |
| `just check-backlog` | `all 14 card-count headers in sync` |

New tests, all green:

- `EchoPerceptiveProdigyScenarioTest` — vigilance; copy-and-retarget a creature-source ability; an
  artifact-source ability is *neither enumerated nor accepted*; the last-known-information case (kill
  the creature with Lightning Bolt, copy its dies trigger from the graveyard).
- `ScientistSupremeOfAimScenarioTest` — copy-and-retarget an artifact-source ability and pay 2 life; a
  creature-source ability rejected; once-per-turn; your-turn-only; and two last-known-information
  cases added in round 3 — a **nontoken** artifact that sacrificed itself to pay for its own ability
  (source in the graveyard), and a **Clue token** whose entity CR 704.5d has deleted outright.
- `AbilitySourceTargetingTest` — the `StackObjectTargeting.permitsAbilities` seam (including that
  "target spell" filters stay spell-only) and the enumeration regression, asserted on a plain
  `Targets.ActivatedOrTriggeredAbilityYouControl` card so it stands independent of this unit's cards.
- Pre-existing `TargetSpellExcludesAbilitiesTest` still passes both ways.

Every "is it offered?" assertion goes through `LegalActionEnumerator.enumerate` — the same
computation the server sends the client — not just `submitSuccess`.

No web-client change was made, so `npm test` was not run.

## Not done

- No manual playthrough in the web client, and no UX pass from either seat. The client analysis above
  is by code reading only.
- No e2e/Playwright run.
- No AI/gym self-play pass over the two cards.
- The token-source last-known-information gap **was** fixed in round 3 (the `lastKnownSourceSnapshot`
  fallback + a Clue-token scenario test). What is still documented-not-fixed is narrower: a deleted
  token source is recoverable only for an *activated* ability whose cost consumed it, not for a
  triggered ability; a nontoken source that left the battlefield some other way reads its printed
  types; and the snapshot arm answers only card types, sub/supertypes, keywords, token-ness and
  controller.

This PR came out of an autonomous loop: independent review is still pending — a reviewer agent will
comment its findings and a corrector agent may push follow-up commits, so this is not final at open
time.
