### PR TITLE
[agent-loop: gpt-5.6-sol] Add Kíli the Resourceful to The Hobbit

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5881,8 +5881,10 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   .canEquipAtInstantSpeed` (enumerator) and `ActivateAbilityHandler.validate` (submit path), both
   keyed on `ActivatedAbility.isEquipAbility`.
 - `FreeFirstEquipEachTurn` — the controller may pay {0} rather than the equip cost of the **first**
-  equip ability they activate during each of their turns (Forge Anew). The engine zeroes the whole
-  cost (colored pips included) of the turn's first equip while the per-player
+  equip ability they activate each turn (Kíli the Resourceful; Forge Anew's separate timing gate
+  confines its equip activations to its controller's turns). This is
+  an alternative activation cost: it replaces the whole equip cost, including colored mana and
+  nonmana parts such as paying life, while the per-player
   `EquipActivationsThisTurnComponent.count == 0`, and increments that counter on every equip
   activation (reset at turn start by `TurnManager`).
 - `ReduceEquipCost(amount, onlyIfTargetIsSource = false, onlyOwnEquip = false)` — the controller's equip abilities cost

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -1407,15 +1407,16 @@ data object EquipAbilitiesAtInstantSpeed : StaticAbility {
 }
 
 /**
- * The controller may pay {0} rather than the equip cost of the first equip ability they
- * activate during each of their turns (Forge Anew). The engine zeroes the mana cost of the
- * controller's first equip activation each turn while this is active and tracks the count via
- * the per-turn `EquipActivationsThisTurnComponent`.
+ * The controller may pay {0} rather than the equip cost of the first equip ability they activate
+ * each turn (Kíli the Resourceful; Forge Anew narrows the usable timing to its controller's turns).
+ * The {0} is an alternative cost for the activation and replaces the entire equip cost, including
+ * nonmana parts. The engine
+ * tracks the activation count via the per-turn `EquipActivationsThisTurnComponent`.
  */
 @SerialName("FreeFirstEquipEachTurn")
 @Serializable
 data object FreeFirstEquipEachTurn : StaticAbility {
-    override val description: String = "You may pay {0} rather than pay the equip cost of the first equip ability you activate during each of your turns"
+    override val description: String = "You may pay {0} rather than pay the equip cost of the first equip ability you activate each turn"
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/KiliTheResourceful.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/KiliTheResourceful.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.storied
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.FreeFirstEquipEachTurn
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Kíli the Resourceful
+ * {1}{W}
+ * Legendary Creature — Dwarf Scout
+ * 1/2
+ *
+ * Storied.
+ * As long as you have an enduring story, you may pay {0} rather than pay the equip cost of the
+ * first equip ability you activate each turn.
+ * Whenever another Dwarf or Equipment you control enters, draw a card. This ability triggers only
+ * once each turn.
+ *
+ * Dwarf and Equipment are both subtypes, so one union filter models the printed "or" without
+ * double-triggering for an object that has both. `excludeSelf` carries "another"; Kíli otherwise
+ * matches the Dwarf half of her own trigger.
+ */
+val KiliTheResourceful = card("Kíli the Resourceful") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Dwarf Scout"
+    oracleText = "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you " +
+        "have an enduring story for the rest of the game.)\n" +
+        "As long as you have an enduring story, you may pay {0} rather than pay the equip cost " +
+        "of the first equip ability you activate each turn.\n" +
+        "Whenever another Dwarf or Equipment you control enters, draw a card. This ability " +
+        "triggers only once each turn."
+    power = 1
+    toughness = 2
+
+    storied()
+
+    staticAbility {
+        condition = Conditions.YouHaveEnduringStory
+        ability = FreeFirstEquipEachTurn
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Any
+                .withAnyOfSubtypes(listOf(Subtype.DWARF, Subtype.EQUIPMENT))
+                .youControl(),
+            binding = TriggerBinding.OTHER,
+        )
+        oncePerTurn = true
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "17"
+        artist = "Yuhong Ding"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/1805532f-6d99-47d0-9529-5f5831a7fdc8.jpg?1785496242"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -6885,6 +6885,69 @@
     }
 }
 
+// Kíli the Resourceful
+{
+    "name": "Kíli the Resourceful",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Dwarf Scout",
+    "oracleText": "Storied (If you control three or more artifacts, legendaries, and/or Sagas, you have an enduring story for the rest of the game.)\nAs long as you have an enduring story, you may pay {0} rather than pay the equip cost of the first equip ability you activate each turn.\nWhenever another Dwarf or Equipment you control enters, draw a card. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "STORIED"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Dwarf",
+                                    "Equipment"
+                                ]
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": "FreeFirstEquipEachTurn",
+                "condition": "PlayerHasEnduringStory"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "RARE",
+        "artist": "Yuhong Ding",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/1805532f-6d99-47d0-9529-5f5831a7fdc8.jpg?1785496242"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Lake-town
 {
     "name": "Lake-town",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -615,11 +615,12 @@ class CastPermissionUtils(
     }
 
     /**
-     * Zero the mana cost of [cost] when [ability] is an equip ability, [playerId] has an active
+     * Replace [cost] with {0} when [ability] is an equip ability, [playerId] has an active
      * [FreeFirstEquipEachTurn] grant (Forge Anew), and this is their first equip this turn
      * (`EquipActivationsThisTurnComponent.count == 0`). Shared by the enumerator (offered/displayed
      * cost) and [ActivateAbilityHandler] (paid cost) so the two always agree. "Pay {0} rather than
-     * pay the equip cost" zeroes the whole cost, including any colored pips.
+     * pay the equip cost" is an alternative cost for the activation, so it replaces every part of
+     * the equip cost, including nonmana costs such as paying life.
      */
     fun applyFreeFirstEquipDiscount(
         cost: AbilityCost,
@@ -631,14 +632,7 @@ class CastPermissionUtils(
         val activations = state.getEntity(playerId)?.get<EquipActivationsThisTurnComponent>()?.count ?: 0
         if (activations > 0) return cost
         if (!hasFreeFirstEquip(state, playerId)) return cost
-        return when (cost) {
-            is AbilityCost.Atom ->
-                if (cost.manaCostOrNull != null) AbilityCost.Atom(CostAtom.Mana(ManaCost.ZERO)) else cost
-            is AbilityCost.Composite -> AbilityCost.Composite(cost.costs.map {
-                if (it.manaCostOrNull != null) AbilityCost.Atom(CostAtom.Mana(ManaCost.ZERO)) else it
-            })
-            else -> cost
-        }
+        return AbilityCost.Atom(CostAtom.Mana(ManaCost.ZERO))
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KiliTheResourcefulScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KiliTheResourcefulScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.enduringstory.EnduringStoryService
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.DwarvenMauler
+import com.wingedsheep.mtg.sets.definitions.hob.cards.KiliTheResourceful
+import com.wingedsheep.mtg.sets.definitions.hob.cards.MyPrecious
+import com.wingedsheep.mtg.sets.definitions.hob.cards.ThorinOakenshield
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kíli the Resourceful — conditional first-equip alternative cost and a once-per-turn Dwarf or
+ * Equipment enters trigger.
+ *
+ * My Precious is the regression fixture for the equip clause: its printed cost combines {2} and
+ * paying 2 life. Kíli's {0} replaces that complete cost rather than acting as a mana reduction.
+ */
+class KiliTheResourcefulScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + KiliTheResourceful + DwarvenMauler + MyPrecious + ThorinOakenshield
+        )
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    val equipId = MyPrecious.activatedAbilities.first().id
+
+    test("with an enduring story the first composite equip costs exactly zero") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Kíli the Resourceful")
+        driver.putCreatureOnBattlefield(you, "Thorin Oakenshield")
+        val firstTarget = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val secondTarget = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val precious = driver.putPermanentOnBattlefield(you, "My Precious")
+
+        EnduringStoryService.has(driver.state, you) shouldBe true
+
+        // No mana is available. The alternative cost also replaces "Pay 2 life".
+        driver.submit(
+            ActivateAbility(you, precious, equipId, targets = listOf(ChosenTarget.Permanent(firstTarget)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.lifeTotal(you) shouldBe 20
+        driver.state.getEntity(precious)?.get<AttachedToComponent>()?.targetId shouldBe firstTarget
+
+        // The use is spent: the next activation has the printed {2}, Pay 2 life cost.
+        driver.submitExpectFailure(
+            ActivateAbility(you, precious, equipId, targets = listOf(ChosenTarget.Permanent(secondTarget)))
+        )
+        driver.giveColorlessMana(you, 2)
+        driver.submit(
+            ActivateAbility(you, precious, equipId, targets = listOf(ChosenTarget.Permanent(secondTarget)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.lifeTotal(you) shouldBe 18
+        driver.state.getEntity(precious)?.get<AttachedToComponent>()?.targetId shouldBe secondTarget
+    }
+
+    test("without an enduring story My Precious keeps its full composite equip cost") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Kíli the Resourceful")
+        val target = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val precious = driver.putPermanentOnBattlefield(you, "My Precious")
+
+        EnduringStoryService.has(driver.state, you) shouldBe false
+        driver.submitExpectFailure(
+            ActivateAbility(you, precious, equipId, targets = listOf(ChosenTarget.Permanent(target)))
+        )
+
+        driver.giveColorlessMana(you, 2)
+        driver.submit(
+            ActivateAbility(you, precious, equipId, targets = listOf(ChosenTarget.Permanent(target)))
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.lifeTotal(you) shouldBe 18
+    }
+
+    test("another Dwarf entering draws only once each turn") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Kíli the Resourceful")
+        val firstDwarf = driver.putCardInHand(you, "Dwarven Mauler")
+        val secondDwarf = driver.putCardInHand(you, "Dwarven Mauler")
+
+        val handBeforeFirst = driver.getHandSize(you)
+        driver.giveMana(you, Color.RED)
+        driver.castSpell(you, firstDwarf).isSuccess shouldBe true
+        driver.bothPass() // Resolve the Dwarf.
+        driver.bothPass() // Resolve Kíli's draw trigger.
+        driver.getHandSize(you) shouldBe handBeforeFirst
+
+        val handBeforeSecond = driver.getHandSize(you)
+        driver.giveMana(you, Color.RED)
+        driver.castSpell(you, secondDwarf).isSuccess shouldBe true
+        driver.bothPass()
+        driver.getHandSize(you) shouldBe handBeforeSecond - 1
+    }
+
+    test("another Equipment entering draws a card") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Kíli the Resourceful")
+        val equipment = driver.putCardInHand(you, "My Precious")
+
+        val handBefore = driver.getHandSize(you)
+        driver.giveColorlessMana(you, 3)
+        driver.castSpell(you, equipment).isSuccess shouldBe true
+        driver.bothPass() // Resolve the Equipment.
+        driver.bothPass() // Resolve Kíli's draw trigger.
+        driver.getHandSize(you) shouldBe handBefore
+    }
+})


### PR DESCRIPTION
## Summary
- add Kíli the Resourceful using existing Storied, conditional static ability, subtype-union trigger, and once-per-turn primitives
- treat the first-equip {0} permission as a complete alternative activation cost, including nonmana cost atoms
- document the corrected SDK semantics and add focused gameplay coverage for both trigger branches and composite equip costs

## Verification
- just test-class KiliTheResourcefulScenarioTest
- just rebless-cards (HOB diff contains only Kíli)
- just check-card-printing Kíli the Resourceful
- just test
- git diff --check

## Review
Reviewed after merging current origin/main. No blocking, important, or minor findings remain. No new SDK vocabulary, event, server contract, or client behavior was introduced.

Agentic set loop driven by gpt-5.6-sol.