### PR TITLE
Add hone counter support and four HOB cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -9652,6 +9652,17 @@ substitution.
   not regeneration (no tap, no removal from combat, marked damage untouched) and it is not a keyword counter, so
   losing all abilities doesn't switch it off. Unpreventable damage (Leyline of Punishment) is still dealt — but
   still removes a counter. An indestructible permanent never "would be destroyed", so its counter stays unspent.
+- `hone` — CR 122.1j, a built-in Layer 7c pump aimed at a *different* object: "A hone counter on an Equipment
+  gives +1/+0 to any creature that Equipment is attached to." Add via `AddCounters(Counters.HONE, n, target)`
+  or `AddDynamicCounters(Counters.HONE, amount, target)` — and that is **all** a hone card does; the bonus is
+  never a `ModifyStats`/`GrantDynamicStats` on the Equipment. Like `shield` and `stun` the behavior belongs to
+  the counter, which is what makes Dwalin, Weaponmaster ("put a hone counter on each Equipment you control")
+  work: a Mirrodin Bonesplitter that has never heard of hone still pumps its equipped creature. Engine-wired in
+  `StateProjector.collectContinuousEffects`, which synthesizes one `Modification.ModifyPowerToughness(n, 0)` per
+  honed Equipment scoped to `AffectsFilter.AttachedPermanent` — so it stacks additively with the Equipment's own
+  printed bonus (CR 613.4c covers "effects **and** counters that modify power and/or toughness"), contributes
+  nothing while the Equipment is unattached, and is inert on a non-Equipment permanent. Not a keyword counter,
+  so it stays out of `KEYWORD_COUNTER_MAP`. Used by Sting, Bilbo's Sword and Dwalin, Weaponmaster (HOB).
 - **Keyword counters** (Rule 122.1b) — `flying`, `first strike`, `double strike`, `vigilance`, `lifelink`,
   `indestructible`, `deathtouch`, `trample`, `hexproof`, `reach`, `haste`, `menace`. `StateProjector` grants the matching `Keyword`
   to any permanent carrying one (mapped in `KEYWORD_COUNTER_MAP`, re-applied after Layer 6 so "loses all abilities"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -103,7 +103,25 @@ enum class CounterType {
      * one is ever placed; it models the permanent "once harnessed" state that resets if the Stone
      * leaves the battlefield.
      */
-    HARNESS;
+    HARNESS,
+
+    /**
+     * Hone counter (The Hobbit). CR 122.1j: "A hone counter on an Equipment gives +1/+0 to any
+     * creature that Equipment is attached to."
+     *
+     * Like [SHIELD] and [STUN], the behavior is inherent to the *counter*, not an ability of the
+     * permanent carrying it — a hone counter placed on an Equipment that never mentions hone still
+     * pumps that Equipment's equipped creature. That is exactly what Dwalin, Weaponmaster relies on
+     * when he puts a counter on *each* Equipment you control, so it cannot be modelled as a static
+     * ability printed on the two cards that happen to grant hone counters.
+     *
+     * Realized in `StateProjector.collectContinuousEffects`, which synthesizes one Layer 7c P/T
+     * modification (CR 613.4c — "effects **and counters** that modify power and/or toughness") per
+     * honed Equipment, aimed at whatever it is attached to. Deliberately **not** a keyword counter,
+     * so it is absent from `StateProjector.KEYWORD_COUNTER_MAP`: it grants the Equipment nothing and
+     * modifies a *different* object than the one it sits on.
+     */
+    HONE;
 
     companion object {
         /**
@@ -439,6 +457,14 @@ object Counters {
 
     /** Harness marker counter — the Infinity Stones' "once harnessed" binary state. */
     const val HARNESS = "harness"
+
+    /**
+     * Hone counter (The Hobbit). CR 122.1j: "A hone counter on an Equipment gives +1/+0 to any
+     * creature that Equipment is attached to." The bonus belongs to the counter rather than to the
+     * permanent holding it, so it applies to Equipment that never mention hone — see
+     * [CounterType.HONE] for the full contract and where the engine realizes it.
+     */
+    const val HONE = "hone"
 
     /**
      * Skewer counter (WOE — Rotisserie Elemental). A tally counter with no inherent rule: the

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BelladonnaTook.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BelladonnaTook.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.IncrementAbilityResolutionCountEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Belladonna Took
+ * {1}{W}
+ * Legendary Creature — Halfling Citizen
+ * 2/2
+ *
+ * Whenever a token you control enters, you gain 1 life if this is the first time this ability has
+ * resolved this turn. If it's the second time, draw a card. If it's the third time, put a +1/+1
+ * counter on each creature you control.
+ *
+ * A per-ability resolution counter, not a per-turn trigger cap: the ability keeps triggering all
+ * turn, and the payoff is selected by *which* resolution this is. [IncrementAbilityResolutionCountEffect]
+ * must run before the three [ConditionalEffect]s read the count, or the first branch would test
+ * against 0 and nothing would ever fire (same ordering trap as Elrond, Lord of Rivendell and
+ * Harvestrite Host). `SourceAbilityResolvedNTimes` compares for **exact** equality, so the branches
+ * are mutually exclusive and the fourth and later resolutions in a turn deliberately do nothing.
+ *
+ * The trigger is on tokens of any kind, not just creature tokens — a Treasure or a Food entering
+ * advances the count just as a Bird does. Belladonna herself is never a token, so she can't trip
+ * her own ability by entering.
+ */
+val BelladonnaTook = card("Belladonna Took") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Halfling Citizen"
+    oracleText = "Whenever a token you control enters, you gain 1 life if this is the first time " +
+        "this ability has resolved this turn. If it's the second time, draw a card. If it's the " +
+        "third time, put a +1/+1 counter on each creature you control."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Any.youControl().token(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = IncrementAbilityResolutionCountEffect
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.SourceAbilityResolvedNTimes(1),
+                    effect = Effects.GainLife(1),
+                )
+            )
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.SourceAbilityResolvedNTimes(2),
+                    effect = Effects.DrawCards(1),
+                )
+            )
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.SourceAbilityResolvedNTimes(3),
+                    effect = Effects.ForEachInGroup(
+                        GroupFilter(GameObjectFilter.Creature.youControl()),
+                        AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                    ),
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        artist = "Xabi Gaztelua"
+        flavorText = "Once in a while, members of the Took clan would go and have adventures."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88f0c189-c9ed-4ea3-ae62-3d8ac6c7fecf.jpg?1784894804"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DwalinWeaponmaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DwalinWeaponmaster.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dwalin, Weaponmaster
+ * {1}{R/W}
+ * Legendary Creature — Dwarf Warrior
+ * 2/1
+ *
+ * First strike
+ * Whenever Dwalin enters or attacks, put a hone counter on each Equipment you control.
+ *
+ * Dwalin is the card that forces hone counters to be a property of the *counter* rather than an
+ * ability printed on the Equipment: he hands a counter to **every** Equipment you control, most of
+ * which have never heard of hone, and CR 122.1j still gives each of their equipped creatures +1/+0.
+ * See [Counters.HONE] — the bonus is synthesized in `StateProjector`, so nothing is needed here
+ * beyond placing the counters.
+ *
+ * "Enters or attacks" is one printed ability but two engine triggers; the project models that split
+ * the way Sentinel of the Nameless City does, since there is no combined enters-or-attacks trigger.
+ * Note the counters land on Equipment whether or not they're attached to anything — an unattached
+ * honed Equipment simply banks the bonus until it's equipped later.
+ */
+val DwalinWeaponmaster = card("Dwalin, Weaponmaster") {
+    manaCost = "{1}{R/W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Dwarf Warrior"
+    oracleText = "First strike\n" +
+        "Whenever Dwalin enters or attacks, put a hone counter on each Equipment you control. " +
+        "(Each hone counter on an Equipment grants +1/+0 to equipped creature.)"
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    val honeEachEquipment = Effects.ForEachInGroup(
+        GroupFilter(GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).youControl()),
+        AddCountersEffect(Counters.HONE, 1, EffectTarget.Self),
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = honeEachEquipment
+        description = "Whenever Dwalin enters, put a hone counter on each Equipment you control."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = honeEachEquipment
+        description = "Whenever Dwalin attacks, put a hone counter on each Equipment you control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "154"
+        artist = "Marco Teixeira"
+        flavorText = "The Company had lost a great deal, but they had killed the Great Goblin and " +
+            "many others besides. All in all, they had the best of it."
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/196d9287-a37d-4b27-a83b-a5489a54f081.jpg?1785496508"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GollumRiddleMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GollumRiddleMaster.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModeOption
+import com.wingedsheep.sdk.scripting.conditions.SourceChosenModeIs
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gollum, Riddle Master
+ * {1}{B}
+ * Legendary Creature — Halfling Horror
+ * 3/1
+ *
+ * As Gollum enters, choose odd or even. (Zero is even.)
+ * Whenever an opponent casts a spell with mana value of the chosen quality, choose one that hasn't
+ * been chosen —
+ * • Put a +1/+1 counter on Gollum.
+ * • Each opponent loses 2 life and you gain 2 life.
+ * • Draw a card.
+ *
+ * The as-enters choice is an [EntersWithChoice] mode (the Khans/Dragons Siege shape), read back by
+ * [SourceChosenModeIs]. There is no "chosen quality" indirection in the SDK — no predicate reads a
+ * parity out of a stored choice slot — so the one printed trigger becomes **two mirrored triggers**,
+ * each gated on the mode it belongs to and filtering on the matching parity. Exactly one of them can
+ * ever be live on a given Gollum, so they can't both fire.
+ *
+ * `chooseOneNotYetChosen` (not the `ThisTurn` variant — Gollum's text has no "this turn") keeps the
+ * chosen-mode memory on the permanent for as long as it stays the same object. Once all three modes
+ * have been taken the ability still triggers but has no legal mode and does nothing; a Gollum that
+ * leaves and returns is a new object and starts over.
+ */
+val GollumRiddleMaster = card("Gollum, Riddle Master") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Halfling Horror"
+    oracleText = "As Gollum enters, choose odd or even. (Zero is even.)\n" +
+        "Whenever an opponent casts a spell with mana value of the chosen quality, choose one " +
+        "that hasn't been chosen —\n" +
+        "• Put a +1/+1 counter on Gollum.\n" +
+        "• Each opponent loses 2 life and you gain 2 life.\n" +
+        "• Draw a card."
+    power = 3
+    toughness = 1
+
+    replacementEffect(
+        EntersWithChoice(
+            choiceType = ChoiceType.MODE,
+            modeOptions = listOf(
+                ModeOption(
+                    id = "odd",
+                    label = "Odd",
+                    description = "Trigger on opponents' spells with an odd mana value.",
+                    iconKey = "odd",
+                ),
+                ModeOption(
+                    id = "even",
+                    label = "Even",
+                    description = "Trigger on opponents' spells with an even mana value. (Zero is even.)",
+                    iconKey = "even",
+                ),
+            )
+        )
+    )
+
+    val riddle = ModalEffect.chooseOneNotYetChosen(
+        Mode.noTarget(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            "Put a +1/+1 counter on Gollum",
+        ),
+        Mode.noTarget(
+            Effects.LoseLife(2, EffectTarget.PlayerRef(Player.EachOpponent))
+                .then(Effects.GainLife(2)),
+            "Each opponent loses 2 life and you gain 2 life",
+        ),
+        Mode.noTarget(
+            Effects.DrawCards(1),
+            "Draw a card",
+        ),
+    )
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(GameObjectFilter.Any.manaValueIsOdd())
+        triggerCondition = SourceChosenModeIs("odd")
+        effect = riddle
+        description = "Whenever an opponent casts a spell with an odd mana value, choose one that " +
+            "hasn't been chosen."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(GameObjectFilter.Any.manaValueIsEven())
+        triggerCondition = SourceChosenModeIs("even")
+        effect = riddle
+        description = "Whenever an opponent casts a spell with an even mana value, choose one " +
+            "that hasn't been chosen."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "70"
+        artist = "Irvin Rodriguez"
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbdc7e37-c65a-497a-92b7-a30a6e369c71.jpg?1784376959"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StingBilbosSword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StingBilbosSword.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sting, Bilbo's Sword
+ * {2}
+ * Legendary Artifact — Equipment
+ *
+ * Flash
+ * When Sting enters, put a hone counter on Sting for each creature target opponent controls.
+ * Attach Sting to up to one target creature you control.
+ * Equip {3}
+ *
+ * The hone counters carry the whole payoff: CR 122.1j gives the equipped creature +1/+0 per hone
+ * counter on the Equipment, so Sting needs no `ModifyStats` of its own — see [Counters.HONE]. That
+ * also means the counters are *sticky*: they are counted when the ETB resolves and stay at that
+ * number afterwards, so a later board wipe on the opponent's side doesn't shrink Sting.
+ *
+ * Target order is load-bearing. The opponent is targeted first and the creature second because the
+ * optional slot has to come last — cast-time target slots are fixed-width and positional, so an
+ * "up to one" ahead of a required target would shift the required one's index when declined.
+ * `Player.TargetOpponent` resolves to the first *player* target in the context rather than
+ * positional slot 0, so the count reads the opponent even with the creature target alongside it.
+ *
+ * "Up to one target creature" is genuinely optional (`TargetCreature(optional = true)`), which
+ * matters for a flashed-in Sting held up during an opponent's turn: declining leaves it unattached
+ * rather than forcing it onto a creature, and it still gets its counters.
+ */
+val StingBilbosSword = card("Sting, Bilbo's Sword") {
+    manaCost = "{2}"
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Flash\n" +
+        "When Sting enters, put a hone counter on Sting for each creature target opponent " +
+        "controls. Attach Sting to up to one target creature you control. (Each hone counter on " +
+        "an Equipment grants +1/+0 to equipped creature.)\n" +
+        "Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target("target opponent", TargetOpponent())
+        val creature = target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl),
+        )
+        effect = Effects.AddDynamicCounters(
+            Counters.HONE,
+            DynamicAmount.AggregateBattlefield(Player.TargetOpponent, GameObjectFilter.Creature),
+            EffectTarget.Self,
+        ).then(Effects.AttachEquipment(creature))
+        description = "When Sting enters, put a hone counter on Sting for each creature target " +
+            "opponent controls. Attach Sting to up to one target creature you control."
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "178"
+        artist = "Tomas Duchek"
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6a8d698-c454-42c4-ad4e-9a7625d5569f.jpg?1784377051"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -505,6 +505,106 @@
     ]
 }
 
+// Belladonna Took
+{
+    "name": "Belladonna Took",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Halfling Citizen",
+    "oracleText": "Whenever a token you control enters, you gain 1 life if this is the first time this ability has resolved this turn. If it's the second time, draw a card. If it's the third time, put a +1/+1 counter on each creature you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "token ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "IncrementAbilityResolutionCount",
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 1
+                                }
+                            },
+                            "then": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 2
+                                }
+                            },
+                            "then": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 3
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "AddCounters",
+                                    "counterType": "+1/+1",
+                                    "count": 1,
+                                    "target": "Self"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "RARE",
+        "artist": "Xabi Gaztelua",
+        "flavorText": "Once in a while, members of the Took clan would go and have adventures.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88f0c189-c9ed-4ea3-ae62-3d8ac6c7fecf.jpg?1784894804"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Beorn the Fierce
 {
     "name": "Beorn the Fierce",
@@ -2758,6 +2858,79 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Dwalin, Weaponmaster
+{
+    "name": "Dwalin, Weaponmaster",
+    "manaCost": "{1}{R/W}",
+    "typeLine": "Legendary Creature — Dwarf Warrior",
+    "oracleText": "First strike\nWhenever Dwalin enters or attacks, put a hone counter on each Equipment you control. (Each hone counter on an Equipment grants +1/+0 to equipped creature.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "artifact Equipment ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "hone",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever Dwalin enters, put a hone counter on each Equipment you control."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "artifact Equipment ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "hone",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever Dwalin attacks, put a hone counter on each Equipment you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "rarity": "RARE",
+        "artist": "Marco Teixeira",
+        "flavorText": "The Company had lost a great deal, but they had killed the Great Goblin and many others besides. All in all, they had the best of it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/196d9287-a37d-4b27-a83b-a5489a54f081.jpg?1785496508"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -5212,6 +5385,189 @@
         "artist": "Andrea Piparo",
         "flavorText": "\"Where iss it? Losst it is, my precious!\"",
         "imageUri": "https://cards.scryfall.io/normal/front/5/0/50d91ef3-6f5d-4255-8d47-be731b5dad30.jpg?1784733916"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Gollum, Riddle Master
+{
+    "name": "Gollum, Riddle Master",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Creature — Halfling Horror",
+    "oracleText": "As Gollum enters, choose odd or even. (Zero is even.)\nWhenever an opponent casts a spell with mana value of the chosen quality, choose one that hasn't been chosen —\n• Put a +1/+1 counter on Gollum.\n• Each opponent loses 2 life and you gain 2 life.\n• Draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "ManaValueIsOdd"
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            "description": "Put a +1/+1 counter on Gollum"
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "LoseLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "EachOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "GainLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    }
+                                ]
+                            },
+                            "description": "Each opponent loses 2 life and you gain 2 life"
+                        },
+                        {
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ],
+                    "excludePreviouslyChosenModes": true,
+                    "countsAsModalSpell": false
+                },
+                "triggerCondition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "odd"
+                },
+                "descriptionOverride": "Whenever an opponent casts a spell with an odd mana value, choose one that hasn't been chosen."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "ManaValueIsEven"
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            "description": "Put a +1/+1 counter on Gollum"
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "LoseLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "EachOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "GainLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    }
+                                ]
+                            },
+                            "description": "Each opponent loses 2 life and you gain 2 life"
+                        },
+                        {
+                            "effect": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ],
+                    "excludePreviouslyChosenModes": true,
+                    "countsAsModalSpell": false
+                },
+                "triggerCondition": {
+                    "type": "SourceChosenModeIs",
+                    "modeId": "even"
+                },
+                "descriptionOverride": "Whenever an opponent casts a spell with an even mana value, choose one that hasn't been chosen."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "MODE",
+                "modeOptions": [
+                    {
+                        "id": "odd",
+                        "label": "Odd",
+                        "description": "Trigger on opponents' spells with an odd mana value.",
+                        "iconKey": "odd"
+                    },
+                    {
+                        "id": "even",
+                        "label": "Even",
+                        "description": "Trigger on opponents' spells with an even mana value. (Zero is even.)",
+                        "iconKey": "even"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "MYTHIC",
+        "artist": "Irvin Rodriguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbdc7e37-c65a-497a-92b7-a30a6e369c71.jpg?1784376959"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -9580,6 +9936,102 @@
     "colorIdentityOverride": [
         "BLUE"
     ]
+}
+
+// Sting, Bilbo's Sword
+{
+    "name": "Sting, Bilbo's Sword",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Flash\nWhen Sting enters, put a hone counter on Sting for each creature target opponent controls. Attach Sting to up to one target creature you control. (Each hone counter on an Equipment grants +1/+0 to equipped creature.)\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "hone",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "TargetOpponent",
+                                "filter": "creature"
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "up to one target creature you control"
+                    }
+                ],
+                "descriptionOverride": "When Sting enters, put a hone counter on Sting for each creature target opponent controls. Attach Sting to up to one target creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "RARE",
+        "artist": "Tomas Duchek",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6a8d698-c454-42c4-ad4e-9a7625d5569f.jpg?1784377051"
+    }
 }
 
 // Stir Up Trouble

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -586,6 +586,45 @@ class StateProjector(
             }
         }
 
+        // 1b. Hone counters (CR 122.1j): "A hone counter on an Equipment gives +1/+0 to any
+        // creature that Equipment is attached to." Synthesized here rather than lowered from a
+        // static ability because the bonus belongs to the *counter*, not to the permanent holding
+        // it — Dwalin, Weaponmaster puts a hone counter on *each* Equipment you control, and those
+        // Equipment pump their equipped creature without ever mentioning hone.
+        //
+        // Layer 7c (CR 613.4c — "effects and counters that modify power and/or toughness"), so it
+        // stacks additively with lords and lands after any Layer 7b base-setting effect.
+        //
+        // The Equipment check reads the in-progress projection, which at collection time holds base
+        // types plus Layer 3 text changes; a Layer 4 effect that turned something into an Equipment
+        // this same projection pass would not be seen. That matches how every other filter resolved
+        // here behaves and no printed card reaches the case.
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val honeCount = container.get<CountersComponent>()?.getCount(CounterType.HONE) ?: 0
+            if (honeCount <= 0) continue
+            if (projectedValues[entityId]?.subtypes?.contains(Subtype.EQUIPMENT.value) != true) continue
+            // AttachedPermanent resolves to the empty set while the Equipment is unattached, so an
+            // unequipped honed Equipment contributes nothing without a separate guard.
+            val affected = filterResolver.resolveAffectedEntities(
+                state,
+                entityId,
+                AffectsFilter.AttachedPermanent,
+                projectedValues
+            )
+            if (affected.isEmpty()) continue
+            effects.add(
+                ContinuousEffect(
+                    sourceId = entityId,
+                    timestamp = container.get<com.wingedsheep.engine.state.components.battlefield.TimestampComponent>()?.timestamp
+                        ?: state.timestamp,
+                    modification = Modification.ModifyPowerToughness(honeCount, 0),
+                    affectedEntities = affected,
+                    affectsFilter = AffectsFilter.AttachedPermanent
+                )
+            )
+        }
+
         // 2. Collect floating effects (from resolved spells like Giant Growth)
         for (floating in state.floatingEffects) {
             if (floating.duration is Duration.WhileSourceTapped) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BelladonnaTookScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BelladonnaTookScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.BelladonnaTook
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.RaiseTheAlarm
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Belladonna Took (HOB #4) — {1}{W} Legendary Creature — Halfling Citizen 2/2.
+ *
+ *   Whenever a token you control enters, you gain 1 life if this is the first time this ability has
+ *   resolved this turn. If it's the second time, draw a card. If it's the third time, put a +1/+1
+ *   counter on each creature you control.
+ *
+ * Two Raise the Alarms give four token-enters triggers in one turn, which walks the counter through
+ * all three branches and one resolution past the end of them. The branches are exact-equality
+ * checks, so the fourth resolution must do nothing at all rather than repeating the third.
+ */
+class BelladonnaTookScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun power(game: TestGame, id: EntityId): Int? = game.state.projectedState.getPower(id)
+
+    init {
+        cardRegistry.register(BelladonnaTook)
+        cardRegistry.register(RaiseTheAlarm)
+
+        context("Belladonna Took") {
+
+            test("first resolution gains life, second draws, third counters everyone, fourth does nothing") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Belladonna Took")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val belladonna = game.findPermanent("Belladonna Took")!!
+                val lifeBefore = game.getLifeTotal(1)
+                val handBefore = game.handSize(1)
+
+                // Two tokens enter → resolutions #1 (gain 1 life) and #2 (draw a card).
+                game.castSpell(1, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+
+                withClue("resolution #1 gained 1 life") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 1
+                }
+                withClue("resolution #2 drew a card (hand: -1 Raise the Alarm, +1 drawn)") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("resolution #3 hasn't happened yet, so nobody has a +1/+1 counter") {
+                    plusOneCounters(game, belladonna) shouldBe 0
+                }
+
+                // Two more tokens → resolutions #3 (counter on each creature) and #4 (nothing).
+                game.castSpell(1, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+
+                val tokens = game.findAllPermanents("Soldier Token")
+                withClue("four Soldier tokens are on the battlefield") {
+                    tokens.size shouldBe 4
+                }
+                withClue("resolution #3 put a +1/+1 counter on each creature you control") {
+                    plusOneCounters(game, belladonna) shouldBe 1
+                    tokens.forEach { plusOneCounters(game, it) shouldBe 1 }
+                }
+                withClue("resolution #4 matched no branch — exactly one counter each, not two") {
+                    power(game, belladonna) shouldBe 3 // 2/2 plus a single +1/+1
+                }
+                withClue("no further life gain after the first resolution") {
+                    game.getLifeTotal(1) shouldBe lifeBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DwalinWeaponmasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DwalinWeaponmasterScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.DwalinWeaponmaster
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Bonesplitter
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.LeoninScimitar
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dwalin, Weaponmaster (HOB #154) — {1}{R/W} Legendary Creature — Dwarf Warrior 2/1, first strike.
+ *
+ *   Whenever Dwalin enters or attacks, put a hone counter on each Equipment you control.
+ *
+ * Deliberately tested against **Mirrodin** Equipment, which predate hone by two decades and have no
+ * ability referencing it. That is the point of CR 122.1j: the +1/+0 rides on the counter, so Dwalin
+ * buffs any Equipment in the deck rather than a curated list of hone cards.
+ */
+class DwalinWeaponmasterScenarioTest : ScenarioTestBase() {
+
+    private fun power(game: TestGame, id: EntityId): Int? = game.state.projectedState.getPower(id)
+    private fun toughness(game: TestGame, id: EntityId): Int? =
+        game.state.projectedState.getToughness(id)
+
+    private fun honeCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.HONE) ?: 0
+
+    init {
+        cardRegistry.register(DwalinWeaponmaster)
+        cardRegistry.register(Bonesplitter)
+        cardRegistry.register(LeoninScimitar)
+
+        context("Dwalin, Weaponmaster") {
+
+            test("entering hones every Equipment you control, and only yours") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Dwalin, Weaponmaster")
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withCardOnBattlefield(1, "Leonin Scimitar")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardOnBattlefield(2, "Bonesplitter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mySplitter = game.findPermanents("Bonesplitter")
+                    .single { game.state.projectedState.getController(it) == game.player1Id }
+                val theirSplitter = game.findPermanents("Bonesplitter")
+                    .single { game.state.projectedState.getController(it) == game.player2Id }
+                val scimitar = game.findPermanent("Leonin Scimitar")!!
+
+                game.castSpell(1, "Dwalin, Weaponmaster").error shouldBe null
+                game.resolveStack()
+
+                withClue("each Equipment you control gets exactly one hone counter") {
+                    honeCounters(game, mySplitter) shouldBe 1
+                    honeCounters(game, scimitar) shouldBe 1
+                }
+                withClue("the opponent's Equipment is untouched — 'each Equipment you control'") {
+                    honeCounters(game, theirSplitter) shouldBe 0
+                }
+            }
+
+            test("attacking hones again, and the counters pump through a card that never mentions hone") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withCardAttachedTo(1, "Bonesplitter", "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Dwalin, Weaponmaster")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val splitter = game.findPermanent("Bonesplitter")!!
+
+                withClue("before combat: base 2/2 plus Bonesplitter's printed +2/+0") {
+                    power(game, bears) shouldBe 4
+                    toughness(game, bears) shouldBe 2
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Dwalin, Weaponmaster" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the attack trigger adds a hone counter to the equipped Bonesplitter") {
+                    honeCounters(game, splitter) shouldBe 1
+                }
+                withClue("CR 122.1j stacks the hone bonus on top of Bonesplitter's own +2/+0") {
+                    power(game, bears) shouldBe 5
+                    toughness(game, bears) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GollumRiddleMasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GollumRiddleMasterScenarioTest.kt
@@ -1,0 +1,186 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.GollumRiddleMaster
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.RaiseTheAlarm
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gollum, Riddle Master (HOB #70) — {1}{B} Legendary Creature — Halfling Horror 3/1.
+ *
+ *   As Gollum enters, choose odd or even. (Zero is even.)
+ *   Whenever an opponent casts a spell with mana value of the chosen quality, choose one that
+ *   hasn't been chosen — • +1/+1 counter on Gollum • drain 2 • draw a card.
+ *
+ * The as-enters choice is preset through [CastChoicesComponent] the way the Siege tests do, so each
+ * test pins one half of the parity gate. The card lowers the single printed trigger to two mirrored
+ * triggers (odd-filtered and even-filtered), so the thing most worth proving is that the *wrong*
+ * parity stays silent — a mis-gated mirror would fire on every opponent spell.
+ */
+class GollumRiddleMasterScenarioTest : ScenarioTestBase() {
+
+    private val counterMode = "Put a +1/+1 counter on Gollum"
+    private val drainMode = "Each opponent loses 2 life and you gain 2 life"
+    private val drawMode = "Draw a card"
+
+    private fun TestGame.setParity(gollum: EntityId, parity: String) {
+        state = state.updateEntity(gollum) {
+            it.with(
+                CastChoicesComponent(
+                    chosen = mapOf(ChoiceSlot.MODE to ChoiceValue.TextChoice(parity))
+                )
+            )
+        }
+    }
+
+    private fun TestGame.chooseMode(decision: ChooseOptionDecision, description: String) {
+        val index = decision.options.indexOf(description)
+        check(index >= 0) { "Mode '$description' not offered; options=${decision.options}" }
+        submitDecision(OptionChosenResponse(decision.id, index))
+    }
+
+    private fun counters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        cardRegistry.register(GollumRiddleMaster)
+        cardRegistry.register(RaiseTheAlarm)
+
+        context("Gollum, Riddle Master") {
+
+            test("odd: an opponent's mana-value-1 spell triggers the riddle") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Gollum, Riddle Master")
+                    .withCardInHand(2, "Lightning Bolt") // mana value 1 — odd
+                    .withLandsOnBattlefield(2, "Mountain", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gollum = game.findPermanent("Gollum, Riddle Master")!!
+                game.setParity(gollum, "odd")
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+
+                val choice = game.getPendingDecision()
+                choice.shouldNotBeNull()
+                choice as ChooseOptionDecision
+
+                withClue("all three modes are available on the first trigger") {
+                    choice.options.size shouldBe 3
+                    choice.options shouldContain counterMode
+                }
+
+                game.chooseMode(choice, counterMode)
+                game.resolveStack()
+
+                withClue("the chosen mode put a +1/+1 counter on Gollum") {
+                    counters(game, gollum) shouldBe 1
+                }
+            }
+
+            test("odd: an opponent's mana-value-2 spell does NOT trigger") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Gollum, Riddle Master")
+                    .withCardInHand(2, "Raise the Alarm") // mana value 2 — even
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gollum = game.findPermanent("Gollum, Riddle Master")!!
+                game.setParity(gollum, "odd")
+
+                game.castSpell(2, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+
+                withClue("an even spell must not wake the odd-gated trigger") {
+                    game.hasPendingDecision() shouldBe false
+                    counters(game, gollum) shouldBe 0
+                }
+            }
+
+            test("even: an opponent's mana-value-2 spell triggers and drains") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Gollum, Riddle Master")
+                    .withCardInHand(2, "Raise the Alarm") // mana value 2 — even
+                    .withLandsOnBattlefield(2, "Plains", 4)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gollum = game.findPermanent("Gollum, Riddle Master")!!
+                game.setParity(gollum, "even")
+
+                val myLife = game.getLifeTotal(1)
+                val theirLife = game.getLifeTotal(2)
+
+                game.castSpell(2, "Raise the Alarm").error shouldBe null
+                game.resolveStack()
+
+                val choice = game.getPendingDecision()
+                choice.shouldNotBeNull()
+                game.chooseMode(choice as ChooseOptionDecision, drainMode)
+                game.resolveStack()
+
+                withClue("each opponent loses 2 and Gollum's controller gains 2") {
+                    game.getLifeTotal(2) shouldBe theirLife - 2
+                    game.getLifeTotal(1) shouldBe myLife + 2
+                }
+            }
+
+            test("a mode already taken is not offered again") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Gollum, Riddle Master")
+                    .withCardsInHand(2, "Lightning Bolt", 2)
+                    .withLandsOnBattlefield(2, "Mountain", 6)
+                    // The draw mode is taken below — without a library Gollum's controller would
+                    // lose to the empty-draw state-based action before the second Bolt is cast.
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val gollum = game.findPermanent("Gollum, Riddle Master")!!
+                game.setParity(gollum, "odd")
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+                val first = game.getPendingDecision() as ChooseOptionDecision
+                first.options.size shouldBe 3
+                game.chooseMode(first, drawMode)
+                game.resolveStack()
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.resolveStack()
+                val second = game.getPendingDecision() as ChooseOptionDecision
+
+                withClue("'choose one that hasn't been chosen' drops the used mode") {
+                    second.options.size shouldBe 2
+                    second.options shouldNotContain drawMode
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HoneCounterTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HoneCounterTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Bonesplitter
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hone counters — CR 122.1j: "A hone counter on an Equipment gives +1/+0 to any creature that
+ * Equipment is attached to."
+ *
+ * The whole point of the rule is that the bonus lives on the *counter*, not on the permanent
+ * carrying it. Every test here therefore uses **Bonesplitter**, a Mirrodin Equipment that has never
+ * heard of hone: if the +1/+0 shows up on the creature it equips, the engine is reading the counter
+ * and not some ability printed on the card. That is what Dwalin, Weaponmaster depends on when he
+ * puts a hone counter on *each* Equipment you control.
+ *
+ * Realized in `StateProjector.collectContinuousEffects` as a Layer 7c modification
+ * (CR 613.4c — "effects **and counters** that modify power and/or toughness").
+ */
+class HoneCounterTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + Bonesplitter)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun addCounters(driver: GameTestDriver, entityId: EntityId, type: CounterType, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(type, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    fun equip(driver: GameTestDriver, player: EntityId, equipment: EntityId, creature: EntityId) {
+        driver.giveColorlessMana(player, 1)
+        driver.submit(
+            ActivateAbility(
+                player,
+                equipment,
+                Bonesplitter.activatedAbilities.first().id,
+                targets = listOf(ChosenTarget.Permanent(creature))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getEntity(equipment)?.get<AttachedToComponent>()?.targetId shouldBe creature
+    }
+
+    test("a hone counter on an equipped Equipment gives the equipped creature +1/+0") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        val sword = driver.putPermanentOnBattlefield(you, "Bonesplitter")
+        equip(driver, you, sword, courser)
+
+        // Bonesplitter's own +2/+0 only.
+        projector.getProjectedPower(driver.state, courser) shouldBe 5
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+
+        addCounters(driver, sword, CounterType.HONE, 1)
+
+        // +1/+0 on top, and toughness is untouched.
+        projector.getProjectedPower(driver.state, courser) shouldBe 6
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+    }
+
+    test("hone counters stack — each one is a separate +1/+0") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        val sword = driver.putPermanentOnBattlefield(you, "Bonesplitter")
+        equip(driver, you, sword, courser)
+
+        addCounters(driver, sword, CounterType.HONE, 3)
+
+        // 3 base + 2 (Bonesplitter) + 3 (hone) = 8.
+        projector.getProjectedPower(driver.state, courser) shouldBe 8
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+    }
+
+    test("hone counters on an UNATTACHED Equipment do nothing") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        val sword = driver.putPermanentOnBattlefield(you, "Bonesplitter")
+
+        addCounters(driver, sword, CounterType.HONE, 4)
+
+        // Nothing is equipped, so there is no creature to pump.
+        driver.state.getEntity(sword)?.get<AttachedToComponent>() shouldBe null
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+    }
+
+    test("hone counters on a NON-Equipment permanent do nothing") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+
+        // CR 122.1j is scoped to Equipment; a hone counter parked on a creature is inert.
+        addCounters(driver, courser, CounterType.HONE, 5)
+
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+    }
+
+    test("re-equipping moves the hone bonus to the new creature") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears") // 2/2
+        val sword = driver.putPermanentOnBattlefield(you, "Bonesplitter")
+
+        equip(driver, you, sword, courser)
+        addCounters(driver, sword, CounterType.HONE, 2)
+
+        projector.getProjectedPower(driver.state, courser) shouldBe 7 // 3 + 2 + 2
+        projector.getProjectedPower(driver.state, bears) shouldBe 2
+
+        equip(driver, you, sword, bears)
+
+        // The counters never moved — they are still on the Equipment — but the rule aims them at
+        // whatever it is attached to *now*.
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.getProjectedPower(driver.state, bears) shouldBe 6 // 2 + 2 + 2
+        driver.state.getEntity(sword)?.get<CountersComponent>()
+            ?.getCount(CounterType.HONE) shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StingBilbosSwordScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StingBilbosSwordScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.cards.StingBilbosSword
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sting, Bilbo's Sword (HOB #178) — {2} Legendary Artifact — Equipment, Flash.
+ *
+ *   When Sting enters, put a hone counter on Sting for each creature target opponent controls.
+ *   Attach Sting to up to one target creature you control.
+ *   Equip {3}
+ *
+ * Two target slots on one ETB trigger — slot 0 is the required opponent whose creatures are counted,
+ * slot 1 is the *optional* creature to attach to. The pump itself is not on the card at all: it
+ * comes from CR 122.1j via the hone counters, so these tests read projected power to prove the
+ * counters actually did something (see `HoneCounterTest` for the rule in isolation).
+ */
+class StingBilbosSwordScenarioTest : ScenarioTestBase() {
+
+    private fun power(game: TestGame, id: EntityId): Int? = game.state.projectedState.getPower(id)
+    private fun toughness(game: TestGame, id: EntityId): Int? =
+        game.state.projectedState.getToughness(id)
+
+    private fun honeCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.HONE) ?: 0
+
+    init {
+        cardRegistry.register(StingBilbosSword)
+
+        context("Sting, Bilbo's Sword") {
+
+            test("counts the opponent's creatures, attaches, and pumps by that many") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sting, Bilbo's Sword")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myBears = game.findPermanents("Grizzly Bears")
+                    .single { game.state.projectedState.getController(it) == game.player1Id }
+
+                game.castSpell(1, "Sting, Bilbo's Sword").error shouldBe null
+                game.resolveStack()
+
+                val sting = game.findPermanent("Sting, Bilbo's Sword")!!
+                val td = game.getPendingDecision()!!
+                game.submitDecision(
+                    TargetsResponse(td.id, mapOf(0 to listOf(game.player2Id), 1 to listOf(myBears)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the opponent controls two creatures, so Sting gets two hone counters") {
+                    honeCounters(game, sting) shouldBe 2
+                }
+                withClue("Sting attached to the chosen creature") {
+                    game.state.getEntity(sting)?.get<AttachedToComponent>()?.targetId shouldBe myBears
+                }
+                withClue("CR 122.1j: +1/+0 per hone counter, toughness untouched") {
+                    power(game, myBears) shouldBe 4 // 2 + 2 hone
+                    toughness(game, myBears) shouldBe 2
+                }
+            }
+
+            test("the creature target is optional — declining leaves Sting unattached but honed") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sting, Bilbo's Sword")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myBears = game.findPermanents("Grizzly Bears")
+                    .single { game.state.projectedState.getController(it) == game.player1Id }
+
+                game.castSpell(1, "Sting, Bilbo's Sword").error shouldBe null
+                game.resolveStack()
+
+                val sting = game.findPermanent("Sting, Bilbo's Sword")!!
+                val td = game.getPendingDecision()!!
+                game.submitDecision(
+                    TargetsResponse(td.id, mapOf(0 to listOf(game.player2Id), 1 to emptyList()))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the counters still land — only the attach half was declined") {
+                    honeCounters(game, sting) shouldBe 1
+                }
+                withClue("nothing is equipped") {
+                    game.state.getEntity(sting)?.get<AttachedToComponent>().shouldBeNull()
+                }
+                withClue("an unattached honed Equipment pumps nobody") {
+                    power(game, myBears) shouldBe 2
+                }
+            }
+
+            test("an opponent with no creatures means no hone counters, but Sting still attaches") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sting, Bilbo's Sword")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myBears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Sting, Bilbo's Sword").error shouldBe null
+                game.resolveStack()
+
+                val sting = game.findPermanent("Sting, Bilbo's Sword")!!
+                val td = game.getPendingDecision()!!
+                game.submitDecision(
+                    TargetsResponse(td.id, mapOf(0 to listOf(game.player2Id), 1 to listOf(myBears)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("zero creatures counted → zero counters, and the effect no-ops cleanly") {
+                    honeCounters(game, sting) shouldBe 0
+                }
+                withClue("the attach half still happens") {
+                    game.state.getEntity(sting)?.get<AttachedToComponent>()?.targetId shouldBe myBears
+                }
+                withClue("no counters, no bonus") {
+                    power(game, myBears) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -140,4 +140,5 @@ export const counterManaClass: Record<string, string> = {
   HARNESS: 'counter-devotion',
   PLAN: 'counter-lore',
   INVASION: 'counter-charge',
+  HONE: 'counter-arrow',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -819,6 +819,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.HARNESS,
   CounterType.PLAN,
   CounterType.INVASION,
+  CounterType.HONE,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,
   CounterType.MINUS_ONE_MINUS_ZERO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -2228,6 +2228,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   HARNESS: { bg: 'rgba(48, 26, 12, 0.95)', border: 'rgba(240, 180, 80, 0.8)', color: '#ffc860', glow: 'rgba(240, 180, 80, 0.7)' },
   PLAN: { bg: 'rgba(24, 40, 62, 0.95)', border: 'rgba(120, 175, 230, 0.7)', color: '#a8cdee', glow: 'rgba(120, 175, 230, 0.55)' },
   INVASION: { bg: 'rgba(52, 22, 20, 0.95)', border: 'rgba(230, 110, 90, 0.7)', color: '#f0a090', glow: 'rgba(230, 110, 90, 0.55)' },
+  HONE: { bg: 'rgba(36, 42, 50, 0.95)', border: 'rgba(196, 214, 228, 0.8)', color: '#e4eef8', glow: 'rgba(196, 214, 228, 0.65)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -471,6 +471,7 @@ export enum CounterType {
   HARNESS = 'HARNESS',
   PLAN = 'PLAN',
   INVASION = 'INVASION',
+  HONE = 'HONE',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -548,6 +549,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.HARNESS]: 'Harness',
   [CounterType.PLAN]: 'Plan',
   [CounterType.INVASION]: 'Invasion',
+  [CounterType.HONE]: 'Hone',
 }
 
 /**


### PR DESCRIPTION
Takes The Hobbit from 175/193 to **179/193**.

## Hone counters (CR 122.1j)

> A hone counter on an Equipment gives +1/+0 to any creature that Equipment is attached to.

The bonus belongs to the **counter**, not to the permanent carrying it. That distinction is load-bearing rather than pedantic: Dwalin, Weaponmaster puts a hone counter on *each Equipment you control*, so a Mirrodin Bonesplitter that has never heard of hone must still pump its equipped creature. Printing the pump as a static ability on the two cards that say "hone" would look correct and resolve wrong on every other Equipment.

Implemented as `CounterType.HONE` plus a block in `StateProjector.collectContinuousEffects` that synthesizes one `Modification.ModifyPowerToughness(n, 0)` per honed Equipment, scoped to `AffectsFilter.AttachedPermanent`. Layer 7c per CR 613.4c — "effects **and counters** that modify power and/or toughness" — so it stacks additively on top of the Equipment's own printed bonus. Like `shield` and `stun`, it is deliberately **not** a keyword counter and stays out of `KEYWORD_COUNTER_MAP`: it grants no keyword, and it modifies a different object than the one it sits on.

`AffectsFilter.AttachedPermanent` resolves to the empty set for an unattached Equipment, so "honed but unequipped does nothing" needs no extra guard.

Client display wiring lands in the same change (`CounterType`, `CounterTypeDisplayNames`, `PASSIVE_COUNTER_TYPES`, palette, mana-font icon) — `passiveCounters.test.ts` fails if any of the four is missed.

## Cards

| Card | Notes |
|---|---|
| **Sting, Bilbo's Sword** | Flash Equipment. ETB counts target opponent's creatures into hone counters, then attaches to *up to one* target creature. The optional slot is declared **last** — cast-time target slots are fixed-width and positional, so an "up to one" ahead of a required target shifts the required one's index when declined. `Player.TargetOpponent` resolves to the first *player* target, not slot 0, so the count reads the opponent correctly alongside the creature target. |
| **Dwalin, Weaponmaster** | First strike; "enters or attacks" is one printed ability but two engine triggers (the Sentinel of the Nameless City split — there is no combined trigger). |
| **Belladonna Took** | `IncrementAbilityResolutionCountEffect` + three `SourceAbilityResolvedNTimes` branches. The increment must run *before* the conditionals read the count, and the comparison is exact equality, so the branches are mutually exclusive and the fourth resolution in a turn deliberately does nothing. |
| **Gollum, Riddle Master** | `EntersWithChoice(ChoiceType.MODE)` odd/even, read back by `SourceChosenModeIs`. There is no "chosen quality" indirection in the SDK, so the single printed trigger lowers to **two mirrored triggers**, each gated on its mode and filtered on the matching parity — only one can ever be live. Payoff is `ModalEffect.chooseOneNotYetChosen`. |

## Tests

New `HoneCounterTest` pins the rule in isolation against **Bonesplitter** specifically — a card that predates hone by two decades — so a regression that quietly turned the bonus back into a per-card ability would fail it. Covers: single counter, stacking, unattached Equipment, hone on a non-Equipment, and re-equipping moving the bonus while the counters stay put.

Per-card scenario tests cover the optional-target decline, a zero-count `AddDynamicCounters` no-op, "each Equipment **you** control" not touching the opponent's, all four resolution branches, both parities firing and staying silent, and the used-mode memory.

## Verification

- `just test` — green
- `just rebless-cards` — only `HOB.json` moved (+452 / −0), so no shared SDK behavior shifted
- `just check-card-printing` — all four canonical in HOB
- `web-client` `npm run typecheck` clean; `passiveCounters` 67/67

## Notes

- `add-feature` Step 8b (teach the mtgish generator) does **not** apply: hone adds no new SDK effect or IR tag. Placing hone counters uses the existing `AddCounters` / `AddDynamicCounters`, which the emitter already renders for any named counter, and the layer-7c rule is engine-intrinsic with nothing for the emitter to map.
- No UI decision flow is added, so no e2e test — the only player-visible surface is the counter badge, covered by the client unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
