### PR TITLE
[agent-loop: gpt-5.6-sol] Add Roads Go Ever, Ever On to The Hobbit

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RoadsGoEverEverOn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/RoadsGoEverEverOn.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Roads Go Ever, Ever On
+ * {1}{W}
+ * Enchantment — Saga
+ *
+ * I — Search your library for up to two basic Plains cards, exile them, then shuffle. You gain 2 life.
+ * II, III — Put a card exiled with this Saga into its owner's hand.
+ * IV — Whenever you attack this turn, target creature you control gets +1/+1 until end of turn for
+ * each Plains you control.
+ *
+ * Chapter I links the selected cards to the Saga. Chapters II and III gather that live linked pile
+ * and let the player choose one card rather than taking an arbitrary entry. Chapter IV installs an
+ * event-based delayed trigger; its target and Plains count are chosen/evaluated when that trigger
+ * fires, not when the chapter resolves.
+ */
+val RoadsGoEverEverOn = card("Roads Go Ever, Ever On") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Saga"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\n" +
+        "I — Search your library for up to two basic Plains cards, exile them, then shuffle. You gain 2 life.\n" +
+        "II, III — Put a card exiled with this Saga into its owner's hand.\n" +
+        "IV — Whenever you attack this turn, target creature you control gets +1/+1 until end of " +
+        "turn for each Plains you control."
+
+    sagaChapter(1) {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        Zone.LIBRARY,
+                        Player.You,
+                        GameObjectFilter.BasicLand.withSubtype("Plains"),
+                    ),
+                    storeAs = "roadsSearchable",
+                ),
+                SelectFromCollectionEffect(
+                    from = "roadsSearchable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    storeSelected = "roadsExiled",
+                    prompt = "Search your library for up to two basic Plains cards",
+                ),
+                MoveCollectionEffect(
+                    from = "roadsExiled",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    linkToSource = true,
+                ),
+                ShuffleLibraryEffect(),
+                Effects.GainLife(2),
+            )
+        )
+    }
+
+    sagaChapter(2) { effect = returnChosenRoad() }
+    sagaChapter(3) { effect = returnChosenRoad() }
+
+    sagaChapter(4) {
+        val plainsCount = DynamicAmounts.battlefield(
+            Player.You,
+            GameObjectFilter.Land.withSubtype("Plains"),
+        ).count()
+        effect = CreateDelayedTriggerEffect(
+            trigger = Triggers.YouAttack,
+            targetRequirement = TargetCreature(filter = TargetFilter.Creature.youControl()),
+            effect = Effects.ModifyStats(
+                power = plainsCount,
+                toughness = plainsCount,
+                target = EffectTarget.ContextTarget(0),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "25"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3c1ebd6-967f-4b8c-8f1f-442ce8c1da24.jpg?1784673434"
+    }
+}
+
+private fun returnChosenRoad() = Effects.Composite(
+    listOf(
+        GatherCardsEffect(
+            source = CardSource.FromLinkedExile(),
+            storeAs = "roadsLinked",
+        ),
+        SelectFromCollectionEffect(
+            from = "roadsLinked",
+            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+            storeSelected = "roadsReturned",
+            prompt = "Choose a card exiled with Roads Go Ever, Ever On to put into its owner's hand",
+        ),
+        MoveCollectionEffect(
+            from = "roadsReturned",
+            destination = CardDestination.ToZone(Zone.HAND),
+            unlinkFromSource = true,
+        ),
+    )
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -9961,6 +9961,177 @@
     ]
 }
 
+// Roads Go Ever, Ever On
+{
+    "name": "Roads Go Ever, Ever On",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Saga",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — Search your library for up to two basic Plains cards, exile them, then shuffle. You gain 2 life.\nII, III — Put a card exiled with this Saga into its owner's hand.\nIV — Whenever you attack this turn, target creature you control gets +1/+1 until end of turn for each Plains you control.",
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland Plains"
+                            },
+                            "storeAs": "roadsSearchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "roadsSearchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeSelected": "roadsExiled",
+                            "prompt": "Search your library for up to two basic Plains cards"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "roadsExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        },
+                        "ShuffleLibrary",
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "roadsLinked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "roadsLinked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "roadsReturned",
+                            "prompt": "Choose a card exiled with Roads Go Ever, Ever On to put into its owner's hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "roadsReturned",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "unlinkFromSource": true
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "roadsLinked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "roadsLinked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "roadsReturned",
+                            "prompt": "Choose a card exiled with Roads Go Ever, Ever On to put into its owner's hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "roadsReturned",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "unlinkFromSource": true
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 4,
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "land Plains"
+                        },
+                        "toughnessModifier": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "land Plains"
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "trigger": {
+                        "event": "YouAttackEvent",
+                        "binding": "ANY"
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "RARE",
+        "artist": "Rovina Cai",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3c1ebd6-967f-4b8c-8f1f-442ce8c1da24.jpg?1784673434"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Roll-Roll-Roll-Roll
 {
     "name": "Roll-Roll-Roll-Roll",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RoadsGoEverEverOnScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RoadsGoEverEverOnScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.RoadsGoEverEverOn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/** Roads Go Ever, Ever On — linked-exile chapters and the targeted attack trigger from chapter IV. */
+class RoadsGoEverEverOnScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + RoadsGoEverEverOn)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.drain(target: EntityId? = null) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard < 100) {
+            when (state.pendingDecision) {
+                is ChooseTargetsDecision -> submitTargetSelection(activePlayer!!, listOfNotNull(target))
+                is SelectCardsDecision -> {
+                    val decision = state.pendingDecision as SelectCardsDecision
+                    submitCardSelection(decision.playerId, decision.options.take(decision.maxSelections))
+                }
+                null -> bothPass()
+                else -> autoResolveDecision()
+            }
+            guard++
+        }
+    }
+
+    fun GameTestDriver.advanceToMain(nthControllerTurn: Int) {
+        val targetTurn = nthControllerTurn * 2 - 1
+        var guard = 0
+        while (!(state.turnNumber == targetTurn && state.step == Step.PRECOMBAT_MAIN) && guard < 500) {
+            when {
+                state.pendingDecision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+            guard++
+        }
+    }
+
+    fun GameTestDriver.castRoads(controller: EntityId): EntityId {
+        giveMana(controller, Color.WHITE)
+        giveColorlessMana(controller, 1)
+        val saga = putCardInHand(controller, "Roads Go Ever, Ever On")
+        castSpell(controller, saga).isSuccess shouldBe true
+        drain()
+        return saga
+    }
+
+    test("chapter I exiles up to two basic Plains linked to the Saga and gains 2 life") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+        val saga = driver.castRoads(controller)
+
+        driver.state.lifeTotal(controller) shouldBe 22
+        driver.state.getEntity(saga)?.get<LinkedExileComponent>()?.exiledIds?.size shouldBe 2
+        driver.getExile(controller).size shouldBe 2
+    }
+
+    test("chapters II and III each return a chosen linked card to its owner's hand") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+        val saga = driver.castRoads(controller)
+
+        driver.advanceToMain(2)
+        driver.drain()
+        driver.state.getEntity(saga)?.get<LinkedExileComponent>()?.exiledIds?.size shouldBe 1
+
+        driver.advanceToMain(3)
+        driver.drain()
+        driver.state.getEntity(saga)?.get<LinkedExileComponent>()?.exiledIds shouldBe emptyList()
+        driver.getExile(controller) shouldBe emptyList()
+    }
+
+    test("chapter IV makes each attack this turn target and pump a creature by the live Plains count") {
+        val driver = createDriver()
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+        val attacker = driver.putCreatureOnBattlefield(controller, "Centaur Courser")
+        driver.removeSummoningSickness(attacker)
+        repeat(3) { driver.putPermanentOnBattlefield(controller, "Plains") }
+        driver.castRoads(controller)
+
+        driver.advanceToMain(2)
+        driver.drain()
+        driver.advanceToMain(3)
+        driver.drain()
+        driver.advanceToMain(4)
+        driver.drain()
+        driver.state.delayedTriggers.size shouldBe 1
+
+        driver.putPermanentOnBattlefield(controller, "Plains")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(controller, listOf(attacker), opponent).error shouldBe null
+        driver.drain(target = attacker)
+
+        driver.state.projectedState.getPower(attacker) shouldBe 7
+        driver.state.projectedState.getToughness(attacker) shouldBe 7
+    }
+})


### PR DESCRIPTION
## Summary
- implement Roads Go Ever, Ever On using existing Saga, linked-exile, delayed-trigger, and dynamic-amount primitives
- add a dedicated scenario test covering all four chapters and live Plains-count evaluation
- refresh the HOB card-definition snapshot

This PR was produced by the autonomous agent loop driven by gpt-5.6-sol.

## Verification
- `just test-class RoadsGoEverEverOnScenarioTest`
- `just rebless-cards`
- `just check-card-printing "Roads Go Ever, Ever On"`
- `just build`

## Review
No blocking, important, or minor findings. The card composes existing SDK primitives and the tests exercise the linked-exile flow, delayed target selection, and live Plains count.

## UX
No manual playthrough, UX pass, or end-to-end test was performed. The card uses existing library-selection, card-selection, and target-selection decision flows.