### PR TITLE
Add Azog, Moria's Ruin

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2191,6 +2191,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   - `ForEachPlayerEffect(players, effects)` → `IterationSpace.Players(players)` — per matching
     player; `controllerId` rebound so `Player.You` is the current player, `opponentId` recomputed,
     fresh `storedCollections` (Winds of Change, Bend or Break, One Ring to Rule Them All).
+    Relational single-player references such as `Player.ControllerOf("target creature")` iterate
+    exactly that player, using last-known controller information if the permanent has left. If the
+    reference is undefined (for example, an optional target was not chosen), the loop is a no-op;
+    it never widens to every active player.
   - `ForEachInCollectionEffect(collection, effect)` → `IterationSpace.Collection(name)` — per
     entity of a named pipeline collection; `pipeline.iterationTarget` bound so `EffectTarget.Self`
     is the current entity; outer collections preserved (Fight or Flight).

--- a/manual-scenarios/cards/a/azog-morias-ruin.json
+++ b/manual-scenarios/cards/a/azog-morias-ruin.json
@@ -1,0 +1,35 @@
+{
+  "player1Name": "Azog",
+  "player2Name": "Moria Defender",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Azog, Moria's Ruin"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Grizzly Bears", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"},
+      {"name": "Glorious Anthem"},
+      {"name": "Chomping Changeling"},
+      {"name": "Omni-Changeling"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Grizzly Bears", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "step": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/AzogMoriasRuin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/AzogMoriasRuin.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Azog, Moria's Ruin — The Hobbit #61
+ * {2}{B} · Legendary Creature — Goblin Soldier · 1/3
+ *
+ * The target's projected power is frozen before it is destroyed, so the amass amount uses the
+ * creature's last-known power even after it leaves the battlefield. The relational player loop
+ * then resolves under that creature's last-known controller; this makes that player choose an
+ * Army when they control several. The outer condition is deliberately evaluated before the
+ * destruction so the final draw remembers whether Azog's controller controlled the creature.
+ */
+val AzogMoriasRuin = card("Azog, Moria's Ruin") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Goblin Soldier"
+    oracleText = "When Azog enters, destroy up to one other target creature. Its controller " +
+        "amasses Goblins X, where X is that creature's power. If you controlled that creature, " +
+        "draw a card. (To amass Goblins X, that player puts X +1/+1 counters on an Army they " +
+        "control. It's also a Goblin. If they don't control an Army, they create a 0/0 black " +
+        "Goblin Army creature token first.)"
+    power = 1
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "up to one other target creature",
+            TargetCreature(optional = true, filter = TargetFilter.OtherCreature),
+        )
+
+        val resolveForItsController = Effects.StoreNumber(
+            name = "azogTargetPower",
+            amount = DynamicAmounts.targetPower(),
+        ).then(
+            Effects.Destroy(creature),
+        ).then(
+            Effects.ForEachPlayer(
+                Player.ControllerOf("that creature"),
+                listOf(
+                    Effects.Amass(DynamicAmount.VariableReference("azogTargetPower"), "Goblin"),
+                ),
+            ),
+        )
+
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(GameObjectFilter.Creature.youControl()),
+            effect = resolveForItsController.then(Effects.DrawCards(1)),
+            elseEffect = resolveForItsController,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "61"
+        artist = "Miklós Ligeti"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/135da718-affc-46ba-be57-c12c23b54dad.jpg?1784798028"
+        ruling("2026-06-29", "If no target is chosen for Azog's ability, \"its controller\" is undefined and no player amasses Goblins.")
+        ruling("2026-06-29", "Use the power of the creature as it last existed on the battlefield to determine the value of X.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -194,6 +194,160 @@
     ]
 }
 
+// Azog, Moria's Ruin
+{
+    "name": "Azog, Moria's Ruin",
+    "manaCost": "{2}{B}",
+    "typeLine": "Legendary Creature — Goblin Soldier",
+    "oracleText": "When Azog enters, destroy up to one other target creature. Its controller amasses Goblins X, where X is that creature's power. If you controlled that creature, draw a card. (To amass Goblins X, that player puts X +1/+1 counters on an Army they control. It's also a Goblin. If they don't control an Army, they create a 0/0 black Goblin Army creature token first.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": "creature ctrl:you"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "StoreNumber",
+                                "name": "azogTargetPower",
+                                "amount": {
+                                    "type": "EntityProperty",
+                                    "entity": "Target",
+                                    "numericProperty": "Power"
+                                }
+                            },
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one other target creature"
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Players",
+                                    "players": {
+                                        "type": "ControllerOf",
+                                        "targetDescription": "that creature"
+                                    }
+                                },
+                                "body": {
+                                    "type": "Amass",
+                                    "amount": {
+                                        "type": "VariableReference",
+                                        "variableName": "azogTargetPower"
+                                    },
+                                    "subtype": "Goblin"
+                                }
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "StoreNumber",
+                                "name": "azogTargetPower",
+                                "amount": {
+                                    "type": "EntityProperty",
+                                    "entity": "Target",
+                                    "numericProperty": "Power"
+                                }
+                            },
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "up to one other target creature"
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Players",
+                                    "players": {
+                                        "type": "ControllerOf",
+                                        "targetDescription": "that creature"
+                                    }
+                                },
+                                "body": {
+                                    "type": "Amass",
+                                    "amount": {
+                                        "type": "VariableReference",
+                                        "variableName": "azogTargetPower"
+                                    },
+                                    "subtype": "Goblin"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature",
+                        "excludeSelf": true
+                    },
+                    "id": "up to one other target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "RARE",
+        "artist": "Miklós Ligeti",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/135da718-affc-46ba-be57-c12c23b54dad.jpg?1784798028",
+        "rulings": [
+            {
+                "date": "2026-06-29",
+                "text": "If no target is chosen for Azog's ability, \"its controller\" is undefined and no player amasses Goblins."
+            },
+            {
+                "date": "2026-06-29",
+                "text": "Use the power of the creature as it last existed on the battlefield to determine the value of X."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Balin, Loremaster
 {
     "name": "Balin, Loremaster",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
@@ -212,13 +212,12 @@ class ForEachExecutor(
             Player.TargetOpponent, Player.TargetPlayer -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
-            // Single-player references (e.g. ControllerOf a targeted spell — Fear of Impostors'
-            // "its controller manifests dread") resolve to exactly that player. Fall back to all
-            // active players only when the reference yields nothing (a truly multi-player or
-            // unresolved ref).
-            else -> TargetResolutionUtils.resolvePlayerRef(player, context, state)
-                ?.let { listOf(it) }
-                ?: state.activePlayers
+            // Single-player references (e.g. ControllerOf a targeted permanent — Unwanted
+            // Remake's "its controller manifests dread") resolve to exactly that player. An
+            // unresolved reference means there is nobody to iterate, not "every player": that
+            // distinction is load-bearing for optional-target abilities whose "its controller"
+            // rider must do nothing when no target was chosen.
+            else -> listOfNotNull(TargetResolutionUtils.resolvePlayerRef(player, context, state))
         }
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachRelationalPlayerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachRelationalPlayerTest.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.engine.handlers.effects.composite
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ForEachEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/** Regression coverage for relational single-player loops with no referent. */
+class ForEachRelationalPlayerTest : FunSpec({
+
+    test("an unresolved ControllerOf reference iterates nobody rather than every active player") {
+        var executions = 0
+        val executor = ForEachExecutor { state, _, _ ->
+            executions += 1
+            EffectResult.success(state)
+        }
+        val player1 = EntityId("player-1")
+        val player2 = EntityId("player-2")
+        val state = GameState(turnOrder = listOf(player1, player2))
+        val effect = Effects.ForEachPlayer(
+            Player.ControllerOf("optional target creature"),
+            listOf(Effects.DrawCards(1)),
+        ) as ForEachEffect
+
+        val result = executor.execute(
+            state,
+            effect,
+            EffectContext(sourceId = null, controllerId = player1, targets = emptyList()),
+        )
+
+        result.error shouldBe null
+        executions shouldBe 0
+        result.state shouldBe state
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AzogMoriasRuinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AzogMoriasRuinScenarioTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Azog, Moria's Ruin — The Hobbit #61.
+ *
+ * Pins the linked sequence: optional other target, frozen last-known power, destruction, amass by
+ * the creature's controller, and the controller-sensitive draw rider.
+ */
+class AzogMoriasRuinScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.goblinArmyControlledBy(playerId: EntityId): EntityId? =
+        state.getBattlefield().firstOrNull { id ->
+            state.getEntity(id)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name ==
+                "Goblin Army" && state.projectedState.getController(id) == playerId
+        }
+
+    private fun TestGame.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    private fun TestGame.castAzog(target: EntityId?) {
+        castSpell(1, "Azog, Moria's Ruin").error shouldBe null
+        resolveStack()
+        if (hasPendingDecision()) {
+            selectTargets(listOfNotNull(target)).error shouldBe null
+        }
+        resolveStack()
+    }
+
+    init {
+        cardRegistry.register(card("Azog Test Army Alpha") {
+            manaCost = "{0}"
+            typeLine = "Creature — Zombie Army"
+            power = 2
+            toughness = 2
+        })
+        cardRegistry.register(card("Azog Test Army Beta") {
+            manaCost = "{0}"
+            typeLine = "Creature — Zombie Army"
+            power = 2
+            toughness = 2
+        })
+
+        context("Azog's enters ability") {
+
+            test("uses the opponent creature's projected last-known power and that opponent amasses") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Azog, Moria's Ruin")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardOnBattlefield(2, "Glorious Anthem")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val target = game.findPermanent("Hill Giant")!!
+
+                game.castAzog(target)
+
+                game.isInGraveyard(2, "Hill Giant") shouldBe true
+                val army = game.goblinArmyControlledBy(game.player2Id)
+                withClue("Hill Giant was 4/4 under Glorious Anthem before it left") {
+                    army shouldBe (army ?: error("opponent did not create a Goblin Army"))
+                    game.plusOneCounters(army) shouldBe 4
+                }
+                game.goblinArmyControlledBy(game.player1Id) shouldBe null
+                withClue("Azog's controller did not control the target, so no card is drawn") {
+                    game.handSize(1) shouldBe 0
+                }
+            }
+
+            test("its controller draws after destroying and amassing from their own creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Azog, Moria's Ruin")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val target = game.findPermanent("Grizzly Bears")!!
+
+                game.castAzog(target)
+
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                val army = game.goblinArmyControlledBy(game.player1Id)
+                army shouldBe (army ?: error("Azog's controller did not create a Goblin Army"))
+                game.plusOneCounters(army) shouldBe 2
+                game.handSize(1) shouldBe 1
+            }
+
+            test("choosing no target destroys nothing, amasses nothing, and draws nothing") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Azog, Moria's Ruin")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castAzog(target = null)
+
+                game.goblinArmyControlledBy(game.player1Id) shouldBe null
+                game.goblinArmyControlledBy(game.player2Id) shouldBe null
+                game.handSize(1) shouldBe 0
+            }
+
+            test("the affected controller chooses which of their Armies receives the counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Azog, Moria's Ruin")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withCardOnBattlefield(2, "Hill Giant")
+                    .withCardOnBattlefield(2, "Azog Test Army Alpha")
+                    .withCardOnBattlefield(2, "Azog Test Army Beta")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val target = game.findPermanent("Hill Giant")!!
+                val alpha = game.findPermanent("Azog Test Army Alpha")!!
+                val beta = game.findPermanent("Azog Test Army Beta")!!
+
+                game.castSpell(1, "Azog, Moria's Ruin").error shouldBe null
+                game.resolveStack()
+                game.selectTargets(listOf(target)).error shouldBe null
+                game.resolveStack()
+
+                val choice = game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+                choice.playerId shouldBe game.player2Id
+                choice.options.toSet() shouldBe setOf(alpha, beta)
+                game.selectCards(listOf(beta)).error shouldBe null
+                game.resolveStack()
+
+                game.plusOneCounters(alpha) shouldBe 0
+                game.plusOneCounters(beta) shouldBe 3
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AzogMoriasRuinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AzogMoriasRuinScenarioTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Phase
@@ -101,6 +102,38 @@ class AzogMoriasRuinScenarioTest : ScenarioTestBase() {
                 army shouldBe (army ?: error("Azog's controller did not create a Goblin Army"))
                 game.plusOneCounters(army) shouldBe 2
                 game.handSize(1) shouldBe 1
+            }
+
+            test("uses projected control and preserves that controller through destruction") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Threaten")
+                    .withCardInHand(1, "Azog, Moria's Ruin")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                val target = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Threaten", target).error shouldBe null
+                game.resolveStack()
+                withClue("Threaten changes projected control without rewriting base ownership/control") {
+                    game.state.projectedState.getController(target) shouldBe game.player1Id
+                    game.state.getEntity(target)?.get<ControllerComponent>()?.playerId shouldBe game.player2Id
+                }
+
+                game.castAzog(target)
+
+                game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                val army = game.goblinArmyControlledBy(game.player1Id)
+                army shouldBe (army ?: error("the stolen creature's last-known controller did not amass"))
+                game.plusOneCounters(army) shouldBe 2
+                game.goblinArmyControlledBy(game.player2Id) shouldBe null
+                game.handSize(1) shouldBe 1
+                game.handSize(2) shouldBe 0
             }
 
             test("choosing no target destroys nothing, amasses nothing, and draws nothing") {


### PR DESCRIPTION
## Summary

- add Azog, Moria's Ruin to The Hobbit with its optional ETB target, frozen last-known power, destruction, affected-controller amass, and controller-sensitive draw
- make unresolved relational single-player `ForEach` references a no-op instead of widening to every active player
- document that relational iteration contract and add a manual client scenario

## Capability design and reuse

Azog composes existing `StoreNumber`, `Destroy`, `ForEachPlayer(Player.ControllerOf(...))`, `Amass`, and conditional/draw primitives. The only engine change corrects the general unresolved-reference semantics used by any optional-target “its controller” rider; no card-specific engine code or new SDK/mtgish IR type was added. Existing targeting and `SelectCardsDecision` UI paths cover the player flow.

## Verification

Passed:
- `just test-class ForEachRelationalPlayerTest`
- `just test-class AzogMoriasRuinScenarioTest` (projected/LKI power, opponent/self controller branches, no target, affected-controller multi-Army choice)
- `just rebless-cards` (only Azog added to `HOB.json`)
- `just check-card-printing "Azog, Moria's Ruin"`
- `just check-backlog`
- image URI HTTP 200
- `git diff --check`

Full gate:
- `just test` ran; 10,893 of 10,894 rules-engine tests passed and the other module suites reported passing before the gate stopped.
- One unrelated existing failure remains: `FlourishingBloomKinScenarioTest` (`Expected value to not be null, but was null`). Neither Flourishing Bloom-Kin nor its test is touched by this diff.

Checks not performed:
- no E2E run because this adds no new visual or decision type
- no mtgish emitter work because no new SDK primitive or IR capability was introduced

Independent review is pending.