### PR TITLE
Add four Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ConcealedWeapon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/ConcealedWeapon.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Concealed Weapon — Murders at Karlov Manor #117
+ * {1}{R} · Artifact — Equipment
+ *
+ * Equipped creature gets +3/+0.
+ * Disguise {2}{R}
+ * When this Equipment is turned face up, attach it to target creature you control.
+ * Equip {1}{R}
+ *
+ * The set's one **noncreature** disguise card, and the reason it works is that face-down-ness is a
+ * characteristic-defining effect in the projection, not a property of the card: CR 708.2 gives *any*
+ * face-down permanent a 2/2 creature body with no name or subtypes, so the Equipment spends its time
+ * face down as a 2/2 with ward {2} and reverts to being a (creature-less) Equipment on the flip.
+ * Neither the face-down cast path nor the turn-up procedure gates on the card being a creature —
+ * only manifest/cloak's "pay the mana cost" route does, which disguise doesn't use.
+ *
+ * The flip is a two-for-one: {3} gets a surprise 2/2 blocker down, then {2}{R} turns it into a real
+ * Equipment *and* attaches it for free. That attachment is a genuine triggered ability
+ * ([Triggers.TurnedFaceUp]) rather than a `disguiseFaceUpEffect` replacement, because the oracle text
+ * says "When", and it matters here: it uses the stack, it targets, and per the official ruling it is
+ * *not* an equip activation — no mana, and none of equip's sorcery-speed timing restriction. So the
+ * Equipment can arrive attached mid-combat.
+ *
+ * Two edge cases the shape gets right for free. Flipping is legal with **no** creatures at all: the
+ * special action isn't gated on the trigger having a target, the targetless trigger is simply removed
+ * from the stack, and the Equipment stays on the battlefield unattached. Likewise if the chosen
+ * creature leaves before the trigger resolves — the trigger fizzles and the Equipment sits unattached
+ * until someone pays equip.
+ */
+val ConcealedWeapon = card("Concealed Weapon") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +3/+0.\n" +
+        "Disguise {2}{R} (You may cast this card face down for {3} as a 2/2 creature with ward " +
+        "{2}. Turn it face up any time for its disguise cost.)\n" +
+        "When this Equipment is turned face up, attach it to target creature you control.\n" +
+        "Equip {1}{R}"
+
+    staticAbility {
+        ability = ModifyStats(+3, +0, Filters.EquippedCreature)
+    }
+
+    disguise = "{2}{R}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        target = Targets.CreatureYouControl
+        effect = Effects.AttachEquipment()
+        description = "When this Equipment is turned face up, attach it to target creature you control."
+    }
+
+    equipAbility("{1}{R}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Nicholas Elias"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/38e31fa6-a445-47c6-a73f-135087f6d760.jpg?1783912886"
+
+        ruling(
+            "2024-02-02",
+            "Attaching Concealed Weapon with its triggered ability isn't the same as using its " +
+                "equip ability. You don't pay mana for the attachment, and the timing restrictions " +
+                "for equip abilities don't apply."
+        )
+        ruling(
+            "2024-02-02",
+            "If the target creature becomes an illegal target, Concealed Weapon remains on the " +
+                "battlefield unattached."
+        )
+        ruling(
+            "2024-02-02",
+            "You may turn Concealed Weapon face up even if you don't control any creatures."
+        )
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CrowdControlWarden.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CrowdControlWarden.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Crowd-Control Warden — Murders at Karlov Manor #193
+ * {3}{G}{W} · Creature — Centaur Soldier · 4/4
+ *
+ * As this creature enters or is turned face up, put X +1/+1 counters on it, where X is the number
+ * of other creatures you control.
+ * Disguise {3}{G/W}{G/W}
+ *
+ * The two halves are two *different* rules constructs that happen to share a sentence, and each
+ * needs its own count.
+ *
+ * **Entering** is a CR 614.1c enters-with-counters replacement ([EntersWithDynamicCounters]). The
+ * Warden isn't on the battlefield yet when the count is evaluated, so a plain "creatures you
+ * control" tally is already "other creatures you control" — the same evaluation timing that makes
+ * Sheriff of Safe Passage work. That is also why the official ruling says creatures entering
+ * *simultaneously* with the Warden don't count: they aren't there yet either.
+ *
+ * **Turning face up** is a replacement riding the turn-up special action, not a triggered ability —
+ * `disguiseFaceUpEffect`, the same slot [BubbleSmuggler] uses. It doesn't use the stack, so an
+ * opponent never gets a window against the 2/2 body before the counters land. Here the Warden *is*
+ * on the battlefield when the count runs, so this half must ask for `excludeSelf = true`; without
+ * it the Warden would count itself and arrive one counter too big.
+ *
+ * Only one half ever applies to a given copy: cast for {3}{G}{W} it enters face up and takes the
+ * replacement; cast face down for {3} it enters as a nameless 2/2 (no abilities at all, CR 708.2)
+ * and only the flip pays out.
+ */
+val CrowdControlWarden = card("Crowd-Control Warden") {
+    manaCost = "{3}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Centaur Soldier"
+    oracleText = "As this creature enters or is turned face up, put X +1/+1 counters on it, where " +
+        "X is the number of other creatures you control.\n" +
+        "Disguise {3}{G/W}{G/W} (You may cast this card face down for {3} as a 2/2 creature with " +
+        "ward {2}. Turn it face up any time for its disguise cost.)"
+    power = 4
+    toughness = 4
+
+    // Entering: the Warden is not yet on the battlefield, so "creatures you control" is already
+    // "other creatures you control".
+    replacementEffect(
+        EntersWithDynamicCounters(
+            count = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature)
+        )
+    )
+
+    disguise = "{3}{G/W}{G/W}"
+    // Turning face up: the Warden IS on the battlefield, so it must be excluded from its own count.
+    disguiseFaceUpEffect = Effects.AddDynamicCounters(
+        Counters.PLUS_ONE_PLUS_ONE,
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Creature,
+            excludeSelf = true
+        ),
+        EffectTarget.Self
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdf0578f-4966-4ecd-81e1-83ae13126f13.jpg?1783912856"
+
+        ruling(
+            "2024-02-02",
+            "If Crowd-Control Warden enters the battlefield at the same time as one or more " +
+                "creatures, those creatures won't count for the purposes of Crowd-Control Warden's " +
+                "first ability."
+        )
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FlourishingBloomKin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/FlourishingBloomKin.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.EmitLibrarySearchedEventEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Flourishing Bloom-Kin — Murders at Karlov Manor #160
+ * {1}{G} · Creature — Plant Elemental · 0/0
+ *
+ * This creature gets +1/+1 for each Forest you control.
+ * Disguise {4}{G}
+ * When this creature is turned face up, search your library for up to two Forest cards and reveal
+ * them. Put one of them onto the battlefield tapped and the other into your hand, then shuffle.
+ *
+ * A printed 0/0 that stays alive only because of its own static ([GrantDynamicStatsEffect] over
+ * [GroupFilter.source]) — it is a continuous effect recomputed in the projection, so playing or
+ * losing a Forest resizes it immediately and the state-based-action check kills it the moment you
+ * control none. Cast face down for {3} it is a plain 2/2 with ward {2} instead: a face-down permanent
+ * has no abilities at all (CR 708.2), so the Forest count isn't applied and the 0/0 body never
+ * appears.
+ *
+ * "Forest cards" is the **subtype**, not `BasicLand` — snow-covered Forests and nonbasic lands with
+ * the Forest type (Bayou, Stomping Ground) are all legal finds, so the filter is
+ * `Land.withSubtype(FOREST)`.
+ *
+ * The split search follows the Cultivate shape used by Bloomvine Regent's Claim Territory: gather,
+ * `ChooseUpTo(2)` for the find, then a second `ChooseExactly(1)` whose *remainder* goes to hand.
+ * That second step is what makes the official ruling fall out for free — find only one Forest and
+ * `ChooseExactly(1)` auto-selects it onto the battlefield with an empty remainder, so you never get
+ * the option to route the single card to your hand instead.
+ *
+ * Unlike [BubbleSmuggler]'s `disguiseFaceUpEffect`, this is a genuine **triggered** ability
+ * ([Triggers.TurnedFaceUp], as on [EssenceOfAntiquity]): "When … is turned face up" uses the stack,
+ * so the flip resolves first and opponents do get a window before the search happens.
+ */
+val FlourishingBloomKin = card("Flourishing Bloom-Kin") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Elemental"
+    // Scryfall's oracle text for this card carries no disguise reminder text (three abilities left
+    // the printed card no room), unlike the rest of the cycle — matched verbatim.
+    oracleText = "This creature gets +1/+1 for each Forest you control.\n" +
+        "Disguise {4}{G}\n" +
+        "When this creature is turned face up, search your library for up to two Forest cards and " +
+        "reveal them. Put one of them onto the battlefield tapped and the other into your hand, " +
+        "then shuffle."
+    power = 0
+    toughness = 0
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Land.withSubtype(Subtype.FOREST)
+            ).count(),
+            toughnessBonus = DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Land.withSubtype(Subtype.FOREST)
+            ).count()
+        )
+    }
+
+    disguise = "{4}{G}"
+
+    triggeredAbility {
+        trigger = Triggers.TurnedFaceUp
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        Zone.LIBRARY,
+                        Player.You,
+                        GameObjectFilter.Land.withSubtype(Subtype.FOREST)
+                    ),
+                    storeAs = "searchable"
+                ),
+                SelectFromCollectionEffect(
+                    from = "searchable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    storeSelected = "found",
+                    prompt = "Search your library for up to two Forest cards"
+                ),
+                SelectFromCollectionEffect(
+                    from = "found",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "toBattlefield",
+                    storeRemainder = "toHand",
+                    selectedLabel = "Onto the battlefield tapped",
+                    remainderLabel = "Into your hand",
+                    prompt = "Choose which Forest enters the battlefield tapped; the other goes to your hand."
+                ),
+                MoveCollectionEffect(
+                    from = "toBattlefield",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped),
+                    revealed = true
+                ),
+                MoveCollectionEffect(
+                    from = "toHand",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                ShuffleLibraryEffect(),
+                EmitLibrarySearchedEventEffect
+            )
+        )
+        description = "When this creature is turned face up, search your library for up to two " +
+            "Forest cards and reveal them. Put one of them onto the battlefield tapped and the " +
+            "other into your hand, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "160"
+        artist = "Ben Hill"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5ddcb31e-9301-44f1-b138-0573fbf56a47.jpg?1783912867"
+
+        ruling(
+            "2024-02-02",
+            "If you find only one Forest card with Flourishing Bloom-Kin's last ability, you'll put " +
+                "it onto the battlefield tapped. You won't have the option to put it into your hand."
+        )
+        ruling(
+            "2024-02-02",
+            "Any time you have priority, you may turn the face-down creature face up by revealing " +
+                "what its disguise cost is and paying that cost. This is a special action. It " +
+                "doesn't use the stack and can't be responded to. Only a face-down permanent can " +
+                "be turned face up this way; a face-down spell cannot."
+        )
+        ruling(
+            "2024-02-02",
+            "Because the permanent is on the battlefield both before and after it's turned face " +
+                "up, turning a permanent face up doesn't cause any enters-the-battlefield " +
+                "abilities to trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PolygraphOrb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/PolygraphOrb.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Polygraph Orb — Murders at Karlov Manor #99
+ * {4}{B} · Artifact
+ *
+ * When this artifact enters, look at the top four cards of your library. Put two of them into your
+ * hand and the rest into your graveyard. You lose 2 life.
+ * {2}, {T}, Collect evidence 3: Each opponent loses 3 life unless they discard a card or sacrifice
+ * a creature.
+ *
+ * The entry clause is the Resentful Revelation shape at a bigger size —
+ * [Patterns.Library.lookAtTopAndKeep] with `count = 4, keepCount = 2`. The two halves aren't
+ * symmetric: keeping is `ChooseExactly(2)`, so with a library of one or two cards you keep what
+ * there is and nothing is milled; the life loss is unconditional either way and happens whether or
+ * not anything was found.
+ *
+ * The activated ability's "unless" is a **choice made by each opponent**, not a cost the Orb's
+ * controller can pay, so it is a [ChooseActionEffect] inside a `ForEachPlayerEffect(EachOpponent)` —
+ * inside the iteration the controller is rebound to the iterated opponent, so `EffectTarget.Controller`
+ * is that opponent. The discard and sacrifice options are feasibility-gated (empty hand, no
+ * creatures) and hide themselves; "lose 3 life" carries **no** gate, because the ruling is explicit
+ * that an opponent may always take the life loss even holding cards and creatures. That makes it
+ * genuinely a punisher rather than an edict.
+ *
+ * `Costs.CollectEvidence(3)` is a real cost atom sitting alongside `{2}` and `{T}`, which is what
+ * makes the official ruling fall out: costs are paid during activation, so opponents get no window
+ * to strand the evidence by emptying your graveyard, and if you can't exile cards totalling mana
+ * value 3 the ability simply can't be activated.
+ */
+val PolygraphOrb = card("Polygraph Orb") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, look at the top four cards of your library. Put two of " +
+        "them into your hand and the rest into your graveyard. You lose 2 life.\n" +
+        "{2}, {T}, Collect evidence 3: Each opponent loses 3 life unless they discard a card or " +
+        "sacrifice a creature. (To collect evidence 3, exile cards with total mana value 3 or " +
+        "greater from your graveyard.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.lookAtTopAndKeep(count = 4, keepCount = 2),
+            Effects.LoseLife(2, EffectTarget.Controller)
+        )
+        description = "When this artifact enters, look at the top four cards of your library. Put " +
+            "two of them into your hand and the rest into your graveyard. You lose 2 life."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.CollectEvidence(3))
+        effect = ForEachPlayerEffect(
+            players = Player.EachOpponent,
+            effects = listOf(
+                ChooseActionEffect(
+                    player = EffectTarget.Controller,
+                    choices = listOf(
+                        EffectChoice(
+                            label = "Discard a card",
+                            effect = Patterns.Hand.discardCards(1, EffectTarget.Controller),
+                            feasibilityCheck = FeasibilityCheck.HasCardsInZone(Zone.HAND),
+                        ),
+                        EffectChoice(
+                            label = "Sacrifice a creature",
+                            effect = ForceSacrificeEffect(
+                                filter = GameObjectFilter.Creature,
+                                count = 1,
+                                target = EffectTarget.Controller,
+                            ),
+                            feasibilityCheck = FeasibilityCheck.ControlsPermanentMatching(
+                                GameObjectFilter.Creature
+                            ),
+                        ),
+                        // No feasibility gate: "Your opponent can always choose to lose 3 life,
+                        // even if they have cards to discard or creatures to sacrifice."
+                        EffectChoice(
+                            label = "Lose 3 life",
+                            effect = Effects.LoseLife(3, EffectTarget.Controller),
+                        ),
+                    ),
+                )
+            ),
+        )
+        description = "Each opponent loses 3 life unless they discard a card or sacrifice a creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Jokubas Uogintas"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6cc4c6f-4a84-4d42-89fa-7405f7ad6ba0.jpg?1783912893"
+
+        ruling(
+            "2024-02-02",
+            "While resolving Polygraph Orb's last ability, your opponent chooses a card to be " +
+                "discarded without revealing it, chooses a creature to be sacrificed, or chooses to " +
+                "do neither. Then that player discards that card, sacrifices that creature, or " +
+                "loses 3 life. Your opponent can always choose to lose 3 life, even if they have " +
+                "cards to discard or creatures to sacrifice."
+        )
+        ruling(
+            "2024-02-02",
+            "In a multiplayer game, each opponent in turn order makes their choice once, then all " +
+                "of the actions occur simultaneously."
+        )
+        ruling(
+            "2024-02-02",
+            "If you can't exile enough cards to meet or exceed the required mana value, you can't " +
+                "choose to collect evidence at all."
+        )
+        ruling(
+            "2024-02-02",
+            "Once you've announced that you're casting a spell, players can't take actions until " +
+                "you've finished doing so. Notably, opponents can't try to remove cards from your " +
+                "graveyard to stop you from collecting evidence."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1613,6 +1613,107 @@
     ]
 }
 
+// Concealed Weapon
+{
+    "name": "Concealed Weapon",
+    "manaCost": "{1}{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +3/+0.\nDisguise {2}{R} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this Equipment is turned face up, attach it to target creature you control.\nEquip {1}{R}",
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{2}{R}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": "AttachEquipment",
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                },
+                "descriptionOverride": "When this Equipment is turned face up, attach it to target creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{1}{R}",
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "UNCOMMON",
+        "artist": "Nicholas Elias",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/38e31fa6-a445-47c6-a73f-135087f6d760.jpg?1783912886",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "Attaching Concealed Weapon with its triggered ability isn't the same as using its equip ability. You don't pay mana for the attachment, and the timing restrictions for equip abilities don't apply."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If the target creature becomes an illegal target, Concealed Weapon remains on the battlefield unattached."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "You may turn Concealed Weapon face up even if you don't control any creatures."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Convenient Target
 {
     "name": "Convenient Target",
@@ -1926,6 +2027,76 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Crowd-Control Warden
+{
+    "name": "Crowd-Control Warden",
+    "manaCost": "{3}{G}{W}",
+    "typeLine": "Creature — Centaur Soldier",
+    "oracleText": "As this creature enters or is turned face up, put X +1/+1 counters on it, where X is the number of other creatures you control.\nDisguise {3}{G/W}{G/W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{3}{G/W}{G/W}"
+                }
+            },
+            "faceUpEffect": {
+                "type": "AddDynamicCounters",
+                "counterType": "+1/+1",
+                "amount": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "creature",
+                    "excludeSelf": true
+                },
+                "target": "Self"
+            }
+        }
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "EntersWithDynamicCounters",
+                "count": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Diego Gisbert",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdf0578f-4966-4ecd-81e1-83ae13126f13.jpg?1783912856",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If Crowd-Control Warden enters the battlefield at the same time as one or more creatures, those creatures won't count for the purposes of Crowd-Control Warden's first ability."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 
@@ -3371,6 +3542,145 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Flourishing Bloom-Kin
+{
+    "name": "Flourishing Bloom-Kin",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Plant Elemental",
+    "oracleText": "This creature gets +1/+1 for each Forest you control.\nDisguise {4}{G}\nWhen this creature is turned face up, search your library for up to two Forest cards and reveal them. Put one of them onto the battlefield tapped and the other into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{4}{G}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "TurnFaceUpEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "land Forest"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "found",
+                            "prompt": "Search your library for up to two Forest cards"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "found",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toBattlefield",
+                            "storeRemainder": "toHand",
+                            "prompt": "Choose which Forest enters the battlefield tapped; the other goes to your hand.",
+                            "selectedLabel": "Onto the battlefield tapped",
+                            "remainderLabel": "Into your hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBattlefield",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "descriptionOverride": "When this creature is turned face up, search your library for up to two Forest cards and reveal them. Put one of them onto the battlefield tapped and the other into your hand, then shuffle."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land Forest"
+                },
+                "toughnessBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land Forest"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "UNCOMMON",
+        "artist": "Ben Hill",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5ddcb31e-9301-44f1-b138-0573fbf56a47.jpg?1783912867",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "If you find only one Forest card with Flourishing Bloom-Kin's last ability, you'll put it onto the battlefield tapped. You won't have the option to put it into your hand."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Any time you have priority, you may turn the face-down creature face up by revealing what its disguise cost is and paying that cost. This is a special action. It doesn't use the stack and can't be responded to. Only a face-down permanent can be turned face up this way; a face-down spell cannot."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Because the permanent is on the battlefield both before and after it's turned face up, turning a permanent face up doesn't cause any enters-the-battlefield abilities to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -7035,6 +7345,216 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Polygraph Orb
+{
+    "name": "Polygraph Orb",
+    "manaCost": "{4}{B}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life.\n{2}, {T}, Collect evidence 3: Each opponent loses 3 life unless they discard a card or sacrifice a creature. (To collect evidence 3, exile cards with total mana value 3 or greater from your graveyard.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 4
+                                        }
+                                    },
+                                    "storeAs": "looked"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "looked",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "kept",
+                                    "storeRemainder": "rest",
+                                    "selectedLabel": "Put in hand",
+                                    "remainderLabel": "Put in graveyard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "kept",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    }
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "rest",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this artifact enters, look at the top four cards of your library. Put two of them into your hand and the rest into your graveyard. You lose 2 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomCollectEvidence",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "ChooseAction",
+                        "choices": [
+                            {
+                                "label": "Discard a card",
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded",
+                                            "prompt": "Choose 1 card to discard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                },
+                                "feasibilityCheck": {
+                                    "type": "HasCardsInZone",
+                                    "zone": "Hand"
+                                }
+                            },
+                            {
+                                "label": "Sacrifice a creature",
+                                "effect": {
+                                    "type": "ForceSacrifice",
+                                    "filter": "creature",
+                                    "target": "Controller"
+                                },
+                                "feasibilityCheck": {
+                                    "type": "ControlsPermanentMatching",
+                                    "filter": "creature"
+                                }
+                            },
+                            {
+                                "label": "Lose 3 life",
+                                "effect": {
+                                    "type": "LoseLife",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    },
+                                    "target": "Controller"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Each opponent loses 3 life unless they discard a card or sacrifice a creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Jokubas Uogintas",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6cc4c6f-4a84-4d42-89fa-7405f7ad6ba0.jpg?1783912893",
+        "rulings": [
+            {
+                "date": "2024-02-02",
+                "text": "While resolving Polygraph Orb's last ability, your opponent chooses a card to be discarded without revealing it, chooses a creature to be sacrificed, or chooses to do neither. Then that player discards that card, sacrifices that creature, or loses 3 life. Your opponent can always choose to lose 3 life, even if they have cards to discard or creatures to sacrifice."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "In a multiplayer game, each opponent in turn order makes their choice once, then all of the actions occur simultaneously."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "If you can't exile enough cards to meet or exceed the required mana value, you can't choose to collect evidence at all."
+            },
+            {
+                "date": "2024-02-02",
+                "text": "Once you've announced that you're casting a spell, players can't take actions until you've finished doing so. Notably, opponents can't try to remove cards from your graveyard to stop you from collecting evidence."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConcealedWeaponScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ConcealedWeaponScenarioTest.kt
@@ -1,0 +1,189 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.ConcealedWeapon
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Concealed Weapon (MKM #117) — {1}{R} Artifact — Equipment with Disguise {2}{R}.
+ *
+ * "Equipped creature gets +3/+0.
+ *  Disguise {2}{R}
+ *  When this Equipment is turned face up, attach it to target creature you control.
+ *  Equip {1}{R}"
+ *
+ * MKM's one **noncreature** disguise card, and that is the first thing worth proving: face-down-ness
+ * is a characteristic-defining effect, not a property of the card, so CR 708.2 gives the Equipment a
+ * 2/2 creature body while it is face down and takes it away again on the flip. Neither the
+ * face-down cast path nor the turn-up procedure may gate on the card being a creature.
+ *
+ * The flip's attachment is a genuine **triggered** ability, not a `disguiseFaceUpEffect`
+ * replacement — the oracle text says "When". That distinction is observable and tested: it uses the
+ * stack and it targets. Per the official ruling it is *not* an equip activation, so it costs no mana
+ * and skips equip's sorcery-speed restriction.
+ *
+ * The two ruling-driven edge cases both come down to the Equipment surviving unattached: flipping is
+ * legal with no creatures at all (the targetless trigger is simply removed from the stack), and a
+ * target that leaves before resolution fizzles the trigger rather than the flip.
+ */
+class ConcealedWeaponScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ConcealedWeapon))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun attachedTo(driver: GameTestDriver, equipment: EntityId): EntityId? =
+        driver.state.getEntity(equipment)?.get<AttachedToComponent>()?.targetId
+
+    /** Cast the Equipment face down for {3} and return the resulting face-down permanent. */
+    fun castFaceDown(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Concealed Weapon")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    /** Turn it face up for its disguise cost {2}{R}. Does not resolve the resulting trigger. */
+    fun flipFaceUp(driver: GameTestDriver, player: EntityId, weapon: EntityId) {
+        driver.giveColorlessMana(player, 2)
+        driver.giveMana(player, Color.RED, 1)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = weapon,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+    }
+
+    /** Pass until the stack is empty, tolerating the trigger's pauses. */
+    fun settle(driver: GameTestDriver) {
+        repeat(4) { if (!driver.isPaused && driver.stackSize > 0) driver.bothPass() }
+    }
+
+    test("a noncreature card can be cast face down, arriving as a 2/2 creature") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val weapon = castFaceDown(driver, player)
+
+        withClue("CR 708.2 gives any face-down permanent a 2/2 creature body") {
+            driver.state.projectedState.isCreature(weapon) shouldBe true
+            driver.state.projectedState.getPower(weapon) shouldBe 2
+            driver.state.projectedState.getToughness(weapon) shouldBe 2
+        }
+        attachedTo(driver, weapon) shouldBe null
+    }
+
+    test("flipping it attaches to the targeted creature and grants +3/+0") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val weapon = castFaceDown(driver, player)
+
+        flipFaceUp(driver, player, weapon)
+
+        withClue("the attachment is a trigger — it uses the stack and it targets") {
+            val decision = driver.pendingDecision
+            (decision is ChooseTargetsDecision) shouldBe true
+        }
+        driver.submitTargetSelection(player, listOf(bears)).error shouldBe null
+        settle(driver)
+
+        driver.state.getEntity(weapon)?.get<FaceDownComponent>() shouldBe null
+        attachedTo(driver, weapon) shouldBe bears
+        withClue("Grizzly Bears is a 2/2; equipped it is a 5/2") {
+            driver.state.projectedState.getPower(bears) shouldBe 5
+            driver.state.projectedState.getToughness(bears) shouldBe 2
+        }
+        withClue("face up it is an Equipment again, not a creature") {
+            driver.state.projectedState.isCreature(weapon) shouldBe false
+        }
+    }
+
+    test("it may be turned face up with no creatures at all, and stays unattached") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val weapon = castFaceDown(driver, player)
+        // The Equipment's own face-down body is the only creature, and it stops being one on the
+        // flip — so the trigger has no legal target.
+        flipFaceUp(driver, player, weapon)
+        settle(driver)
+
+        withClue("the special action isn't gated on the trigger having a target") {
+            driver.state.getEntity(weapon)?.get<FaceDownComponent>() shouldBe null
+        }
+        driver.findPermanent(player, "Concealed Weapon").shouldNotBeNull()
+        attachedTo(driver, weapon) shouldBe null
+    }
+
+    test("an opponent's creature is not a legal target") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        val theirBears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        val myBears = driver.putCreatureOnBattlefield(player, "Centaur Courser")
+        val weapon = castFaceDown(driver, player)
+
+        flipFaceUp(driver, player, weapon)
+
+        val decision = driver.pendingDecision as? ChooseTargetsDecision
+        decision.shouldNotBeNull()
+        withClue("'target creature you control' — the opponent's creature is not offered") {
+            decision.legalTargets.values.flatten().contains(theirBears) shouldBe false
+            decision.legalTargets.values.flatten().contains(myBears) shouldBe true
+        }
+    }
+
+    test("cast face up for its mana cost it is a plain Equipment with no trigger") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bears = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val card = driver.putCardInHand(player, "Concealed Weapon")
+        driver.giveColorlessMana(player, 1)
+        driver.giveMana(player, Color.RED, 1)
+        driver.submit(
+            CastSpell(playerId = player, cardId = card, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        driver.bothPass()
+
+        val weapon = driver.findPermanent(player, "Concealed Weapon").shouldNotBeNull()
+        withClue("nothing was turned face up, so nothing attached itself") {
+            driver.pendingDecision shouldBe null
+            attachedTo(driver, weapon) shouldBe null
+            driver.state.projectedState.getPower(bears) shouldBe 2
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrowdControlWardenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CrowdControlWardenScenarioTest.kt
@@ -1,0 +1,217 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.CrowdControlWarden
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Crowd-Control Warden (MKM #193) — {3}{G}{W} 4/4 Centaur Soldier with Disguise {3}{G/W}{G/W}.
+ *
+ * "As this creature enters or is turned face up, put X +1/+1 counters on it, where X is the number
+ *  of other creatures you control."
+ *
+ * One sentence, two different rules constructs, and the whole point of these tests is that both
+ * arrive at the *same* number by opposite routes:
+ *
+ *  - **Entering** is a CR 614.1c enters-with-counters replacement. The Warden isn't on the
+ *    battlefield yet when the count runs, so a plain "creatures you control" tally is already
+ *    "other creatures you control".
+ *  - **Turning face up** is a replacement riding the turn-up special action, and there the Warden
+ *    *is* on the battlefield — so it needs `excludeSelf`. Without it the flip pays out one counter
+ *    too many, which is the off-by-one these tests exist to catch.
+ *
+ * Also pinned: only *your* creatures count, and a Warden that enters face down gets nothing at all
+ * (CR 708.2 — a face-down permanent has no abilities, so neither half can apply).
+ */
+class CrowdControlWardenScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CrowdControlWarden))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun counterCount(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Cast the Warden face down for {3} and return the resulting face-down permanent. */
+    fun castFaceDown(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Crowd-Control Warden")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    /** Turn a face-down Warden face up for its disguise cost {3}{G/W}{G/W}. */
+    fun flipFaceUp(driver: GameTestDriver, player: EntityId, warden: EntityId) {
+        driver.giveColorlessMana(player, 3)
+        driver.giveMana(player, Color.GREEN, 2)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = warden,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+    }
+
+    test("entering face up counts the other creatures you control, not itself") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        val card = driver.putCardInHand(player, "Crowd-Control Warden")
+        driver.giveColorlessMana(player, 3)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.submit(
+            CastSpell(playerId = player, cardId = card, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        driver.bothPass()
+
+        val warden = driver.findPermanent(player, "Crowd-Control Warden").shouldNotBeNull()
+        withClue("two other creatures — the Warden must not count itself") {
+            counterCount(driver, warden) shouldBe 2
+        }
+        driver.state.projectedState.getPower(warden) shouldBe 6
+        driver.state.projectedState.getToughness(warden) shouldBe 6
+    }
+
+    test("entering with no other creatures puts no counters on it") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val card = driver.putCardInHand(player, "Crowd-Control Warden")
+        driver.giveColorlessMana(player, 3)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.submit(
+            CastSpell(playerId = player, cardId = card, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        driver.bothPass()
+
+        val warden = driver.findPermanent(player, "Crowd-Control Warden").shouldNotBeNull()
+        counterCount(driver, warden) shouldBe 0
+        driver.state.projectedState.getPower(warden) shouldBe 4
+        driver.state.projectedState.getToughness(warden) shouldBe 4
+    }
+
+    test("the opponent's creatures never count") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val card = driver.putCardInHand(player, "Crowd-Control Warden")
+        driver.giveColorlessMana(player, 3)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveMana(player, Color.WHITE, 1)
+        driver.submit(
+            CastSpell(playerId = player, cardId = card, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        driver.bothPass()
+
+        val warden = driver.findPermanent(player, "Crowd-Control Warden").shouldNotBeNull()
+        withClue("only the one creature you control counts") {
+            counterCount(driver, warden) shouldBe 1
+        }
+    }
+
+    test("cast face down it is a vanilla 2/2 — neither half of the ability applies") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        val warden = castFaceDown(driver, player)
+
+        withClue("CR 708.2 — a face-down permanent has no abilities") {
+            counterCount(driver, warden) shouldBe 0
+        }
+        driver.state.projectedState.getPower(warden) shouldBe 2
+        driver.state.projectedState.getToughness(warden) shouldBe 2
+    }
+
+    test("turning it face up excludes itself from the count — the off-by-one guard") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(player, "Centaur Courser")
+
+        val warden = castFaceDown(driver, player)
+        // Face down the Warden is itself a creature on the battlefield. A count without
+        // `excludeSelf` would see three creatures and hand out three counters.
+        flipFaceUp(driver, player, warden)
+
+        driver.state.getEntity(warden)?.get<FaceDownComponent>() shouldBe null
+        withClue("two other creatures, so exactly two counters — not three") {
+            counterCount(driver, warden) shouldBe 2
+        }
+        driver.state.projectedState.getPower(warden) shouldBe 6
+        driver.state.projectedState.getToughness(warden) shouldBe 6
+    }
+
+    test("the flip payout lands inside the special action — nothing uses the stack") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val warden = castFaceDown(driver, player)
+
+        flipFaceUp(driver, player, warden)
+
+        // A replacement riding the turn-up procedure, not a triggered ability: the opponent never
+        // gets priority with a counter-less 4/4 Warden on the battlefield.
+        driver.stackSize shouldBe 0
+        driver.pendingDecision shouldBe null
+        counterCount(driver, warden) shouldBe 1
+    }
+
+    test("turning it face up with no other creatures puts no counters on it") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val warden = castFaceDown(driver, player)
+        flipFaceUp(driver, player, warden)
+
+        withClue("the Warden is the only creature, and it doesn't count itself") {
+            counterCount(driver, warden) shouldBe 0
+        }
+        driver.state.projectedState.getPower(warden) shouldBe 4
+        driver.state.projectedState.getToughness(warden) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlourishingBloomKinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlourishingBloomKinScenarioTest.kt
@@ -1,0 +1,222 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mkm.cards.FlourishingBloomKin
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Flourishing Bloom-Kin (MKM #160) — {1}{G} 0/0 Plant Elemental with Disguise {4}{G}.
+ *
+ * "This creature gets +1/+1 for each Forest you control.
+ *  Disguise {4}{G}
+ *  When this creature is turned face up, search your library for up to two Forest cards and reveal
+ *  them. Put one of them onto the battlefield tapped and the other into your hand, then shuffle."
+ *
+ * A printed 0/0 that is alive only because of its own static ability, so the static is the first
+ * thing tested: it is a continuous effect recomputed in the projection, which means losing your last
+ * Forest kills it on the next state-based-action check. Face down it dodges that entirely — CR 708.2
+ * strips the ability along with everything else, and the 2/2 body needs no Forests to survive.
+ *
+ * The search is the Cultivate split: `ChooseUpTo(2)` for the find, then `ChooseExactly(1)` whose
+ * *remainder* goes to hand. The official ruling — find one Forest and it must go to the battlefield,
+ * with no option to route it to hand instead — falls out of `ChooseExactly(1)` auto-selecting the
+ * only card and leaving an empty remainder, and that is what the last test pins.
+ *
+ * Unlike [BubbleSmugglerScenarioTest]'s replacement, this is a **triggered** ability: the flip
+ * resolves first and the search happens off the stack afterwards.
+ */
+class FlourishingBloomKinScenarioTest : FunSpec({
+
+    fun createDriver(deck: Deck): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FlourishingBloomKin))
+        driver.initMirrorMatch(deck = deck, skipMulligans = true)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Cast the Bloom-Kin face down for {3} and return the resulting face-down permanent. */
+    fun castFaceDown(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Flourishing Bloom-Kin")
+        driver.giveColorlessMana(player, 3)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = card,
+                castFaceDown = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.getPermanents(player).single {
+            driver.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+    }
+
+    /** Turn it face up for its disguise cost {4}{G}. Does not resolve the resulting trigger. */
+    fun flipFaceUp(driver: GameTestDriver, player: EntityId, bloomKin: EntityId) {
+        driver.giveColorlessMana(player, 4)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.submit(
+            TurnFaceUp(
+                playerId = player,
+                sourceId = bloomKin,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).error shouldBe null
+    }
+
+    fun castFaceUp(driver: GameTestDriver, player: EntityId): EntityId {
+        val card = driver.putCardInHand(player, "Flourishing Bloom-Kin")
+        driver.giveColorlessMana(player, 1)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.submit(
+            CastSpell(playerId = player, cardId = card, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        driver.bothPass()
+        return driver.findPermanent(player, "Flourishing Bloom-Kin")
+            ?: error("Flourishing Bloom-Kin did not resolve onto the battlefield")
+    }
+
+    test("it is a 0/0 plus one for each Forest you control") {
+        val driver = createDriver(Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+
+        repeat(3) { driver.putLandOnBattlefield(player, "Forest") }
+        val bloomKin = castFaceUp(driver, player)
+
+        driver.state.projectedState.getPower(bloomKin) shouldBe 3
+        driver.state.projectedState.getToughness(bloomKin) shouldBe 3
+    }
+
+    test("only your own Forests count") {
+        val driver = createDriver(Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        driver.putLandOnBattlefield(player, "Forest")
+        repeat(3) { driver.putLandOnBattlefield(opponent, "Forest") }
+        val bloomKin = castFaceUp(driver, player)
+
+        withClue("one Forest of your own — the opponent's three are irrelevant") {
+            driver.state.projectedState.getPower(bloomKin) shouldBe 1
+            driver.state.projectedState.getToughness(bloomKin) shouldBe 1
+        }
+    }
+
+    test("with no Forests it is a 0/0 and dies to state-based actions") {
+        val driver = createDriver(Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+
+        val card = driver.putCardInHand(player, "Flourishing Bloom-Kin")
+        driver.giveColorlessMana(player, 1)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.submit(
+            CastSpell(playerId = player, cardId = card, paymentStrategy = PaymentStrategy.FromPool)
+        ).error shouldBe null
+        driver.bothPass()
+
+        withClue("a 0/0 with no Forests to prop it up never survives its own arrival") {
+            driver.findPermanent(player, "Flourishing Bloom-Kin") shouldBe null
+            driver.getGraveyardCardNames(player).contains("Flourishing Bloom-Kin") shouldBe true
+        }
+    }
+
+    test("face down it is a 2/2 that survives with no Forests at all") {
+        val driver = createDriver(Deck.of("Plains" to 40))
+        val player = driver.activePlayer!!
+
+        val bloomKin = castFaceDown(driver, player)
+
+        withClue("CR 708.2 — no abilities, so no Forest count and no 0/0 body") {
+            driver.state.projectedState.getPower(bloomKin) shouldBe 2
+            driver.state.projectedState.getToughness(bloomKin) shouldBe 2
+        }
+    }
+
+    test("flipping it searches out two Forests — one onto the battlefield tapped, one to hand") {
+        val driver = createDriver(Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+
+        val bloomKin = castFaceDown(driver, player)
+        val landsBefore = driver.getLands(player).size
+        val handBefore = driver.getHandSize(player)
+
+        flipFaceUp(driver, player, bloomKin)
+        driver.state.getEntity(bloomKin)?.get<FaceDownComponent>() shouldBe null
+
+        // The trigger uses the stack, unlike a `disguiseFaceUpEffect` replacement.
+        withClue("'When … is turned face up' is a trigger, so it goes on the stack") {
+            driver.stackSize shouldBe 1
+        }
+        driver.bothPass()
+
+        val find = driver.pendingDecision as? SelectCardsDecision
+        find.shouldNotBeNull()
+        val forests = find.options.take(2)
+        driver.submitCardSelection(player, forests).error shouldBe null
+
+        val split = driver.pendingDecision as? SelectCardsDecision
+        split.shouldNotBeNull()
+        withClue("the split step picks exactly one of the two found cards") {
+            split.minSelections shouldBe 1
+            split.maxSelections shouldBe 1
+        }
+        driver.submitCardSelection(player, listOf(forests.first())).error shouldBe null
+
+        withClue("one Forest entered tapped") {
+            driver.getLands(player).size shouldBe landsBefore + 1
+            driver.isTapped(forests.first()) shouldBe true
+        }
+        withClue("the other went to hand") {
+            driver.getHandSize(player) shouldBe handBefore + 1
+            driver.getHand(player).contains(forests[1]) shouldBe true
+        }
+        withClue("the Bloom-Kin is now a 1/1 off the Forest it just put onto the battlefield") {
+            driver.state.projectedState.getPower(bloomKin) shouldBe 1
+        }
+    }
+
+    test("finding only one Forest puts it onto the battlefield, never into your hand") {
+        // A library with exactly one Forest in it: the ruling's case.
+        val driver = createDriver(Deck.of("Plains" to 39, "Forest" to 1))
+        val player = driver.activePlayer!!
+
+        val bloomKin = castFaceDown(driver, player)
+        val landsBefore = driver.getLands(player).size
+        val handBefore = driver.getHandSize(player)
+
+        flipFaceUp(driver, player, bloomKin)
+        driver.bothPass()
+
+        val find = driver.pendingDecision as? SelectCardsDecision
+        find.shouldNotBeNull()
+        withClue("only one Forest is findable in the whole library") {
+            find.options.size shouldBe 1
+        }
+        val forest = find.options.single()
+        driver.submitCardSelection(player, listOf(forest)).error shouldBe null
+
+        withClue("ChooseExactly(1) auto-selects the only card — no second prompt") {
+            driver.pendingDecision shouldBe null
+        }
+        withClue("it goes onto the battlefield tapped, with nothing left over for hand") {
+            driver.getLands(player).size shouldBe landsBefore + 1
+            driver.isTapped(forest) shouldBe true
+            driver.getHandSize(player) shouldBe handBefore
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PolygraphOrbScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PolygraphOrbScenarioTest.kt
@@ -1,0 +1,235 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Polygraph Orb (MKM #99) — {4}{B} Artifact.
+ *
+ * "When this artifact enters, look at the top four cards of your library. Put two of them into your
+ *  hand and the rest into your graveyard. You lose 2 life.
+ *  {2}, {T}, Collect evidence 3: Each opponent loses 3 life unless they discard a card or sacrifice
+ *  a creature."
+ *
+ * The activated ability is a **punisher**, not an edict, and that is the distinction these tests are
+ * built around: the "unless" is a choice the *opponent* makes, so "lose 3 life" carries no
+ * feasibility gate and stays on the menu even for an opponent holding a hand full of cards and a
+ * board full of creatures. The official ruling is explicit about it. Gating that option — the
+ * natural mistake — would silently turn the card into an edict.
+ *
+ * Collect evidence 3 is a real cost atom alongside `{2}` and `{T}`, so CR 701.59b makes the ability
+ * simply unactivatable under the threshold, and the exile happens during activation where no
+ * opponent can respond to strand it.
+ */
+class PolygraphOrbScenarioTest : ScenarioTestBase() {
+
+    /** Activate the Orb's only activated ability, letting the engine auto-pay. */
+    private fun TestGame.activateOrb() = execute(
+        ActivateAbility(
+            playerId = player1Id,
+            sourceId = findPermanent("Polygraph Orb") ?: error("Polygraph Orb is not on the battlefield"),
+            abilityId = cardRegistry.getCard("Polygraph Orb")!!.activatedAbilities[0].id,
+            paymentStrategy = PaymentStrategy.AutoPay,
+        )
+    )
+
+    /** A board where the Orb is online: two lands for {2} and a mana-value-3 card to exile. */
+    private fun orbReady() = scenario()
+        .withPlayers("Caster", "Opponent")
+        .withCardOnBattlefield(1, "Polygraph Orb")
+        .withCardInGraveyard(1, "Centaur Courser")
+        .withLandsOnBattlefield(1, "Swamp", 2)
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+
+    init {
+        test("entering keeps two cards, bins the rest, and costs 2 life") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardInHand(1, "Polygraph Orb")
+                .withLandsOnBattlefield(1, "Swamp", 5)
+                // The builder seeds no library, so the top four have to be put there explicitly.
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Centaur Courser")
+                .withCardInLibrary(1, "Lightning Bolt")
+                .withCardInLibrary(1, "Savannah Lions")
+                .withCardInLibrary(1, "Doom Blade")
+                .withCardInLibrary(1, "Giant Growth")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val life = game.getLifeTotal(1)
+            val hand = game.handSize(1)
+            val graveyard = game.graveyardSize(1)
+            val library = game.librarySize(1)
+
+            game.castSpell(1, "Polygraph Orb").error shouldBe null
+            game.resolveStack()
+
+            val look = game.getPendingDecision() as? SelectCardsDecision
+            look.shouldNotBeNull()
+            withClue("look at the top four, keep exactly two") {
+                look.options.size shouldBe 4
+                look.minSelections shouldBe 2
+                look.maxSelections shouldBe 2
+            }
+            game.selectCards(look.options.take(2)).error shouldBe null
+
+            // The Orb left hand and the two kept cards arrived, so the net hand change is +1.
+            game.handSize(1) shouldBe hand + 1
+            game.graveyardSize(1) shouldBe graveyard + 2
+            game.librarySize(1) shouldBe library - 4
+            withClue("the life loss is unconditional") {
+                game.getLifeTotal(1) shouldBe life - 2
+            }
+        }
+
+        test("the opponent may take the 3 life even holding a card and a creature") {
+            val game = orbReady()
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardInHand(2, "Centaur Courser")
+                .build()
+
+            val life = game.getLifeTotal(2)
+            val hand = game.handSize(2)
+
+            game.activateOrb().error shouldBe null
+            game.resolveStack()
+
+            val choice = game.getPendingDecision() as? ChooseOptionDecision
+            choice.shouldNotBeNull()
+            choice.playerId shouldBe game.player2Id
+            withClue("all three options are live — 'lose 3 life' carries no feasibility gate") {
+                choice.options.size shouldBe 3
+            }
+            // Option 2 = "Lose 3 life".
+            game.submitDecision(OptionChosenResponse(choice.id, 2)).error shouldBe null
+
+            withClue("a punisher, not an edict: nothing was taken from them") {
+                game.getLifeTotal(2) shouldBe life - 3
+                game.handSize(2) shouldBe hand
+                game.isOnBattlefield("Grizzly Bears") shouldBe true
+            }
+        }
+
+        test("an opponent who discards takes no damage") {
+            val game = orbReady()
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                // Two cards, so the discard is a genuine choice rather than an auto-pick.
+                .withCardInHand(2, "Centaur Courser")
+                .withCardInHand(2, "Lightning Bolt")
+                .build()
+
+            val life = game.getLifeTotal(2)
+            val hand = game.handSize(2)
+
+            game.activateOrb().error shouldBe null
+            game.resolveStack()
+
+            val choice = game.getPendingDecision() as? ChooseOptionDecision
+            choice.shouldNotBeNull()
+            // Option 0 = "Discard a card".
+            game.submitDecision(OptionChosenResponse(choice.id, 0)).error shouldBe null
+            // The discard pauses to let the opponent pick which card.
+            game.getPendingDecision().shouldNotBeNull()
+            game.selectCards(game.findCardsInHand(2, "Centaur Courser")).error shouldBe null
+
+            game.handSize(2) shouldBe hand - 1
+            game.isInGraveyard(2, "Centaur Courser") shouldBe true
+            game.getLifeTotal(2) shouldBe life
+            game.isOnBattlefield("Grizzly Bears") shouldBe true
+        }
+
+        test("an opponent who sacrifices a creature takes no damage") {
+            val game = orbReady()
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardInHand(2, "Centaur Courser")
+                .build()
+
+            val life = game.getLifeTotal(2)
+            val hand = game.handSize(2)
+
+            game.activateOrb().error shouldBe null
+            game.resolveStack()
+
+            val choice = game.getPendingDecision() as? ChooseOptionDecision
+            choice.shouldNotBeNull()
+            // Option 1 = "Sacrifice a creature".
+            game.submitDecision(OptionChosenResponse(choice.id, 1)).error shouldBe null
+            if (game.getPendingDecision() is SelectCardsDecision) {
+                game.selectCards(listOfNotNull(game.findPermanent("Grizzly Bears")))
+            }
+
+            game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+            game.getLifeTotal(2) shouldBe life
+            game.handSize(2) shouldBe hand
+        }
+
+        test("with an empty hand and no creatures, losing 3 life is the only option left") {
+            val game = orbReady().build()
+
+            val life = game.getLifeTotal(2)
+
+            game.activateOrb().error shouldBe null
+            game.resolveStack()
+
+            val choice = game.getPendingDecision()
+            if (choice is ChooseOptionDecision) {
+                withClue("the two infeasible options hide themselves") {
+                    choice.options.size shouldBe 1
+                }
+                game.submitDecision(OptionChosenResponse(choice.id, 0)).error shouldBe null
+            }
+            withClue("either way the opponent ends up 3 life down") {
+                game.getLifeTotal(2) shouldBe life - 3
+            }
+        }
+
+        test("CR 701.59b — the ability is unactivatable below the evidence threshold") {
+            val game = scenario()
+                .withPlayers("Caster", "Opponent")
+                .withCardOnBattlefield(1, "Polygraph Orb")
+                // Mana value 1, short of 3.
+                .withCardInGraveyard(1, "Lightning Bolt")
+                .withLandsOnBattlefield(1, "Swamp", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val life = game.getLifeTotal(2)
+
+            game.getLegalActions(1)
+                .filter { it.description.contains("Each opponent loses 3 life") }
+                .none { it.isAffordable } shouldBe true
+
+            game.activateOrb().error.shouldNotBeNull()
+            withClue("nothing was spent and nothing happened") {
+                game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                game.getLifeTotal(2) shouldBe life
+            }
+        }
+
+        test("activating exiles the evidence as a cost") {
+            val game = orbReady()
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .build()
+
+            game.activateOrb().error shouldBe null
+
+            withClue("costs are paid during activation, before anyone can respond") {
+                game.isInExile(1, "Centaur Courser") shouldBe true
+                game.isInGraveyard(1, "Centaur Courser") shouldBe false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Four MKM cards, all composed from existing SDK primitives — three disguise cards plus the set's collect-evidence punisher artifact.

## Cards

- **Concealed Weapon** ({1}{R} Equipment, #117) — MKM's one *noncreature* disguise card. Face-down-ness is a characteristic-defining effect, not a property of the card, so CR 708.2 gives the Equipment a 2/2 body while face down and takes it away on the flip. The attachment is a genuine triggered ability (`Triggers.TurnedFaceUp` + `Effects.AttachEquipment`) rather than a `disguiseFaceUpEffect` replacement, because the oracle says "When" — it uses the stack, it targets, and per the ruling it is *not* an equip activation (no mana, no sorcery-speed restriction).
- **Crowd-Control Warden** ({3}{G}{W} 4/4, #193) — one sentence, two rules constructs. Entering is a CR 614.1c `EntersWithDynamicCounters` replacement where the Warden isn't on the battlefield yet, so "creatures you control" is already "other creatures you control". Turning face up rides the turn-up special action where it *is* on the battlefield, so that half needs `excludeSelf`.
- **Flourishing Bloom-Kin** ({1}{G} 0/0, #160) — a 0/0 alive only by its own `GrantDynamicStatsEffect`, recomputed in the projection. "Forest cards" is the subtype, not `BasicLand`. The search is the Cultivate split (`ChooseUpTo(2)` then `ChooseExactly(1)` with the remainder to hand).
- **Polygraph Orb** ({4}{B} Artifact, #99) — `Patterns.Library.lookAtTopAndKeep(4, 2)` on entry, and a `ChooseActionEffect` punisher inside `ForEachPlayerEffect(EachOpponent)`. `Costs.CollectEvidence(3)` sits alongside `{2}` and `{T}` as a real cost atom.

## Notable rules details pinned by tests

- **The Warden's off-by-one.** Face down, the Warden is itself a creature on the battlefield; a count without `excludeSelf` would hand out three counters instead of two. Both halves are tested to land on the same number by opposite routes.
- **Polygraph Orb is a punisher, not an edict.** "Lose 3 life" carries *no* feasibility gate, so it stays on the menu even for an opponent holding cards and creatures — the official ruling is explicit. Gating it would silently change the card.
- **Bloom-Kin's single-Forest ruling falls out of the shape.** `ChooseExactly(1)` auto-selects the only found card onto the battlefield with an empty remainder, so the player never gets the option to route it to hand.
- **Concealed Weapon flips legally with no creatures.** The special action isn't gated on the trigger having a target; the targetless trigger is removed from the stack and the Equipment stays unattached.

## Verification

- `just build` — green (full project build + tests).
- 25 new scenario tests across four files (`ConcealedWeaponScenarioTest`, `CrowdControlWardenScenarioTest`, `FlourishingBloomKinScenarioTest`, `PolygraphOrbScenarioTest`), all passing.
- `just check-card-printing` — all four confirm MKM as the canonical earliest printing.
- All four re-verified field-by-field against Scryfall: mana cost, type line, P/T, rarity, collector number, artist, image URI, and oracle text. (Flourishing Bloom-Kin genuinely carries no disguise reminder text on Scryfall — three abilities left no room — so it is matched verbatim rather than normalized to the rest of the cycle.)
- MKM card snapshot re-blessed; the diff is purely additive — 520 added lines, 0 removals, no existing card moved.

No new SDK vocabulary was needed, so no `card-sdk-language-reference.md` update applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)