### PR TITLE
Add five Murders at Karlov Manor cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7374,6 +7374,14 @@ answer it and would silently return `false`.
   an attack-trigger intervening-if), etc. Preacher of the Schism gates its two attack triggers with
   `PlayerHasMostLife(Player.DefendingPlayer)` ("attacks the player with the most life") and
   `PlayerHasMostLife(Player.You)` ("attacks while you have the most life").
+- `PlayerControlsMostPermanents(player, filter = GameObjectFilter.Creature)` — `player` controls the
+  most permanents matching `filter`, or is tied for the most, among all players. The board-count
+  sibling of `PlayerHasMostLife`: the same "max over every player" shape a binary `CompareAmounts`
+  can't express. Counts are read off the **projected** battlefield, so an animated land counts as a
+  creature. Wrap it in a per-player loop for "each player who controls the most X" —
+  `ForEachPlayerEffect(Player.Each, ConditionalEffect(PlayerControlsMostPermanents(Player.You,
+  GameObjectFilter.Creature), …))`, where `Player.You` inside the loop is the iterated player
+  (No Witnesses: "Each player who controls the most creatures investigates").
 - `AmountIsPrime(amount)` / `AmountIsEven(amount)` / `AmountIsOdd(amount)` /
   `AmountIsMultipleOf(amount, divisor)` — the **unary** numeric-predicate family, the counterpart to
   `CompareAmounts` for properties a two-sided threshold can't express (primality, parity,
@@ -7856,6 +7864,17 @@ default to "you" so card authors don't need to pass it explicitly.
   `PlayerDescendedThisTurnComponent`, incremented in `ZoneTransitionService` whenever a
   permanent (nontoken) card lands in a player's graveyard, and cleared by
   `CleanupPhaseManager` at end of turn.
+- `CreatureCardPutIntoYourGraveyardThisTurn(atLeast = 1)` — at least `atLeast` creature cards were put
+  into your graveyard from *any* zone this turn (battlefield, hand, library, stack). The creature-typed
+  sibling of `YouDescendedThisTurn`, composing through
+  `Compare(DynamicAmount.TurnTracking(Player.You, TurnTracker.CREATURE_CARDS_PUT_INTO_GRAVEYARD), GTE,
+  Fixed(atLeast))`. Tokens never count (a token isn't a card, CR 111.6), and it's owner-scoped — a
+  creature card hitting an *opponent's* graveyard never sets yours. Turn history, not a graveyard scan:
+  reanimating the creature later in the turn doesn't clear it. Backed by the per-player
+  `CreatureCardsPutIntoGraveyardThisTurnComponent`, incremented in `ZoneTransitionService` alongside the
+  descend counter and cleared by `CleanupPhaseManager`. Gates Macabre Reconstruction's cost reduction
+  ("This spell costs {2} less to cast if a creature card was put into your graveyard from anywhere this
+  turn") via `ModifySpellCost(SelfCast, ReduceGeneric(2), CostGating.OnlyIf(...))`.
 - `YouSacrificedPermanentsThisTurn(atLeast = 1)` — at least `atLeast` permanents (any type) were
   sacrificed by you this turn. Composes through `Compare(DynamicAmount.TurnTracking(Player.You,
   TurnTracker.PERMANENTS_SACRIFICED), GTE, Fixed(atLeast))`. Backed by the per-player
@@ -8771,6 +8790,10 @@ this turn").
   count of nontoken permanent cards put into that player's graveyard from any zone.
   Backs `Conditions.YouDescendedThisTurn(atLeast)` and `DynamicAmounts.descendedThisTurn`
   (descend N / fathomless descent ability words).
+- `CREATURE_CARDS_PUT_INTO_GRAVEYARD` — number of creature cards put into a player's graveyard from
+  any zone this turn; the creature-typed sibling of `DESCENDED`, recorded by the same
+  `ZoneTransitionService` hook, keyed on the card's owner, tokens excluded. Backs
+  `Conditions.CreatureCardPutIntoYourGraveyardThisTurn(atLeast)` (Macabre Reconstruction).
 - `CARDS_DRAWN` — number of cards a player has drawn this turn (backed by
   `CardsDrawnThisTurnComponent`, reset to 0 for every player at turn start). Powers
   characteristic-defining stats like Duelist of the Mind's "power is equal to the number of

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -502,6 +502,21 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.PlayerHasMostLife(player)
 
     /**
+     * [player] controls the most permanents matching [filter], or is tied for the most, among all
+     * players. The board-count sibling of [PlayerHasMostLife] — same "max over every player" shape
+     * a binary comparison can't express. Counts come from the projected battlefield.
+     *
+     * Wrap it in a per-player loop for "each player who controls the most X" (No Witnesses):
+     * `ForEachPlayerEffect(Player.Each, ConditionalEffect(PlayerControlsMostPermanents(Player.You,
+     * GameObjectFilter.Creature), …))` — inside the loop `Player.You` is the iterated player.
+     */
+    fun PlayerControlsMostPermanents(
+        player: Player,
+        filter: GameObjectFilter = GameObjectFilter.Creature,
+    ): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.PlayerControlsMostPermanents(player, filter)
+
+    /**
      * If the context target at [targetIndex] is a tapped battlefield permanent. Branch on a
      * target's tapped state at resolution — e.g. Shackle Slinger's "If it's tapped, put a stun
      * counter on it. Otherwise, tap it."
@@ -1646,6 +1661,23 @@ object Conditions {
      */
     fun YouDescendedThisTurn(atLeast: Int = 1): ConditionInterface =
         trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.DESCENDED, atLeast = atLeast)
+
+    /**
+     * If [atLeast] or more creature cards were put into your graveyard from anywhere this turn —
+     * the creature-typed sibling of [YouDescendedThisTurn]. Tokens don't count (a token isn't a
+     * card); the origin zone doesn't matter (battlefield, hand, library, stack all qualify).
+     *
+     * Controller-scoped turn history, not a graveyard scan: reanimating the creature later in the
+     * turn doesn't clear it, and a creature card hitting an *opponent's* graveyard never sets it.
+     *
+     * Gates Macabre Reconstruction's cost reduction ("This spell costs {2} less to cast if a
+     * creature card was put into your graveyard from anywhere this turn").
+     */
+    fun CreatureCardPutIntoYourGraveyardThisTurn(atLeast: Int = 1): ConditionInterface =
+        trackerAtLeast(
+            com.wingedsheep.sdk.scripting.values.TurnTracker.CREATURE_CARDS_PUT_INTO_GRAVEYARD,
+            atLeast = atLeast,
+        )
 
     /**
      * If you've sacrificed [atLeast] or more permanents this turn (controller-scoped, any

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
@@ -207,6 +207,34 @@ data class PlayerHasMostLife(val player: Player) : Condition {
 }
 
 /**
+ * True when [player] controls the most permanents matching [filter], or is tied for the most,
+ * among all players (their count ≥ every player's). The board-count sibling of
+ * [PlayerHasMostLife] — the same shape a binary [Compare] can't express, since it needs the max
+ * over every player rather than a fixed threshold.
+ *
+ * Counts are read from the projected battlefield, so type-changing continuous effects (an animated
+ * land, a creature that lost its types) are honored.
+ *
+ * No Witnesses: "Each player who controls the most creatures investigates" — a per-player loop
+ * whose body is gated on `PlayerControlsMostPermanents(Player.You, GameObjectFilter.Creature)`,
+ * which inside the loop asks about the iterated player. Ties are included, exactly as printed.
+ */
+@SerialName("PlayerControlsMostPermanents")
+@Serializable
+data class PlayerControlsMostPermanents(
+    val player: Player,
+    val filter: GameObjectFilter = GameObjectFilter.Creature,
+) : Condition {
+    override val description: String =
+        "if ${player.description} controls the most ${filter.description} or is tied for the most"
+
+    override fun applyTextReplacement(replacer: TextReplacer): Condition {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * A unary arithmetic property a single number can satisfy, tested by [NumberMatches].
  *
  * Distinct from [ComparisonOperator], which is *binary* (compares two amounts). These are

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -125,6 +125,18 @@ enum class TurnTracker {
      */
     DESCENDED,
     /**
+     * Number of creature cards put into the player's graveyard from any zone this turn — the
+     * creature-typed sibling of [DESCENDED], keyed on the card's owner and excluding tokens
+     * (a token isn't a card, CR 111.6). Backed by
+     * `CreatureCardsPutIntoGraveyardThisTurnComponent`, cleared at end of turn.
+     *
+     * Turn history, not a graveyard scan: the card need not still be there, so reanimating it
+     * later in the turn doesn't clear the count. Reach for the threshold form via
+     * `Conditions.CreatureCardPutIntoYourGraveyardThisTurn` — Murders at Karlov Manor's "if a
+     * creature card was put into your graveyard from anywhere this turn" (Macabre Reconstruction).
+     */
+    CREATURE_CARDS_PUT_INTO_GRAVEYARD,
+    /**
      * Number of cards the player has drawn this turn (CR 120). Backed by
      * `CardsDrawnThisTurnComponent`, reset to 0 for every player at the start of each turn.
      * Powers "equal to the number of cards you've drawn this turn" (Duelist of the Mind).
@@ -195,6 +207,8 @@ enum class TurnTracker {
         ARTIFACT_SACRIFICED -> "whether ${player.description} sacrificed an artifact this turn"
         CARDS_LEFT_GRAVEYARD -> "the number of cards that left ${player.possessive} graveyard this turn"
         DESCENDED -> "the number of times ${player.description} descended this turn"
+        CREATURE_CARDS_PUT_INTO_GRAVEYARD ->
+            "the number of creature cards put into ${player.possessive} graveyard this turn"
         CARDS_DRAWN -> "the number of cards ${player.description} have drawn this turn"
         CARDS_DISCARDED -> "the number of cards ${player.description} have discarded this turn"
         CARDS_PUT_INTO_EXILE -> "the number of cards put into exile this turn"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BarbedServitor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/BarbedServitor.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Barbed Servitor — Murders at Karlov Manor #77
+ * {3}{B} · Artifact Creature — Construct · 1/1
+ *
+ * Indestructible
+ * When this creature enters, suspect it.
+ * Whenever this creature deals combat damage to a player, you draw a card and you lose 1 life.
+ * Whenever this creature is dealt damage, target opponent loses that much life.
+ *
+ * An indestructible 1/1 that wants to be hit. Suspecting itself is what makes the last ability
+ * live: menace pushes it through, "can't block" is no loss on a body this small, and anything the
+ * opponent points at it converts straight into life loss for them.
+ *
+ * "That much life" reads the *damage event's* amount, not the Servitor's toughness — CR damage is
+ * dealt in full even when it exceeds toughness, so a Lightning Bolt drains 3 off an indestructible
+ * 1/1. That's [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT] off [Triggers.TakesDamage], the same
+ * idiom Innocent Bystander uses for its "3 or more damage" gate — and it fires once per damage
+ * *event*, so two blockers dealing 2 each queue two separate triggers of 2.
+ *
+ * The dealt-damage ability targets, so it goes on the stack after the damage is already dealt.
+ * Ordering matters for the printed ruling about simultaneous lethal damage: if the same combat
+ * brings you to 0, you lose to the state-based check before this ever resolves. The engine's SBA
+ * pass runs before triggers go on the stack, which is exactly that behaviour.
+ */
+val BarbedServitor = card("Barbed Servitor") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact Creature — Construct"
+    power = 1
+    toughness = 1
+    oracleText = "Indestructible\n" +
+        "When this creature enters, suspect it. (It has menace and can't block.)\n" +
+        "Whenever this creature deals combat damage to a player, you draw a card and you lose 1 life.\n" +
+        "Whenever this creature is dealt damage, target opponent loses that much life."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Suspect(EffectTarget.Self)
+        description = "When this creature enters, suspect it."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Effects.LoseLife(1, EffectTarget.Controller),
+        )
+        description = "Whenever this creature deals combat damage to a player, you draw a card " +
+            "and you lose 1 life."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.LoseLife(
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            opponent,
+        )
+        description = "Whenever this creature is dealt damage, target opponent loses that much life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "77"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c34e4ae-9bf3-4098-88f1-267e7d6cfa35.jpg?1783912901"
+
+        ruling(
+            "2024-02-02",
+            "A creature can be dealt an amount of damage greater than its toughness. For example, " +
+                "if Barbed Servitor is dealt 3 damage, its last ability causes the target opponent " +
+                "to lose 3 life."
+        )
+        ruling(
+            "2024-02-02",
+            "If your life total is brought to 0 or less at the same time that Barbed Servitor is " +
+                "dealt damage, you lose the game before its last ability goes on the stack."
+        )
+        ruling(
+            "2024-02-02",
+            "When an effect suspects a creature, it becomes suspected. It gains menace and \"This " +
+                "creature can't block\" for as long as it's suspected. It stays suspected until it " +
+                "leaves the battlefield or another effect causes it to no longer be suspected."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MacabreReconstruction.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/MacabreReconstruction.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Macabre Reconstruction — Murders at Karlov Manor #93
+ * {3}{B} · Sorcery
+ *
+ * This spell costs {2} less to cast if a creature card was put into your graveyard from anywhere
+ * this turn.
+ * Return up to two target creature cards from your graveyard to your hand.
+ *
+ * The reduction is the Punishing Punch shape — a self-cast [ModifySpellCost] whose whole
+ * modification is gated on a state condition rather than folded into the amount, so only the
+ * generic {3} shrinks and the {B} pip survives.
+ *
+ * The gate is deliberately **turn history, not a graveyard scan**
+ * ([Conditions.CreatureCardPutIntoYourGraveyardThisTurn], the creature-typed sibling of descend's
+ * tracker): a creature milled and then reanimated earlier in the turn still pays off, and a
+ * creature card that has been sitting in your graveyard since last turn does not. "From anywhere"
+ * means any origin zone — battlefield, hand, library, stack — and tokens never qualify, since a
+ * token isn't a card (CR 111.6). Only *your* graveyard counts.
+ *
+ * "Up to two target" is a single optional two-slot [TargetObject], so casting it with an empty
+ * graveyard is legal and simply returns nothing; each surviving target is moved independently by
+ * [ForEachTargetEffect], so one target becoming illegal doesn't cost you the other.
+ */
+val MacabreReconstruction = card("Macabre Reconstruction") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "This spell costs {2} less to cast if a creature card was put into your graveyard " +
+        "from anywhere this turn.\n" +
+        "Return up to two target creature cards from your graveyard to your hand."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.OnlyIf(Conditions.CreatureCardPutIntoYourGraveyardThisTurn()),
+        )
+    }
+
+    spell {
+        target = TargetObject(
+            count = 2,
+            optional = true,
+            filter = TargetFilter.CreatureInYourGraveyard,
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Sam Guay"
+        flavorText = "\"Eyewitness testimony, coming right up! Just let me finish regenerating " +
+            "their eyes.\"\n—Nelo, Agency coroner"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abb6184c-e3d0-4275-b25b-95e4a64b26f3.jpg?1783912895"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/NoWitnesses.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/NoWitnesses.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * No Witnesses — Murders at Karlov Manor #27
+ * {2}{W}{W} · Sorcery
+ *
+ * Each player who controls the most creatures investigates. Then destroy all creatures.
+ *
+ * A wrath that pays the player who was ahead on board — including you, if you're the one who was
+ * ahead — with a Clue apiece.
+ *
+ * "Each player who controls the most creatures" is the Outpace Oblivion shape: one
+ * [ForEachPlayerEffect] over [Player.Each] whose body is a [ConditionalEffect]. Inside the loop
+ * the controller is rebound to the iterated player, so
+ * [Conditions.PlayerControlsMostPermanents] asks about *that* player and the Clue lands in front
+ * of them. Ties all qualify (the condition is "most, or tied for most"), which is why this can
+ * hand out several Clues — or, in a mirrored board, one to everybody.
+ *
+ * Order matters and is printed: every qualifying player investigates *before* the wipe, so the
+ * counts are read off the pre-destruction battlefield. Sequential iteration is safe here because
+ * creating a Clue can't change anyone's creature count.
+ *
+ * The counts come from the projected battlefield, so an animated land or a creature that has lost
+ * its types is counted the way the board actually reads.
+ */
+val NoWitnesses = card("No Witnesses") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Each player who controls the most creatures investigates. Then destroy all " +
+        "creatures. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice " +
+        "this token: Draw a card.\")"
+
+    spell {
+        effect = Effects.Composite(
+            ForEachPlayerEffect(
+                players = Player.Each,
+                effects = listOf(
+                    ConditionalEffect(
+                        condition = Conditions.PlayerControlsMostPermanents(
+                            Player.You,
+                            GameObjectFilter.Creature,
+                        ),
+                        effect = Effects.Investigate(controller = EffectTarget.Controller),
+                    ),
+                ),
+            ),
+            Effects.DestroyAll(GameObjectFilter.Creature),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "27"
+        artist = "Michele Giorgi"
+        flavorText = "When cunning fails, there's always violence."
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f98db67a-c39c-45a8-ae21-85133be46ed5.jpg?1783912920"
+
+        ruling(
+            "2024-02-02",
+            "Clue is an artifact type. Even though it appears on some cards with other permanent " +
+                "types, it's never a creature type, a land type, or anything but an artifact type."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SoulEnervation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SoulEnervation.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Soul Enervation — Murders at Karlov Manor #106
+ * {3}{B} · Enchantment
+ *
+ * Flash
+ * When this enchantment enters, target creature gets -4/-4 until end of turn.
+ * Whenever one or more creature cards leave your graveyard, each opponent loses 1 life and you
+ * gain 1 life.
+ *
+ * Flash plus a -4/-4 makes this a combat trick that stays on the battlefield; the second ability
+ * is the payoff for the graveyard decks that want the first one to be filling their yard.
+ *
+ * "One or more creature cards leave your graveyard" is a **batching** trigger (CR 603.2c) —
+ * [Triggers.CardsLeaveYourGraveyard] fires at most once per batch no matter how many cards left,
+ * which is the printed ruling. Leaving covers every exit: cast from the yard, reanimated, exiled
+ * to delve or escape, shuffled back in. The graveyard is scoped to the enchantment's controller,
+ * so an opponent recurring their own creature never drains them.
+ *
+ * The drain is a fixed 1 life gained, not "equal to the life lost" — with three opponents this
+ * costs them 1 each and still gains only 1, so it is `LoseLife` + `GainLife` rather than
+ * [Effects.DrainLife], whose gain totals across the losers.
+ */
+val SoulEnervation = card("Soul Enervation") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Flash\n" +
+        "When this enchantment enters, target creature gets -4/-4 until end of turn.\n" +
+        "Whenever one or more creature cards leave your graveyard, each opponent loses 1 life and " +
+        "you gain 1 life."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-4, -4, creature)
+        description = "When this enchantment enters, target creature gets -4/-4 until end of turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CardsLeaveYourGraveyard(GameObjectFilter.Creature)
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1),
+        )
+        description = "Whenever one or more creature cards leave your graveyard, each opponent " +
+            "loses 1 life and you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "106"
+        artist = "Domenico Cava"
+        flavorText = "Judith's plan was close to fruition. She couldn't have Agrus get in the way."
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f22ac67-06ce-47cc-a515-d216d30b9cae.jpg?1783912889"
+
+        ruling(
+            "2024-02-02",
+            "If multiple creature cards leave your graveyard at the same time, Soul Enervation's " +
+                "last ability will trigger only once."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SteamcoreScholar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/SteamcoreScholar.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Steamcore Scholar — Murders at Karlov Manor #71
+ * {2}{U} · Creature — Weird Detective · 2/2
+ *
+ * Flying, vigilance
+ * When this creature enters, draw two cards. Then discard two cards unless you discard an instant
+ * or sorcery card or a creature card with flying.
+ *
+ * The "unless" is a choice the controller makes as the trigger resolves, not a condition checked
+ * beforehand: two cards of any kind, or a single card with one of the listed characteristics. That
+ * is [Patterns.Hand.discardCardsUnlessMatching] — one choose-exactly-two selection carrying a
+ * `ReducedMinimumIfMatches` restriction that drops the minimum to one the moment the selection
+ * holds a qualifying card. Modelling it as a prior modal choice would be wrong: the printed ruling
+ * lets you pitch two cards even when one of them qualifies.
+ *
+ * The two draws and the discard live in one trigger, so the freshly drawn cards are in hand and
+ * legal to discard.
+ *
+ * The qualifying filter is a homogeneous OR — instant-or-sorcery, or a creature card carrying
+ * flying — which collapses to a single flat `CardPredicate.Or`. Keywords on a card in hand come
+ * from its printed `baseKeywords` (there is no battlefield projection to read), so "creature card
+ * with flying" is the card's own printed flying, exactly as the text means it.
+ */
+val SteamcoreScholar = card("Steamcore Scholar") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Weird Detective"
+    power = 2
+    toughness = 2
+    oracleText = "Flying, vigilance\n" +
+        "When this creature enters, draw two cards. Then discard two cards unless you discard an " +
+        "instant or sorcery card or a creature card with flying."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Effects.DrawCards(2),
+            Patterns.Hand.discardCardsUnlessMatching(
+                count = 2,
+                unlessFilter = GameObjectFilter.InstantOrSorcery or
+                    GameObjectFilter.Creature.withKeyword(Keyword.FLYING),
+                prompt = "Discard two cards, or a single instant, sorcery, or creature card with flying",
+            ),
+        )
+        description = "When this creature enters, draw two cards. Then discard two cards unless " +
+            "you discard an instant or sorcery card or a creature card with flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "David Astruga"
+        flavorText = "Hm. That's weird."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6bbf7394-9b17-45f8-a25b-d865e8452b2c.jpg?1783912907"
+
+        ruling(
+            "2024-02-02",
+            "You can discard an instant card, a sorcery card, a creature card with flying, or any " +
+                "two cards, even if one or both of those cards have the listed characteristics."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -486,6 +486,126 @@
     ]
 }
 
+// Barbed Servitor
+{
+    "name": "Barbed Servitor",
+    "manaCost": "{3}{B}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Indestructible\nWhen this creature enters, suspect it. (It has menace and can't block.)\nWhenever this creature deals combat damage to a player, you draw a card and you lose 1 life.\nWhenever this creature is dealt damage, target opponent loses that much life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SetSuspected",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": "Self",
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "CantBlockTargetCreatures",
+                            "target": "Self",
+                            "duration": "Permanent"
+                        }
+                    ],
+                    "descriptionOverride": "this creature becomes suspected"
+                },
+                "descriptionOverride": "When this creature enters, suspect it."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, you draw a card and you lose 1 life."
+            },
+            {
+                "id": "ability_3",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "Whenever this creature is dealt damage, target opponent loses that much life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "RARE",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c34e4ae-9bf3-4098-88f1-267e7d6cfa35.jpg?1783912901",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "A creature can be dealt an amount of damage greater than its toughness. For example, if Barbed Servitor is dealt 3 damage, its last ability causes the target opponent to lose 3 life."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If your life total is brought to 0 or less at the same time that Barbed Servitor is dealt damage, you lose the game before its last ability goes on the stack."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "When an effect suspects a creature, it becomes suspected. It gains menace and \"This creature can't block\" for as long as it's suspected. It stays suspected until it leaves the battlefield or another effect causes it to no longer be suspected."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Basilica Stalker
 {
     "name": "Basilica Stalker",
@@ -5631,6 +5751,74 @@
     ]
 }
 
+// Macabre Reconstruction
+{
+    "name": "Macabre Reconstruction",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "This spell costs {2} less to cast if a creature card was put into your graveyard from anywhere this turn.\nReturn up to two target creature cards from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Hand"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "OnlyIf",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "TurnTracking",
+                            "player": "You",
+                            "tracker": "CREATURE_CARDS_PUT_INTO_GRAVEYARD"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "artist": "Sam Guay",
+        "flavorText": "\"Eyewitness testimony, coming right up! Just let me finish regenerating their eyes.\"\n—Nelo, Agency coroner",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abb6184c-e3d0-4275-b25b-95e4a64b26f3.jpg?1783912895"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Make Your Move
 {
     "name": "Make Your Move",
@@ -6213,6 +6401,81 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// No Witnesses
+{
+    "name": "No Witnesses",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Each player who controls the most creatures investigates. Then destroy all creatures. (To investigate, create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "PlayerControlsMostPermanents",
+                                "player": "You"
+                            }
+                        },
+                        "then": {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Clue",
+                            "controller": "Controller"
+                        }
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature"
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "RARE",
+        "artist": "Michele Giorgi",
+        "flavorText": "When cunning fails, there's always violence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f98db67a-c39c-45a8-ae21-85133be46ed5.jpg?1783912920",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Clue is an artifact type. Even though it appears on some cards with other permanent types, it's never a creature type, a land type, or anything but an artifact type."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -8686,6 +8949,99 @@
     ]
 }
 
+// Soul Enervation
+{
+    "name": "Soul Enervation",
+    "manaCost": "{3}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Flash\nWhen this enchantment enters, target creature gets -4/-4 until end of turn.\nWhenever one or more creature cards leave your graveyard, each opponent loses 1 life and you gain 1 life.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this enchantment enters, target creature gets -4/-4 until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CardsLeftYourGraveyardEvent",
+                    "filter": "creature"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever one or more creature cards leave your graveyard, each opponent loses 1 life and you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "rarity": "UNCOMMON",
+        "artist": "Domenico Cava",
+        "flavorText": "Judith's plan was close to fruition. She couldn't have Agrus get in the way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f22ac67-06ce-47cc-a515-d216d30b9cae.jpg?1783912889",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If multiple creature cards leave your graveyard at the same time, Soul Enervation's last ability will trigger only once."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Soul Search
 {
     "name": "Soul Search",
@@ -8798,6 +9154,129 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Steamcore Scholar
+{
+    "name": "Steamcore Scholar",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Weird Detective",
+    "oracleText": "Flying, vigilance\nWhen this creature enters, draw two cards. Then discard two cards unless you discard an instant or sorcery card or a creature card with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Discard two cards, or a single instant, sorcery, or creature card with flying",
+                                    "restrictions": [
+                                        {
+                                            "type": "ReducedMinimumIfMatches",
+                                            "reducedMinimum": 1,
+                                            "filter": {
+                                                "cardPredicates": [
+                                                    {
+                                                        "type": "Or",
+                                                        "predicates": [
+                                                            {
+                                                                "type": "Or",
+                                                                "predicates": [
+                                                                    "IsInstant",
+                                                                    "IsSorcery"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "And",
+                                                                "predicates": [
+                                                                    "IsCreature",
+                                                                    {
+                                                                        "type": "HasKeyword",
+                                                                        "keyword": "FLYING"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, draw two cards. Then discard two cards unless you discard an instant or sorcery card or a creature card with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "David Astruga",
+        "flavorText": "Hm. That's weird.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bbf7394-9b17-45f8-a25b-d865e8452b2c.jpg?1783912907",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "You can discard an instant card, a sorcery card, a creature card with flying, or any two cards, even if one or both of those cards have the listed characteristics."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -52,6 +52,7 @@ import com.wingedsheep.engine.state.components.player.FlashGrantsThisTurnCompone
 import com.wingedsheep.engine.state.components.player.PlayerCantPlayFromHandComponent
 import com.wingedsheep.engine.state.components.player.PlayerProtectionComponent
 import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurnComponent
+import com.wingedsheep.engine.state.components.player.CreatureCardsPutIntoGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeGainedAmountThisTurnComponent
@@ -698,6 +699,9 @@ class CleanupPhaseManager(
                 }
                 if (result.has<PlayerDescendedThisTurnComponent>()) {
                     result = result.without<PlayerDescendedThisTurnComponent>()
+                }
+                if (result.has<CreatureCardsPutIntoGraveyardThisTurnComponent>()) {
+                    result = result.without<CreatureCardsPutIntoGraveyardThisTurnComponent>()
                 }
                 if (result.has<FlippedCoinsThisTurnComponent>()) {
                     result = result.without<FlippedCoinsThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -574,6 +574,7 @@ val engineSerializersModule = SerializersModule {
         subclass(NonTokenCreaturesDiedThisTurnComponent::class)
         subclass(OpponentCreaturesExiledThisTurnComponent::class)
         subclass(PlayerDescendedThisTurnComponent::class)
+        subclass(CreatureCardsPutIntoGraveyardThisTurnComponent::class)
         subclass(FlippedCoinsThisTurnComponent::class)
         subclass(PermanentsSacrificedThisTurnComponent::class)
         subclass(RedNoncombatDamageDealtThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -139,6 +139,7 @@ import com.wingedsheep.sdk.scripting.conditions.PlayerCastSpellsThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerCommittedCrimeThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerHasCitysBlessing
 import com.wingedsheep.sdk.scripting.conditions.PlayerHasEnduringStory
+import com.wingedsheep.sdk.scripting.conditions.PlayerControlsMostPermanents
 import com.wingedsheep.sdk.scripting.conditions.PlayerHasMostLife
 import com.wingedsheep.sdk.scripting.conditions.TriggeringPlayerIs
 import com.wingedsheep.sdk.scripting.conditions.RingHasTemptedPlayerAtLeast
@@ -450,6 +451,9 @@ class ConditionEvaluator(
                     state.turnOrder.all { state.lifeTotal(it) <= life }
                 }
             }
+
+            is PlayerControlsMostPermanents ->
+                evaluatePlayerControlsMostPermanentsCtx(state, condition, ctx)
 
             is RingHasTemptedPlayerAtLeast -> {
                 val playerId = resolvePlayer(state, condition.player, ctx)
@@ -862,6 +866,38 @@ class ConditionEvaluator(
             }
         }
         return if (condition.negate) !found else found
+    }
+
+    /**
+     * "Controls the most [filter], or is tied for the most" — the board-count sibling of
+     * [PlayerHasMostLife]. Counts every player's matching permanents off the *projected*
+     * battlefield (so an animated land counts as a creature) and returns true when nobody has
+     * strictly more than the named player. `state.turnOrder` is the comparison set, matching
+     * [PlayerHasMostLife]; a player with zero matches still qualifies when everyone has zero,
+     * exactly as "the most" reads with an empty board.
+     */
+    private fun evaluatePlayerControlsMostPermanentsCtx(
+        state: GameState,
+        condition: PlayerControlsMostPermanents,
+        ctx: ConditionEvaluationContext
+    ): Boolean {
+        val playerId = resolvePlayer(state, condition.player, ctx) ?: return false
+        val projected = ctx.projectedStateFor(state)
+        val predicateEvaluator = PredicateEvaluator()
+        val predicateContext = when (ctx) {
+            is Resolution -> PredicateContext.fromEffectContext(ctx.effectContext)
+            is Projection -> PredicateContext(controllerId = playerId, sourceId = ctx.sourceId)
+        }
+
+        val counts = state.getBattlefield()
+            .filter { entityId ->
+                predicateEvaluator.matches(state, projected, entityId, condition.filter, predicateContext)
+            }
+            .groupingBy { entityId -> projected.getController(entityId) }
+            .eachCount()
+
+        val mine = counts[playerId] ?: 0
+        return state.turnOrder.all { (counts[it] ?: 0) <= mine }
     }
 
     private fun evaluateSourceIsModifiedCtx(state: GameState, ctx: ConditionEvaluationContext): Boolean {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -558,6 +558,11 @@ class DynamicAmountEvaluator(
                             ?.get<com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent>()
                             ?.count ?: 0
                     }
+                    TurnTracker.CREATURE_CARDS_PUT_INTO_GRAVEYARD -> playerIds.sumOf { playerId ->
+                        state.getEntity(playerId)
+                            ?.get<com.wingedsheep.engine.state.components.player.CreatureCardsPutIntoGraveyardThisTurnComponent>()
+                            ?.count ?: 0
+                    }
                     TurnTracker.CARDS_DRAWN -> playerIds.sumOf { playerId ->
                         state.getEntity(playerId)
                             ?.get<com.wingedsheep.engine.state.components.player.CardsDrawnThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -40,6 +40,7 @@ import com.wingedsheep.engine.state.components.player.PermanentEnteredFaceDownTh
 import com.wingedsheep.engine.state.components.player.PermanentLeftBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CreatureLeftBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentsSacrificedThisTurnComponent
+import com.wingedsheep.engine.state.components.player.CreatureCardsPutIntoGraveyardThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PlayerDescendedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.SacrificedArtifactThisTurnComponent
 import com.wingedsheep.engine.state.components.player.SacrificedFoodThisTurnComponent
@@ -754,6 +755,22 @@ object ZoneTransitionService {
                 val existing = playerContainer.get<PlayerDescendedThisTurnComponent>()
                     ?: PlayerDescendedThisTurnComponent()
                 playerContainer.with(PlayerDescendedThisTurnComponent(existing.count + 1))
+            }
+        }
+
+        // 8d2. "A creature card was put into your graveyard from anywhere this turn" (Macabre
+        // Reconstruction). The creature-typed slice of the same arrival: any origin zone, keyed
+        // on the owner, tokens excluded. Turn history — reanimating the card later in the turn
+        // doesn't undo the count.
+        if (actualDestZone == Zone.GRAVEYARD &&
+            fromZone != Zone.GRAVEYARD &&
+            cardComponent.typeLine.isCreature &&
+            !container.has<TokenComponent>()
+        ) {
+            newState = newState.updateEntity(ownerId) { playerContainer ->
+                val existing = playerContainer.get<CreatureCardsPutIntoGraveyardThisTurnComponent>()
+                    ?: CreatureCardsPutIntoGraveyardThisTurnComponent()
+                playerContainer.with(CreatureCardsPutIntoGraveyardThisTurnComponent(existing.count + 1))
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -1274,6 +1274,22 @@ data class TurnedPermanentFaceUpThisTurnComponent(val count: Int = 0) : Componen
 data class PlayerDescendedThisTurnComponent(val count: Int = 0) : Component
 
 /**
+ * Tracks the number of creature cards put into this player's graveyard from any zone during
+ * the current turn. Cleared at end of turn by CleanupPhaseManager.
+ *
+ * The creature-typed sibling of [PlayerDescendedThisTurnComponent], recorded by the same
+ * `moveToZone` hook and keyed the same way — on the card's **owner** ("your graveyard" is the
+ * owner's graveyard), from any origin zone, tokens excluded (a token isn't a card, CR 111.6).
+ * Like descend it is pure turn history: the card need not still be in the graveyard, so
+ * reanimating it later in the turn doesn't clear the count.
+ *
+ * Backs Murders at Karlov Manor's "if a creature card was put into your graveyard from anywhere
+ * this turn" (Macabre Reconstruction's cost reduction).
+ */
+@Serializable
+data class CreatureCardsPutIntoGraveyardThisTurnComponent(val count: Int = 0) : Component
+
+/**
  * Marks that this player has flipped one or more coins already this turn. Presence alone is the
  * signal — it is set the first time the player flips (regardless of who controls any coin-flip
  * replacement) so that a "the first time you flip one or more coins each turn" effect

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MacabreReconstructionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MacabreReconstructionScenarioTest.kt
@@ -1,0 +1,164 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Macabre Reconstruction (MKM #93) — {3}{B} sorcery, "costs {2} less to cast if a creature card was
+ * put into your graveyard from anywhere this turn", returns up to two target creature cards from
+ * your graveyard to your hand.
+ *
+ * Covers the new `TurnTracker.CREATURE_CARDS_PUT_INTO_GRAVEYARD` end to end. The point of the
+ * tracker is that it is *turn history*, not a graveyard scan, so the tests pin the mana actually
+ * required rather than reading the component: three lands can't cast it cold even with creature
+ * cards sitting in the yard from before, three lands *can* cast it once a creature has died this
+ * turn, and the discount is gone again next turn.
+ *
+ * Killing your own Grizzly Bears with a Lightning Bolt is the outlet — it routes the creature card
+ * through `ZoneTransitionService` the same way any death does, and it leaves two Swamps untapped,
+ * exactly the reduced {1}{B}.
+ */
+class MacabreReconstructionScenarioTest : ScenarioTestBase() {
+
+    /**
+     * Shared board: the Reconstruction and a Bolt in hand, a 2/2 of your own to point the Bolt at,
+     * two creature cards already in the graveyard (legal targets — and proof that a pre-existing
+     * graveyard doesn't discount anything), and one Mountain plus two Swamps.
+     *
+     * Three lands is the whole test: {3}{B} needs four mana, the reduced {1}{B} needs two, and the
+     * Mountain pays for the Bolt.
+     */
+    private fun board(swamps: Int = 2): ScenarioBuilder {
+        var builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "Macabre Reconstruction")
+            .withCardInHand(1, "Lightning Bolt")
+            .withCardOnBattlefield(1, "Grizzly Bears")
+            .withCardInGraveyard(1, "Craw Wurm")
+            .withCardInGraveyard(1, "Hill Giant")
+            .withLandsOnBattlefield(1, "Swamp", swamps)
+            .withLandsOnBattlefield(1, "Mountain", 1)
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        repeat(10) {
+            builder = builder.withCardInLibrary(1, "Island").withCardInLibrary(2, "Island")
+        }
+        return builder
+    }
+
+    /** Bolt your own Bears so a creature card lands in your graveyard this turn. */
+    private fun boltYourOwnBears(game: TestGame) {
+        val bears = game.findPermanent("Grizzly Bears") ?: error("no Grizzly Bears on the battlefield")
+        game.castSpell(1, "Lightning Bolt", bears).error shouldBe null
+        game.resolveStack()
+        withClue("the Bears must actually have died") {
+            game.findPermanent("Grizzly Bears") shouldBe null
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+        }
+    }
+
+    /** Cast the Reconstruction naming [targetNames] in your own graveyard. */
+    private fun castTargeting(game: TestGame, vararg targetNames: String) =
+        game.execute(
+            CastSpell(
+                playerId = game.player1Id,
+                cardId = game.findCardsInHand(1, "Macabre Reconstruction").first(),
+                targets = targetNames.map { name ->
+                    val id = game.state.getGraveyard(game.player1Id).first { entityId ->
+                        game.state.getEntity(entityId)?.get<CardComponent>()?.name == name
+                    }
+                    ChosenTarget.Card(id, game.player1Id, Zone.GRAVEYARD)
+                },
+            )
+        )
+
+    init {
+        test("costs its full {3}{B} when no creature card hit your graveyard this turn") {
+            val game = board().build()
+
+            withClue("two creature cards already in the yard are not the trigger — they arrived earlier") {
+                castTargeting(game, "Craw Wurm").error shouldNotBe null
+            }
+        }
+
+        test("a creature dying this turn discounts it to {1}{B} and it returns two cards") {
+            val game = board().build()
+
+            boltYourOwnBears(game)
+
+            withClue("the {2} reduction must bring {3}{B} within reach of two Swamps") {
+                castTargeting(game, "Craw Wurm", "Hill Giant").error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("both targets go back to hand") {
+                game.isInHand(1, "Craw Wurm") shouldBe true
+                game.isInHand(1, "Hill Giant") shouldBe true
+            }
+        }
+
+        test("'up to two' accepts a single target") {
+            val game = board().build()
+
+            boltYourOwnBears(game)
+
+            castTargeting(game, "Hill Giant").error shouldBe null
+            game.resolveStack()
+
+            withClue("only the named card comes back") {
+                game.isInHand(1, "Hill Giant") shouldBe true
+                game.isInGraveyard(1, "Craw Wurm") shouldBe true
+            }
+        }
+
+        test("one death discounts every cast that turn, and survives the card leaving the yard") {
+            // Four Swamps is exactly two discounted casts. An undiscounted second cast would need
+            // four mana with only two Swamps left, so this fails loudly if the discount were
+            // consumed by the first cast or undone by pulling the dead creature back out.
+            val game = board(swamps = 4).withCardInHand(1, "Macabre Reconstruction").build()
+
+            boltYourOwnBears(game)
+
+            withClue("first cast: discounted, and it takes the Bears back out of the graveyard") {
+                castTargeting(game, "Grizzly Bears").error shouldBe null
+            }
+            game.resolveStack()
+            game.isInHand(1, "Grizzly Bears") shouldBe true
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+
+            withClue("second cast: the same death still discounts it") {
+                castTargeting(game, "Hill Giant").error shouldBe null
+            }
+            game.resolveStack()
+            game.isInHand(1, "Hill Giant") shouldBe true
+        }
+
+        test("the discount is turn-scoped — it's gone next turn") {
+            val game = board().build()
+
+            boltYourOwnBears(game)
+
+            // Round the table back to player 1's next main phase. Each stop has to be a distinct
+            // (phase, step) or passUntilPhase returns immediately without advancing.
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // player 2's upkeep
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // player 2's main
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP) // player 1's next upkeep
+            game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN) // player 1's next main
+            withClue("we must actually be back on player 1's turn") {
+                game.state.activePlayerId shouldBe game.player1Id
+            }
+
+            withClue("a creature that died last turn must not discount this spell") {
+                castTargeting(game, "Craw Wurm").error shouldNotBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NoWitnessesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NoWitnessesScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * No Witnesses (MKM #27) — {2}{W}{W} sorcery, "Each player who controls the most creatures
+ * investigates. Then destroy all creatures."
+ *
+ * Covers the new `Conditions.PlayerControlsMostPermanents` on all three shapes the wording has: one
+ * player strictly ahead (only they investigate), a tie (everyone tied investigates), and the case
+ * where the caster is the one behind. Clue counts are read *after* the wipe, since the printed
+ * order investigates first and destroys second.
+ */
+class NoWitnessesScenarioTest : ScenarioTestBase() {
+
+    /** Board with [mine] / [theirs] Grizzly Bears and the sorcery in player 1's hand. */
+    private fun board(mine: Int, theirs: Int): ScenarioBuilder {
+        var builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withCardInHand(1, "No Witnesses")
+            .withLandsOnBattlefield(1, "Plains", 4)
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        repeat(mine) { builder = builder.withCardOnBattlefield(1, "Grizzly Bears") }
+        repeat(theirs) { builder = builder.withCardOnBattlefield(2, "Grizzly Bears") }
+        repeat(5) {
+            builder = builder.withCardInLibrary(1, "Island").withCardInLibrary(2, "Island")
+        }
+        return builder
+    }
+
+    private fun TestGame.cluesOf(playerNumber: Int): Int {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return findPermanents("Clue").count { state.projectedState.getController(it) == playerId }
+    }
+
+    init {
+        test("only the player with the most creatures investigates, and everything dies") {
+            val game = board(mine = 3, theirs = 1).build()
+
+            game.castSpell(1, "No Witnesses").error shouldBe null
+            game.resolveStack()
+
+            withClue("player 1 was strictly ahead → exactly one Clue, and it's theirs") {
+                game.cluesOf(1) shouldBe 1
+                game.cluesOf(2) shouldBe 0
+            }
+            withClue("then destroy all creatures") {
+                game.findPermanents("Grizzly Bears") shouldBe emptyList()
+            }
+        }
+
+        test("the opponent investigates when they're the one ahead") {
+            val game = board(mine = 1, theirs = 3).build()
+
+            game.castSpell(1, "No Witnesses").error shouldBe null
+            game.resolveStack()
+
+            withClue("the Clue follows the board, not the caster") {
+                game.cluesOf(1) shouldBe 0
+                game.cluesOf(2) shouldBe 1
+            }
+            game.findPermanents("Grizzly Bears") shouldBe emptyList()
+        }
+
+        test("a tie means every tied player investigates") {
+            val game = board(mine = 2, theirs = 2).build()
+
+            game.castSpell(1, "No Witnesses").error shouldBe null
+            game.resolveStack()
+
+            withClue("'the most, or tied for the most' — both players qualify") {
+                game.cluesOf(1) shouldBe 1
+                game.cluesOf(2) shouldBe 1
+            }
+            game.findPermanents("Grizzly Bears") shouldBe emptyList()
+        }
+
+        test("an empty board is a tie at zero — everyone investigates") {
+            val game = board(mine = 0, theirs = 0).build()
+
+            game.castSpell(1, "No Witnesses").error shouldBe null
+            game.resolveStack()
+
+            withClue("nobody controls more creatures than anybody else") {
+                game.cluesOf(1) shouldBe 1
+                game.cluesOf(2) shouldBe 1
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five MKM cards, all canonical in MKM (`just check-card-printing` clean on each).

## Cards on existing vocabulary

| Card | Notes |
|---|---|
| **Barbed Servitor** `{3}{B}` | `Triggers.TakesDamage` + `TRIGGER_DAMAGE_AMOUNT` gives "target opponent loses **that much** life" the damage *event's* amount, not the 1/1's toughness — a Bolt drains 3 off an indestructible body. Self-suspect on entry is what makes the ability live. |
| **Steamcore Scholar** `{2}{U}` | `Patterns.Hand.discardCardsUnlessMatching` over a homogeneous OR (instant-or-sorcery, or a creature card with flying). One selection with a `ReducedMinimumIfMatches` restriction, not a prior modal choice — the printed ruling lets you pitch two cards even when one qualifies. |
| **Soul Enervation** `{3}{B}` | `Triggers.CardsLeaveYourGraveyard(Creature)` is the batching trigger the ruling requires (several cards leaving at once fires it once). `LoseLife` + `GainLife` rather than `DrainLife`, since the gain is a flat 1 no matter how many opponents lost life. |

## Cards that needed new SDK vocabulary

**Macabre Reconstruction** `{3}{B}` — "costs {2} less if a creature card was put into your graveyard from anywhere this turn."

Added `Conditions.CreatureCardPutIntoYourGraveyardThisTurn`, backed by `TurnTracker.CREATURE_CARDS_PUT_INTO_GRAVEYARD` and a new per-player `CreatureCardsPutIntoGraveyardThisTurnComponent` — the creature-typed sibling of the descend tracker, incremented by the same `ZoneTransitionService` hook and cleared by `CleanupPhaseManager`. It is deliberately **turn history, not a graveyard scan**, which is what the wording means: a creature milled and reanimated earlier in the turn still pays off, and a creature card sitting in your yard since last turn does not. The reduction rides it via `CostGating.OnlyIf`, so only the generic `{3}` shrinks and the `{B}` pip survives.

**No Witnesses** `{2}{W}{W}` — "Each player who controls the most creatures investigates. Then destroy all creatures."

Added `Conditions.PlayerControlsMostPermanents`, the board-count sibling of the existing `PlayerHasMostLife` — the same "max over every player" shape a binary `Compare` can't express, counted off the *projected* battlefield so an animated land counts. The card wraps it in the Outpace Oblivion pattern: `ForEachPlayerEffect(Player.Each, ConditionalEffect(…))`, where `Player.You` inside the loop is the iterated player, so ties all qualify and each Clue lands in front of its own player.

## Verification

`just build` green (full suite). Card snapshot reblessed — the diff is 479 added lines and **0 removed**, i.e. only these five cards moved.

Nine new scenario tests, all passing, pinning both new primitives on the axes they could be wrong on:

- `MacabreReconstructionScenarioTest` (5) — full price with creature cards *already* in the yard (proves it isn't a graveyard scan), discounted after a death this turn, "up to two" accepting one target, the discount surviving the dead creature being pulled back out and applying to a second cast, and gone again next turn.
- `NoWitnessesScenarioTest` (4) — caster ahead, opponent ahead, tied, and tied at zero on an empty board.

`docs/card-sdk-language-reference.md` updated in the same change (condition entries + the `TurnTracker` enum table).

## Player experience

No new decision UI. Macabre Reconstruction uses the existing graveyard-targeting flow (same as Fight On!), Steamcore Scholar the existing card-selection flow (same as Wrench Mind), Soul Enervation and Barbed Servitor ordinary battlefield/player targeting, No Witnesses no decisions at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
