### PR TITLE
Add three HOB cards: Balin, Bifur, and Glamdring

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2065,6 +2065,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     ability (see §8, and note that it is *not* the `oncePerTurn` trigger cap).
   - The multi-player APNAP `AnyPlayerMayPayEffect` stays a **standalone effect**, not a gate — a
     single `decisionMaker` can't express its turn-order loop (see below).
+
+  **Pipeline storage crosses the gate.** Whatever the taken branch stores — collections, numbers,
+  chosen values — is handed to the frame beneath through `exposeCollectionsToNextFrame`, on both the
+  synchronous path and the paused/continuation-drain path. That is what lets a gate sit *inside* a
+  composite whose later siblings read what the branch produced: "you may discard your hand. Draw X
+  cards, where X is the number of cards discarded this way" (**Balin, Loremaster**) gates only the
+  discard, and the sibling `DrawCards(VariableReference("discardedHand_count"))` sees the collection
+  the `then` branch gathered. Scoping the gate to just the optional clause — rather than wrapping the
+  whole rider — is also what makes a decline read X = 0 (an unset `VariableReference` evaluates to 0)
+  instead of skipping the mandatory half.
 - `MayEffect(effect, descriptionOverride?, sourceRequiredZone?, inlineOnTrigger?, hint?, dynamicHint?, decisionMaker?, otherwise?, feasibility?)`
   — "You may [effect]." Facade preserved for existing cards; it now **lowers to
   `GatedEffect(Gate.MayDecide(...), then = effect, otherwise = otherwise, decisionMaker = decisionMaker)`**
@@ -5526,7 +5536,15 @@ staticAbility {
   `TotalPropertyAmongPermanentsYouControl(Power, Creature.withKeyword(FLYING))`. The filter runs
   through `PredicateEvaluator` against projected state, so granted flying and animated permanents
   count; negative power subtracts from the total (Ghalta's ruling on the same wording) and only the
-  finished sum is floored at 0. … — see `CostStaticAbilities.kt`
+  finished sum is floored at 0,
+  `AttachedPermanentProperty(property)` — "{X} less, where X is equipped creature's `<property>`"
+  (Glamdring, Foe-hammer's `AttachedPermanentProperty(Power)`). The odd one out in this family: it
+  reads a *single* permanent found by walking the reducing permanent's own `AttachedToComponent`
+  rather than aggregating over a group the caster controls, so it is only meaningful on a
+  `ModifySpellCost` printed on an Equipment/Aura. Same `EntityNumericProperty` axis and read rules as
+  the two above (projected state for P/T, card definition for mana value). Nothing attached — or a
+  `SelfCast` reduction, which has no source permanent — reads 0, which is the correct reading of an
+  unequipped Equipment; negative power floors at 0. … — see `CostStaticAbilities.kt`
   for the full list.
 - `gating: CostGating` — gates whether/how often the modifier fires:
   - `None` (default) — applies to every matching cast.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CostStaticAbilities.kt
@@ -600,6 +600,32 @@ sealed interface CostReductionSource {
     }
 
     /**
+     * Reduces cost by a numeric [property] of the permanent the *reducing ability's own source* is
+     * attached to — "{X} less to cast, where X is equipped creature's power" (Glamdring,
+     * Foe-hammer).
+     *
+     * The odd one out in this family: every other source aggregates over a group the caster
+     * controls, while this one reads a single permanent found by walking the Equipment's/Aura's
+     * attachment. It is therefore only meaningful on a [ModifySpellCost] printed on a permanent
+     * that can be attached; an unattached (or non-attaching) source contributes 0, which is exactly
+     * what an Equipment sitting on the battlefield with nothing equipped should do.
+     *
+     * Shares the read rules of [GreatestPropertyAmongPermanentsYouControl] and
+     * [TotalPropertyAmongPermanentsYouControl]: power/toughness come from projected state (CR 613),
+     * so counters, anthems, and the Equipment's own bonus all count; mana value comes from the card
+     * definition. Negative power floors at 0 — a cost can't be *increased* by a reduction clause.
+     *
+     * @property property Which numeric characteristic of the attached permanent to read
+     */
+    @SerialName("AttachedPermanentProperty")
+    @Serializable
+    data class AttachedPermanentProperty(
+        val property: EntityNumericProperty
+    ) : CostReductionSource {
+        override val description: String = "the attached permanent's ${property.description}"
+    }
+
+    /**
      * Reduces cost by a fixed amount if a creature is currently attacking the caster.
      * Used for cards like Swat Away ("This spell costs {2} less to cast if a creature
      * is attacking you").

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BalinLoremaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BalinLoremaster.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.storied
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Balin, Loremaster
+ * {3}{R}{R}
+ * Legendary Creature — Dwarf Bard
+ * 4/4
+ *
+ * Storied.
+ * Whenever Balin or another Dwarf you control enters, you may discard your hand. Draw X cards,
+ * where X is the number of cards discarded this way. If you have an enduring story, Balin deals
+ * X damage to each opponent.
+ *
+ * "Balin or another Dwarf you control" is the Fíli/Arahbo shape: a single `ANY`-bound enters
+ * trigger over `Dwarf.youControl()` covers both halves, because Balin is himself a Dwarf you
+ * control and so matches his own filter.
+ *
+ * X is *"discarded this way"*, not "your hand size" — so it has to be the size of the collection
+ * the discard actually moved, read back as `discardedHand_count`.
+ * [Patterns.Hand.discardHand] gathers the hand into `discardedHand` before discarding it and
+ * `GatherCardsEffect` auto-publishes the `_count` companion (the Borrowed Knowledge idiom).
+ *
+ * Only the *discard* is optional; the draw and the damage happen either way. Modelling the "may"
+ * as a [Gate.MayDecide] around just the discard — rather than around the whole rider — is what
+ * makes a decline read X = 0 instead of skipping the rest of the ability. That works because an
+ * unset `VariableReference` evaluates to 0, and because pipeline storage survives the decision
+ * pause the gate introduces — the gated resumer hands the taken branch's collections to the frame
+ * beneath via `exposeCollectionsToNextFrame`, which this card is the first to depend on. Drawing 0
+ * and dealing 0 damage are both no-ops, so a decline is correctly indistinguishable from discarding
+ * an empty hand.
+ *
+ * The enduring-story clause is a resolution-time state test ([ConditionalEffect] → a
+ * `Gate.WhenCondition`), not an intervening-if: the ability triggers and goes on the stack
+ * regardless, and only the damage half checks the designation as it resolves.
+ */
+val BalinLoremaster = card("Balin, Loremaster") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dwarf Bard"
+    oracleText = "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you " +
+        "have an enduring story for the rest of the game.)\n" +
+        "Whenever Balin or another Dwarf you control enters, you may discard your hand. Draw X " +
+        "cards, where X is the number of cards discarded this way. If you have an enduring story, " +
+        "Balin deals X damage to each opponent."
+    power = 4
+    toughness = 4
+
+    storied()
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.DWARF).youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Composite(
+            GatedEffect(
+                gate = Gate.MayDecide(),
+                then = Patterns.Hand.discardHand(),
+                descriptionOverride = "You may discard your hand.",
+            ),
+            Effects.DrawCards(DynamicAmount.VariableReference("discardedHand_count")),
+            ConditionalEffect(
+                condition = Conditions.YouHaveEnduringStory,
+                effect = DealDamageEffect(
+                    amount = DynamicAmount.VariableReference("discardedHand_count"),
+                    target = EffectTarget.PlayerRef(Player.EachOpponent),
+                ),
+            ),
+        )
+        description = "Whenever Balin or another Dwarf you control enters, you may discard your " +
+            "hand. Draw X cards, where X is the number of cards discarded this way. If you have " +
+            "an enduring story, Balin deals X damage to each opponent."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "87"
+        artist = "Colin Boyer"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42d7ca7b-c983-40fd-ad57-59f6972bb375.jpg?1785496498"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BifurMelodicRider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/BifurMelodicRider.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.TriggeredAbilityBuilder
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.storied
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Bifur, Melodic Rider
+ * {4}{R/W}{R/W}
+ * Legendary Creature — Dwarf Bard
+ * 4/5
+ *
+ * Storied.
+ * Whenever Bifur enters or attacks, put a +1/+1 counter on target creature.
+ * As long as you have an enduring story, if a triggered ability of a Dwarf you control triggers,
+ * that ability triggers an additional time.
+ *
+ * The doubler is [AdditionalSourceTriggers] — the generic "if a triggered ability of a permanent
+ * matching the filter you control triggers, it triggers an additional time" static. Two parameter
+ * choices carry the oracle text:
+ *  - `excludeSelf = false`, because the text says "a Dwarf you control", not "*another* Dwarf".
+ *    Bifur is himself a Dwarf you control, so his own enters/attacks trigger is doubled — the
+ *    printed ruling spells this out ("If Bifur entering causes you to have an enduring story, his
+ *    'enters or attacks' ability triggers an additional time").
+ *  - `condition = Conditions.YouHaveEnduringStory` rather than a
+ *    [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] wrapper:
+ *    `TriggerDetector.duplicateSourceTriggers` scans battlefield statics for a bare
+ *    `AdditionalSourceTriggers`, so a wrapped one would never be seen. The field exists for exactly
+ *    this shape and is evaluated against the doubler's source and controller.
+ *
+ * Because the doubler causes a *second trigger* rather than copying the first, each instance
+ * chooses its own target independently (CR 603.2d) — which is what the engine's duplicate-then-
+ * target flow already does.
+ *
+ * "Enters or attacks" is the repo's two-ability idiom (Queen's Bay Paladin, Sentinel of the
+ * Nameless City): one `EntersBattlefield` and one `Attacks` ability sharing a rider.
+ */
+val BifurMelodicRider = card("Bifur, Melodic Rider") {
+    manaCost = "{4}{R/W}{R/W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Dwarf Bard"
+    oracleText = "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you " +
+        "have an enduring story for the rest of the game.)\n" +
+        "Whenever Bifur enters or attacks, put a +1/+1 counter on target creature.\n" +
+        "As long as you have an enduring story, if a triggered ability of a Dwarf you control " +
+        "triggers, that ability triggers an additional time."
+    power = 4
+    toughness = 5
+
+    storied()
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        counterRider()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        counterRider()
+    }
+
+    staticAbility {
+        ability = AdditionalSourceTriggers(
+            sourceFilter = GameObjectFilter.Creature.withSubtype(Subtype.DWARF).youControl(),
+            excludeSelf = false,
+            condition = Conditions.YouHaveEnduringStory,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "147"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee88cc80-8fbf-451c-b2b8-09158426c26a.jpg?1784377019"
+    }
+}
+
+/** The rider shared by the enters and attacks halves: a +1/+1 counter on one target creature. */
+private fun TriggeredAbilityBuilder.counterRider() {
+    val creature = target("target creature", Targets.Creature)
+    effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GlamdringFoeHammer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/GlamdringFoeHammer.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+
+/**
+ * Glamdring, Foe-hammer // Gleam of Death
+ * {2}
+ * Legendary Artifact — Equipment
+ *
+ * Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature's power.
+ * Equip {2}
+ *
+ * Adventure: Gleam of Death — {3}{U}, Sorcery — Adventure
+ * Mill six cards, then put all instant and sorcery cards from among them into your hand.
+ *
+ * The cost reduction is the first one in the family that reads a *single* permanent found through
+ * the reducing permanent's own attachment rather than aggregating over a group the caster controls,
+ * so it needed a new [CostReductionSource.AttachedPermanentProperty] plus the ability's source id
+ * threaded into `CostCalculator.evaluateReduction` (every other source only needs the caster).
+ * Parameterising it over [EntityNumericProperty] keeps it in line with its neighbours
+ * `GreatestPropertyAmongPermanentsYouControl` / `TotalPropertyAmongPermanentsYouControl`.
+ *
+ * The value is read from projected state at cast time, so the equipped creature's counters and any
+ * anthems count, and an *unequipped* Glamdring reduces by 0 — which is what the oracle text means
+ * when there is no equipped creature. Negative power floors at 0; a reduction clause can never make
+ * a spell cost more.
+ *
+ * The Adventure is the Cantankerous Keepers shape: mill into a stored collection, then split that
+ * collection with [FilterCollectionEffect] and move the matching half to hand. "All instant and
+ * sorcery cards" is a filter over the milled six, not a choice, so there is no selection step.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the caster
+ * cast the artifact from exile afterwards.)
+ */
+val GlamdringFoeHammer = card("Glamdring, Foe-hammer") {
+    manaCost = "{2}"
+    colorIdentity = "U"
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Instant and sorcery spells you cast cost {X} less to cast, where X is equipped " +
+        "creature's power.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(Filters.Unified.instantOrSorcery),
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.AttachedPermanentProperty(EntityNumericProperty.Power)
+            ),
+        )
+    }
+
+    equipAbility("{2}")
+
+    adventure("Gleam of Death") {
+        manaCost = "{3}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Mill six cards, then put all instant and sorcery cards from among them into " +
+            "your hand. (Then exile this card. You may cast the artifact later from exile.)"
+        spell {
+            effect = Effects.Composite(
+                listOf(
+                    // Mill six cards.
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(DynamicAmount.Fixed(6), Player.You, isMill = true),
+                        storeAs = "milled"
+                    ),
+                    MoveCollectionEffect(
+                        from = "milled",
+                        destination = CardDestination.ToZone(Zone.GRAVEYARD)
+                    ),
+                    // Then put all instant and sorcery cards from among them into your hand.
+                    FilterCollectionEffect(
+                        from = "milled",
+                        filter = CollectionFilter.MatchesFilter(GameObjectFilter.InstantOrSorcery),
+                        storeMatching = "spells",
+                        storeNonMatching = "rest"
+                    ),
+                    MoveCollectionEffect(
+                        from = "spells",
+                        destination = CardDestination.ToZone(Zone.HAND)
+                    )
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "174"
+        artist = "Chris Cold"
+        flavorText = "Suddenly a sword flashed in its own light."
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a5cfbfde-783e-46ca-b3cf-11f16209d6cb.jpg?1785496394"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -194,6 +194,101 @@
     ]
 }
 
+// Balin, Loremaster
+{
+    "name": "Balin, Loremaster",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Legendary Creature — Dwarf Bard",
+    "oracleText": "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you have an enduring story for the rest of the game.)\nWhenever Balin or another Dwarf you control enters, you may discard your hand. Draw X cards, where X is the number of cards discarded this way. If you have an enduring story, Balin deals X damage to each opponent.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "STORIED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Dwarf ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "discardedHand"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discardedHand",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            "descriptionOverride": "You may discard your hand."
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "VariableReference",
+                                "variableName": "discardedHand_count"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": "PlayerHasEnduringStory"
+                            },
+                            "then": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "VariableReference",
+                                    "variableName": "discardedHand_count"
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Balin or another Dwarf you control enters, you may discard your hand. Draw X cards, where X is the number of cards discarded this way. If you have an enduring story, Balin deals X damage to each opponent."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "RARE",
+        "artist": "Colin Boyer",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42d7ca7b-c983-40fd-ad57-59f6972bb375.jpg?1785496498"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Bard the Bowman
 {
     "name": "Bard the Bowman",
@@ -836,6 +931,86 @@
                 }
             }
         }
+    ]
+}
+
+// Bifur, Melodic Rider
+{
+    "name": "Bifur, Melodic Rider",
+    "manaCost": "{4}{R/W}{R/W}",
+    "typeLine": "Legendary Creature — Dwarf Bard",
+    "oracleText": "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you have an enduring story for the rest of the game.)\nWhenever Bifur enters or attacks, put a +1/+1 counter on target creature.\nAs long as you have an enduring story, if a triggered ability of a Dwarf you control triggers, that ability triggers an additional time.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywords": [
+        "STORIED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "AdditionalSourceTriggers",
+                "sourceFilter": "creature Dwarf ctrl:you",
+                "excludeSelf": false,
+                "condition": "PlayerHasEnduringStory"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee88cc80-8fbf-451c-b2b8-09158426c26a.jpg?1784377019"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -4821,6 +4996,127 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Glamdring, Foe-hammer
+{
+    "name": "Glamdring, Foe-hammer",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature's power.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "instant|sorcery"
+                },
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "AttachedPermanentProperty",
+                        "property": "Power"
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "RARE",
+        "artist": "Chris Cold",
+        "flavorText": "Suddenly a sword flashed in its own light.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a5cfbfde-783e-46ca-b3cf-11f16209d6cb.jpg?1785496394"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Gleam of Death",
+            "manaCost": "{3}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Mill six cards, then put all instant and sorcery cards from among them into your hand. (Then exile this card. You may cast the artifact later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "milled",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "instant|sorcery"
+                            },
+                            "storeMatching": "spells",
+                            "storeNonMatching": "rest"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "spells",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -503,18 +503,32 @@ class EffectAndTriggerContinuationResumer(
             return checkForMore(state, emptyList())
         }
 
-        val result = services.effectExecutorRegistry
+        val branchResult = services.effectExecutorRegistry
             .execute(state, effectToExecute, continuation.effectContext)
-            .toExecutionResult()
+        val result = branchResult.toExecutionResult()
 
         if (result.isPaused) {
             return result
         }
 
+        // The branch's pipeline storage belongs to the frame beneath, exactly as a drained composite's
+        // does in [resumeEffect]. A gate sits *inside* a composite ("you may discard your hand. Draw X
+        // cards, where X is the number of cards discarded this way" — Balin, Loremaster), so the
+        // later siblings are the readers of whatever the `then` branch gathered. Dropping it here made
+        // the same card work or not depending on whether the may-question happened to be asked: an
+        // auto-answered or skipped gate runs `then` synchronously and keeps its storage, while a
+        // prompted one lost it and the sibling read an unset variable as 0.
+        val stateWithCollections = exposeCollectionsToNextFrame(
+            result.state,
+            continuation.effectContext.pipeline.storedCollections + branchResult.updatedCollections,
+            continuation.effectContext.pipeline.storedNumbers + branchResult.updatedStoredNumbers,
+            continuation.effectContext.pipeline.chosenValues + branchResult.updatedChosenValues,
+        )
+
         // Preserve `triggersAlreadyProcessed` across the continuation drain: if the gated effect ran
         // a nested cast that already stacked its cast-triggers (Vaan casting an opponent's card via
         // MayEffect), SubmitDecisionHandler must not re-detect the same SpellCastEvent.
-        return checkForMore(result.state, result.events.toList())
+        return checkForMore(stateWithCollections, result.events.toList())
             .copy(triggersAlreadyProcessed = result.triggersAlreadyProcessed)
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -138,6 +138,7 @@ class CostCalculator(
                 addColoredReduction = { coloredReductionSymbols += it },
                 addColoredReductionWithOverflow = { coloredReductionWithOverflow += it },
                 addColoredIncrease = { coloredIncreaseSymbols += it },
+                abilitySourceId = sourceId,
             )
         }
 
@@ -353,18 +354,22 @@ class CostCalculator(
         addColoredReduction: (ManaSymbol) -> Unit,
         addColoredReductionWithOverflow: (ManaSymbol) -> Unit,
         addColoredIncrease: (ManaSymbol) -> Unit,
+        abilitySourceId: EntityId? = null,
     ) {
         when (modification) {
             is CostModification.ReduceGeneric -> addGenericReduction(modification.amount)
             is CostModification.ReduceGenericBy ->
-                addGenericReduction(evaluateReduction(state, modification.source, casterId, chosenTargets))
+                addGenericReduction(
+                    evaluateReduction(state, modification.source, casterId, chosenTargets, abilitySourceId)
+                )
             is CostModification.ReduceColored -> {
                 ManaCost.parse(modification.symbols).symbols
                     .filterIsInstance<ManaSymbol.Colored>()
                     .forEach(addColoredReduction)
             }
             is CostModification.ReduceColoredPerUnit -> {
-                val units = evaluateReduction(state, modification.countSource, casterId, chosenTargets)
+                val units =
+                    evaluateReduction(state, modification.countSource, casterId, chosenTargets, abilitySourceId)
                 val coloredSymbols = ManaCost.parse(modification.symbols).symbols
                     .filterIsInstance<ManaSymbol.Colored>()
                 repeat(units) { coloredSymbols.forEach(addColoredReductionWithOverflow) }
@@ -404,12 +409,18 @@ class CostCalculator(
 
     /**
      * Evaluate the reduction amount from a CostReductionSource.
+     *
+     * [abilitySourceId] is the battlefield permanent the reducing [ModifySpellCost] is printed on,
+     * or null when the reduction comes from the spell's own script (a `SelfCast` reduction, where
+     * there is no permanent to read). Only the attachment-reading sources need it; everything else
+     * aggregates over what [playerId] controls.
      */
     private fun evaluateReduction(
         state: GameState,
         source: CostReductionSource,
         playerId: EntityId,
-        chosenTargets: List<EntityId> = emptyList()
+        chosenTargets: List<EntityId> = emptyList(),
+        abilitySourceId: EntityId? = null
     ): Int {
         return when (source) {
             is CostReductionSource.Fixed -> source.amount
@@ -448,6 +459,9 @@ class CostCalculator(
             }
             is CostReductionSource.TotalPropertyAmongPermanentsYouControl -> {
                 totalPropertyAmongMatching(state, playerId, source.filter, source.property)
+            }
+            is CostReductionSource.AttachedPermanentProperty -> {
+                attachedPermanentProperty(state, abilitySourceId, source.property)
             }
             is CostReductionSource.FixedIfCreatureDiedThisTurn -> {
                 if (anyCreatureDiedThisTurn(state)) source.amount else 0
@@ -611,6 +625,36 @@ class CostCalculator(
             total += numericProperty(projected, entityId, card, cardDef, property)
         }
         return total.coerceAtLeast(0)
+    }
+
+    /**
+     * The [property] of the permanent [abilitySourceId] is attached to — "equipped creature's
+     * power" (Glamdring, Foe-hammer).
+     *
+     * Returns 0 whenever there is nothing to read: no source permanent (a `SelfCast` reduction
+     * printed on the spell itself), a source that isn't attached to anything, or an attachment
+     * target that has since left the battlefield. An unequipped Equipment reducing costs by 0 is
+     * the correct reading of the oracle text, so failing to 0 here is faithful rather than merely
+     * defensive.
+     *
+     * The attachment is read from the source's `AttachedToComponent` — the same seam
+     * `Scope.AttachedTo` uses — and the value from projected state, so the equipped creature's
+     * counters, anthems, and the Equipment's own P/T bonus are all included.
+     */
+    private fun attachedPermanentProperty(
+        state: GameState,
+        abilitySourceId: EntityId?,
+        property: EntityNumericProperty
+    ): Int {
+        val sourceId = abilitySourceId ?: return 0
+        val attachedTo = state.getEntity(sourceId)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
+            ?.targetId
+            ?: return 0
+        val card = state.getEntity(attachedTo)?.get<CardComponent>() ?: return 0
+        val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: return 0
+        return numericProperty(state.projectedState, attachedTo, card, cardDef, property)
+            .coerceAtLeast(0)
     }
 
     /**
@@ -1243,7 +1287,9 @@ class CostCalculator(
             when (val mod = ability.modification) {
                 is CostModification.ReduceGeneric -> totalReduction += mod.amount
                 is CostModification.ReduceGenericBy ->
-                    totalReduction += evaluateReduction(state, mod.source, casterId)
+                    totalReduction += evaluateReduction(
+                        state, mod.source, casterId, abilitySourceId = sourceId
+                    )
                 else -> { /* face-down only supports generic reduction */ }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BalinLoremasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BalinLoremasterScenarioTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.enduringstory.EnduringStoryService
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Balin, Loremaster — {3}{R}{R} Legendary Creature — Dwarf Bard 4/4.
+ *
+ *   Storied.
+ *   Whenever Balin or another Dwarf you control enters, you may discard your hand. Draw X cards,
+ *   where X is the number of cards discarded this way. If you have an enduring story, Balin deals
+ *   X damage to each opponent.
+ *
+ * X is "discarded **this way**", so it is the size of the collection the discard actually moved —
+ * `discardedHand_count`, published by the `GatherCardsEffect` inside `Patterns.Hand.discardHand`.
+ * The fragile part is that the "may" pauses for a yes/no *between* the gather and the read: the
+ * pipeline storage has to survive that continuation round-trip, or the draw silently reads 0
+ * (an unset `VariableReference` evaluates to 0, so nothing errors). Both branches are exercised
+ * below, and the decline branch pins that declining reads X = 0 rather than skipping the rest of
+ * the ability.
+ */
+class BalinLoremasterScenarioTest : ScenarioTestBase() {
+
+    init {
+
+        test("discarding your hand draws that many, and deals no damage without an enduring story") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Balin, Loremaster")
+                .withCardInHand(1, "Dwarven Mauler")
+                .withCardsInHand(1, "Grizzly Bears", 2)
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Hill Giant")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            withClue("Balin alone is one legendary permanent — no enduring story") {
+                EnduringStoryService.has(game.state, game.player1Id) shouldBe false
+            }
+
+            game.castSpell(1, "Dwarven Mauler").error shouldBe null
+            game.resolveStack()
+
+            (game.getPendingDecision() is YesNoDecision) shouldBe true
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+
+            withClue("the two Grizzly Bears left in hand were discarded") {
+                game.graveyardSize(1) shouldBe 2
+            }
+            withClue("X = 2 cards discarded this way, so two cards were drawn") {
+                game.handSize(1) shouldBe 2
+                game.librarySize(1) shouldBe 1
+            }
+            withClue("no enduring story — the damage clause is skipped entirely") {
+                game.getLifeTotal(2) shouldBe 20
+            }
+        }
+
+        test("declining the discard reads X = 0 — no draw, no damage, hand intact") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Balin, Loremaster")
+                .withCardOnBattlefield(1, "Óin the Brave")
+                .withCardOnBattlefield(1, "Thorin Oakenshield")
+                .withCardInHand(1, "Dwarven Mauler")
+                .withCardsInHand(1, "Grizzly Bears", 2)
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Hill Giant")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            EnduringStoryService.has(game.state, game.player1Id) shouldBe true
+
+            game.castSpell(1, "Dwarven Mauler").error shouldBe null
+            game.resolveStack()
+
+            game.answerYesNo(false).error shouldBe null
+            game.resolveStack()
+
+            withClue("nothing was discarded, so X is 0 — not 'the ability was skipped'") {
+                game.graveyardSize(1) shouldBe 0
+                game.handSize(1) shouldBe 2
+                game.librarySize(1) shouldBe 2
+            }
+            withClue("the story is on but X = 0, so Balin deals no damage") {
+                game.getLifeTotal(2) shouldBe 20
+            }
+        }
+
+        test("with an enduring story Balin also burns each opponent for X") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Balin, Loremaster")
+                .withCardOnBattlefield(1, "Óin the Brave")
+                .withCardOnBattlefield(1, "Thorin Oakenshield")
+                .withCardInHand(1, "Dwarven Mauler")
+                .withCardsInHand(1, "Grizzly Bears", 2)
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Hill Giant")
+                .withCardInLibrary(1, "Hill Giant")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            EnduringStoryService.has(game.state, game.player1Id) shouldBe true
+
+            game.castSpell(1, "Dwarven Mauler").error shouldBe null
+            game.resolveStack()
+
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+
+            game.graveyardSize(1) shouldBe 2
+            game.handSize(1) shouldBe 2
+            withClue("the same X that drove the draw drives the damage — two discarded, two damage") {
+                game.getLifeTotal(2) shouldBe 18
+            }
+            withClue("'each opponent', not 'each player' — Balin's controller is untouched") {
+                game.getLifeTotal(1) shouldBe 20
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BifurMelodicRiderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BifurMelodicRiderScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.enduringstory.EnduringStoryService
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bifur, Melodic Rider — {4}{R/W}{R/W} Legendary Creature — Dwarf Bard 4/5.
+ *
+ *   Storied.
+ *   Whenever Bifur enters or attacks, put a +1/+1 counter on target creature.
+ *   As long as you have an enduring story, if a triggered ability of a Dwarf you control triggers,
+ *   that ability triggers an additional time.
+ *
+ * Two things the doubler's parameters have to get right, and neither is visible from the card text
+ * alone. `excludeSelf = false` — the text says "a Dwarf you control", not "*another* Dwarf", and
+ * Bifur is a Dwarf, so his own enters trigger is one of the abilities he doubles (the printed
+ * ruling says so explicitly). And the enduring-story gate rides `AdditionalSourceTriggers.condition`
+ * rather than a `ConditionalStaticAbility` wrapper, because `TriggerDetector.duplicateSourceTriggers`
+ * only recognizes a *bare* `AdditionalSourceTriggers` — a wrapped one would double nothing, silently.
+ *
+ * Each firing is a separate trigger, not a copy, so each one picks its own target (CR 603.2d).
+ */
+class BifurMelodicRiderScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+
+        test("without an enduring story Bifur's enters trigger fires exactly once") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Bifur, Melodic Rider")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Bifur, Melodic Rider").error shouldBe null
+            game.resolveStack()
+
+            withClue("Bifur alone is one legendary permanent — no enduring story") {
+                EnduringStoryService.has(game.state, game.player1Id) shouldBe false
+            }
+
+            (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+            game.selectTargets(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            plusOneCounters(game, bears) shouldBe 1
+            withClue("no second trigger is waiting behind the first") {
+                game.hasPendingDecision() shouldBe false
+            }
+        }
+
+        test("Bifur entering as your third legendary doubles his own enters trigger") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Bifur, Melodic Rider")
+                .withCardOnBattlefield(1, "Óin the Brave")
+                .withCardOnBattlefield(1, "Thorin Oakenshield")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Mountain", 6)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Bifur, Melodic Rider").error shouldBe null
+            game.resolveStack()
+
+            withClue("Bifur is the third legendary permanent, so the story is on before his trigger doubles") {
+                EnduringStoryService.has(game.state, game.player1Id) shouldBe true
+            }
+
+            // Two independent triggers, each choosing its own target — both aimed at the Bears here.
+            game.selectTargets(listOf(bears)).error shouldBe null
+            game.resolveStack()
+            withClue("the doubler produced a second instance of Bifur's own enters trigger") {
+                (game.getPendingDecision() is ChooseTargetsDecision) shouldBe true
+            }
+            game.selectTargets(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            plusOneCounters(game, bears) shouldBe 2
+        }
+
+        test("the doubler also fires for another Dwarf's trigger, and only with the story on") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Bifur, Melodic Rider")
+                .withCardOnBattlefield(1, "Fíli the Pathfinder")
+                .withCardOnBattlefield(1, "Thorin Oakenshield")
+                .withCardInHand(1, "Dwarven Mauler")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            EnduringStoryService.has(game.state, game.player1Id) shouldBe true
+
+            game.castSpell(1, "Dwarven Mauler").error shouldBe null
+            game.resolveStack()
+
+            withClue("Fíli's Dwarf-entering trigger is doubled by Bifur, so two tokens, not one") {
+                game.findPermanents("Dwarf Token").size shouldBe 2
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlamdringFoeHammerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlamdringFoeHammerScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Glamdring, Foe-hammer // Gleam of Death — {2} Legendary Artifact — Equipment.
+ *
+ *   Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature's power.
+ *   Equip {2}
+ *   Gleam of Death — {3}{U} Sorcery — Adventure: Mill six cards, then put all instant and sorcery
+ *   cards from among them into your hand.
+ *
+ * The reduction is the first `CostReductionSource` that reads a single permanent reached through the
+ * *reducing permanent's own attachment* instead of aggregating over what the caster controls, so it
+ * needed the ability's source id threaded into `CostCalculator.evaluateReduction`. The tests pin the
+ * three things that can go wrong with that: it reads the attached creature (not the caster's board),
+ * it reads the right *amount* (power, not a flat 1), and it reads 0 rather than throwing when
+ * Glamdring is equipping nothing.
+ *
+ * Divination is {2}{U}, so with one Island in play it is castable exactly when the reduction is 2 or
+ * more — which makes affordability a clean proxy for the reduction amount.
+ */
+class GlamdringFoeHammerScenarioTest : ScenarioTestBase() {
+
+    init {
+
+        test("equipped creature's power pays for the generic half of an instant or sorcery") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Hill Giant") // 3/3
+                .withCardAttachedTo(1, "Glamdring, Foe-hammer", "Hill Giant")
+                .withCardInHand(1, "Divination")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            withClue("{2}{U} minus the 3/3's power leaves {U}, payable by the single Island") {
+                game.castSpell(1, "Divination").error shouldBe null
+            }
+            game.resolveStack()
+            game.handSize(1) shouldBe 2
+        }
+
+        test("the amount is the equipped creature's power, not a flat discount") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Devoted Hero") // 1/2
+                .withCardAttachedTo(1, "Glamdring, Foe-hammer", "Devoted Hero")
+                .withCardInHand(1, "Divination")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            withClue("power 1 shaves only {1}, leaving {1}{U} — one Island can't pay it") {
+                game.castSpell(1, "Divination").error.shouldNotBeNull()
+            }
+        }
+
+        test("an unequipped Glamdring reduces nothing") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Glamdring, Foe-hammer")
+                .withCardOnBattlefield(1, "Hill Giant")
+                .withCardInHand(1, "Divination")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            withClue("nothing is attached, so X is 0 — the board's Hill Giant must not count") {
+                game.castSpell(1, "Divination").error.shouldNotBeNull()
+            }
+        }
+
+        test("Gleam of Death mills six and takes every instant and sorcery from among them") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Glamdring, Foe-hammer")
+                .withCardInLibrary(1, "Divination")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Divination")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 4)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val glamdring = game.findCardsInHand(1, "Glamdring, Foe-hammer").single()
+
+            game.execute(
+                CastSpell(playerId = game.player1Id, cardId = glamdring, faceIndex = 0)
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("all six cards were milled") {
+                game.librarySize(1) shouldBe 0
+            }
+            withClue("both Divinations were pulled out of the milled six — 'all', not 'up to one'") {
+                game.handSize(1) shouldBe 2
+                game.findCardsInHand(1, "Divination").size shouldBe 2
+            }
+            withClue("the four creatures stay in the graveyard") {
+                game.graveyardSize(1) shouldBe 4
+            }
+            withClue("CR 715.3d — the Adventure exiles itself, ready to be cast as the artifact") {
+                game.isInExile(1, "Glamdring, Foe-hammer") shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resumes and finishes the in-flight HOB worktree.

## Cards

**Balin, Loremaster** — {3}{R}{R} Legendary Creature — Dwarf Bard 4/4. Storied. "Whenever Balin or another Dwarf you control enters, you may discard your hand. Draw X cards, where X is the number of cards discarded this way. If you have an enduring story, Balin deals X damage to each opponent."

The "Balin or another Dwarf you control" half is the Fíli/Arahbo shape — a single `ANY`-bound enters trigger over `Dwarf.youControl()` covers both, since Balin matches his own filter. The `Gate.MayDecide` wraps *only* the discard, not the whole rider, so declining reads X = 0 (an unset `VariableReference` evaluates to 0) rather than skipping the mandatory draw and damage. The enduring-story clause is a resolution-time state test, not an intervening-if.

**Bifur, Melodic Rider** — {4}{R/W}{R/W} 4/5. Enters-or-attacks +1/+1 counter, plus "as long as you have an enduring story, if a triggered ability of a Dwarf you control triggers, that ability triggers an additional time." The doubler is the existing `AdditionalSourceTriggers` static with `excludeSelf = false` (the text says "a Dwarf you control", not "*another*" — the printed ruling confirms Bifur doubles his own trigger) and `condition = Conditions.YouHaveEnduringStory` on the field rather than a `ConditionalStaticAbility` wrapper, because `TriggerDetector.duplicateSourceTriggers` scans for a bare `AdditionalSourceTriggers` and would never see a wrapped one.

**Glamdring, Foe-hammer // Gleam of Death** — {2} Legendary Artifact — Equipment. "Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature's power." Equip {2}. The Adventure mills six and takes every instant and sorcery from among them (the Cantankerous Keepers filter-a-stored-collection shape, no selection step).

## Engine changes

**`CostReductionSource.AttachedPermanentProperty`** — the first reduction source that reads a *single* permanent found by walking the reducing permanent's own `AttachedToComponent`, rather than aggregating over a group the caster controls. That required threading the reducing ability's source id into `CostCalculator.evaluateReduction`; every other source only needs the caster. Parameterised over `EntityNumericProperty` to stay in line with its neighbours `GreatestPropertyAmongPermanentsYouControl` / `TotalPropertyAmongPermanentsYouControl`, and it shares their read rules — P/T from projected state (CR 613), so the equipped creature's counters, anthems, and Glamdring's own bonus all count. An unattached Equipment contributes 0, which is the correct reading of the oracle text, and negative power floors at 0.

**`resumeGatedEffect` now propagates pipeline storage.** It dropped the taken branch's `updatedCollections` / `updatedStoredNumbers` / `updatedChosenValues`, where `resumeEffect` right above it routes them through `exposeCollectionsToNextFrame`. A gate sitting *inside* a composite therefore lost whatever its branch gathered, and the same ability worked or not depending on whether the may-question was actually prompted: a skipped or auto-answered gate runs `then` synchronously and keeps its storage, while a prompted one lost it and the later sibling read an unset variable as 0. Balin is the first card to depend on this — it surfaced as his draw and damage both reading X = 0 after answering "yes". This is the same seam, and the same class of bug, as the earlier `RepeatWhile` / Bolg of the North fixes.

`docs/card-sdk-language-reference.md` gains both: the new reduction source, and a note under `GatedEffect` that pipeline storage crosses the gate.

## Verification

- `just build` — green, including `:mtg-sets` card lint and snapshots
- `just test` — green, 10842 rules-engine tests
- HOB card snapshot re-blessed; the diff is 296 added lines and nothing else moved, confirming the shared cost/continuation changes didn't shift any existing card
- `just check-card-printing` clean for all three (HOB is each card's earliest printing)

One test file per card, as required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)