### PR TITLE
DDQ Extra: printings + six new cardDefs (dao-desk-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,8 @@ gradle-app.setting
 # Claude Code local-only files (auto-loaded, machine/contributor-specific — never commit)
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Local Python / knowledge-index artifacts (never commit)
+__pycache__/
+*.py[cod]
+/uncommitted/

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4872,6 +4872,13 @@ copy of it (CR 707.10e). The activated-ability analogue of the spell-level `cant
 > `Triggers.youCastSpell(GameObjectFilter.Instant, requires = setOf(SpellCastPredicate.CastFromZone(Zone.HAND)))`
 > → `GrantKeywordToSpellEffect(Keyword.REBOUND, EffectTarget.TriggeringEntity)`.
 
+> **Undying** (CR 702.92). `keywords(Keyword.UNDYING)` — "When this creature dies, if it had no +1/+1
+> counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it."
+> Modeled like **Persist**: a synthesized SELF dies-trigger detected in
+> `DeathAndLeaveTriggerDetector.detectUndyingTriggers`, gated on last-known +1/+1 counter count being
+> zero and suppressed on tokens (704.5s). The synthesized effect is `MoveToZoneEffect(Self, BATTLEFIELD)`
+> then `AddCountersEffect(+1/+1, 1, Self)`.
+
 > **Enduring** (Duskmourn Glimmer cycle). `card { enduring() }` wires the full mechanic: "When this
 > permanent dies, if it was a creature, return it to the battlefield under its owner's control. It's an
 > enchantment. (It's not a creature.)" Modeled like **Persist** — a synthesized SELF dies-trigger detected
@@ -4910,7 +4917,7 @@ Flying, Menace, Intimidate, Fear, Shadow, Horsemanship, all basic landwalks (Pla
 `LandwalkRule` checks `typeLine.isLand && !isBasicLand`; Trailblazer's Boots), First Strike, Double
 Strike, Trample, Deathtouch, Lifelink, Vigilance, Reach, Provoke, Defender, Indestructible, Hexproof, Shroud, Haste,
 Flash, Prowess, Flurry, Changeling, Convoke, Delve, Affinity, Storm, Flashback, Harmonize, Evoke, Sneak, Ninjutsu, Impending, Conspire, Casualty, Miracle, Hideaway, Cascade, Plot,
-Offspring, Persist, Enduring, Ascend, Wither, Toxic, Eerie, Vivid, Fateful Bite, Exploit, … (display-only — engine effect lives in handlers or
+Offspring, Persist, Undying, Enduring, Ascend, Wither, Toxic, Eerie, Vivid, Fateful Bite, Exploit, … (display-only — engine effect lives in handlers or
 composite abilities).
 
 **Parameterized `KeywordAbility.*`**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -257,6 +257,19 @@ enum class Keyword(val displayName: String) {
     PERSIST("Persist"),
 
     /**
+     * Undying (CR 702.92).
+     * "When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield
+     * under its owner's control with a +1/+1 counter on it."
+     *
+     * Modeled like [PERSIST]: a synthesized self-return triggered ability detected in
+     * [com.wingedsheep.engine.event.DeathAndLeaveTriggerDetector.detectUndyingTriggers]. Fires
+     * only when the dying nontoken creature had no +1/+1 counters (intervening-if); suppressed
+     * on tokens (they cease to exist via 704.5s before any return could happen). Cards declare
+     * `keywords(Keyword.UNDYING)`; the engine synthesizes the return + counter effect.
+     */
+    UNDYING("Undying"),
+
+    /**
      * Enduring (Duskmourn: House of Horror — the Glimmer "Enduring" cycle).
      * "When this permanent dies, if it was a creature, return it to the battlefield under its
      * owner's control. It's an enchantment. (It's not a creature.)"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AppetiteForBrains.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/AppetiteForBrains.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Appetite for Brains
+ * {B}
+ * Sorcery
+ *
+ * Target opponent reveals their hand. You choose a card from it with mana value 4 or greater
+ * and exile that card.
+ *
+ * Canonical AVR printing. Same RevealHand → Gather → Select → exile pipeline as Aggressive
+ * Negotiations, filtered to mana value ≥ 4.
+ */
+val AppetiteForBrains = card("Appetite for Brains") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You choose a card from it with mana value " +
+        "4 or greater and exile that card."
+
+    spell {
+        val opponent = target("target opponent", Targets.Opponent)
+
+        effect = Effects.Composite(
+            listOf(
+                RevealHandEffect(opponent),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.HAND,
+                        player = Player.ContextPlayer(0),
+                        filter = GameObjectFilter.Any.manaValueAtLeast(4),
+                    ),
+                    storeAs = "mv4Plus",
+                ),
+                SelectFromCollectionEffect(
+                    from = "mv4Plus",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    storeSelected = "chosenCard",
+                    prompt = "Choose a card with mana value 4 or greater to exile",
+                ),
+                MoveCollectionEffect(
+                    from = "chosenCard",
+                    destination = CardDestination.ToZone(Zone.EXILE, Player.ContextPlayer(0)),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Michael C. Hayes"
+        flavorText = "Just as with a peach, the first bite is always the juiciest."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/0/6/062ee892-cce7-42bd-97c7-032cec61faca.jpg?1783940710"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BarterInBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/BarterInBloodReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barter in Blood reprint in AVR. Canonical CardDefinition lives in its earliest set.
+ */
+val BarterInBloodReprint = Printing(
+    oracleId = "9167998d-5cac-47d7-99f2-f38122f7b8e7",
+    name = "Barter in Blood",
+    setCode = "AVR",
+    collectorNumber = "85",
+    scryfallId = "39b4fab6-73ce-4a56-a305-4d2e93dbb4ee",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39b4fab6-73ce-4a56-a305-4d2e93dbb4ee.jpg",
+    releaseDate = "2012-05-04",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ButcherGhoul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ButcherGhoul.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Butcher Ghoul
+ * {1}{B}
+ * Creature — Zombie
+ * 1/1
+ * Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield
+ * under its owner's control with a +1/+1 counter on it.)
+ */
+val ButcherGhoul = card("Butcher Ghoul") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    oracleText =
+        "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the " +
+            "battlefield under its owner's control with a +1/+1 counter on it.)"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.UNDYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Christopher Moeller"
+        flavorText = "Without a mind, it doesn't fear death. Without a soul, it doesn't mind killing."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/4/4/44a91e62-e946-4101-8cef-d1c147caebf2.jpg?1783940705"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CaptainOfTheMists.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CaptainOfTheMists.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Captain of the Mists
+ * {2}{U}
+ * Creature — Human Wizard
+ * 2/3
+ * Whenever another Human you control enters, untap this creature.
+ * {1}{U}, {T}: You may tap or untap target permanent.
+ */
+val CaptainOfTheMists = card("Captain of the Mists") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText =
+        "Whenever another Human you control enters, untap this creature.\n" +
+            "{1}{U}, {T}: You may tap or untap target permanent."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.HUMAN).youControl(),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap)
+        val t = target("target permanent", TargetPermanent())
+        effect = MayEffect(
+            Effects.ChooseAction(
+                listOf(
+                    EffectChoice("Tap it", Effects.Tap(t)),
+                    EffectChoice("Untap it", Effects.Untap(t)),
+                ),
+            ),
+            descriptionOverride = "You may tap or untap that permanent",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "45"
+        artist = "Allen Williams"
+        flavorText =
+            "\"I am no mere ship's captain. The north wind is my accomplice. The tide is my first mate.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/c/4/c43aa68e-a182-4006-b4d6-b4fc67e68583.jpg?1783940723"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CathedralSanctifier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/CathedralSanctifier.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cathedral Sanctifier
+ * {W}
+ * Creature — Human Cleric
+ * 1/1
+ * When this creature enters, you gain 3 life.
+ */
+val CathedralSanctifier = card("Cathedral Sanctifier") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "When this creature enters, you gain 3 life."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Michael C. Hayes"
+        flavorText = "\"Evil will soon be vanquished. What Innistrad most needs now is healing.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/7/6/76cac47a-9e83-4039-8d80-fa9bdadb7527.jpg?1783940738"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/EmancipationAngel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/EmancipationAngel.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Emancipation Angel
+ * {1}{W}{W}
+ * Creature — Angel
+ * 3/3
+ * Flying
+ * When this creature enters, return a permanent you control to its owner's hand.
+ */
+val EmancipationAngel = card("Emancipation Angel") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText = "Flying\nWhen this creature enters, return a permanent you control to its owner's hand."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "a permanent you control",
+            TargetPermanent(filter = TargetFilter.Permanent.youControl()),
+        )
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Scott Chou"
+        flavorText = "\"You have done your best. I give you leave to rest.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/7/a/7a4bc00e-28ca-4152-b832-f36425d2b615.jpg?1783940736"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GoldnightRedeemer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GoldnightRedeemer.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Goldnight Redeemer
+ * {4}{W}{W}
+ * Creature — Angel
+ * 4/4
+ * Flying
+ * When this creature enters, you gain 2 life for each other creature you control.
+ */
+val GoldnightRedeemer = card("Goldnight Redeemer") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText =
+        "Flying\nWhen this creature enters, you gain 2 life for each other creature you control."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(
+            DynamicAmount.Multiply(
+                DynamicAmount.AggregateBattlefield(
+                    player = Player.You,
+                    filter = GameObjectFilter.Creature,
+                    excludeSelf = true,
+                ),
+                2,
+            ),
+            EffectTarget.Controller,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "23"
+        artist = "Karl Kopinski"
+        flavorText =
+            "The Host sings of Avacyn's return without a single verse about its own suffering."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/d/f/df5656e3-5f53-41f8-9f24-04caad5e4ca3.jpg?1783940734"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GryffVanguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GryffVanguard.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+/**
+ * Gryff Vanguard
+ * {4}{U}
+ * Creature — Human Knight
+ * 3/2
+ * Flying
+ * When this creature enters, draw a card.
+ */
+val GryffVanguard = card("Gryff Vanguard") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Knight"
+    oracleText = "Flying\nWhen this creature enters, draw a card."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = DrawCardsEffect(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Jason Chan"
+        flavorText =
+            "\"Ghouls smashed the door, but I heard the call of the gryffs and knew we were saved.\"\n—Ekka, shopkeeper of Hanweir"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/b/7/b7238136-c8de-4949-9b54-ff75094e0569.jpg?1783940717"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HarvesterOfSouls.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HarvesterOfSouls.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Harvester of Souls
+ * {4}{B}{B}
+ * Creature — Demon
+ * 5/5
+ * Deathtouch
+ * Whenever another nontoken creature dies, you may draw a card.
+ */
+val HarvesterOfSouls = card("Harvester of Souls") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    oracleText =
+        "Deathtouch\nWhenever another nontoken creature dies, you may draw a card."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter(
+                    cardPredicates = listOf(CardPredicate.IsCreature, CardPredicate.IsNontoken),
+                ),
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD,
+            ),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = MayEffect(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "107"
+        artist = "Slawomir Maniak"
+        flavorText =
+            "\"He is judge, jury, and executioner because he killed them all to claim those positions.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/5/0/505c0d25-dc1f-402e-9183-01c273efe0e1.jpg?1592708993"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HumanFrailty.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/HumanFrailty.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Human Frailty
+ * {B}
+ * Instant
+ * Destroy target Human creature.
+ */
+val HumanFrailty = card("Human Frailty") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Destroy target Human creature."
+
+    spell {
+        val t = target(
+            "Human creature",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withSubtype("Human"))),
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "109"
+        artist = "David Palumbo"
+        flavorText =
+            "\"I have seen a hundred mortal families rise and fall. I shall outlast a thousand more.\"\n—Olivia Voldaren"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/1/d/1d1de712-86ac-4c03-be86-2403cd121f66.jpg?1783940696"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MoorlandInquisitor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/MoorlandInquisitor.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Moorland Inquisitor
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * {2}{W}: This creature gains first strike until end of turn.
+ */
+val MoorlandInquisitor = card("Moorland Inquisitor") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText =
+        "{2}{W}: This creature gains first strike until end of turn. " +
+            "(It deals combat damage before creatures without first strike.)"
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{W}")
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self, Duration.EndOfTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "David Palumbo"
+        flavorText =
+            "Inquisitors are taught scripture, philosophy, and the fine art of sharpening an axe."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/5/8/581dbbea-9995-4e4b-ba5c-d6d5597e4ace.jpg?1783940731"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/NephaliaSmuggler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/NephaliaSmuggler.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nephalia Smuggler
+ * {U}
+ * Creature — Human Rogue
+ * 1/1
+ * {3}{U}, {T}: Exile another target creature you control, then return that card to the
+ * battlefield under your control.
+ */
+val NephaliaSmuggler = card("Nephalia Smuggler") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Rogue"
+    oracleText =
+        "{3}{U}, {T}: Exile another target creature you control, then return that card to the " +
+            "battlefield under your control."
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{U}"), Costs.Tap)
+        val creature = target("another target creature you control", Targets.OtherCreatureYouControl)
+        effect = Effects.Exile(creature)
+            .then(
+                Effects.Move(
+                    creature,
+                    Zone.BATTLEFIELD,
+                    controllerOverride = EffectTarget.Controller,
+                ),
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "69"
+        artist = "Matt Stewart"
+        flavorText = "\"My drivers are trustworthy. I removed their tongues myself.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/1/a/1a531b2f-2a9e-4cc9-aea6-9dce239f5511.jpg?1592708698"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ScrapskinDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/ScrapskinDrake.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Scrapskin Drake
+ * {2}{U}
+ * Creature — Zombie Drake
+ * 2/3
+ * Flying
+ * This creature can block only creatures with flying.
+ */
+val ScrapskinDrake = card("Scrapskin Drake") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Drake"
+    oracleText =
+        "Flying (This creature can't be blocked except by creatures with flying or reach.)\n" +
+            "This creature can block only creatures with flying."
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CanOnlyBlockCreaturesWith(
+            blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Kev Walker"
+        flavorText =
+            "\"The cathars killed my skaabs down below. Let's see how high their swords can reach.\"\n—Ludevic, necro-alchemist"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/c/9/c9f03bae-1d23-43ea-9079-4b09d61bbadd.jpg?1783940711"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SeraphSanctuary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/SeraphSanctuary.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+
+/**
+ * Seraph Sanctuary
+ * Land
+ * When this land enters, you gain 1 life.
+ * Whenever an Angel you control enters, you gain 1 life.
+ * {T}: Add {C}.
+ */
+val SeraphSanctuary = card("Seraph Sanctuary") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText =
+        "When this land enters, you gain 1 life.\n" +
+            "Whenever an Angel you control enters, you gain 1 life.\n" +
+            "{T}: Add {C}."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = GainLifeEffect(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.ANGEL).youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = GainLifeEffect(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "228"
+        artist = "David Palumbo"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/f/9/f903b04a-2733-4ce7-9d83-9db8d5e1e10d.jpg?1783940648"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/VoiceOfTheProvinces.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/VoiceOfTheProvinces.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Voice of the Provinces
+ * {4}{W}{W}
+ * Creature — Angel
+ * 3/3
+ * Flying
+ * When this creature enters, create a 1/1 white Human creature token.
+ */
+val VoiceOfTheProvinces = card("Voice of the Provinces") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText = "Flying\nWhen this creature enters, create a 1/1 white Human creature token."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human"),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Igor Kieryluk"
+        flavorText = "Her horn is heard across Innistrad, lifting the hearts of the righteous."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/b/7/b785276b-3778-49f3-b46f-a1f3d91db097.jpg?1783940726"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BarterInBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/BarterInBloodReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barter in Blood reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val BarterInBloodReprint = Printing(
+    oracleId = "9167998d-5cac-47d7-99f2-f38122f7b8e7",
+    name = "Barter in Blood",
+    setCode = "C15",
+    collectorNumber = "115",
+    scryfallId = "2bc350c9-0c1e-40a1-bb08-1b2e1f37320e",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/2/b/2bc350c9-0c1e-40a1-bb08-1b2e1f37320e.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SeverTheBloodlineReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/SeverTheBloodlineReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sever the Bloodline reprint in C15. Canonical CardDefinition lives in its earliest set.
+ */
+val SeverTheBloodlineReprint = Printing(
+    oracleId = "b9019332-2f02-48d9-be0a-a2b41b79e136",
+    name = "Sever the Bloodline",
+    setCode = "C15",
+    collectorNumber = "136",
+    scryfallId = "4dedd68c-9d5f-4265-9891-23ef9745ce09",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/4/d/4dedd68c-9d5f-4265-9891-23ef9745ce09.jpg",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/AbattoirGhoulReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/AbattoirGhoulReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Abattoir Ghoul reprint in Duel Decks: Blessed vs. Cursed.
+ *
+ * Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in ISD.
+ */
+val AbattoirGhoulReprint = Printing(
+    oracleId = "2b211adb-de44-4468-b65d-907a09aa7e9d",
+    name = "Abattoir Ghoul",
+    setCode = "DDQ",
+    collectorNumber = "50",
+    scryfallId = "43297ddd-276f-4d2d-9d9c-937603d0e376",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/43297ddd-276f-4d2d-9d9c-937603d0e376.jpg?1783937842",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/AppetiteForBrainsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/AppetiteForBrainsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Appetite for Brains reprint in Duel Decks: Blessed vs. Cursed.
+ *
+ * Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in AVR.
+ */
+val AppetiteForBrainsReprint = Printing(
+    oracleId = "4ffc16e0-1778-4aba-ade3-58146c800f5f",
+    name = "Appetite for Brains",
+    setCode = "DDQ",
+    collectorNumber = "51",
+    scryfallId = "ef9b4e72-2ac9-444c-81a9-756c5d3f2d65",
+    artist = "Michael C. Hayes",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef9b4e72-2ac9-444c-81a9-756c5d3f2d65.jpg?1783937842",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/BarterInBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/BarterInBloodReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val BarterInBloodReprint = Printing(
+    oracleId = "9167998d-5cac-47d7-99f2-f38122f7b8e7",
+    name = "Barter in Blood",
+    setCode = "DDQ",
+    collectorNumber = "52",
+    scryfallId = "cb3411cb-8c43-4f06-8583-49dd9ba5db63",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cb3411cb-8c43-4f06-8583-49dd9ba5db63.jpg?1783937842",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/BondsOfFaithReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/BondsOfFaithReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Bonds of Faith reprint in DDQ. Canonical def lives in ISD. */
+val BondsOfFaithReprint = Printing(
+    oracleId = "79af045e-2c73-4003-8f62-b8611a225f08",
+    name = "Bonds of Faith",
+    setCode = "DDQ",
+    collectorNumber = "2",
+    scryfallId = "cc5dbb93-63a2-478e-b874-1fdf3a03cbff",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/c/c/cc5dbb93-63a2-478e-b874-1fdf3a03cbff.jpg?1783937858",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ButcherGhoulReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ButcherGhoulReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Butcher Ghoul reprint in DDQ. Canonical def lives in AVR. */
+val ButcherGhoulReprint = Printing(
+    oracleId = "28caeed4-c175-469f-8d8e-f45bc0a51a1c",
+    name = "Butcher Ghoul",
+    setCode = "DDQ",
+    collectorNumber = "53",
+    scryfallId = "37117234-76eb-4a94-8230-a0a8c9b92e47",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37117234-76eb-4a94-8230-a0a8c9b92e47.jpg?1783937841",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ButchersCleaverReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ButchersCleaverReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Butcher's Cleaver reprint in DDQ. Canonical def lives in ISD. */
+val ButchersCleaverReprint = Printing(
+    oracleId = "5cc5be7a-cbe6-4853-bb95-0390e25b4f2b",
+    name = "Butcher's Cleaver",
+    setCode = "DDQ",
+    collectorNumber = "31",
+    scryfallId = "9359d59f-872e-4e43-94b6-90d6616f17e0",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/9359d59f-872e-4e43-94b6-90d6616f17e0.jpg?1783937849",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/CaptainOfTheMistsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/CaptainOfTheMistsReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Captain of the Mists reprint in DDQ. Canonical def lives in AVR. */
+val CaptainOfTheMistsReprint = Printing(
+    oracleId = "a7b6cd8b-1bed-4742-8c97-8be4edbfc8ee",
+    name = "Captain of the Mists",
+    setCode = "DDQ",
+    collectorNumber = "24",
+    scryfallId = "aa959355-ffac-442c-9c59-b2a654b4b400",
+    artist = "Allen Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa959355-ffac-442c-9c59-b2a654b4b400.jpg?1783937852",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/CathedralSanctifierReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/CathedralSanctifierReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Cathedral Sanctifier reprint in DDQ. Canonical def lives in AVR. */
+val CathedralSanctifierReprint = Printing(
+    oracleId = "1050f029-60d4-4769-b39f-9100c949a822",
+    name = "Cathedral Sanctifier",
+    setCode = "DDQ",
+    collectorNumber = "3",
+    scryfallId = "de3d0a45-3b3a-4718-9cb8-ff0c2464d634",
+    artist = "Michael C. Hayes",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/de3d0a45-3b3a-4718-9cb8-ff0c2464d634.jpg?1783937860",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ChampionOfTheParishReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ChampionOfTheParishReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Champion of the Parish reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val ChampionOfTheParishReprint = Printing(
+    oracleId = "faeaa3eb-6eb8-4621-98c7-0c6f58bbff85",
+    name = "Champion of the Parish",
+    setCode = "DDQ",
+    collectorNumber = "4",
+    scryfallId = "ec2120ff-a6d4-4192-96c0-33c139155ddf",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ec2120ff-a6d4-4192-96c0-33c139155ddf.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ChapelGeistReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ChapelGeistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chapel Geist reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val ChapelGeistReprint = Printing(
+    oracleId = "f8219a99-1620-40aa-a257-fc3dfb239d51",
+    name = "Chapel Geist",
+    setCode = "DDQ",
+    collectorNumber = "5",
+    scryfallId = "36fcc018-76c2-4246-8eca-b78115d568be",
+    artist = "Peter Mohrbacher",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/36fcc018-76c2-4246-8eca-b78115d568be.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/CobbledWingsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/CobbledWingsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cobbled Wings reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val CobbledWingsReprint = Printing(
+    oracleId = "8d8682f3-9ef3-4aa7-9ea6-8a2ce09bff6f",
+    name = "Cobbled Wings",
+    setCode = "DDQ",
+    collectorNumber = "69",
+    scryfallId = "6f8fe253-8f0c-43b6-81cd-357e33fe7e0d",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6f8fe253-8f0c-43b6-81cd-357e33fe7e0d.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DdqBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DdqBasicLands.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/** DDQ basic lands. */
+val DdqPlains38 = basicLand("Plains") {
+    collectorNumber = "38"
+    artist = "Adam Paquette"
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a3cc4f04-9fc2-4ee0-b60c-a102e442141f.jpg?1783937847"
+}
+
+val DdqIsland35 = basicLand("Island") {
+    collectorNumber = "35"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c234458f-1b0a-47a2-9cee-b6920e1ad54e.jpg?1783937847"
+}
+
+val DdqSwamp74 = basicLand("Swamp") {
+    collectorNumber = "74"
+    artist = "James Paick"
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b0d5294d-8f26-47f9-90f2-c0eb095dbcfc.jpg?1783937833"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DdqTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DdqTokens.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/** DDQ #77 — 4/4 white Angel creature token with flying. */
+val AngelToken = card("Angel") {
+    colorIdentity = "W"
+    typeLine = "Token Creature — Angel"
+    oracleText = "Flying"
+    power = 4
+    toughness = 4
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Winona Nelson"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/8/e/8e3a583e-2310-4284-ac44-fd28c72ec11b.jpg?1783937832"
+    }
+}
+
+/** DDQ #78 — 1/1 white Human creature token. */
+val HumanToken = card("Human") {
+    colorIdentity = "W"
+    typeLine = "Token Creature — Human"
+    power = 1
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "John Stanko"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/1/5/15a620da-5056-4582-8da5-2c955c3f4c0d.jpg?1783937832"
+    }
+}
+
+/** DDQ #79 — 1/1 white Spirit creature token with flying. */
+val SpiritToken = card("Spirit") {
+    colorIdentity = "W"
+    typeLine = "Token Creature — Spirit"
+    oracleText = "Flying"
+    power = 1
+    toughness = 1
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Kev Walker"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/b/3/b38c8153-ded1-499f-929a-b7bc8a09cd5a.jpg?1783937831"
+    }
+}
+
+/** DDQ #80 — 2/2 black Zombie creature token. */
+val ZombieToken = card("Zombie") {
+    colorIdentity = "B"
+    typeLine = "Token Creature — Zombie"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Lucas Graciano"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/7/c/7c60e495-8fb7-43bb-b11d-52882c0246bc.jpg?1783937831"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DiregrafCaptainReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DiregrafCaptainReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Diregraf Captain reprint in DDQ. Canonical def lives in DKA. */
+val DiregrafCaptainReprint = Printing(
+    oracleId = "70de24d9-c585-4bf6-ac2c-c5b4b7aa298c",
+    name = "Diregraf Captain",
+    setCode = "DDQ",
+    collectorNumber = "68",
+    scryfallId = "f71d26ad-2d32-4202-8237-bc4612a53ea0",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f71d26ad-2d32-4202-8237-bc4612a53ea0.jpg?1783937843",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DiregrafGhoulReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DiregrafGhoulReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Diregraf Ghoul reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val DiregrafGhoulReprint = Printing(
+    oracleId = "6048fc70-0dcc-4b54-977d-16e240225f82",
+    name = "Diregraf Ghoul",
+    setCode = "DDQ",
+    collectorNumber = "54",
+    scryfallId = "6adfcecf-bd58-4546-a058-0aa3fd93bce1",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6adfcecf-bd58-4546-a058-0aa3fd93bce1.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DismalBackwaterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DismalBackwaterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dismal Backwater reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val DismalBackwaterReprint = Printing(
+    oracleId = "865a2194-fca0-446e-aae3-ca475cd66e00",
+    name = "Dismal Backwater",
+    setCode = "DDQ",
+    collectorNumber = "70",
+    scryfallId = "a5f74adf-e66b-4b5c-9e26-db4f23c721f6",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5f74adf-e66b-4b5c-9e26-db4f23c721f6.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DoomedTravelerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DoomedTravelerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Doomed Traveler reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val DoomedTravelerReprint = Printing(
+    oracleId = "a30907c0-fbde-4fd3-a8c7-f304305fcea7",
+    name = "Doomed Traveler",
+    setCode = "DDQ",
+    collectorNumber = "7",
+    scryfallId = "86f7fae8-a03a-4535-83c1-cece267fedec",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/86f7fae8-a03a-4535-83c1-cece267fedec.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DreadReturnReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DreadReturnReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Dread Return reprint in DDQ. Canonical def lives in TSP. */
+val DreadReturnReprint = Printing(
+    oracleId = "352b64d2-2ae5-44ee-a64f-94932ef545d3",
+    name = "Dread Return",
+    setCode = "DDQ",
+    collectorNumber = "55",
+    scryfallId = "fee9b318-15c1-45cf-97a5-2ad4764e06d0",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fee9b318-15c1-45cf-97a5-2ad4764e06d0.jpg?1783937840",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DriverOfTheDeadReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/DriverOfTheDeadReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Driver of the Dead reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val DriverOfTheDeadReprint = Printing(
+    oracleId = "7c179e54-3beb-4761-bddf-41fa98b082db",
+    name = "Driver of the Dead",
+    setCode = "DDQ",
+    collectorNumber = "56",
+    scryfallId = "fcb29d03-2287-4586-a199-b31759ced9dc",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fcb29d03-2287-4586-a199-b31759ced9dc.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/EerieInterlude.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/EerieInterlude.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Eerie Interlude
+ * {2}{W}
+ * Instant
+ * Exile any number of target creatures you control. Return those cards to the battlefield under
+ * their owner's control at the beginning of the next end step.
+ *
+ * Canonical printing is DDQ (pre-SOI). Same multi-blink shape as Morningtide's Light.
+ */
+val EerieInterlude = card("Eerie Interlude") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText =
+        "Exile any number of target creatures you control. Return those cards to the battlefield " +
+            "under their owner's control at the beginning of the next end step."
+
+    spell {
+        target(
+            "any number of target creatures you control",
+            TargetCreature(
+                unlimited = true,
+                optional = true,
+                filter = TargetFilter.Creature.youControl(),
+            ),
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(
+                Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE),
+                CreateDelayedTriggerEffect(
+                    step = Step.END,
+                    effect = Effects.Move(
+                        target = EffectTarget.ContextTarget(0),
+                        destination = Zone.BATTLEFIELD,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "8"
+        artist = "Svetlin Velinov"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/a/a/aa8e63c6-6bbc-405d-84c0-6958931ad310.jpg?1783937858"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ElderCatharReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ElderCatharReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Elder Cathar reprint in DDQ. Canonical def lives in ISD. */
+val ElderCatharReprint = Printing(
+    oracleId = "ba9ac0a9-735d-4bca-9d24-586aca963872",
+    name = "Elder Cathar",
+    setCode = "DDQ",
+    collectorNumber = "9",
+    scryfallId = "26c38fbf-09ab-46fc-905e-ca45a85d794b",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/2/6/26c38fbf-09ab-46fc-905e-ca45a85d794b.jpg?1783937857",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/EmancipationAngelReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/EmancipationAngelReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Emancipation Angel reprint in DDQ. Canonical def lives in AVR. */
+val EmancipationAngelReprint = Printing(
+    oracleId = "3834d3b0-9b66-465a-a8dc-22875a819fd9",
+    name = "Emancipation Angel",
+    setCode = "DDQ",
+    collectorNumber = "10",
+    scryfallId = "796583d3-8738-438a-bf6d-906acebff0ce",
+    artist = "Scott Chou",
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/796583d3-8738-438a-bf6d-906acebff0ce.jpg?1783937856",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/FalkenrathNobleReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/FalkenrathNobleReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Falkenrath Noble reprint in DDQ. Canonical def lives in ISD. */
+val FalkenrathNobleReprint = Printing(
+    oracleId = "3739b179-bc81-4737-8376-66a57e16b942",
+    name = "Falkenrath Noble",
+    setCode = "DDQ",
+    collectorNumber = "57",
+    scryfallId = "65b51d77-2335-4170-8d86-96052e9dc260",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/6/5/65b51d77-2335-4170-8d86-96052e9dc260.jpg?1783937838",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ForbiddenAlchemyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ForbiddenAlchemyReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forbidden Alchemy reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val ForbiddenAlchemyReprint = Printing(
+    oracleId = "66d65cda-e3d1-4a00-8ff3-c6d5ef0ab0c1",
+    name = "Forbidden Alchemy",
+    setCode = "DDQ",
+    collectorNumber = "43",
+    scryfallId = "96fd7354-7069-4e3e-b4f2-f9cd15c970ea",
+    artist = "David Rapoza",
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/96fd7354-7069-4e3e-b4f2-f9cd15c970ea.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GatherTheTownsfolkReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GatherTheTownsfolkReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gather the Townsfolk reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val GatherTheTownsfolkReprint = Printing(
+    oracleId = "ff45677d-977e-4ef5-859c-52393ed71a6c",
+    name = "Gather the Townsfolk",
+    setCode = "DDQ",
+    collectorNumber = "12",
+    scryfallId = "76f66ee8-8289-4780-aaec-feabd8ea9e3d",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/76f66ee8-8289-4780-aaec-feabd8ea9e3d.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GeistOfSaintTraftReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GeistOfSaintTraftReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Geist of Saint Traft reprint in DDQ. Canonical def lives in ISD. */
+val GeistOfSaintTraftReprint = Printing(
+    oracleId = "4304035c-c3e4-4a19-aa1f-92a83d8aed1f",
+    name = "Geist of Saint Traft",
+    setCode = "DDQ",
+    collectorNumber = "1",
+    scryfallId = "0ba5dd1a-6906-4b45-bbf7-2f10cb955083",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/0/b/0ba5dd1a-6906-4b45-bbf7-2f10cb955083.jpg?1783937860",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GhoulraiserReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GhoulraiserReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Ghoulraiser reprint in DDQ. Canonical def lives in ISD. */
+val GhoulraiserReprint = Printing(
+    oracleId = "614f748b-5d31-440d-a7c0-3ba12dc63c24",
+    name = "Ghoulraiser",
+    setCode = "DDQ",
+    collectorNumber = "58",
+    scryfallId = "b1155a94-1e6a-43d5-8438-5fa5aaec62d1",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b1155a94-1e6a-43d5-8438-5fa5aaec62d1.jpg?1783937839",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GoldnightRedeemerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GoldnightRedeemerReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Goldnight Redeemer reprint in DDQ. Canonical def lives in AVR. */
+val GoldnightRedeemerReprint = Printing(
+    oracleId = "6fe35d1f-20b6-4fa8-a318-79e2d415701a",
+    name = "Goldnight Redeemer",
+    setCode = "DDQ",
+    collectorNumber = "13",
+    scryfallId = "9396d218-35e4-4457-9f3a-18bae368b526",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/9396d218-35e4-4457-9f3a-18bae368b526.jpg?1783937855",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GravecrawlerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GravecrawlerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gravecrawler reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val GravecrawlerReprint = Printing(
+    oracleId = "09ff28b1-b6c9-48e6-b12e-2f0e644f709f",
+    name = "Gravecrawler",
+    setCode = "DDQ",
+    collectorNumber = "59",
+    scryfallId = "3c189fe5-a5f9-4057-bb70-0a88ae3169de",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c189fe5-a5f9-4057-bb70-0a88ae3169de.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GryffVanguardReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/GryffVanguardReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Gryff Vanguard reprint in DDQ. Canonical def lives in AVR. */
+val GryffVanguardReprint = Printing(
+    oracleId = "3bcdf832-4ce2-4043-b46a-0c5fd7019fcd",
+    name = "Gryff Vanguard",
+    setCode = "DDQ",
+    collectorNumber = "25",
+    scryfallId = "53a14ab8-62f4-4873-b4ef-650f0aded095",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/53a14ab8-62f4-4873-b4ef-650f0aded095.jpg?1783937852",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/HarvesterOfSoulsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/HarvesterOfSoulsReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Harvester of Souls reprint in DDQ. Canonical def lives in AVR. */
+val HarvesterOfSoulsReprint = Printing(
+    oracleId = "5987ce77-10ad-4871-900a-5a005fcf4955",
+    name = "Harvester of Souls",
+    setCode = "DDQ",
+    collectorNumber = "60",
+    scryfallId = "ba7827c0-0b31-46d0-8489-e7c14d25035e",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba7827c0-0b31-46d0-8489-e7c14d25035e.jpg?1783937844",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/HavengulRunebinderReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/HavengulRunebinderReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Havengul Runebinder reprint in DDQ. Canonical def lives in DKA. */
+val HavengulRunebinderReprint = Printing(
+    oracleId = "e91e7f62-0788-445e-ba93-2c9d233ec3ab",
+    name = "Havengul Runebinder",
+    setCode = "DDQ",
+    collectorNumber = "44",
+    scryfallId = "beca3e00-2c04-41be-98d1-59bc2b5f05e4",
+    artist = "Bud Cook",
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/beca3e00-2c04-41be-98d1-59bc2b5f05e4.jpg?1783937846",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/HumanFrailtyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/HumanFrailtyReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val HumanFrailtyReprint = Printing(
+    oracleId = "bd95c832-9ae9-404a-a2bc-0760a5b9ff56",
+    name = "Human Frailty",
+    setCode = "DDQ",
+    collectorNumber = "61",
+    scryfallId = "80b582e3-1e02-4c24-87be-05880b56df70",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80b582e3-1e02-4c24-87be-05880b56df70.jpg?1783937837",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/IncreasingDevotionReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/IncreasingDevotionReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Increasing Devotion reprint in DDQ. Canonical def lives in DKA. */
+val IncreasingDevotionReprint = Printing(
+    oracleId = "7a5ff4d4-27b7-47d4-ba88-970c63c4e3fb",
+    name = "Increasing Devotion",
+    setCode = "DDQ",
+    collectorNumber = "14",
+    scryfallId = "bd7844a2-70a1-4195-b2b7-1653cb882c6a",
+    artist = "Daniel Ljunggren",
+    imageUri = "https://cards.scryfall.io/normal/front/b/d/bd7844a2-70a1-4195-b2b7-1653cb882c6a.jpg?1783937856",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MakeshiftMaulerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MakeshiftMaulerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Makeshift Mauler reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val MakeshiftMaulerReprint = Printing(
+    oracleId = "03025ec0-75fe-439d-b0c1-9bdb0f0ff336",
+    name = "Makeshift Mauler",
+    setCode = "DDQ",
+    collectorNumber = "45",
+    scryfallId = "8782f856-06d3-43ef-958a-d2397353fa3a",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/8782f856-06d3-43ef-958a-d2397353fa3a.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MindwrackDemon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MindwrackDemon.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.NotCondition
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mindwrack Demon
+ * {2}{B}{B}
+ * Creature — Demon
+ * 4/5
+ * Flying, trample
+ * When this creature enters, mill four cards.
+ * Delirium — At the beginning of your upkeep, you lose 4 life unless there are four or more
+ * card types among cards in your graveyard.
+ *
+ * Canonical printing is DDQ (pre-SOI).
+ */
+val MindwrackDemon = card("Mindwrack Demon") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    oracleText =
+        "Flying, trample\n" +
+            "When this creature enters, mill four cards.\n" +
+            "Delirium — At the beginning of your upkeep, you lose 4 life unless there are " +
+            "four or more card types among cards in your graveyard."
+    power = 4
+    toughness = 5
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(4)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = ConditionalEffect(
+            condition = NotCondition(Conditions.Delirium(4)),
+            effect = Effects.LoseLife(4, EffectTarget.Controller),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "41"
+        artist = "Daarken"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/d/d/dd80262b-5f4a-4ea5-88da-f21fca83df3e.jpg?1783937845"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MistRavenReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MistRavenReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mist Raven reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val MistRavenReprint = Printing(
+    oracleId = "12654457-3aae-4046-a976-8e41c3f78927",
+    name = "Mist Raven",
+    setCode = "DDQ",
+    collectorNumber = "26",
+    scryfallId = "4784a4d2-8af8-47dc-9ef8-053c6c873f93",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/4784a4d2-8af8-47dc-9ef8-053c6c873f93.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MoanOfTheUnhallowedReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MoanOfTheUnhallowedReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moan of the Unhallowed reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val MoanOfTheUnhallowedReprint = Printing(
+    oracleId = "ce87e5ed-2562-4563-9a5b-bd53c04ec4a5",
+    name = "Moan of the Unhallowed",
+    setCode = "DDQ",
+    collectorNumber = "62",
+    scryfallId = "bbed06f6-c7f0-4304-b57a-b996a531adb1",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bbed06f6-c7f0-4304-b57a-b996a531adb1.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MomentaryBlinkReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MomentaryBlinkReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Momentary Blink reprint in DDQ. Canonical def lives in TSP. */
+val MomentaryBlinkReprint = Printing(
+    oracleId = "a3ec6b5d-08ec-4ae0-b1db-c4b87a1849c7",
+    name = "Momentary Blink",
+    setCode = "DDQ",
+    collectorNumber = "15",
+    scryfallId = "b2cefcc4-8fb2-4acf-b8f0-e40acba87b42",
+    artist = "Evan Shipard",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2cefcc4-8fb2-4acf-b8f0-e40acba87b42.jpg?1783937855",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MoorlandInquisitorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/MoorlandInquisitorReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val MoorlandInquisitorReprint = Printing(
+    oracleId = "76bbd280-dcbc-43b3-a8a1-603443b2ccaa",
+    name = "Moorland Inquisitor",
+    setCode = "DDQ",
+    collectorNumber = "16",
+    scryfallId = "8bcf35f7-ac95-46e9-b84d-eae5adaf8109",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8bcf35f7-ac95-46e9-b84d-eae5adaf8109.jpg?1783937855",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/NephaliaSmugglerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/NephaliaSmugglerReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Nephalia Smuggler reprint in DDQ. Canonical def lives in AVR. */
+val NephaliaSmugglerReprint = Printing(
+    oracleId = "f96a2aa6-3259-4bb6-92cd-4d17215d04d0",
+    name = "Nephalia Smuggler",
+    setCode = "DDQ",
+    collectorNumber = "27",
+    scryfallId = "a67bcad1-b535-4e51-a5f4-50612b0346ce",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a67bcad1-b535-4e51-a5f4-50612b0346ce.jpg?1783937852",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/PoreOverThePages.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/PoreOverThePages.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Pore Over the Pages
+ * {3}{U}{U}
+ * Sorcery
+ * Draw three cards, untap up to two lands, then discard a card.
+ *
+ * Canonical printing is DDQ (pre-SOI).
+ */
+val PoreOverThePages = card("Pore Over the Pages") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw three cards, untap up to two lands, then discard a card."
+
+    spell {
+        target(
+            "up to two lands",
+            TargetPermanent(optional = true, count = 2, filter = TargetFilter.Land),
+        )
+        effect = Effects.Composite(
+            Effects.DrawCards(3),
+            Effects.UntapEachTarget(),
+            Patterns.Hand.discardCards(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "28"
+        artist = "Magali Villeneuve"
+        flavorText =
+            "\"I'm certain that the fate of Markov Manor is connected to these cryptoliths . . . " +
+                "but with every page I turn, the less sure I am of the answer.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/a/7/a7f9b8f0-f2b9-48ec-86c2-71d1419e396b.jpg?1783937850"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/RebukeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/RebukeReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rebuke reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val RebukeReprint = Printing(
+    oracleId = "cf35ec1e-11e2-4028-89df-9755fd6772bf",
+    name = "Rebuke",
+    setCode = "DDQ",
+    collectorNumber = "17",
+    scryfallId = "9b6b0457-024c-4957-bf77-75fe0a33c51f",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9b6b0457-024c-4957-bf77-75fe0a33c51f.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/RelentlessSkaabsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/RelentlessSkaabsReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Relentless Skaabs reprint in DDQ. Canonical def lives in DKA. */
+val RelentlessSkaabsReprint = Printing(
+    oracleId = "5089cd0f-1338-4ecd-bb1b-664d7e72f8fc",
+    name = "Relentless Skaabs",
+    setCode = "DDQ",
+    collectorNumber = "46",
+    scryfallId = "7cf48c1a-5709-4e24-8a85-8292a4457150",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7cf48c1a-5709-4e24-8a85-8292a4457150.jpg?1783937843",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ScrapskinDrakeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ScrapskinDrakeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Scrapskin Drake reprint in DDQ. Canonical def lives in AVR. */
+val ScrapskinDrakeReprint = Printing(
+    oracleId = "910e8269-6001-479a-ab2e-5a935569c33c",
+    name = "Scrapskin Drake",
+    setCode = "DDQ",
+    collectorNumber = "47",
+    scryfallId = "740fc68d-1f08-4e9e-a797-427dcd7733ba",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/7/4/740fc68d-1f08-4e9e-a797-427dcd7733ba.jpg?1783937842",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ScreechingSkaabReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ScreechingSkaabReprint.kt
@@ -1,0 +1,16 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+val ScreechingSkaabReprint = Printing(
+    oracleId = "c339982a-45d6-4c1a-aefc-c72427b40744",
+    name = "Screeching Skaab",
+    setCode = "DDQ",
+    collectorNumber = "48",
+    scryfallId = "3d0142f7-7461-446a-b690-6882ccd93116",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d0142f7-7461-446a-b690-6882ccd93116.jpg?1783937842",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SeraphSanctuaryReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SeraphSanctuaryReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Seraph Sanctuary reprint in DDQ. Canonical def lives in AVR. */
+val SeraphSanctuaryReprint = Printing(
+    oracleId = "0b504dc6-61cc-4a72-907c-145fa4c72466",
+    name = "Seraph Sanctuary",
+    setCode = "DDQ",
+    collectorNumber = "33",
+    scryfallId = "e1c1fa29-362f-40b4-b67f-513f6592fb3b",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1c1fa29-362f-40b4-b67f-513f6592fb3b.jpg?1783937848",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SeverTheBloodlineReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SeverTheBloodlineReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sever the Bloodline reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val SeverTheBloodlineReprint = Printing(
+    oracleId = "b9019332-2f02-48d9-be0a-a2b41b79e136",
+    name = "Sever the Bloodline",
+    setCode = "DDQ",
+    collectorNumber = "63",
+    scryfallId = "9895dbaf-2a5e-472b-a605-d3d8075eb927",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/9/8/9895dbaf-2a5e-472b-a605-d3d8075eb927.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SharpenedPitchforkReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SharpenedPitchforkReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Sharpened Pitchfork reprint in DDQ. Canonical def lives in ISD. */
+val SharpenedPitchforkReprint = Printing(
+    oracleId = "409b44fc-fae2-4804-83a7-78cf95038f58",
+    name = "Sharpened Pitchfork",
+    setCode = "DDQ",
+    collectorNumber = "32",
+    scryfallId = "36c8cdec-5ca9-40b0-ba90-48966e674546",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/36c8cdec-5ca9-40b0-ba90-48966e674546.jpg?1783937849",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SlayerOfTheWickedReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/SlayerOfTheWickedReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slayer of the Wicked reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val SlayerOfTheWickedReprint = Printing(
+    oracleId = "d93299d4-3aaf-48fb-8227-26203963c8b9",
+    name = "Slayer of the Wicked",
+    setCode = "DDQ",
+    collectorNumber = "18",
+    scryfallId = "22580e42-c164-4e9b-8210-6fa48bec7b8b",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22580e42-c164-4e9b-8210-6fa48bec7b8b.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/StitchedDrakeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/StitchedDrakeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Stitched Drake reprint in DDQ. Canonical def lives in ISD. */
+val StitchedDrakeReprint = Printing(
+    oracleId = "10fd868f-45b3-4e2f-89d9-5c0b8a92f9fe",
+    name = "Stitched Drake",
+    setCode = "DDQ",
+    collectorNumber = "49",
+    scryfallId = "3ff74655-3156-4a02-af5a-f57c285e9d45",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3ff74655-3156-4a02-af5a-f57c285e9d45.jpg?1783937842",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ThrabenHereticReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ThrabenHereticReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Thraben Heretic reprint in DDQ. Canonical def lives in DKA. */
+val ThrabenHereticReprint = Printing(
+    oracleId = "67247945-17b7-4cb8-ba65-d0dfec367b77",
+    name = "Thraben Heretic",
+    setCode = "DDQ",
+    collectorNumber = "20",
+    scryfallId = "20eb4f21-2f20-4e4b-998c-a72527585549",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/20eb4f21-2f20-4e4b-998c-a72527585549.jpg?1783937854",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ToothCollector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/ToothCollector.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Tooth Collector
+ * {2}{B}
+ * Creature — Human Rogue
+ * 3/2
+ * When this creature enters, target creature an opponent controls gets -1/-1 until end of turn.
+ * Delirium — At the beginning of each opponent's upkeep, if there are four or more card types
+ * among cards in your graveyard, target creature that player controls gets -1/-1 until end of turn.
+ *
+ * Canonical printing is DDQ (pre-SOI).
+ */
+val ToothCollector = card("Tooth Collector") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Rogue"
+    oracleText =
+        "When this creature enters, target creature an opponent controls gets -1/-1 until end of turn.\n" +
+            "Delirium — At the beginning of each opponent's upkeep, if there are four or more " +
+            "card types among cards in your graveyard, target creature that player controls " +
+            "gets -1/-1 until end of turn."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.Creature.opponentControls()),
+        )
+        effect = Effects.ModifyStats(-1, -1, t, Duration.EndOfTurn)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EachOpponentUpkeep
+        triggerCondition = Conditions.Delirium(4)
+        val t = target(
+            "target creature that player controls",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.controlledByTriggeringPlayer()),
+            ),
+        )
+        effect = Effects.ModifyStats(-1, -1, t, Duration.EndOfTurn)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "64"
+        artist = "Bud Cook"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/a/0/a0f7106b-6550-4b84-82df-98d47b823548.jpg?1783937836"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/Topplegeist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/Topplegeist.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Topplegeist
+ * {W}
+ * Creature — Spirit
+ * 1/1
+ * Flying
+ * When this creature enters, tap target creature an opponent controls.
+ * Delirium — At the beginning of each opponent's upkeep, if there are four or more card types
+ * among cards in your graveyard, tap target creature that player controls.
+ *
+ * Canonical printing is DDQ (pre-SOI).
+ */
+val Topplegeist = card("Topplegeist") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText =
+        "Flying\n" +
+            "When this creature enters, tap target creature an opponent controls.\n" +
+            "Delirium — At the beginning of each opponent's upkeep, if there are four or more " +
+            "card types among cards in your graveyard, tap target creature that player controls."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.Creature.opponentControls()),
+        )
+        effect = Effects.Tap(t)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EachOpponentUpkeep
+        triggerCondition = Conditions.Delirium(4)
+        val t = target(
+            "target creature that player controls",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.controlledByTriggeringPlayer()),
+            ),
+        )
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Seb McKinnon"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/c/9/c987f24a-679f-4c4f-a04f-251cec3aef67.jpg?1783937853"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/TowerGeistReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/TowerGeistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tower Geist reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val TowerGeistReprint = Printing(
+    oracleId = "10e19453-84fb-4845-8db0-c9da52847e09",
+    name = "Tower Geist",
+    setCode = "DDQ",
+    collectorNumber = "30",
+    scryfallId = "3304c2bc-2d05-497d-b92a-3de21a9d6b45",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/3304c2bc-2d05-497d-b92a-3de21a9d6b45.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/TranquilCoveReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/TranquilCoveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Cove reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilCoveReprint = Printing(
+    oracleId = "5d641bf6-0f93-4189-8dc1-ec7ea446dade",
+    name = "Tranquil Cove",
+    setCode = "DDQ",
+    collectorNumber = "34",
+    scryfallId = "6b403e68-4696-4c8a-bb25-68dc7f98e5e4",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b403e68-4696-4c8a-bb25-68dc7f98e5e4.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/VictimOfNightReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/VictimOfNightReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Victim of Night reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val VictimOfNightReprint = Printing(
+    oracleId = "d92b9f63-17b6-4ed2-b6ae-083a8161863e",
+    name = "Victim of Night",
+    setCode = "DDQ",
+    collectorNumber = "67",
+    scryfallId = "c128272d-4611-477c-84b9-081bddcc7188",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c128272d-4611-477c-84b9-081bddcc7188.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/VillageBellRingerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/VillageBellRingerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Village Bell-Ringer reprint in DDQ. Canonical CardDefinition lives in its earliest set.
+ */
+val VillageBellRingerReprint = Printing(
+    oracleId = "d7b50175-b473-452a-bb30-19a71c42e649",
+    name = "Village Bell-Ringer",
+    setCode = "DDQ",
+    collectorNumber = "22",
+    scryfallId = "3543ed04-9519-4d69-b2ab-cd6c0747d9fd",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/3543ed04-9519-4d69-b2ab-cd6c0747d9fd.jpg",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/VoiceOfTheProvincesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/VoiceOfTheProvincesReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Voice of the Provinces reprint in DDQ. Canonical def lives in AVR. */
+val VoiceOfTheProvincesReprint = Printing(
+    oracleId = "81b15ed1-7069-4f8b-96b9-f6d67298afef",
+    name = "Voice of the Provinces",
+    setCode = "DDQ",
+    collectorNumber = "23",
+    scryfallId = "11a8437f-a783-4d76-8af1-a347d48a1bad",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/11a8437f-a783-4d76-8af1-a347d48a1bad.jpg?1783937853",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/DiregrafCaptain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/DiregrafCaptain.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Diregraf Captain
+ * {1}{U}{B}
+ * Creature — Zombie Soldier
+ * 2/2
+ * Deathtouch
+ * Other Zombie creatures you control get +1/+1.
+ * Whenever another Zombie you control dies, target opponent loses 1 life.
+ */
+val DiregrafCaptain = card("Diregraf Captain") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Zombie Soldier"
+    oracleText =
+        "Deathtouch\n" +
+            "Other Zombie creatures you control get +1/+1.\n" +
+            "Whenever another Zombie you control dies, target opponent loses 1 life."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.DEATHTOUCH)
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE).youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE).youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.LoseLife(1, opponent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "135"
+        artist = "Slawomir Maniak"
+        flavorText =
+            "Though its mind has long since rotted away, it wields a sword with devastating skill."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/0/e/0e5f41eb-609b-4882-af9e-904daa717484.jpg?1562898409"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/HavengulRunebinder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/HavengulRunebinder.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Havengul Runebinder
+ * {2}{U}{U}
+ * Creature — Human Wizard
+ * 2/2
+ * {2}{U}, {T}, Exile a creature card from your graveyard: Create a 2/2 black Zombie creature token,
+ * then put a +1/+1 counter on each Zombie creature you control.
+ */
+val HavengulRunebinder = card("Havengul Runebinder") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText =
+        "{2}{U}, {T}, Exile a creature card from your graveyard: Create a 2/2 black Zombie " +
+            "creature token, then put a +1/+1 counter on each Zombie creature you control."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = AbilityCost.Composite(
+            listOf(
+                Costs.Mana(ManaCost.parse("{2}{U}")),
+                AbilityCost.Tap,
+                Costs.ExileFromGraveyard(count = 1, filter = GameObjectFilter.Creature),
+            ),
+        )
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Zombie"),
+            ),
+            Effects.ForEachInGroup(
+                filter = GroupFilter(
+                    GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE).youControl(),
+                ),
+                effect = Effects.AddCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    1,
+                    EffectTarget.Self,
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "39"
+        artist = "Bud Cook"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/d/e/de766c12-eb2c-466a-8630-8242a153eb1f.jpg?1783940998"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/IncreasingDevotion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/IncreasingDevotion.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Increasing Devotion
+ * {3}{W}{W}
+ * Sorcery
+ * Create five 1/1 white Human creature tokens. If this spell was cast from a graveyard,
+ * create ten of those tokens instead.
+ * Flashback {7}{W}{W}
+ */
+val IncreasingDevotion = card("Increasing Devotion") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText =
+        "Create five 1/1 white Human creature tokens. If this spell was cast from a graveyard, " +
+            "create ten of those tokens instead.\n" +
+            "Flashback {7}{W}{W} (You may cast this card from your graveyard for its flashback cost. " +
+            "Then exile it.)"
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmount.Conditional(
+                condition = Conditions.WasCastFromGraveyard,
+                ifTrue = DynamicAmount.Fixed(10),
+                ifFalse = DynamicAmount.Fixed(5),
+            ),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Human"),
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{7}{W}{W}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "11"
+        artist = "Daniel Ljunggren"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/8/7/87b5de81-65a6-4a74-8a71-767b92e89e91.jpg?1783941024"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/RelentlessSkaabs.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/RelentlessSkaabs.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Relentless Skaabs
+ * {3}{U}{U}
+ * Creature — Zombie
+ * 4/4
+ * As an additional cost to cast this spell, exile a creature card from your graveyard.
+ * Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield
+ * under its owner's control with a +1/+1 counter on it.)
+ */
+val RelentlessSkaabs = card("Relentless Skaabs") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    oracleText =
+        "As an additional cost to cast this spell, exile a creature card from your graveyard.\n" +
+            "Undying (When this creature dies, if it had no +1/+1 counters on it, return it to the " +
+            "battlefield under its owner's control with a +1/+1 counter on it.)"
+    power = 4
+    toughness = 4
+
+    additionalCost(Costs.additional.ExileCards(count = 1, filter = GameObjectFilter.Creature))
+    keywords(Keyword.UNDYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "45"
+        artist = "Karl Kopinski"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/b/3/b3304cab-0dc9-47e4-ac68-00974b64f5a0.jpg?1783940838"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/ScreechingSkaab.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/ScreechingSkaab.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Screeching Skaab
+ * {1}{U}
+ * Creature — Zombie
+ * 2/1
+ * When this creature enters, mill two cards.
+ */
+val ScreechingSkaab = card("Screeching Skaab") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    oracleText = "When this creature enters, mill two cards."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "Clint Cearley"
+        flavorText = "Its screeching is the sound of you losing your mind."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/3/c/3c40a2c7-df7a-41a6-a49e-5f7db808b810.jpg?1783940837"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/ThrabenHeretic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/ThrabenHeretic.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thraben Heretic
+ * {1}{W}
+ * Creature — Human Wizard
+ * 2/2
+ * {T}: Exile target creature card from a graveyard.
+ */
+val ThrabenHeretic = card("Thraben Heretic") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "{T}: Exile target creature card from a graveyard."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target creature card from a graveyard", Targets.CreatureCardInGraveyard)
+        effect = Effects.Move(t, Zone.EXILE)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "26"
+        artist = "James Ryman"
+        flavorText =
+            "\"Let them decry me for burning the dead. I'm not giving those ghoulcallers any more fuel for their madness.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/f/8/f8cc36df-040b-4f29-bcc1-f5600803f71d.jpg?1783940850"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/DismalBackwaterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/DismalBackwaterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dismal Backwater reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val DismalBackwaterReprint = Printing(
+    oracleId = "865a2194-fca0-446e-aae3-ca475cd66e00",
+    name = "Dismal Backwater",
+    setCode = "IKO",
+    collectorNumber = "246",
+    scryfallId = "9de0981e-54fc-4919-96a4-a9608a5452fc",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9de0981e-54fc-4919-96a4-a9608a5452fc.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/TranquilCoveReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/TranquilCoveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Cove reprint in IKO. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilCoveReprint = Printing(
+    oracleId = "5d641bf6-0f93-4189-8dc1-ec7ea446dade",
+    name = "Tranquil Cove",
+    setCode = "IKO",
+    collectorNumber = "257",
+    scryfallId = "366ac097-39cb-4401-87c7-1dd73bf34329",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/366ac097-39cb-4401-87c7-1dd73bf34329.jpg",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/AbattoirGhoul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/AbattoirGhoul.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Abattoir Ghoul
+ * {3}{B}
+ * Creature — Zombie
+ * 3/2
+ * First strike
+ * Whenever a creature dealt damage by this creature this turn dies, you gain life equal to that
+ * creature's toughness.
+ *
+ * Canonical ISD printing. Uses [Triggers.CreatureDealtDamageByThisDies] (same shape as Predator Ooze)
+ * with [DynamicAmounts.triggeringToughness] for last-known toughness.
+ */
+val AbattoirGhoul = card("Abattoir Ghoul") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    oracleText = "First strike\nWhenever a creature dealt damage by this creature this turn dies, " +
+        "you gain life equal to that creature's toughness."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.CreatureDealtDamageByThisDies
+        effect = Effects.GainLife(DynamicAmounts.triggeringToughness())
+        description =
+            "Whenever a creature dealt damage by this creature this turn dies, you gain life " +
+                "equal to that creature's toughness."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "85"
+        artist = "Volkan Baǵa"
+        flavorText = "Death took his humanity but not his skill with the knife."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/5/9/59cf0906-04fa-4b30-a7a6-3d117931154f.jpg?1783940963"
+        ruling(
+            "2011-09-22",
+            "You'll gain life equal to the creature's last known toughness before it died. " +
+                "For example, if Abattoir Ghoul deals 3 first-strike damage to a 7/7 creature and " +
+                "then you give the creature -5/-5 before the regular combat damage step, you'll " +
+                "gain 2 life.",
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/BondsOfFaith.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/BondsOfFaith.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttack
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureHasSubtype
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Bonds of Faith
+ * {1}{W}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +2/+2 as long as it's a Human. Otherwise, it can't attack or block.
+ */
+val BondsOfFaith = card("Bonds of Faith") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText =
+        "Enchant creature\n" +
+            "Enchanted creature gets +2/+2 as long as it's a Human. Otherwise, it can't attack or block."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2, GroupFilter.attachedCreature())
+        condition = EnchantedCreatureHasSubtype(Subtype.HUMAN)
+    }
+
+    staticAbility {
+        ability = CantAttack(filter = GroupFilter.attachedCreature())
+        condition = Conditions.Not(EnchantedCreatureHasSubtype(Subtype.HUMAN))
+    }
+
+    staticAbility {
+        ability = CantBlock(filter = GroupFilter.attachedCreature())
+        condition = Conditions.Not(EnchantedCreatureHasSubtype(Subtype.HUMAN))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Steve Argyle"
+        flavorText = "\"What cannot be destroyed will be bound.\"\n—Oath of Avacyn"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/c/c/cc8d1ce0-78c5-4e97-9cca-33e7b6ff3440.jpg?1562835456"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/ElderCathar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/ElderCathar.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Elder Cathar
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * When this creature dies, put a +1/+1 counter on target creature you control.
+ * If that creature is a Human, put two +1/+1 counters on it instead.
+ */
+val ElderCathar = card("Elder Cathar") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText =
+        "When this creature dies, put a +1/+1 counter on target creature you control. " +
+            "If that creature is a Human, put two +1/+1 counters on it instead."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.HUMAN),
+            ),
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, creature),
+            elseEffect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Chris Rahn"
+        flavorText =
+            "\"My greatest hope is that you will surpass me in every way, " +
+                "my student. Then I can consider my life's work complete.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/c/2/c21b9e51-fecd-4f9a-9354-a6dc1613feb3.jpg?1562837015"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/FalkenrathNoble.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/FalkenrathNoble.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Falkenrath Noble
+ * {3}{B}
+ * Creature — Vampire Noble
+ * 2/2
+ * Flying
+ * Whenever this creature or another creature dies, target player loses 1 life and you gain 1 life.
+ */
+val FalkenrathNoble = card("Falkenrath Noble") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Noble"
+    oracleText =
+        "Flying\nWhenever this creature or another creature dies, target player loses 1 life and you gain 1 life."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.AnyCreatureDies
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            Effects.LoseLife(1, player),
+            Effects.GainLife(1, EffectTarget.Controller),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "100"
+        artist = "Slawomir Maniak"
+        flavorText = "\"I often think on how excited they must feel to be chosen as my prey.\""
+        imageUri =
+            "https://cards.scryfall.io/normal/front/e/2/e2286f94-4cf9-4462-b5d7-cee7f6910018.jpg?1782714754"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/GeistOfSaintTraft.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/GeistOfSaintTraft.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Geist of Saint Traft
+ * {1}{W}{U}
+ * Legendary Creature — Spirit Cleric
+ * 2/2
+ * Hexproof
+ * Whenever this creature attacks, create a 4/4 white Angel creature token with flying that's
+ * tapped and attacking. Exile that token at end of combat.
+ */
+val GeistOfSaintTraft = card("Geist of Saint Traft") {
+    manaCost = "{1}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Spirit Cleric"
+    oracleText =
+        "Hexproof\n" +
+            "Whenever this creature attacks, create a 4/4 white Angel creature token with flying " +
+            "that's tapped and attacking. Exile that token at end of combat."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.HEXPROOF)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = CreateTokenEffect(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Angel"),
+            keywords = setOf(Keyword.FLYING),
+            tapped = true,
+            attacking = true,
+        ).then(
+            CreateDelayedTriggerEffect(
+                step = Step.END_COMBAT,
+                effect = Effects.Move(
+                    target = EffectTarget.PipelineTarget(CREATED_TOKENS, 0),
+                    destination = Zone.EXILE,
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "213"
+        artist = "Igor Kieryluk"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/3/5/35b57113-b39a-460b-b4aa-02606b40bbd0.jpg?1783940907"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/Ghoulraiser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/Ghoulraiser.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ghoulraiser
+ * {1}{B}{B}
+ * Creature — Zombie
+ * 2/2
+ * When this creature enters, return a Zombie card at random from your graveyard to your hand.
+ */
+val Ghoulraiser = card("Ghoulraiser") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    oracleText =
+        "When this creature enters, return a Zombie card at random from your graveyard to your hand."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    Zone.GRAVEYARD,
+                    Player.You,
+                    GameObjectFilter.Any.withSubtype(Subtype.ZOMBIE),
+                ),
+                storeAs = "zombies",
+            ),
+            SelectFromCollectionEffect(
+                from = "zombies",
+                selection = SelectionMode.Random(DynamicAmount.Fixed(1)),
+                storeSelected = "chosen",
+            ),
+            MoveCollectionEffect(
+                from = "chosen",
+                destination = CardDestination.ToZone(Zone.HAND),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Steve Prescott"
+        flavorText =
+            "\"Come. Bring your brothers. Tonight, you feast on living flesh.\"\n—Jadar, ghoulcaller of Nephalia"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/5/2/52c537d1-2d57-4a87-9dac-594d40d95633.jpg?1783940954"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/SharpenedPitchfork.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/SharpenedPitchfork.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sharpened Pitchfork
+ * {2}
+ * Artifact — Equipment
+ * Equipped creature has first strike.
+ * As long as equipped creature is a Human, it gets +1/+1.
+ * Equip {1}
+ */
+val SharpenedPitchfork = card("Sharpened Pitchfork") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText =
+        "Equipped creature has first strike.\n" +
+            "As long as equipped creature is a Human, it gets +1/+1.\n" +
+            "Equip {1}"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.EquippedCreature)
+    }
+    staticAbility {
+        condition = Conditions.EntityMatches(
+            EffectTarget.EquippedCreature,
+            GameObjectFilter.Creature.withSubtype(Subtype.HUMAN),
+        )
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
+    }
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "232"
+        artist = "Winona Nelson"
+        flavorText = "Not everyone can have a sword of blessed silver. Not everyone needs one, either."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/4/c/4ce20f19-a159-40e6-bb67-6108872ac1e0.jpg?1782714678"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/StitchedDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/StitchedDrake.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Stitched Drake
+ * {1}{U}{U}
+ * Creature — Zombie Drake
+ * 3/4
+ * As an additional cost to cast this spell, exile a creature card from your graveyard.
+ * Flying
+ */
+val StitchedDrake = card("Stitched Drake") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Drake"
+    oracleText =
+        "As an additional cost to cast this spell, exile a creature card from your graveyard.\nFlying"
+    power = 3
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    additionalCost(Costs.additional.ExileCards(count = 1, filter = GameObjectFilter.Creature))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Chris Rahn"
+        flavorText =
+            "\"The best skaab are more powerful and more beautiful than the sum of their parts.\"\n—Stitcher Geralf"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/a/d/ad81266a-488f-449a-9daf-637727564865.jpg?1782714763"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DoomedTravelerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DoomedTravelerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Doomed Traveler reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val DoomedTravelerReprint = Printing(
+    oracleId = "a30907c0-fbde-4fd3-a8c7-f304305fcea7",
+    name = "Doomed Traveler",
+    setCode = "J22",
+    collectorNumber = "178",
+    scryfallId = "e98c3007-c45f-4502-ae4b-693bd64f23ba",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/e/9/e98c3007-c45f-4502-ae4b-693bd64f23ba.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GravecrawlerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GravecrawlerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gravecrawler reprint in J22. Canonical CardDefinition lives in its earliest set.
+ */
+val GravecrawlerReprint = Printing(
+    oracleId = "09ff28b1-b6c9-48e6-b12e-2f0e644f709f",
+    name = "Gravecrawler",
+    setCode = "J22",
+    collectorNumber = "423",
+    scryfallId = "128351fb-2ce0-4439-982a-9cc741936992",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/128351fb-2ce0-4439-982a-9cc741936992.jpg",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BarterInBloodReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BarterInBloodReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barter in Blood reprint in JMP. Canonical CardDefinition lives in its earliest set.
+ */
+val BarterInBloodReprint = Printing(
+    oracleId = "9167998d-5cac-47d7-99f2-f38122f7b8e7",
+    name = "Barter in Blood",
+    setCode = "JMP",
+    collectorNumber = "202",
+    scryfallId = "23986add-b33d-4bad-86f3-e2d0f99cf949",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/23986add-b33d-4bad-86f3-e2d0f99cf949.jpg",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/MistRavenReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/MistRavenReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mist Raven reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val MistRavenReprint = Printing(
+    oracleId = "12654457-3aae-4046-a976-8e41c3f78927",
+    name = "Mist Raven",
+    setCode = "KHC",
+    collectorNumber = "41",
+    scryfallId = "8f868751-dd1a-4beb-b3cc-c4a88980299b",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8f868751-dd1a-4beb-b3cc-c4a88980299b.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/TranquilCoveReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khc/cards/TranquilCoveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.khc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Cove reprint in KHC. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilCoveReprint = Printing(
+    oracleId = "5d641bf6-0f93-4189-8dc1-ec7ea446dade",
+    name = "Tranquil Cove",
+    setCode = "KHC",
+    collectorNumber = "119",
+    scryfallId = "be3a2d81-adda-49f7-980f-64bd567f89b6",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be3a2d81-adda-49f7-980f-64bd567f89b6.jpg",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DiregrafGhoulReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DiregrafGhoulReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Diregraf Ghoul reprint in M19. Canonical CardDefinition lives in its earliest set.
+ */
+val DiregrafGhoulReprint = Printing(
+    oracleId = "6048fc70-0dcc-4b54-977d-16e240225f82",
+    name = "Diregraf Ghoul",
+    setCode = "M19",
+    collectorNumber = "92",
+    scryfallId = "5cf2d355-404e-4c21-9bc2-973d09a845a5",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5cf2d355-404e-4c21-9bc2-973d09a845a5.jpg",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/MoorlandInquisitorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/MoorlandInquisitorReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moorland Inquisitor reprint in M20. Canonical CardDefinition lives in its earliest set.
+ */
+val MoorlandInquisitorReprint = Printing(
+    oracleId = "76bbd280-dcbc-43b3-a8a1-603443b2ccaa",
+    name = "Moorland Inquisitor",
+    setCode = "M20",
+    collectorNumber = "31",
+    scryfallId = "9d7b1446-7c9f-4b62-9877-e3d1060948aa",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9d7b1446-7c9f-4b62-9877-e3d1060948aa.jpg",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BarterInBlood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BarterInBlood.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Barter in Blood
+ * {2}{B}{B}
+ * Sorcery
+ * Each player sacrifices two creatures of their choice.
+ *
+ * Same ForEachPlayer + ForceSacrifice shape as Abyssal Gorestalker's ETB.
+ */
+val BarterInBlood = card("Barter in Blood") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Each player sacrifices two creatures of their choice."
+
+    spell {
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                ForceSacrificeEffect(
+                    filter = GameObjectFilter.Creature,
+                    count = 2,
+                    target = EffectTarget.Controller,
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "57"
+        artist = "Paolo Parente"
+        flavorText =
+            "\"In the game of conquest, who cares about the pawns if the king yet reigns?\"\n—Geth, keeper of the Vault"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/b/e/beccbb2c-ca1d-4b72-9eca-a64a313fd830.jpg?1783944550"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SeverTheBloodlineReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/SeverTheBloodlineReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sever the Bloodline reprint in NCC. Canonical CardDefinition lives in its earliest set.
+ */
+val SeverTheBloodlineReprint = Printing(
+    oracleId = "b9019332-2f02-48d9-be0a-a2b41b79e136",
+    name = "Sever the Bloodline",
+    setCode = "NCC",
+    collectorNumber = "259",
+    scryfallId = "22bfced7-8fbf-44d2-a439-7ac7c8c7e365",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22bfced7-8fbf-44d2-a439-7ac7c8c7e365.jpg",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/DismalBackwaterReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/DismalBackwaterReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dismal Backwater reprint in NEO. Canonical CardDefinition lives in its earliest set.
+ */
+val DismalBackwaterReprint = Printing(
+    oracleId = "865a2194-fca0-446e-aae3-ca475cd66e00",
+    name = "Dismal Backwater",
+    setCode = "NEO",
+    collectorNumber = "267",
+    scryfallId = "fab0660b-81f8-40ca-8098-5f8d51219a40",
+    artist = "Chris Ostrowski",
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/fab0660b-81f8-40ca-8098-5f8d51219a40.jpg",
+    releaseDate = "2022-02-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/TranquilCoveReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/TranquilCoveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tranquil Cove reprint in NEO. Canonical CardDefinition lives in its earliest set.
+ */
+val TranquilCoveReprint = Printing(
+    oracleId = "5d641bf6-0f93-4189-8dc1-ec7ea446dade",
+    name = "Tranquil Cove",
+    setCode = "NEO",
+    collectorNumber = "280",
+    scryfallId = "68f822b7-efc5-42c8-93ea-7dd17b4c3e7a",
+    artist = "Alayna Danner",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/68f822b7-efc5-42c8-93ea-7dd17b4c3e7a.jpg",
+    releaseDate = "2022-02-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ScrapskinDrakeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ScrapskinDrakeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Scrapskin Drake reprint in ORI. Canonical def lives in AVR. */
+val ScrapskinDrakeReprint = Printing(
+    oracleId = "910e8269-6001-479a-ab2e-5a935569c33c",
+    name = "Scrapskin Drake",
+    setCode = "ORI",
+    collectorNumber = "69",
+    scryfallId = "f5a1b7fc-6b0e-4228-b320-b1274e5ed14b",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f5a1b7fc-6b0e-4228-b320-b1274e5ed14b.jpg?1783938348",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TowerGeistReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/TowerGeistReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tower Geist reprint in ORI. Canonical CardDefinition lives in its earliest set.
+ */
+val TowerGeistReprint = Printing(
+    oracleId = "10e19453-84fb-4845-8db0-c9da52847e09",
+    name = "Tower Geist",
+    setCode = "ORI",
+    collectorNumber = "80",
+    scryfallId = "c62815ee-d1d6-4c96-8ab0-4c0a8250ae86",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c62815ee-d1d6-4c96-8ab0-4c0a8250ae86.jpg",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/EerieInterludeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/EerieInterludeReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Eerie Interlude reprint in SOI. Canonical def lives in DDQ. */
+val EerieInterludeReprint = Printing(
+    oracleId = "0634091a-a74c-4cea-b6d1-7324a725554a",
+    name = "Eerie Interlude",
+    setCode = "SOI",
+    collectorNumber = "16",
+    scryfallId = "dcbab6e4-d317-4e73-a6ff-bed49aa6b70b",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dcbab6e4-d317-4e73-a6ff-bed49aa6b70b.jpg?1576383815",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MindwrackDemonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/MindwrackDemonReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Mindwrack Demon reprint in SOI. Canonical def lives in DDQ. */
+val MindwrackDemonReprint = Printing(
+    oracleId = "3dda8d3d-89e2-4600-be8d-9b76b4f36e33",
+    name = "Mindwrack Demon",
+    setCode = "SOI",
+    collectorNumber = "124",
+    scryfallId = "b804cb9c-349e-4143-a372-cf65470d5b46",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b804cb9c-349e-4143-a372-cf65470d5b46.jpg?1783937768",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/PoreOverThePagesReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/PoreOverThePagesReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Pore Over the Pages reprint in SOI. Canonical def lives in DDQ. */
+val PoreOverThePagesReprint = Printing(
+    oracleId = "55fe5ec3-1c81-4e9d-9e4c-f68ce6d7c2de",
+    name = "Pore Over the Pages",
+    setCode = "SOI",
+    collectorNumber = "79",
+    scryfallId = "b2288f7b-05b1-4a6c-8d02-42ffcadc6f0b",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b2288f7b-05b1-4a6c-8d02-42ffcadc6f0b.jpg?1576384290",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ToothCollectorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ToothCollectorReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Tooth Collector reprint in SOI. Canonical def lives in DDQ. */
+val ToothCollectorReprint = Printing(
+    oracleId = "b7c165a4-53a2-4117-a452-b9a8fe309c09",
+    name = "Tooth Collector",
+    setCode = "SOI",
+    collectorNumber = "140",
+    scryfallId = "febc9f63-a225-438d-b835-07a561ba91f5",
+    artist = "Bud Cook",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/febc9f63-a225-438d-b835-07a561ba91f5.jpg?1576384754",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/TopplegeistReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/TopplegeistReprint.kt
@@ -1,0 +1,17 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/** Topplegeist reprint in SOI. Canonical def lives in DDQ. */
+val TopplegeistReprint = Printing(
+    oracleId = "4a71f404-e48d-4c86-882e-4e21c8210dea",
+    name = "Topplegeist",
+    setCode = "SOI",
+    collectorNumber = "45",
+    scryfallId = "ec9e8653-13ae-446c-b341-85c9b3fa6ca8",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ec9e8653-13ae-446c-b341-85c9b3fa6ca8.jpg?1783937803",
+    releaseDate = "2016-04-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DreadReturn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/DreadReturn.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Dread Return
+ * {2}{B}{B}
+ * Sorcery
+ * Return target creature card from your graveyard to the battlefield.
+ * Flashback—Sacrifice three creatures.
+ */
+val DreadReturn = card("Dread Return") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText =
+        "Return target creature card from your graveyard to the battlefield.\n" +
+            "Flashback—Sacrifice three creatures. (You may cast this card from your graveyard " +
+            "for its flashback cost. Then exile it.)"
+
+    spell {
+        val card = target(
+            "target creature card from your graveyard",
+            Targets.CreatureCardInYourGraveyard,
+        )
+        effect = Effects.Move(card, Zone.BATTLEFIELD)
+    }
+
+    keywordAbility(
+        KeywordAbility.flashback(
+            "",
+            Costs.additional.SacrificePermanent(Filters.Creature, count = 3),
+        ),
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "104"
+        artist = "Kev Walker"
+        flavorText = "Those who forget the horrors of the past are doomed to re-meet them."
+        imageUri =
+            "https://cards.scryfall.io/normal/front/d/7/d7e304fc-0ace-459e-8d2f-376f1899639c.jpg?1783943234"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/MomentaryBlink.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/MomentaryBlink.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Momentary Blink
+ * {1}{W}
+ * Instant
+ * Exile target creature you control, then return it to the battlefield under its owner's control.
+ * Flashback {3}{U}
+ */
+val MomentaryBlink = card("Momentary Blink") {
+    manaCost = "{1}{W}"
+    colorIdentity = "WU"
+    typeLine = "Instant"
+    oracleText =
+        "Exile target creature you control, then return it to the battlefield under its owner's control.\n" +
+            "Flashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Exile(creature).then(Effects.Move(creature, Zone.BATTLEFIELD))
+    }
+
+    keywordAbility(KeywordAbility.flashback("{3}{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Anthony S. Waters"
+        imageUri =
+            "https://cards.scryfall.io/normal/front/0/3/032e072a-0630-472b-9106-5df554dff785.jpg?1783943252"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CobbledWingsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/CobbledWingsReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cobbled Wings reprint in XLN. Canonical CardDefinition lives in its earliest set.
+ */
+val CobbledWingsReprint = Printing(
+    oracleId = "8d8682f3-9ef3-4aa7-9ea6-8a2ce09bff6f",
+    name = "Cobbled Wings",
+    setCode = "XLN",
+    collectorNumber = "233",
+    scryfallId = "3b2ff4f0-0dd1-4551-826b-68e8ff1e5860",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3b2ff4f0-0dd1-4551-826b-68e8ff1e5860.jpg",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.COMMON,
+)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
@@ -383,6 +383,60 @@ class DeathAndLeaveTriggerDetector(
     }
 
     /**
+     * Detect undying triggers (CR 702.92) when a nontoken creature dies with no +1/+1 counters on it.
+     *
+     * Undying is a triggered ability keyword: "When this creature dies, if it had no +1/+1 counters
+     * on it, return it to the battlefield under its owner's control with a +1/+1 counter on it."
+     *
+     * Symmetric with [detectPersistTriggers] — same projected-keyword + token-suppression gates,
+     * opposite counter polarity.
+     */
+    fun detectUndyingTriggers(
+        state: GameState,
+        event: ZoneChangeEvent,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        if (event.fromZone != Zone.BATTLEFIELD || event.toZone != Zone.GRAVEYARD) return
+        if (event.lastKnown?.wasToken == true) return
+        if ((event.lastKnown?.plusOnePlusOneCounters ?: 0) > 0) return
+        if (Keyword.UNDYING.name !in (event.lastKnown?.keywords ?: emptySet())) return
+
+        val info = resolveDyingEntity(state, event) ?: return
+
+        val undyingAbility = TriggeredAbility.create(
+            trigger = EventPattern.ZoneChangeEvent(
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD
+            ),
+            binding = TriggerBinding.SELF,
+            effect = CompositeEffect(
+                listOf(
+                    MoveToZoneEffect(
+                        target = EffectTarget.Self,
+                        destination = Zone.BATTLEFIELD
+                    ),
+                    AddCountersEffect(
+                        counterType = Counters.PLUS_ONE_PLUS_ONE,
+                        count = 1,
+                        target = EffectTarget.Self
+                    )
+                )
+            ),
+            descriptionOverride = "Undying — Return ${info.name} to the battlefield with a +1/+1 counter on it"
+        )
+
+        triggers.add(
+            PendingTrigger(
+                ability = undyingAbility,
+                sourceId = event.entityId,
+                sourceName = info.name,
+                controllerId = event.ownerId,
+                triggerContext = TriggerContext.fromEvent(event)
+            )
+        )
+    }
+
+    /**
      * Detect Enduring triggers (Duskmourn Glimmer cycle) when a permanent dies.
      *
      * Enduring: "When this permanent dies, if it was a creature, return it to the battlefield

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1389,6 +1389,8 @@ class TriggerDetector(
             deathAndLeaveDetector.detectDeadAuraAttachmentTriggers(state, event, triggers)
             // Handle persist (CR 702.79) — nontoken creature with persist dies with no -1/-1 counter
             deathAndLeaveDetector.detectPersistTriggers(state, event, triggers)
+            // Handle undying (CR 702.92) — nontoken creature with undying dies with no +1/+1 counter
+            deathAndLeaveDetector.detectUndyingTriggers(state, event, triggers)
             // Handle Enduring (Duskmourn Glimmer cycle) — nontoken creature with Enduring dies and
             // returns as an enchantment.
             deathAndLeaveDetector.detectEnduringTriggers(state, event, triggers)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbattoirGhoulScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbattoirGhoulScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.isd.cards.AbattoirGhoul
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Abattoir Ghoul: first strike + "whenever a creature dealt damage by this this turn dies,
+ * gain life equal to that creature's toughness."
+ */
+class AbattoirGhoulScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AbattoirGhoul)
+        return driver
+    }
+
+    test("gains life equal to toughness when a creature it damaged dies in combat") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val ghoul = driver.putCreatureOnBattlefield(attacker, "Abattoir Ghoul")
+        driver.removeSummoningSickness(ghoul)
+
+        // 2/2 blocker dies to first-strike 3 damage; toughness LKI is 2.
+        val blocker = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        driver.removeSummoningSickness(blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(ghoul), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(defender, mapOf(blocker to listOf(ghoul)))
+
+        // First-strike damage kills the 2/2; dies trigger gains 2 life.
+        driver.passPriorityUntil(Step.END_COMBAT)
+        driver.bothPass()
+
+        driver.getLifeTotal(attacker) shouldBe 22
+        driver.findPermanent(defender, "Grizzly Bears") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AppetiteForBrainsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AppetiteForBrainsScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Appetite for Brains (AVR #84): target opponent reveals hand; exile a card with MV ≥ 4.
+ */
+class AppetiteForBrainsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("reveal hand and exile a mana-value-4+ card") {
+
+            test("exiles the chosen high-MV card and leaves cheaper cards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Appetite for Brains")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withCardInHand(2, "Hill Giant") // MV 4 — legal
+                    .withCardInHand(2, "Glory Seeker") // MV 2 — not legal
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Appetite for Brains"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Player(game.player2Id)),
+                    ),
+                )
+                withClue("Casting Appetite for Brains should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val giant = game.state.getHand(game.player2Id).first {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name == "Hill Giant"
+                    }
+                    game.selectCards(listOf(giant))
+                    game.resolveStack()
+                }
+
+                withClue("Hill Giant is exiled") {
+                    game.state.getExile(game.player2Id).mapNotNull {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name
+                    } shouldBe listOf("Hill Giant")
+                }
+                withClue("Glory Seeker stays in hand") {
+                    game.state.getZone(game.player2Id, Zone.HAND).mapNotNull {
+                        game.state.getEntity(it)?.get<CardComponent>()?.name
+                    } shouldBe listOf("Glory Seeker")
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarterInBloodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarterInBloodScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.BarterInBlood
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class BarterInBloodScenarioTest : FunSpec({
+
+    fun GameTestDriver.drainStack(maxIterations: Int = 40) {
+        var guard = 0
+        while (guard++ < maxIterations) {
+            val pd = pendingDecision
+            when {
+                pd is SelectCardsDecision ->
+                    submitCardSelection(pd.playerId, pd.options.take(pd.minSelections))
+                state.stack.isNotEmpty() -> bothPass()
+                else -> return
+            }
+        }
+    }
+
+    test("each player sacrifices two creatures") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(BarterInBlood)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.player1
+        val opp = driver.player2
+        repeat(3) { driver.putCreatureOnBattlefield(me, "Grizzly Bears") }
+        repeat(3) { driver.putCreatureOnBattlefield(opp, "Grizzly Bears") }
+
+        val card = driver.putCardInHand(me, "Barter in Blood")
+        driver.giveColorlessMana(me, 2)
+        driver.giveMana(me, Color.BLACK, 2)
+        driver.castSpell(me, card).isSuccess shouldBe true
+        driver.drainStack()
+
+        // 3 bears each → sacrifice 2 → 1 left each.
+        driver.getCreatures(me).size shouldBe 1
+        driver.getCreatures(opp).size shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BondsOfFaithScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BondsOfFaithScenarioTest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+class BondsOfFaithScenarioTest : ScenarioTestBase() {
+    init {
+        test("Human host gets +2/+2") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Glory Seeker")
+                .withCardAttachedTo(1, "Bonds of Faith", "Glory Seeker")
+                .build()
+
+            val human = game.findPermanent("Glory Seeker")!!
+            // Glory Seeker is 2/2; Human branch is +2/+2 → 4/4.
+            game.state.projectedState.getPower(human) shouldBe 4
+            game.state.projectedState.getToughness(human) shouldBe 4
+            game.state.projectedState.cantAttack(human) shouldBe false
+            game.state.projectedState.cantBlock(human) shouldBe false
+        }
+
+        test("non-Human host can't attack or block") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardAttachedTo(1, "Bonds of Faith", "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            withClue("non-Human should not get the +2/+2") {
+                game.state.projectedState.getPower(bears) shouldBe 2
+                game.state.projectedState.getToughness(bears) shouldBe 2
+            }
+            game.state.projectedState.cantAttack(bears) shouldBe true
+            game.state.projectedState.cantBlock(bears) shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptainOfTheMistsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptainOfTheMistsScenarioTest.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.CaptainOfTheMists
+import com.wingedsheep.mtg.sets.definitions.avr.cards.CathedralSanctifier
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class CaptainOfTheMistsScenarioTest : FunSpec({
+    test("another Human entering untaps the Captain") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CaptainOfTheMists)
+        driver.registerCard(CathedralSanctifier)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Plains" to 20), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val captainId = driver.putPermanentOnBattlefield(you, "Captain of the Mists")
+        driver.tapPermanent(captainId)
+        driver.isTapped(captainId) shouldBe true
+
+        val human = driver.putCardInHand(you, "Cathedral Sanctifier")
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.castSpell(you, human)
+        driver.bothPass() // resolve Human
+        driver.bothPass() // resolve one ETB trigger
+        driver.bothPass() // resolve the other ETB trigger
+
+        driver.isTapped(captainId) shouldBe false
+        driver.findPermanent(you, "Captain of the Mists") shouldNotBe null
+        driver.findPermanent(you, "Cathedral Sanctifier") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CathedralSanctifierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CathedralSanctifierScenarioTest.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.CathedralSanctifier
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/** Cathedral Sanctifier: ETB gain 3 life. */
+class CathedralSanctifierScenarioTest : FunSpec({
+
+    test("entering the battlefield gains 3 life") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CathedralSanctifier)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Cathedral Sanctifier")
+        driver.bothPass()
+
+        driver.getLifeTotal(you) shouldBe 23
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CathedralSanctifierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CathedralSanctifierScenarioTest.kt
@@ -3,6 +3,8 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.avr.cards.CathedralSanctifier
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -17,8 +19,13 @@ class CathedralSanctifierScenarioTest : FunSpec({
         driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
 
         val you = driver.activePlayer!!
-        driver.putCreatureOnBattlefield(you, "Cathedral Sanctifier")
-        driver.bothPass()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val card = driver.putCardInHand(you, "Cathedral Sanctifier")
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.castSpell(you, card)
+        driver.bothPass() // creature resolves; ETB on stack
+        driver.bothPass() // ETB resolves
 
         driver.getLifeTotal(you) shouldBe 23
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiregrafCaptainScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiregrafCaptainScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+class DiregrafCaptainScenarioTest : ScenarioTestBase() {
+    init {
+        test("other Zombies you control get +1/+1") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Diregraf Captain")
+                .withCardOnBattlefield(1, "Diregraf Ghoul")
+                .build()
+
+            val captain = game.findPermanent("Diregraf Captain")!!
+            val ghoul = game.findPermanent("Diregraf Ghoul")!!
+            game.state.projectedState.getPower(captain) shouldBe 2
+            game.state.projectedState.getToughness(captain) shouldBe 2
+            game.state.projectedState.getPower(ghoul) shouldBe 3
+            game.state.projectedState.getToughness(ghoul) shouldBe 3
+        }
+
+        test("when another Zombie you control dies, target opponent loses 1") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Diregraf Captain")
+                .withCardOnBattlefield(1, "Diregraf Ghoul")
+                .withCardInHand(1, "Lightning Bolt")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ghoul = game.findPermanent("Diregraf Ghoul")!!
+            // Buffed Ghoul is 3/3 — Bolt (3) is needed; Shock (2) leaves it alive.
+            game.castSpell(1, "Lightning Bolt", ghoul).error shouldBe null
+            game.resolveStack()
+
+            // Single legal opponent may already be chosen; otherwise choose.
+            if (game.state.pendingDecision is ChooseTargetsDecision) {
+                game.selectTargets(listOf(game.player2Id))
+            }
+            if (game.state.stack.isNotEmpty()) {
+                game.resolveStack()
+            }
+
+            withClue(
+                "ghoul dead=${!game.isOnBattlefield("Diregraf Ghoul")} " +
+                    "life2=${game.getLifeTotal(2)} stack=${game.state.stack.size} " +
+                    "pending=${game.state.pendingDecision}",
+            ) {
+                game.isOnBattlefield("Diregraf Ghoul") shouldBe false
+                game.isOnBattlefield("Diregraf Captain") shouldBe true
+                game.getLifeTotal(2) shouldBe 19
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadReturnScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadReturnScenarioTest.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class DreadReturnScenarioTest : ScenarioTestBase() {
+    init {
+        test("returns a creature card from your graveyard to the battlefield") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withCardInHand(1, "Dread Return")
+                .withLandsOnBattlefield(1, "Swamp", 4)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpellTargetingGraveyardCard(1, "Dread Return", 1, "Grizzly Bears")
+                .error shouldBe null
+            game.resolveStack()
+
+            game.findPermanent("Grizzly Bears") shouldNotBe null
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EerieInterludeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EerieInterludeScenarioTest.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+class EerieInterludeScenarioTest : ScenarioTestBase() {
+    init {
+        test("exiles target creatures you control") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardInHand(1, "Eerie Interlude")
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Eerie Interlude", bears).error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Grizzly Bears") shouldBe false
+            game.isOnBattlefield("Eerie Interlude") shouldBe false
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElderCatharScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElderCatharScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class ElderCatharScenarioTest : ScenarioTestBase() {
+    init {
+        test("dies putting two +1/+1 counters on a Human") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Elder Cathar")
+                .withCardOnBattlefield(1, "Glory Seeker")
+                .withCardInHand(1, "Shock")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cathar = game.findPermanent("Elder Cathar")!!
+            val human = game.findPermanent("Glory Seeker")!!
+            val shock = game.findCardsInHand(1, "Shock").single()
+
+            val cast = game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = shock,
+                    targets = listOf(entityIdToChosenTarget(game.state, cathar)),
+                ),
+            )
+            withClue("Shock cast: ${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+
+            withClue("dies trigger should ask for a creature you control") {
+                (game.state.pendingDecision as? ChooseTargetsDecision).shouldNotBeNull()
+            }
+            game.selectTargets(listOf(human))
+            game.resolveStack()
+
+            game.isOnBattlefield("Elder Cathar") shouldBe false
+            val counters = game.state.getEntity(human)
+                ?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+            counters shouldBe 2
+        }
+
+        test("dies putting one +1/+1 counter on a non-Human") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Elder Cathar")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInHand(1, "Shock")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cathar = game.findPermanent("Elder Cathar")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val shock = game.findCardsInHand(1, "Shock").single()
+
+            val cast = game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = shock,
+                    targets = listOf(entityIdToChosenTarget(game.state, cathar)),
+                ),
+            )
+            withClue("Shock cast: ${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+
+            (game.state.pendingDecision as? ChooseTargetsDecision).shouldNotBeNull()
+            game.selectTargets(listOf(bears))
+            game.resolveStack()
+
+            val counters = game.state.getEntity(bears)
+                ?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+            counters shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmancipationAngelScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmancipationAngelScenarioTest.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.EmancipationAngel
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class EmancipationAngelScenarioTest : FunSpec({
+    test("ETB returns a permanent you control to hand") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(EmancipationAngel)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val beforeHand = driver.getHandSize(you)
+        val card = driver.putCardInHand(you, "Emancipation Angel")
+        driver.giveMana(you, Color.WHITE, 2)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpell(you, card)
+        driver.bothPass() // resolve angel — may prompt target
+
+        val decision = driver.pendingDecision
+        if (decision != null) {
+            driver.submitTargetSelection(you, listOf(bears))
+        }
+        driver.bothPass()
+
+        driver.findPermanent(you, "Emancipation Angel") shouldNotBe null
+        driver.findPermanent(you, "Grizzly Bears") shouldBe null
+        // put(+1) cast(-1) bounce(+1) => beforeHand + 1
+        driver.getHandSize(you) shouldBe beforeHand + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FalkenrathNobleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FalkenrathNobleScenarioTest.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class FalkenrathNobleScenarioTest : ScenarioTestBase() {
+    init {
+        test("when another creature dies, target player loses 1 and you gain 1") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Falkenrath Noble")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInHand(1, "Shock")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")
+            bears.shouldNotBeNull()
+            val shock = game.findCardsInHand(1, "Shock").single()
+
+            val cast = game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = shock,
+                    targets = listOf(entityIdToChosenTarget(game.state, bears)),
+                ),
+            )
+            withClue("Shock cast: ${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+
+            // After Shock resolves, Bears die and Noble triggers — choose player 2
+            withClue("Noble trigger should ask for a player target") {
+                (game.state.pendingDecision as? ChooseTargetsDecision).shouldNotBeNull()
+            }
+            game.selectTargets(listOf(game.player2Id))
+            game.resolveStack()
+
+            game.getLifeTotal(2) shouldBe 19
+            game.getLifeTotal(1) shouldBe 21
+            game.isOnBattlefield("Falkenrath Noble") shouldBe true
+            game.isOnBattlefield("Grizzly Bears") shouldBe false
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeistOfSaintTraftScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeistOfSaintTraftScenarioTest.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class GeistOfSaintTraftScenarioTest : ScenarioTestBase() {
+    init {
+        test("has hexproof") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Geist of Saint Traft")
+                .build()
+
+            val geist = game.findPermanent("Geist of Saint Traft")!!
+            game.state.projectedState.hasKeyword(geist, Keyword.HEXPROOF) shouldBe true
+        }
+
+        test("attacking creates a tapped-and-attacking Angel token") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Geist of Saint Traft", summoningSickness = false)
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Geist of Saint Traft" to 2)).error shouldBe null
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+
+            // Angel token should exist alongside Geist
+            game.state.getZone(game.player1Id, com.wingedsheep.sdk.core.Zone.BATTLEFIELD).size shouldBe 2
+            game.findPermanent("Geist of Saint Traft") shouldNotBe null
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhoulraiserScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhoulraiserScenarioTest.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class GhoulraiserScenarioTest : ScenarioTestBase() {
+    init {
+        test("ETB returns a random Zombie from graveyard to hand") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardInGraveyard(1, "Diregraf Ghoul")
+                .withCardInHand(1, "Ghoulraiser")
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handBefore = game.state.getZone(game.player1Id, Zone.HAND).size
+            game.castSpell(1, "Ghoulraiser").error shouldBe null
+            game.resolveStack()
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+
+            game.findPermanent("Ghoulraiser") shouldNotBe null
+            // put(+1 via cast from hand accounted) cast(-1) return(+1) => handBefore
+            // handBefore includes Ghoulraiser; after cast+ETB return: handBefore - 1 + 1 = handBefore
+            game.state.getZone(game.player1Id, Zone.HAND).size shouldBe handBefore
+            game.state.getZone(game.player1Id, Zone.GRAVEYARD).isEmpty() shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldnightRedeemerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldnightRedeemerScenarioTest.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.GoldnightRedeemer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class GoldnightRedeemerScenarioTest : FunSpec({
+    test("ETB gains 2 life per other creature you control") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GoldnightRedeemer)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two other creatures already on the battlefield
+        driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        val card = driver.putCardInHand(you, "Goldnight Redeemer")
+        driver.giveMana(you, Color.WHITE, 2)
+        driver.giveColorlessMana(you, 4)
+        driver.castSpell(you, card)
+        driver.bothPass() // resolve creature
+        driver.bothPass() // resolve ETB gain life
+
+        // 2 other creatures * 2 life = +4 (self excluded)
+        driver.getLifeTotal(you) shouldBe 24
+        driver.findPermanent(you, "Goldnight Redeemer") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GryffVanguardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GryffVanguardScenarioTest.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.GryffVanguard
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class GryffVanguardScenarioTest : FunSpec({
+    test("ETB draws a card") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GryffVanguard)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val beforeHand = driver.getHandSize(you)
+        val card = driver.putCardInHand(you, "Gryff Vanguard")
+        driver.giveMana(you, Color.BLUE, 1)
+        driver.giveColorlessMana(you, 4)
+        driver.castSpell(you, card)
+        driver.bothPass() // resolve creature
+        driver.bothPass() // resolve ETB draw
+
+        // Hand: put card (+1) then cast (-1) then draw (+1) => +1 vs beforeHand
+        driver.getHandSize(you) shouldBe beforeHand + 1
+        driver.findPermanent(you, "Gryff Vanguard") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarvesterOfSoulsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HarvesterOfSoulsScenarioTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class HarvesterOfSoulsScenarioTest : ScenarioTestBase() {
+    init {
+        test("when another nontoken creature dies, you may draw a card") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Harvester of Souls")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInHand(1, "Shock")
+                .withLandsOnBattlefield(1, "Mountain", 1)
+                .withCardInLibrary(1, "Island")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val shock = game.findCardsInHand(1, "Shock").single()
+            val handBefore = game.state.getZone(game.player1Id, Zone.HAND).size
+
+            val cast = game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = shock,
+                    targets = listOf(entityIdToChosenTarget(game.state, bears)),
+                ),
+            )
+            withClue("Shock cast: ${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+
+            game.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+
+            game.isOnBattlefield("Harvester of Souls") shouldBe true
+            game.isOnBattlefield("Grizzly Bears") shouldBe false
+            // Shock left hand (-1), then may-draw yes (+1) → back to handBefore.
+            withClue("drew a card after accepting may") {
+                game.state.getZone(game.player1Id, Zone.HAND).size shouldBe handBefore
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HavengulRunebinderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HavengulRunebinderScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.dka.cards.HavengulRunebinder
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class HavengulRunebinderScenarioTest : ScenarioTestBase() {
+    init {
+        val abilityId = HavengulRunebinder.activatedAbilities.first().id
+
+        test("creates a Zombie and pumps Zombies you control") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Havengul Runebinder", summoningSickness = false)
+                .withCardOnBattlefield(1, "Diregraf Ghoul")
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val runebinder = game.findPermanent("Havengul Runebinder")!!
+            val bfBefore = game.state.getZone(game.player1Id, Zone.BATTLEFIELD).size
+            val result = game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = runebinder,
+                    abilityId = abilityId,
+                ),
+            )
+            withClue("${result.error}") { result.error shouldBe null }
+
+            repeat(4) {
+                when (val d = game.state.pendingDecision) {
+                    is SelectCardsDecision -> game.selectCards(d.options.take(d.minSelections))
+                    else -> return@repeat
+                }
+            }
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+
+            game.state.getZone(game.player1Id, Zone.BATTLEFIELD).size shouldBeGreaterThanOrEqual bfBefore + 1
+            game.state.getZone(game.player1Id, Zone.GRAVEYARD).isEmpty() shouldBe true
+            val ghoul = game.findPermanent("Diregraf Ghoul")
+            ghoul shouldNotBe null
+            val counters = game.state.getEntity(ghoul!!)
+                ?.get<CountersComponent>()
+                ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+            counters shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HumanFrailtyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HumanFrailtyScenarioTest.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+class HumanFrailtyScenarioTest : ScenarioTestBase() {
+    init {
+        test("destroys a target Human") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Human Frailty")
+                .withLandsOnBattlefield(1, "Swamp", 1)
+                .withCardOnBattlefield(2, "Cathedral Sanctifier")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val human = game.findPermanent("Cathedral Sanctifier")!!
+            val cardId = game.state.getHand(game.player1Id).first {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Human Frailty"
+            }
+            val cast = game.execute(
+                CastSpell(game.player1Id, cardId, listOf(ChosenTarget.Permanent(human))),
+            )
+            withClue("${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+            game.findPermanent("Cathedral Sanctifier") shouldBe null
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IncreasingDevotionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IncreasingDevotionScenarioTest.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+
+class IncreasingDevotionScenarioTest : ScenarioTestBase() {
+    init {
+        test("creates five 1/1 Human tokens") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardInHand(1, "Increasing Devotion")
+                .withLandsOnBattlefield(1, "Plains", 5)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Increasing Devotion").error shouldBe null
+            game.resolveStack()
+
+            game.state.getZone(game.player1Id, Zone.BATTLEFIELD).size shouldBeGreaterThanOrEqual 10
+            // 5 Plains + 5 Human tokens
+            game.state.getZone(game.player1Id, Zone.BATTLEFIELD).size shouldBe 10
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MindwrackDemonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MindwrackDemonScenarioTest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ddq.cards.MindwrackDemon
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class MindwrackDemonScenarioTest : FunSpec({
+    test("ETB mills four; upkeep loses 4 without delirium") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MindwrackDemon)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val beforeGy = driver.getGraveyardCardNames(you).size
+        val card = driver.putCardInHand(you, "Mindwrack Demon")
+        driver.giveMana(you, Color.BLACK, 2)
+        driver.giveColorlessMana(you, 2)
+        driver.castSpell(you, card)
+        driver.bothPass() // resolve creature
+        driver.bothPass() // resolve ETB mill
+
+        driver.getGraveyardCardNames(you).size shouldBe beforeGy + 4
+        driver.findPermanent(you, "Mindwrack Demon") shouldNotBe null
+
+        // Advance to your next upkeep (pass through opponent's turn first)
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.passPriorityUntil(Step.UPKEEP) // opponent upkeep
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.passPriorityUntil(Step.UPKEEP) // your upkeep
+        driver.state.activePlayerId shouldBe you
+        driver.state.step shouldBe Step.UPKEEP
+
+        driver.bothPass() // resolve delirium trigger
+        driver.getLifeTotal(you) shouldBe 16
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomentaryBlinkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomentaryBlinkScenarioTest.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class MomentaryBlinkScenarioTest : ScenarioTestBase() {
+    init {
+        test("exiles then returns a creature you control") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardInHand(1, "Momentary Blink")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            game.state.getEntity(bears)!!.has<SummoningSicknessComponent>() shouldBe false
+
+            game.castSpell(1, "Momentary Blink", bears).error shouldBe null
+            game.resolveStack()
+
+            val blinked = game.findPermanent("Grizzly Bears")
+            blinked shouldNotBe null
+            withClue("blink re-enters with summoning sickness") {
+                game.state.getEntity(blinked!!)!!.has<SummoningSicknessComponent>() shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoorlandInquisitorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoorlandInquisitorScenarioTest.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.avr.cards.MoorlandInquisitor
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+class MoorlandInquisitorScenarioTest : ScenarioTestBase() {
+    init {
+        val activateAbilityId = MoorlandInquisitor.activatedAbilities.first().id
+
+        test("activated ability grants first strike until end of turn") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Moorland Inquisitor")
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val inquisitor = game.findPermanent("Moorland Inquisitor")!!
+            val result = game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = inquisitor,
+                    abilityId = activateAbilityId,
+                ),
+            )
+            withClue("${result.error}") { result.error shouldBe null }
+            if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                game.submitManaSourcesAutoPay()
+            }
+            game.resolveStack()
+
+            game.state.projectedState.hasKeyword(inquisitor, Keyword.FIRST_STRIKE) shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NephaliaSmugglerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NephaliaSmugglerScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.avr.cards.NephaliaSmuggler
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class NephaliaSmugglerScenarioTest : ScenarioTestBase() {
+    init {
+        val abilityId = NephaliaSmuggler.activatedAbilities.first().id
+
+        test("blinks another creature you control under your control") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Nephalia Smuggler", summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withLandsOnBattlefield(1, "Island", 4)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val smuggler = game.findPermanent("Nephalia Smuggler")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+            game.state.getEntity(bears)!!.has<SummoningSicknessComponent>() shouldBe false
+
+            val result = game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = smuggler,
+                    abilityId = abilityId,
+                    targets = listOf(entityIdToChosenTarget(game.state, bears)),
+                ),
+            )
+            withClue("${result.error}") { result.error shouldBe null }
+            game.resolveStack()
+
+            game.findPermanent("Nephalia Smuggler") shouldNotBe null
+            val blinked = game.findPermanent("Grizzly Bears")
+            blinked shouldNotBe null
+            // Fresh battlefield entry from exile → summoning sickness again.
+            game.state.getEntity(blinked!!)!!.has<SummoningSicknessComponent>() shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PoreOverThePagesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PoreOverThePagesScenarioTest.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+class PoreOverThePagesScenarioTest : ScenarioTestBase() {
+    init {
+        test("draws three then discards one") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardInHand(1, "Pore Over the Pages")
+                .withLandsOnBattlefield(1, "Island", 5)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Mountain")
+                .withCardInLibrary(1, "Swamp")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handBefore = game.state.getZone(game.player1Id, Zone.HAND).size
+            game.castSpell(1, "Pore Over the Pages").error shouldBe null
+            game.resolveStack()
+
+            repeat(8) {
+                when (val d = game.state.pendingDecision) {
+                    is ChooseTargetsDecision -> game.selectTargets(emptyList())
+                    is SelectCardsDecision -> game.selectCards(d.options.take(d.minSelections))
+                    else -> return@repeat
+                }
+                if (game.state.stack.isNotEmpty()) game.resolveStack()
+            }
+
+            withClue("net +1 after cast/draw3/discard1 (Pore left hand)") {
+                game.state.getZone(game.player1Id, Zone.HAND).size shouldBe handBefore + 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScrapskinDrakeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScrapskinDrakeScenarioTest.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scrapskin Drake (AVR #73) — Flying; can block only creatures with flying.
+ */
+class ScrapskinDrakeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Scrapskin Drake can only block creatures with flying") {
+
+            test("is a 2/3 flyer") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scrapskin Drake")
+                    .build()
+
+                val drake = game.findPermanent("Scrapskin Drake")!!
+                game.state.projectedState.getPower(drake) shouldBe 2
+                game.state.projectedState.getToughness(drake) shouldBe 3
+                game.state.projectedState.hasKeyword(drake, Keyword.FLYING) shouldBe true
+            }
+
+            test("can legally block a flying attacker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scrapskin Drake", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Birds of Paradise", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Birds of Paradise" to 1)).error shouldBe null
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                val result = game.declareBlockers(mapOf("Scrapskin Drake" to listOf("Birds of Paradise")))
+                withClue("blocking a flying attacker is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+
+            test("cannot legally block a non-flying attacker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Scrapskin Drake", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hill Giant" to 1)).error shouldBe null
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                val result = game.declareBlockers(mapOf("Scrapskin Drake" to listOf("Hill Giant")))
+                withClue("blocking a non-flying attacker is illegal: ${result.error}") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScreechingSkaabScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScreechingSkaabScenarioTest.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dka.cards.ScreechingSkaab
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class ScreechingSkaabScenarioTest : FunSpec({
+    test("ETB mills two cards") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ScreechingSkaab)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val beforeGy = driver.getGraveyardCardNames(you).size
+        val card = driver.putCardInHand(you, "Screeching Skaab")
+        driver.giveMana(you, Color.BLUE, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpell(you, card)
+        driver.bothPass() // resolve creature
+        driver.bothPass() // resolve ETB mill
+
+        driver.getGraveyardCardNames(you).size shouldBe beforeGy + 2
+        driver.findPermanent(you, "Screeching Skaab") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeraphSanctuaryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeraphSanctuaryScenarioTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.GoldnightRedeemer
+import com.wingedsheep.mtg.sets.definitions.avr.cards.SeraphSanctuary
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class SeraphSanctuaryScenarioTest : FunSpec({
+    test("ETB gains 1 life; Angel you control entering gains 1 more") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(SeraphSanctuary)
+        driver.registerCard(GoldnightRedeemer)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = driver.putCardInHand(you, "Seraph Sanctuary")
+        driver.playLand(you, land)
+        driver.bothPass() // resolve land ETB
+
+        driver.getLifeTotal(you) shouldBe 21
+        driver.findPermanent(you, "Seraph Sanctuary") shouldNotBe null
+
+        // Angel ETB: Sanctuary trigger +1. Redeemer ETB with no other creatures: +0.
+        val angel = driver.putCardInHand(you, "Goldnight Redeemer")
+        driver.giveMana(you, Color.WHITE, 2)
+        driver.giveColorlessMana(you, 4)
+        driver.castSpell(you, angel)
+        driver.bothPass() // resolve angel (Sanctuary + Redeemer triggers stack)
+        driver.bothPass() // resolve one ETB trigger
+        driver.bothPass() // resolve the other ETB trigger
+
+        driver.getLifeTotal(you) shouldBe 22
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StitchedDrakeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StitchedDrakeScenarioTest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+class StitchedDrakeScenarioTest : ScenarioTestBase() {
+    init {
+        test("casting exiles a creature card from the graveyard as an additional cost") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Stitched Drake")
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val drake = game.findCardsInHand(1, "Stitched Drake").single()
+            val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+
+            val cast = game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = drake,
+                    targets = emptyList(),
+                    additionalCostPayment = AdditionalCostPayment(exiledCards = listOf(bears)),
+                ),
+            )
+            withClue("casting should succeed: ${cast.error}") { cast.error shouldBe null }
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+            game.isInExile(1, "Grizzly Bears") shouldBe true
+            game.isOnBattlefield("Stitched Drake") shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThrabenHereticScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThrabenHereticScenarioTest.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.dka.cards.ThrabenHeretic
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class ThrabenHereticScenarioTest : ScenarioTestBase() {
+    init {
+        val abilityId = ThrabenHeretic.activatedAbilities.first().id
+
+        test("tap ability exiles a creature card from a graveyard") {
+            val game = scenario()
+                .withPlayers("Player", "Opponent")
+                .withCardOnBattlefield(1, "Thraben Heretic", summoningSickness = false)
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val heretic = game.findPermanent("Thraben Heretic")!!
+            val gyCard = game.state.getZone(game.player1Id, Zone.GRAVEYARD).first()
+
+            val result = game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = heretic,
+                    abilityId = abilityId,
+                    targets = listOf(entityIdToChosenTarget(game.state, gyCard)),
+                ),
+            )
+            withClue("${result.error}") { result.error shouldBe null }
+            game.resolveStack()
+
+            game.state.getZone(game.player1Id, Zone.GRAVEYARD).isEmpty() shouldBe true
+            game.findPermanent("Thraben Heretic") shouldNotBe null
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ToothCollectorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ToothCollectorScenarioTest.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class ToothCollectorScenarioTest : ScenarioTestBase() {
+    init {
+        test("ETB gives opponent creature -1/-1 until end of turn") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withCardInHand(1, "Tooth Collector")
+                .withLandsOnBattlefield(1, "Swamp", 3)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            game.castSpell(1, "Tooth Collector", bears).error shouldBe null
+            game.resolveStack()
+            // ETB may need a second resolve if target wasn't bound at cast time
+            if (game.state.pendingDecision != null) {
+                game.selectTargets(listOf(bears))
+            }
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+
+            game.findPermanent("Tooth Collector") shouldNotBe null
+            game.state.projectedState.getPower(bears) shouldBe 1
+            game.state.projectedState.getToughness(bears) shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TopplegeistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TopplegeistScenarioTest.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.ddq.cards.Topplegeist
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class TopplegeistScenarioTest : FunSpec({
+    test("ETB taps target creature an opponent controls") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(Topplegeist)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val card = driver.putCardInHand(you, "Topplegeist")
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.castSpell(you, card)
+        driver.bothPass() // resolve Topplegeist
+        val decision = driver.pendingDecision
+        decision shouldNotBe null
+        driver.submitTargetSelection(you, listOf(bears))
+        driver.bothPass()
+
+        driver.isTapped(bears) shouldBe true
+        driver.findPermanent(you, "Topplegeist") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndyingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndyingScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the undying keyword (CR 702.92).
+ *
+ * Undying: "When this creature dies, if it had no +1/+1 counters on it, return it to the
+ * battlefield under its owner's control with a +1/+1 counter on it."
+ *
+ * Tests use [TestCards.UndyingTestCreature] (1/1) and Lightning Bolt as removal.
+ */
+class UndyingScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of(
+                "Swamp" to 20,
+                "Mountain" to 20
+            ),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    test("undying returns the creature with a +1/+1 counter when it dies with no +1/+1 counters") {
+        val driver = createDriver()
+        val caster = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(caster, "Undying Test Creature")
+        val creature = driver.findPermanent(caster, "Undying Test Creature")
+        creature.shouldNotBeNull()
+
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+
+        driver.castSpell(caster, bolt, listOf(creature)).isSuccess shouldBe true
+        driver.bothPass() // resolve Lightning Bolt (3 damage → lethal)
+
+        driver.stackSize shouldBeGreaterThanOrEqual 1
+
+        driver.bothPass() // resolve undying trigger
+
+        val returned = driver.findPermanent(caster, "Undying Test Creature")
+        returned.shouldNotBeNull()
+
+        val counters = driver.state.getEntity(returned)?.get<CountersComponent>()
+        counters.shouldNotBeNull()
+        counters.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+    }
+
+    test("undying does not fire when the creature already has a +1/+1 counter at time of death") {
+        val driver = createDriver()
+        val caster = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(caster, "Undying Test Creature")
+        val creature = driver.findPermanent(caster, "Undying Test Creature")
+        creature.shouldNotBeNull()
+
+        driver.replaceState(
+            driver.state.updateEntity(creature) { c ->
+                val counters = c.get<CountersComponent>() ?: CountersComponent()
+                c.with(counters.withAdded(CounterType.PLUS_ONE_PLUS_ONE, 1))
+            }
+        )
+
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+
+        driver.castSpell(caster, bolt, listOf(creature)).isSuccess shouldBe true
+        driver.bothPass() // resolve Lightning Bolt
+
+        driver.findPermanent(caster, "Undying Test Creature") shouldBe null
+        driver.getGraveyardCardNames(caster) shouldContain "Undying Test Creature"
+    }
+
+    test("a creature returned by undying cannot undying a second time (it now has a +1/+1 counter)") {
+        val driver = createDriver()
+        val caster = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(caster, "Undying Test Creature")
+        val creature = driver.findPermanent(caster, "Undying Test Creature")
+        creature.shouldNotBeNull()
+
+        val bolt1 = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+        driver.castSpell(caster, bolt1, listOf(creature)).isSuccess shouldBe true
+        driver.bothPass() // resolve Lightning Bolt
+        driver.bothPass() // resolve undying trigger
+
+        val returned = driver.findPermanent(caster, "Undying Test Creature")
+        returned.shouldNotBeNull()
+
+        val bolt2 = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+        driver.castSpell(caster, bolt2, listOf(returned)).isSuccess shouldBe true
+        driver.bothPass() // resolve Lightning Bolt
+
+        driver.findPermanent(caster, "Undying Test Creature") shouldBe null
+        driver.getGraveyardCardNames(caster).count { it == "Undying Test Creature" } shouldBe 1
+    }
+
+    test("undying does not fire on tokens (Rule 704.5d — tokens cease to exist)") {
+        val driver = createDriver()
+        val caster = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(caster, "Undying Test Creature")
+        val tokenId = driver.findPermanent(caster, "Undying Test Creature")
+        tokenId.shouldNotBeNull()
+        driver.replaceState(
+            driver.state.updateEntity(tokenId) { c -> c.with(TokenComponent) }
+        )
+
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+
+        driver.castSpell(caster, bolt, listOf(tokenId)).isSuccess shouldBe true
+        driver.bothPass() // resolve Lightning Bolt
+
+        driver.findPermanent(caster, "Undying Test Creature") shouldBe null
+        driver.state.getBattlefield().contains(tokenId) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoiceOfTheProvincesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoiceOfTheProvincesScenarioTest.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.avr.cards.VoiceOfTheProvinces
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class VoiceOfTheProvincesScenarioTest : FunSpec({
+    test("ETB creates a 1/1 white Human token") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(VoiceOfTheProvinces)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val card = driver.putCardInHand(you, "Voice of the Provinces")
+        driver.giveMana(you, Color.WHITE, 2)
+        driver.giveColorlessMana(you, 4)
+        driver.castSpell(you, card)
+        driver.bothPass() // resolve angel
+        driver.bothPass() // resolve ETB token
+
+        driver.findPermanent(you, "Voice of the Provinces") shouldNotBe null
+        driver.getCreatures(you).size shouldBe 2
+    }
+})

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/TestCards.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/TestCards.kt
@@ -618,6 +618,19 @@ object TestCards {
     )
 
     /**
+     * Young Wolf stand-in — 1/1 with undying. Used to exercise the undying keyword pipeline.
+     */
+    val UndyingTestCreature = CardDefinition.creature(
+        name = "Undying Test Creature",
+        manaCost = ManaCost.parse("{B}"),
+        subtypes = setOf(Subtype("Zombie")),
+        power = 1,
+        toughness = 1,
+        oracleText = "Undying",
+        keywords = setOf(Keyword.UNDYING)
+    )
+
+    /**
      * Back face of the DFC test pair — a 4/4 Werewolf with no abilities.
      */
     val TestDfcBack = CardDefinition.creature(
@@ -702,6 +715,8 @@ object TestCards {
         TestEnchantment,
         // Persist
         SafeholdElite,
+        // Undying
+        UndyingTestCreature,
         // Double-faced cards
         TestDfcFront,
         // Transform test helper


### PR DESCRIPTION
## Summary
- Drain DDQ printing-only backlog (20 reprints + companion scaffolded sets)
- New cardDefs: Abattoir Ghoul, Appetite for Brains, Cathedral Sanctifier, Human Frailty, Moorland Inquisitor, Barter in Blood
- Scenario tests green for each new def

## Test plan
- [x] `just test-class` for each new scenario
- [x] `check-card-printing.py` OK for shipped cards
- [x] campaign hygiene + DDQ export

Made with [Cursor](https://cursor.com)