### PR TITLE
Generalize the exiled-abilities grant into a donor-pool grant (adds Thranduil, the Elvenking)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2716,7 +2716,7 @@ effect = Effects.Pipeline {
 - `CardSource.FromLinkedExile(count?)` — the cards in the source's linked-exile pile.
 - `CardSource.CraftedMaterials` — the cards exiled to Craft the source (its
   `CraftedFromExiledComponent`), restricted to those still in exile. The gather-pipeline twin of
-  `ExiledCardsSource.CRAFTED` (which feeds back-face CDAs/ability grants). Backs The Grim Captain's
+  `DonorCards.CRAFT_MATERIALS` (which feeds back-face CDAs/ability grants). Backs The Grim Captain's
   "put an exiled creature card used to craft it onto the battlefield tapped and attacking":
   `GatherCards(CraftedMaterials) → SelectFromCollection(ChooseUpTo 1, filter = Creature) →
   MoveCollection(BATTLEFIELD, ZonePlacement.TappedAndAttacking)`.
@@ -5635,35 +5635,39 @@ staticAbility {
   entry in §3 for the durational, targeted form (Braided Net:
   `PreventActivatedAbilities(GameObjectFilter.Permanent.sourceItself())` +
   `Duration.WhileAffectedTapped`).
-- `HasAllActivatedAbilitiesOfExiledCards(source = ExiledCardsSource.LINKED, filter = GroupFilter.source(), creatureCardsOnly = false, oncePerTurnEach = false)`
-  — the permanents matching `filter` gain **all activated abilities of the cards in this source's exile
-  pile**. `source` selects the pile: `LINKED` reads the `LinkedExileComponent`; `CRAFTED` reads the
-  `CraftedFromExiledComponent` recorded by a `craft(...)` cost (CR 702.167c). Resolved dynamically at
-  activation-legality time: the engine pulls each exiled card's `activatedAbilities` and surfaces them on
-  every matching permanent, with **that permanent** as granter (so `{T}` taps it and "this card"
-  self-references bind to it — CR 113.7). Grants *activated* abilities only, not triggered/static/replacement.
-    - `filter = GroupFilter.source()` (the default) → "This permanent has all activated abilities of
-      the exiled cards" — the source grants to *itself* (Territory Forge with `LINKED`; Locus of
-      Enlightenment with `CRAFTED`).
+- `HasAllActivatedAbilitiesOfCards(donors, cardFilter = GameObjectFilter.Any, receivedBy = GroupFilter.source(), oncePerTurnEach = false)`
+  — the permanents matching `receivedBy` gain **all activated abilities of the cards in this source's
+  donor pool**. `donors` (a `DonorCards`, required) selects the pool: `LINKED_EXILE` reads the
+  `LinkedExileComponent`; `CRAFT_MATERIALS` reads the `CraftedFromExiledComponent` recorded by a
+  `craft(...)` cost (CR 702.167c); `YOUR_GRAVEYARD` reads the graveyard of the source's *current
+  controller*. Resolved dynamically at activation-legality time: the engine pulls each donor card's
+  `activatedAbilities` and surfaces them on every matching permanent, with **that permanent** as granter
+  (so `{T}` taps it and "this card" self-references bind to it — CR 113.7). Grants *activated* abilities
+  only, not triggered/static/replacement.
+    - `receivedBy = GroupFilter.source()` (the default) → "This permanent has all activated abilities of
+      the donor cards" — the source grants to *itself* (Territory Forge with `LINKED_EXILE`; Locus of
+      Enlightenment with `CRAFT_MATERIALS`; Thranduil, the Elvenking with `YOUR_GRAVEYARD`).
     - any battlefield filter → the source grants to *other* matching permanents ("Creatures you control
       with +1/+1 counters on them have all activated abilities of all creature cards exiled with this" —
       Agatha's Soul Cauldron →
-      `HasAllActivatedAbilitiesOfExiledCards(filter = GroupFilter.AllCreaturesYouControl.withCounter(Counters.PLUS_ONE_PLUS_ONE), creatureCardsOnly = true)`).
-    - `creatureCardsOnly = true` restricts the pile to *creature* cards (the exiled card's printed type),
-      for the "all **creature** cards exiled with" wording.
+      `HasAllActivatedAbilitiesOfCards(donors = DonorCards.LINKED_EXILE, cardFilter = Filters.Creature, receivedBy = GroupFilter.AllCreaturesYouControl.withCounter(Counters.PLUS_ONE_PLUS_ONE))`).
+    - `cardFilter` narrows the donor pool by the *donor card's own* characteristics, for wordings that
+      restrict which cards contribute: `Filters.Creature` for Agatha's "all **creature** cards exiled
+      with", `GameObjectFilter.Any.withSubtype(Subtype.ELF)` for Thranduil's "all **Elf** cards in your
+      graveyard". Donor cards are never on the battlefield, so it matches base card data.
     - `oncePerTurnEach = true` (Locus of Enlightenment's "only once each turn") gives each granted ability
-      an `ActivationRestriction.OncePerTurn` **tracked per exiled card**: each granted ability is re-stamped
-      with an exiled-card-derived `AbilityId` (`exiled_<entity>_<printedId>`), so two exiled copies of one
-      card get independent budgets rather than sharing one, and duplicate materials aren't collapsed by the
-      granter-dedup. Left `false`, abilities are granted unmodified (Territory Forge, Agatha). Locus →
-      `HasAllActivatedAbilitiesOfExiledCards(source = ExiledCardsSource.CRAFTED, oncePerTurnEach = true)`.
-    - Fill a `LINKED` pile with `Effects.ExileLinkedToSource(target)`; a `CRAFTED` pile is filled by the
-      `craft(...)` cost.
+      an `ActivationRestriction.OncePerTurn` **tracked per donor card**: each granted ability is re-stamped
+      with a donor-derived `AbilityId` (`donor_<entity>_<printedId>`), so two copies of one card get
+      independent budgets rather than sharing one, and duplicate donors aren't collapsed by the
+      granter-dedup. Left `false`, abilities are granted unmodified (Territory Forge, Agatha, Thranduil).
+      Locus → `HasAllActivatedAbilitiesOfCards(donors = DonorCards.CRAFT_MATERIALS, oncePerTurnEach = true)`.
+    - Fill a `LINKED_EXILE` pool with `Effects.ExileLinkedToSource(target)`; a `CRAFT_MATERIALS` pool is
+      filled by the `craft(...)` cost; a `YOUR_GRAVEYARD` pool needs no wiring — it follows the zone.
 - `HasAbilitiesOfChosenLinkedExiledCard(grantActivated = true, grantTriggered = true)` — the source
   permanent has all **activated and/or triggered abilities of the single card it most recently *chose***
   from its linked-exile pile (its "last chosen card", stamped by
   `Effects.RecordChosenLinkedExile(from)`). The self-scoped, one-card, activated-**and**-triggered
-  sibling of `HasAllActivatedAbilitiesOfExiledCards`: it reads the source's
+  sibling of `HasAllActivatedAbilitiesOfCards`: it reads the source's
   `ChosenLinkedExileComponent` and re-reads it live, so re-choosing a different exiled card swaps which
   abilities the source has. Granted abilities use the source as their own source (`{T}`/self-references
   bind to it). Use the two flags to grant activated abilities, triggered abilities, or both; it never

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AbilityGrantStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AbilityGrantStaticAbilities.kt
@@ -61,73 +61,88 @@ data class GrantActivatedAbility(
 }
 
 /**
- * Which exile pile a [HasAllActivatedAbilitiesOfExiledCards] static reads to find the cards whose
- * activated abilities it grants.
+ * Which pool of cards a [HasAllActivatedAbilitiesOfCards] static reads to find the cards whose
+ * activated abilities it donates.
  */
 @Serializable
-enum class ExiledCardsSource {
+enum class DonorCards {
     /** Cards exiled *with* the source — its `LinkedExileComponent` (Territory Forge, Agatha's Soul Cauldron). */
-    @SerialName("Linked") LINKED,
+    @SerialName("LinkedExile") LINKED_EXILE,
 
     /** Cards exiled *to craft* the source — its `CraftedFromExiledComponent` (Locus of Enlightenment, CR 702.167c). */
-    @SerialName("Crafted") CRAFTED,
+    @SerialName("CraftMaterials") CRAFT_MATERIALS,
+
+    /**
+     * Cards in the graveyard of the source's *controller* (Thranduil, the Elvenking). Unlike the two
+     * exile pools — which are anchored to the source permanent by a component — this pool is anchored
+     * to the player, so it re-reads live as cards enter and leave that graveyard.
+     */
+    @SerialName("YourGraveyard") YOUR_GRAVEYARD,
 }
 
 /**
- * Grants the permanents matching [filter] **all activated abilities of the cards in the source's
- * [source] exile pile** — the single primitive behind both "exiled with this" (linked-exile) grants
- * and "exiled to craft this" (craft-material) grants. Shapes:
- *  - `filter = GroupFilter.source()` (the default) → "This permanent has all activated abilities of
- *    the exiled cards" (Territory Forge / Locus of Enlightenment — the source grants to *itself*).
+ * Grants the permanents matching [receivedBy] **all activated abilities of the cards in the
+ * [donors] pool that match [cardFilter]** — the single primitive behind "exiled with this"
+ * (linked-exile) grants, "exiled to craft this" (craft-material) grants, and "cards in your
+ * graveyard" grants. Shapes:
+ *  - `receivedBy = GroupFilter.source()` (the default) → "This permanent has all activated abilities
+ *    of the donor cards" (Territory Forge / Locus of Enlightenment / Thranduil, the Elvenking — the
+ *    source grants to *itself*).
  *  - any battlefield filter → "Creatures you control with +1/+1 counters on them have all activated
  *    abilities of all creature cards exiled with this" (Agatha's Soul Cauldron — grants to *other*
- *    matching permanents). Pair with [creatureCardsOnly] when the text restricts the pile to
- *    creature cards.
+ *    matching permanents).
  *
- * Resolution is dynamic: the engine reads the source's exile pile (linked or crafted, per [source])
- * at activation-legality time, pulls every activated ability off each exiled card's definition, and
- * surfaces them as activatable on each *matching* permanent — with that permanent as the ability's
- * source, so self-references and `{T}` resolve against the permanent that gained the ability (CR
- * 113.7 — a granted ability's source is the object that has it; faithful to the rulings that the
- * exiled card's "this card" references become references to the permanent that has the ability).
+ * [cardFilter] narrows the donor pool by the *card's own* characteristics — `Filters.Creature` for
+ * Agatha's "all **creature** cards exiled with", `Filters.WithSubtype("Elf")` for Thranduil's "all
+ * **Elf** cards in your graveyard". It matches against base card data (donor cards are never on the
+ * battlefield, so there is no projection entry to consult).
+ *
+ * Resolution is dynamic: the engine reads the donor pool at activation-legality time, pulls every
+ * activated ability off each donor card's definition, and surfaces them as activatable on each
+ * *matching* permanent — with that permanent as the ability's source, so self-references and `{T}`
+ * resolve against the permanent that gained the ability (CR 113.7 — a granted ability's source is the
+ * object that has it; faithful to the rulings that the donor card's "this card" references become
+ * references to the permanent that has the ability).
  *
  * It grants only *activated* abilities — not triggered, static, or replacement abilities.
  *
- * @property source The exile pile to read — [ExiledCardsSource.LINKED] (default) or [ExiledCardsSource.CRAFTED].
- * @property filter The permanents that gain the exiled cards' abilities (default: the source itself).
- * @property creatureCardsOnly When true, only *creature* cards in the pile contribute their abilities
- *   (Agatha's "all **creature** cards exiled with"). When false, every exiled card contributes.
+ * @property donors Which pool of cards donates its abilities — see [DonorCards].
+ * @property cardFilter Restricts the donor pool to cards matching it (default: every card in the pool).
+ * @property receivedBy The permanents that gain the donor cards' abilities (default: the source itself).
  * @property oncePerTurnEach When true (Locus of Enlightenment's "only once each turn"), each granted
- *   ability additionally carries a once-each-turn cap tracked *per exiled card* — two exiled copies of
- *   one card each get their own budget, not a shared one. The engine implements this by re-stamping
- *   each granted ability with an exiled-card-derived [AbilityId] (`exiled_<entity>_<printedId>`), which
- *   also stops duplicate materials collapsing under the granter-dedup. When false (Territory Forge,
- *   Agatha), abilities are granted unmodified and duplicates dedup as before.
+ *   ability additionally carries a once-each-turn cap tracked *per donor card* — two copies of one
+ *   card each get their own budget, not a shared one. The engine implements this by re-stamping each
+ *   granted ability with a donor-derived [AbilityId] (`donor_<entity>_<printedId>`), which also stops
+ *   duplicate donors collapsing under the granter-dedup. When false (Territory Forge, Agatha,
+ *   Thranduil), abilities are granted unmodified and duplicates dedup as before.
  */
-@SerialName("HasAllActivatedAbilitiesOfExiledCards")
+@SerialName("HasAllActivatedAbilitiesOfCards")
 @Serializable
-data class HasAllActivatedAbilitiesOfExiledCards(
-    val source: ExiledCardsSource = ExiledCardsSource.LINKED,
-    val filter: GroupFilter = GroupFilter.source(),
-    val creatureCardsOnly: Boolean = false,
+data class HasAllActivatedAbilitiesOfCards(
+    val donors: DonorCards,
+    val cardFilter: GameObjectFilter = GameObjectFilter.Any,
+    val receivedBy: GroupFilter = GroupFilter.source(),
     val oncePerTurnEach: Boolean = false,
 ) : StaticAbility {
     override val description: String = buildString {
-        append(filter.description)
+        append(receivedBy.description)
         append(" have all activated abilities of the")
-        if (creatureCardsOnly) append(" creature")
+        if (cardFilter != GameObjectFilter.Any) append(" ${cardFilter.description}")
         append(
-            when (source) {
-                ExiledCardsSource.LINKED -> " cards exiled with this"
-                ExiledCardsSource.CRAFTED -> " cards exiled to craft this"
+            when (donors) {
+                DonorCards.LINKED_EXILE -> " cards exiled with this"
+                DonorCards.CRAFT_MATERIALS -> " cards exiled to craft this"
+                DonorCards.YOUR_GRAVEYARD -> " cards in your graveyard"
             }
         )
         if (oncePerTurnEach) append(" (each only once each turn)")
     }
 
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
-        val newFilter = filter.applyTextReplacement(replacer)
-        return if (newFilter !== filter) copy(filter = newFilter) else this
+        val newReceivedBy = receivedBy.applyTextReplacement(replacer)
+        val newCardFilter = cardFilter.applyTextReplacement(replacer)
+        return if (newReceivedBy !== receivedBy || newCardFilter !== cardFilter)
+            copy(receivedBy = newReceivedBy, cardFilter = newCardFilter) else this
     }
 }
 
@@ -137,7 +152,7 @@ data class HasAllActivatedAbilitiesOfExiledCards(
  * choose-from-your-exile mechanic (Koh, the Face Stealer: "Pay 1 life: Choose a creature card exiled
  * with Koh. Koh has all activated and triggered abilities of the last chosen card").
  *
- * Unlike [HasAllActivatedAbilitiesOfExiledCards] — which surfaces the abilities of *every* card
+ * Unlike [HasAllActivatedAbilitiesOfCards] — which surfaces the abilities of *every* card
  * in the pile — this reads the source's `ChosenLinkedExileComponent` (stamped by
  * [com.wingedsheep.sdk.scripting.effects.RecordChosenLinkedExileEffect]) and contributes only the
  * abilities of that one chosen card. It is always self-scoped ("this permanent has …"); use the two

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -227,7 +227,7 @@ sealed interface CardSource {
     /**
      * The cards exiled to Craft the source permanent (its
      * [com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent]), filtered
-     * to those still in exile. The gather counterpart of `ExiledCardsSource.CRAFTED` (which the
+     * to those still in exile. The gather counterpart of `DonorCards.CRAFT_MATERIALS` (which the
      * back-face CDAs read): where that feeds ability grants and dynamic amounts, this feeds a
      * gather → select → move pipeline.
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/TerritoryForge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/TerritoryForge.kt
@@ -6,7 +6,8 @@ import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfExiledCards
+import com.wingedsheep.sdk.scripting.DonorCards
+import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards
 
 /**
  * Territory Forge — {4}{R} Artifact (The Big Score, mythic).
@@ -17,7 +18,7 @@ import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfExiledCards
  * Implementation:
  *  - ETB trigger gated by an intervening-if [Conditions.WasCast] ("if you cast it"): exile
  *    a target artifact or land, linking it to Territory Forge's `LinkedExileComponent`.
- *  - The static ability [HasAllActivatedAbilitiesOfExiledCards] (default `source = LINKED`) reads
+ *  - The static ability [HasAllActivatedAbilitiesOfCards] (`donors = LINKED_EXILE`) reads
  *    that linked-exile pile at activation-legality time and surfaces every activated ability of the
  *    exiled card on Territory Forge itself.
  *
@@ -44,7 +45,7 @@ val TerritoryForge = card("Territory Forge") {
 
     staticAbility {
         // Default source = LINKED, filter = the source itself ("This artifact has all activated abilities …").
-        ability = HasAllActivatedAbilitiesOfExiledCards()
+        ability = HasAllActivatedAbilitiesOfCards(donors = DonorCards.LINKED_EXILE)
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilTheElvenking.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilTheElvenking.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DonorCards
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Thranduil, the Elvenking
+ * {2}{B}{G}{U}
+ * Legendary Creature — Elf Noble (The Hobbit, rare)
+ *
+ * "Thranduil has all activated abilities of all Elf cards in your graveyard.
+ *  Whenever another legendary Elf you control enters, draw two cards, then discard a card."
+ *
+ * Implementation:
+ *  - The ability grant is [HasAllActivatedAbilitiesOfCards] with `donors = YOUR_GRAVEYARD` — the
+ *    graveyard arm of the same primitive that backs Territory Forge (linked exile) and Locus of
+ *    Enlightenment (craft materials). `cardFilter` narrows the pool to Elf cards; `receivedBy`
+ *    defaults to the source, so Thranduil grants to himself. The engine re-reads the graveyard on
+ *    every legality query, so the granted set changes live as Elf cards arrive and leave, and each
+ *    ability is granted with *Thranduil* as its source — `{T}` taps him and the donor card's
+ *    self-references bind to him (CR 113.7, and the printed ruling that an ability referencing its
+ *    own card by name is treated as referencing Thranduil).
+ *  - The trigger filters on `Any` rather than `Creature`: the text says "legendary Elf", not
+ *    "legendary Elf creature", so a noncreature Elf permanent counts. Same reason the graveyard
+ *    filter is "Elf card", not "Elf creature card".
+ *
+ * Rulings (2026-08-14):
+ *  - An activated ability of a donor Elf card that references its own card by name is treated as
+ *    referencing Thranduil instead.
+ *  - Linked activated abilities (one exiles a card, another refers to "the card exiled with it")
+ *    stay linked only while Thranduil has them; losing and regaining the abilities breaks the link.
+ *  - Only *activated* abilities are granted — those with a colon in their cost/effect separator,
+ *    including keyword abilities whose reminder text contains one.
+ */
+val ThranduilTheElvenking = card("Thranduil, the Elvenking") {
+    manaCost = "{2}{B}{G}{U}"
+    colorIdentity = "BGU"
+    typeLine = "Legendary Creature — Elf Noble"
+    oracleText = "Thranduil has all activated abilities of all Elf cards in your graveyard.\n" +
+        "Whenever another legendary Elf you control enters, draw two cards, then discard a card."
+    power = 5
+    toughness = 6
+
+    // "Thranduil has all activated abilities of all Elf cards in your graveyard."
+    staticAbility {
+        ability = HasAllActivatedAbilitiesOfCards(
+            donors = DonorCards.YOUR_GRAVEYARD,
+            cardFilter = GameObjectFilter.Any.withSubtype(Subtype.ELF)
+        )
+    }
+
+    // "Whenever another legendary Elf you control enters, draw two cards, then discard a card."
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Any.legendary().withSubtype(Subtype.ELF).youControl(),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.Composite(
+            Effects.DrawCards(2),
+            Patterns.Hand.discardCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "167"
+        artist = "Magali Villeneuve"
+        flavorText = "In a great hall with pillars hewn out of the living stone sat the Elvenking " +
+            "on a chair of carven wood."
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe2fe8fa-3b99-44c1-bab9-922e5c864952.jpg?1784377043"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TheEnigmaJewel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TheEnigmaJewel.kt
@@ -8,8 +8,8 @@ import com.wingedsheep.sdk.dsl.craft
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.ExiledCardsSource
-import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfExiledCards
+import com.wingedsheep.sdk.scripting.DonorCards
+import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.effects.ManaRestriction
@@ -42,7 +42,7 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *    more nonlands with activated abilities" (CR 702.167a/b; the material pool spans battlefield
  *    permanents you control and cards in your graveyard, and `HasActivatedAbility` counts mana
  *    abilities too, so a mana rock/dork qualifies).
- *  - The back face's **ability grant** is the [HasAllActivatedAbilitiesOfExiledCards] static with
+ *  - The back face's **ability grant** is the [HasAllActivatedAbilitiesOfCards] static with
  *    `source = CRAFTED` and `oncePerTurnEach = true` (CR 702.167c): the Locus has each activated
  *    ability of the cards exiled to craft it, each usable only once each turn (tracked per exiled
  *    card — two exiled copies of one card each get their own budget). `{T}` costs tap the Locus and
@@ -105,8 +105,8 @@ private val LocusOfEnlightenment = card("Locus of Enlightenment") {
     // Locus of Enlightenment has each activated ability of the exiled cards used to craft it.
     // You may activate each of those abilities only once each turn.
     staticAbility {
-        ability = HasAllActivatedAbilitiesOfExiledCards(
-            source = ExiledCardsSource.CRAFTED,
+        ability = HasAllActivatedAbilitiesOfCards(
+            donors = DonorCards.CRAFT_MATERIALS,
             oncePerTurnEach = true
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThroneOfTheGrimCaptain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThroneOfTheGrimCaptain.kt
@@ -47,7 +47,7 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  *    and `CraftSlotMatching` (engine) does the matching in `canPay`, the legal-action enumerator,
  *    and payment. The union of the slots stays in `filter`, so the flat BF+GY candidate gathering
  *    and the client's material overlay work unchanged.
- *  - **`CardSource.CraftedMaterials`** — the gather-pipeline twin of `ExiledCardsSource.CRAFTED`,
+ *  - **`CardSource.CraftedMaterials`** — the gather-pipeline twin of `DonorCards.CRAFT_MATERIALS`,
  *    reading the source's `CraftedFromExiledComponent` (the cards exiled to craft it) filtered to
  *    those still in exile. It powers the attack trigger's second sentence.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AgathasSoulCauldron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AgathasSoulCauldron.kt
@@ -4,10 +4,12 @@ import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfExiledCards
+import com.wingedsheep.sdk.scripting.DonorCards
+import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards
 import com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
@@ -30,8 +32,8 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *    colored/colorless requirements of the mana cost of any ability activated from a creature you
  *    control (CR 609.4b), so the granted (and printed) abilities of your creatures can be paid with
  *    mana of any type. Same engine seam as Sharkey, Tyrant of the Shire (there scoped to Self).
- *  - [HasAllActivatedAbilitiesOfExiledCards] with a battlefield filter ("creatures you control
- *    with a +1/+1 counter") and `creatureCardsOnly = true`: every creature card in the Cauldron's
+ *  - [HasAllActivatedAbilitiesOfCards] with a battlefield `receivedBy` filter ("creatures you control
+ *    with a +1/+1 counter") and `cardFilter = Creature`: every creature card in the Cauldron's
  *    linked-exile pile lends its activated abilities to each such creature, with that creature as
  *    the abilities' source (so `{T}` taps it and self-references bind to it — the printed ruling).
  *  - The `{T}` activated ability exiles a targeted graveyard card linked to the Cauldron, then —
@@ -63,9 +65,10 @@ val AgathasSoulCauldron = card("Agatha's Soul Cauldron") {
     // "Creatures you control with +1/+1 counters on them have all activated abilities of all
     // creature cards exiled with Agatha's Soul Cauldron."
     staticAbility {
-        ability = HasAllActivatedAbilitiesOfExiledCards(
-            filter = GroupFilter.AllCreaturesYouControl.withCounter(Counters.PLUS_ONE_PLUS_ONE),
-            creatureCardsOnly = true
+        ability = HasAllActivatedAbilitiesOfCards(
+            donors = DonorCards.LINKED_EXILE,
+            cardFilter = Filters.Creature,
+            receivedBy = GroupFilter.AllCreaturesYouControl.withCounter(Counters.PLUS_ONE_PLUS_ONE)
         )
     }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/BIG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BIG.json
@@ -2121,7 +2121,10 @@
             }
         ],
         "staticAbilities": [
-            "HasAllActivatedAbilitiesOfExiledCards"
+            {
+                "type": "HasAllActivatedAbilitiesOfCards",
+                "donors": "LinkedExile"
+            }
         ]
     },
     "metadata": {

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -13190,6 +13190,106 @@
     ]
 }
 
+// Thranduil, the Elvenking
+{
+    "name": "Thranduil, the Elvenking",
+    "manaCost": "{2}{B}{G}{U}",
+    "typeLine": "Legendary Creature — Elf Noble",
+    "oracleText": "Thranduil has all activated abilities of all Elf cards in your graveyard.\nWhenever another legendary Elf you control enters, draw two cards, then discard a card.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsLegendary",
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Elf"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "HasAllActivatedAbilitiesOfCards",
+                "donors": "YourGraveyard",
+                "cardFilter": "Elf"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "rarity": "RARE",
+        "artist": "Magali Villeneuve",
+        "flavorText": "In a great hall with pillars hewn out of the living stone sat the Elvenking on a chair of carven wood.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe2fe8fa-3b99-44c1-bab9-922e5c864952.jpg?1784377043"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Through the Forest Gate
 {
     "name": "Through the Forest Gate",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -18748,8 +18748,8 @@
             ],
             "staticAbilities": [
                 {
-                    "type": "HasAllActivatedAbilitiesOfExiledCards",
-                    "source": "Crafted",
+                    "type": "HasAllActivatedAbilitiesOfCards",
+                    "donors": "CraftMaterials",
                     "oncePerTurnEach": true
                 }
             ]

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -312,8 +312,10 @@
                 }
             },
             {
-                "type": "HasAllActivatedAbilitiesOfExiledCards",
-                "filter": {
+                "type": "HasAllActivatedAbilitiesOfCards",
+                "donors": "LinkedExile",
+                "cardFilter": "creature",
+                "receivedBy": {
                     "baseFilter": {
                         "cardPredicates": [
                             "IsCreature"
@@ -326,8 +328,7 @@
                         ],
                         "controllerPredicate": "ControlledByYou"
                     }
-                },
-                "creatureCardsOnly": true
+                }
             }
         ]
     },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -2916,35 +2916,36 @@ class ActivateAbilityHandler(
                     }
                     else -> rawAbility
                 }
-                // "[filter] have all activated abilities of the [creature] cards exiled with/to craft
-                // this" (Territory Forge / Locus of Enlightenment = Self; Agatha's Soul Cauldron =
-                // creatures you control with a +1/+1 counter). Mirror
-                // CastPermissionUtils.getStaticGrantedAbilitiesWithGranter: grant each pile ability
-                // (linked or crafted, per `ability.source`) to every matching permanent, recording the
+                // "[receivedBy] have all activated abilities of the [cardFilter] cards exiled with/to
+                // craft this / in your graveyard" (Territory Forge / Locus of Enlightenment /
+                // Thranduil = Self; Agatha's Soul Cauldron = creatures you control with a +1/+1
+                // counter). Mirror CastPermissionUtils.getStaticGrantedAbilitiesWithGranter: grant each
+                // donor ability (per `ability.donors`) to every matching permanent, recording the
                 // *receiver* as the granter so `{T}`/self-references bind to the permanent that gained
                 // the ability. When `oncePerTurnEach` is set (Locus), the util re-stamps each ability
-                // with an exiled-card-derived AbilityId + once-per-turn cap.
-                if (ability is com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfExiledCards) {
-                    val receives = when (val scope = ability.filter.scope) {
+                // with a donor-derived AbilityId + once-per-turn cap.
+                if (ability is com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards) {
+                    val receives = when (val scope = ability.receivedBy.scope) {
                         is Scope.Self -> permanentId == entityId
                         is Scope.Specific -> scope.entityId == entityId
                         is Scope.AttachedTo -> container.get<AttachedToComponent>()?.targetId == entityId
                         is Scope.SoulbondPair ->
                             com.wingedsheep.engine.mechanics.SoulbondPairing.isInPairOf(state, permanentId, entityId)
                         is Scope.Battlefield -> {
-                            if (ability.filter.excludeSelf && permanentId == entityId) false
+                            if (ability.receivedBy.excludeSelf && permanentId == entityId) false
                             else {
                                 val granterController = state.projectedState.getController(permanentId)
                                 granterController != null && predicateEvaluator.matches(
-                                    state, state.projectedState, entityId, ability.filter.baseFilter,
+                                    state, state.projectedState, entityId, ability.receivedBy.baseFilter,
                                     PredicateContext(controllerId = granterController, sourceId = permanentId)
                                 )
                             }
                         }
                     }
                     if (receives) {
-                        for (granted in com.wingedsheep.engine.legalactions.utils.exiledCardsActivatedAbilities(
-                            state, permanentId, cardRegistry, ability.source, ability.creatureCardsOnly, ability.oncePerTurnEach
+                        for (granted in com.wingedsheep.engine.legalactions.utils.donorCardsActivatedAbilities(
+                            state, permanentId, cardRegistry, predicateEvaluator,
+                            ability.donors, ability.cardFilter, ability.oncePerTurnEach
                         )) {
                             result.add(granted to entityId)
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -233,7 +233,7 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
 
             is CardSource.CraftedMaterials -> {
                 // The cards exiled to Craft this permanent (CraftedFromExiledComponent), filtered to
-                // those still in exile — the gather-pipeline twin of ExiledCardsSource.CRAFTED.
+                // those still in exile — the gather-pipeline twin of DonorCards.CRAFT_MATERIALS.
                 // Backs The Grim Captain's "put an exiled creature card used to craft it" clause.
                 val sourceId = context.sourceId
                     ?: return EffectResult.error(state, "No source entity for CraftedMaterials")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -1186,17 +1186,18 @@ class CastPermissionUtils(
                     }
                     else -> rawAbility
                 }
-                // "[filter] have all activated abilities of the [creature] cards exiled with/to craft
-                // this": pull every activated ability off each card in the granter's exile pile (linked
-                // or crafted, per `ability.source`) and grant it to each matching permanent. Self filter
-                // = Territory Forge / Locus of Enlightenment (grants to itself); a battlefield filter =
-                // Agatha's Soul Cauldron (grants to other creatures you control with +1/+1 counters). The
-                // granter recorded is the *receiver* so the ability's `{T}`/self-references bind to the
-                // permanent that gained it (CR-faithful). When `oncePerTurnEach` is set (Locus), each
-                // ability is re-stamped with an exiled-card-derived AbilityId so duplicate materials don't
-                // collapse and each gets its own once-per-turn budget (see exiledCardsActivatedAbilities).
-                if (ability is com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfExiledCards) {
-                    val receives = when (val scope = ability.filter.scope) {
+                // "[receivedBy] have all activated abilities of the [cardFilter] cards exiled with/to
+                // craft this / in your graveyard": pull every activated ability off each card in the
+                // granter's donor pool (per `ability.donors`) and grant it to each matching permanent.
+                // Self filter = Territory Forge / Locus of Enlightenment / Thranduil (grants to itself);
+                // a battlefield filter = Agatha's Soul Cauldron (grants to other creatures you control
+                // with +1/+1 counters). The granter recorded is the *receiver* so the ability's
+                // `{T}`/self-references bind to the permanent that gained it (CR-faithful). When
+                // `oncePerTurnEach` is set (Locus), each ability is re-stamped with a donor-derived
+                // AbilityId so duplicate donors don't collapse and each gets its own once-per-turn
+                // budget (see donorCardsActivatedAbilities).
+                if (ability is com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards) {
+                    val receives = when (val scope = ability.receivedBy.scope) {
                         is com.wingedsheep.sdk.scripting.filters.unified.Scope.Self -> permanentId == entityId
                         is com.wingedsheep.sdk.scripting.filters.unified.Scope.Specific -> scope.entityId == entityId
                         is com.wingedsheep.sdk.scripting.filters.unified.Scope.AttachedTo ->
@@ -1204,19 +1205,20 @@ class CastPermissionUtils(
                         is com.wingedsheep.sdk.scripting.filters.unified.Scope.SoulbondPair ->
                             com.wingedsheep.engine.mechanics.SoulbondPairing.isInPairOf(state, permanentId, entityId)
                         is com.wingedsheep.sdk.scripting.filters.unified.Scope.Battlefield -> {
-                            if (ability.filter.excludeSelf && permanentId == entityId) false
+                            if (ability.receivedBy.excludeSelf && permanentId == entityId) false
                             else {
                                 val granterController = state.projectedState.getController(permanentId)
                                 granterController != null && predicateEvaluator.matches(
-                                    state, state.projectedState, entityId, ability.filter.baseFilter,
+                                    state, state.projectedState, entityId, ability.receivedBy.baseFilter,
                                     PredicateContext(controllerId = granterController, sourceId = permanentId)
                                 )
                             }
                         }
                     }
                     if (receives) {
-                        for (granted in exiledCardsActivatedAbilities(
-                            state, permanentId, cardRegistry, ability.source, ability.creatureCardsOnly, ability.oncePerTurnEach
+                        for (granted in donorCardsActivatedAbilities(
+                            state, permanentId, cardRegistry, predicateEvaluator,
+                            ability.donors, ability.cardFilter, ability.oncePerTurnEach
                         )) {
                             result.add(StaticGrantedAbility(granted, entityId))
                         }
@@ -1550,54 +1552,75 @@ data class StaticGrantedAbility(
 )
 
 /**
- * The activated abilities of every card in [sourceId]'s exile pile — the engine half of
- * [com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfExiledCards]. [source] selects the pile:
- * [ExiledCardsSource.LINKED] reads the source's `LinkedExileComponent` (Territory Forge, Agatha's
- * Soul Cauldron); [ExiledCardsSource.CRAFTED] reads its `CraftedFromExiledComponent` (Locus of
- * Enlightenment; CR 702.167c — "the exiled cards used to craft it"). It looks up each exiled card's
- * definition and returns its `activatedAbilities`. The caller grants each with the *receiver* as the
- * granter so the ability activates against that permanent (its `{T}` taps it, self-references bind to
- * it — CR 113.7, faithful to the ruling that the exiled card's "this card" references become
+ * The activated abilities of every card in [sourceId]'s donor pool — the engine half of
+ * [com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards]. [donors] selects the pool:
+ * [DonorCards.LINKED_EXILE] reads the source's `LinkedExileComponent` (Territory Forge, Agatha's
+ * Soul Cauldron); [DonorCards.CRAFT_MATERIALS] reads its `CraftedFromExiledComponent` (Locus of
+ * Enlightenment; CR 702.167c — "the exiled cards used to craft it"); [DonorCards.YOUR_GRAVEYARD]
+ * reads the graveyard of the source's *controller* (Thranduil, the Elvenking). It looks up each donor
+ * card's definition and returns its `activatedAbilities`. The caller grants each with the *receiver*
+ * as the granter so the ability activates against that permanent (its `{T}` taps it, self-references
+ * bind to it — CR 113.7, faithful to the ruling that the donor card's "this card" references become
  * references to the permanent that has the ability).
  *
+ * [cardFilter] narrows the pool by the donor card's own characteristics (Agatha's "all *creature*
+ * cards exiled with", Thranduil's "all *Elf* cards in your graveyard"). Donor cards are never on the
+ * battlefield, so `matches` falls through to base `CardComponent` data — but the projected state is
+ * still passed, per the `PredicateEvaluator` contract, and the *controller* of the granting permanent
+ * is always read from projection.
+ *
  * When [oncePerTurnEach] is true (Locus of Enlightenment's "only once each turn"), each returned
- * ability is re-stamped with a **synthesized [AbilityId] derived from the exiled card's entity id**
- * (`exiled_<exiledEntity>_<printedAbilityId>`) and gains an
+ * ability is re-stamped with a **synthesized [AbilityId] derived from the donor card's entity id**
+ * (`donor_<donorEntity>_<printedAbilityId>`) and gains an
  * [com.wingedsheep.sdk.scripting.ActivationRestriction.OncePerTurn]. The re-stamp is load-bearing:
- *  - It stops the caller's `distinctBy { it.ability.id }` dedup from collapsing two exiled copies of
+ *  - It stops the caller's `distinctBy { it.ability.id }` dedup from collapsing two copies of
  *    the *same* printed card (which share one printed `AbilityId`) into a single granted ability.
  *  - It makes the standard once-per-turn tracker (`AbilityActivatedThisTurnComponent`, keyed by
- *    receiver-entity + `AbilityId`) give each exiled card its *own* once-each-turn budget for free,
+ *    receiver-entity + `AbilityId`) give each donor card its *own* once-each-turn budget for free,
  *    with no bespoke tracker.
  *
- * When [oncePerTurnEach] is false (Territory Forge, Agatha), abilities are returned unmodified — the
- * dedup collapses duplicate copies, which is fine when there's no per-card budget to keep apart.
+ * When [oncePerTurnEach] is false (Territory Forge, Agatha, Thranduil), abilities are returned
+ * unmodified — the dedup collapses duplicate copies, which is fine when there's no per-card budget to
+ * keep apart.
  */
-fun exiledCardsActivatedAbilities(
+fun donorCardsActivatedAbilities(
     state: GameState,
     sourceId: EntityId,
     cardRegistry: CardRegistry,
-    source: com.wingedsheep.sdk.scripting.ExiledCardsSource,
-    creatureCardsOnly: Boolean = false,
+    predicateEvaluator: com.wingedsheep.engine.handlers.PredicateEvaluator,
+    donors: com.wingedsheep.sdk.scripting.DonorCards,
+    cardFilter: com.wingedsheep.sdk.scripting.GameObjectFilter,
     oncePerTurnEach: Boolean = false
 ): List<com.wingedsheep.sdk.scripting.ActivatedAbility> {
-    val exiledIds = when (source) {
-        com.wingedsheep.sdk.scripting.ExiledCardsSource.LINKED -> state.getEntity(sourceId)
+    // Projected controller (with the base component as fallback) — "your graveyard" follows the
+    // granting permanent's *current* controller, so a stolen Thranduil reads its new controller's
+    // graveyard, and it is also the context a non-trivial cardFilter is evaluated against.
+    val controllerId = state.projectedState.getController(sourceId)
+        ?: state.getEntity(sourceId)?.get<ControllerComponent>()?.playerId
+    val donorIds = when (donors) {
+        com.wingedsheep.sdk.scripting.DonorCards.LINKED_EXILE -> state.getEntity(sourceId)
             ?.get<com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent>()?.exiledIds
-        com.wingedsheep.sdk.scripting.ExiledCardsSource.CRAFTED -> state.getEntity(sourceId)
+        com.wingedsheep.sdk.scripting.DonorCards.CRAFT_MATERIALS -> state.getEntity(sourceId)
             ?.get<com.wingedsheep.engine.state.components.battlefield.CraftedFromExiledComponent>()?.exiledIds
+        com.wingedsheep.sdk.scripting.DonorCards.YOUR_GRAVEYARD -> controllerId?.let { state.getGraveyard(it) }
     } ?: return emptyList()
-    return exiledIds.flatMap { exiledId ->
-        val card = state.getEntity(exiledId)?.get<CardComponent>()
-        // Agatha's "all *creature* cards exiled" restricts the pile by the exiled card's printed
-        // type; the other users (creatureCardsOnly = false) take every exiled card.
-        if (creatureCardsOnly && card?.typeLine?.isCreature != true) return@flatMap emptyList()
-        val cardDef = card?.cardDefinitionId?.let { cardRegistry.getCard(it) }
+    val unfiltered = cardFilter == com.wingedsheep.sdk.scripting.GameObjectFilter.Any
+    // A filtered pool with no resolvable controller can't be evaluated — fail closed (grant nothing)
+    // rather than handing out every donor card's abilities unfiltered.
+    if (!unfiltered && controllerId == null) return emptyList()
+    return donorIds.flatMap { donorId ->
+        val card = state.getEntity(donorId)?.get<CardComponent>() ?: return@flatMap emptyList()
+        if (!unfiltered && !predicateEvaluator.matches(
+                state, state.projectedState, donorId, cardFilter,
+                PredicateContext(controllerId = controllerId!!, sourceId = sourceId)
+            )
+        ) return@flatMap emptyList()
+        val cardDef = cardRegistry.getCard(card.cardDefinitionId)
         val abilities = cardDef?.script?.activatedAbilities ?: emptyList()
         if (!oncePerTurnEach) abilities
         else abilities.map { ability ->
             ability.copy(
-                id = com.wingedsheep.sdk.scripting.AbilityId("exiled_${exiledId.value}_${ability.id.value}"),
+                id = com.wingedsheep.sdk.scripting.AbilityId("donor_${donorId.value}_${ability.id.value}"),
                 restrictions = ability.restrictions + com.wingedsheep.sdk.scripting.ActivationRestriction.OncePerTurn
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -118,7 +118,7 @@ import com.wingedsheep.sdk.scripting.DivideCombatDamageFreely
 import com.wingedsheep.sdk.scripting.ExtraLoyaltyActivation
 import com.wingedsheep.sdk.scripting.GainActivatedAbilitiesOfPermanents
 import com.wingedsheep.sdk.scripting.GrantActivatedAbility
-import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfExiledCards
+import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfCards
 import com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities
 import com.wingedsheep.sdk.scripting.GrantAdditionalLandDrop
 import com.wingedsheep.sdk.scripting.GrantAlternativeCastingCost
@@ -1001,7 +1001,7 @@ class StaticAbilityHandler(
             // Activated abilities (ActivateAbilityHandler / ActivatedAbilityEnumerator):
             is ExtraLoyaltyActivation,
             is GrantActivatedAbility,
-            is HasAllActivatedAbilitiesOfExiledCards,
+            is HasAllActivatedAbilitiesOfCards,
             is com.wingedsheep.sdk.scripting.HasAbilitiesOfChosenLinkedExiledCard,
             is GainActivatedAbilitiesOfPermanents,
             is SpendAnyManaTypeForActivatedAbilities,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheEnigmaJewelScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheEnigmaJewelScenarioTest.kt
@@ -204,9 +204,9 @@ class TheEnigmaJewelScenarioTest : FunSpec({
     fun GameTestDriver.abilitiesOn(player: EntityId, source: EntityId): List<ActivateAbility> =
         legalActions(player).mapNotNull { it.action as? ActivateAbility }.filter { it.sourceId == source }
 
-    // A granted ability's synthesized id is "exiled_<exiledEntity>_<printedAbilityId>", so this
+    // A granted ability's synthesized id is "donor_<donorEntity>_<printedAbilityId>", so this
     // fragment identifies the ability contributed by a specific exiled material entity.
-    fun fromMaterial(material: EntityId) = "exiled_${material.value}_"
+    fun fromMaterial(material: EntityId) = "donor_${material.value}_"
 
     /** Craft The Enigma Jewel using [materials]; returns the (same) entity, now the Locus. */
     fun GameTestDriver.craftJewel(player: EntityId, jewel: EntityId, materials: List<EntityId>): EntityId {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThranduilTheElvenkingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThranduilTheElvenkingScenarioTest.kt
@@ -1,0 +1,230 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.ThranduilTheElvenking
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thranduil, the Elvenking — {2}{B}{G}{U} Legendary Creature — Elf Noble (The Hobbit #167).
+ *
+ *  - "Thranduil has all activated abilities of all Elf cards in your graveyard."
+ *  - "Whenever another legendary Elf you control enters, draw two cards, then discard a card."
+ *
+ * The first ability is the `DonorCards.YOUR_GRAVEYARD` arm of `HasAllActivatedAbilitiesOfCards`.
+ * These tests pin the parts of that arm that could silently regress: the `cardFilter` narrowing,
+ * the "**your** graveyard" ownership scope, the live re-read as the graveyard changes, and the
+ * CR 113.7 source binding (the granted `{T}` taps *Thranduil*, not the donor card).
+ */
+class ThranduilTheElvenkingScenarioTest : FunSpec({
+
+    // Donor: an Elf whose only ability is activated and has a {T} in its cost, so activating it
+    // through Thranduil proves both the grant and the source binding.
+    val elfHealer = card("Thranduil Test Elf Healer") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Elf Cleric"
+        power = 1
+        toughness = 1
+        oracleText = "{T}: You gain 2 life."
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.GainLife(2)
+        }
+    }
+    val healerAbilityId = elfHealer.activatedAbilities[0].id
+
+    // Same shape, but NOT an Elf — the cardFilter must exclude it.
+    val goblinTinkerer = card("Thranduil Test Goblin Tinkerer") {
+        manaCost = "{1}{R}"
+        typeLine = "Creature — Goblin Artificer"
+        power = 1
+        toughness = 1
+        oracleText = "{T}: You gain 2 life."
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.GainLife(2)
+        }
+    }
+    val tinkererAbilityId = goblinTinkerer.activatedAbilities[0].id
+
+    // Trigger fodder: a legendary Elf, a nonlegendary Elf, and a legendary non-Elf.
+    val legendaryElf = card("Thranduil Test Elven Lord") {
+        manaCost = "{G}"
+        typeLine = "Legendary Creature — Elf Noble"
+        power = 1
+        toughness = 1
+    }
+    val plainElf = card("Thranduil Test Elf Scout") {
+        manaCost = "{G}"
+        typeLine = "Creature — Elf Scout"
+        power = 1
+        toughness = 1
+    }
+    val legendaryDwarf = card("Thranduil Test Dwarf Lord") {
+        manaCost = "{G}"
+        typeLine = "Legendary Creature — Dwarf Noble"
+        power = 1
+        toughness = 1
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(
+                ThranduilTheElvenking, elfHealer, goblinTinkerer,
+                legendaryElf, plainElf, legendaryDwarf
+            )
+        )
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Thranduil on the battlefield and able to use a `{T}` ability. Clearing summoning sickness is
+     * load-bearing for the *negative* tests too: without it a missing grant and an unusable `{T}`
+     * both fail, and the assertion would pass for the wrong reason.
+     */
+    fun readyThranduil(driver: GameTestDriver, you: com.wingedsheep.sdk.model.EntityId) =
+        driver.putCreatureOnBattlefield(you, "Thranduil, the Elvenking")
+            .also { driver.removeSummoningSickness(it) }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && driver.state.pendingDecision == null && guard++ < 20) {
+            driver.bothPass()
+        }
+    }
+
+    test("an Elf card in your graveyard lends its activated ability, and the {T} taps Thranduil") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val thranduil = readyThranduil(driver, you)
+        driver.putCardInGraveyard(you, "Thranduil Test Elf Healer")
+
+        val lifeBefore = driver.getLifeTotal(you)
+        driver.submitSuccess(ActivateAbility(playerId = you, sourceId = thranduil, abilityId = healerAbilityId))
+        resolveStack(driver)
+
+        driver.getLifeTotal(you) shouldBe lifeBefore + 2
+        // CR 113.7 — the granted ability's source is Thranduil, so its {T} cost tapped him.
+        driver.state.getEntity(thranduil)?.has<TappedComponent>() shouldBe true
+    }
+
+    test("a non-Elf card in your graveyard lends nothing (cardFilter narrows the donor pool)") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val thranduil = readyThranduil(driver, you)
+        driver.putCardInGraveyard(you, "Thranduil Test Goblin Tinkerer")
+
+        driver.submitExpectFailure(
+            ActivateAbility(playerId = you, sourceId = thranduil, abilityId = tinkererAbilityId)
+        )
+    }
+
+    test("an Elf card in an OPPONENT's graveyard lends nothing (\"your\" graveyard only)") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val thranduil = readyThranduil(driver, you)
+        driver.putCardInGraveyard(opponent, "Thranduil Test Elf Healer")
+
+        driver.submitExpectFailure(
+            ActivateAbility(playerId = you, sourceId = thranduil, abilityId = healerAbilityId)
+        )
+    }
+
+    test("the donor pool is re-read live — the ability appears when an Elf hits the graveyard mid-game") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val thranduil = readyThranduil(driver, you)
+        val healerOnBoard = driver.putCreatureOnBattlefield(you, "Thranduil Test Elf Healer")
+
+        // Nothing in the graveyard yet: the ability isn't Thranduil's to activate. (Activating the
+        // Healer's own printed copy would tap the Healer, so this proves the *grant* is absent.)
+        driver.submitExpectFailure(
+            ActivateAbility(playerId = you, sourceId = thranduil, abilityId = healerAbilityId)
+        )
+
+        // A real zone change puts the Elf in the graveyard; the grant must appear without any
+        // re-projection prompt, because the pool is read on every legality query.
+        driver.moveToGraveyard(healerOnBoard)
+        driver.getGraveyard(you).contains(healerOnBoard) shouldBe true
+
+        val lifeBefore = driver.getLifeTotal(you)
+        driver.submitSuccess(ActivateAbility(playerId = you, sourceId = thranduil, abilityId = healerAbilityId))
+        resolveStack(driver)
+        driver.getLifeTotal(you) shouldBe lifeBefore + 2
+    }
+
+    test("another legendary Elf entering draws two cards, then discards one") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Thranduil, the Elvenking")
+        val elf = driver.putCardInHand(you, "Thranduil Test Elven Lord")
+
+        val handBefore = driver.getHandSize(you)
+        val graveBefore = driver.getGraveyard(you).size
+        driver.giveMana(you, Color.GREEN)
+        driver.castSpell(you, elf).isSuccess shouldBe true
+        driver.bothPass() // Resolve the Elf.
+        resolveStack(driver) // Resolve the draw-two trigger, pausing on the discard choice.
+
+        // Cast one (-1), drew two (+2), then discard one (-1) → net level with the starting hand.
+        (driver.pendingDecision != null) shouldBe true
+        val toDiscard = driver.getHand(you).first()
+        driver.submitCardSelection(you, listOf(toDiscard)).isSuccess shouldBe true
+        resolveStack(driver)
+
+        driver.getHandSize(you) shouldBe handBefore
+        driver.getGraveyard(you).size shouldBe graveBefore + 1
+    }
+
+    test("a nonlegendary Elf and a legendary non-Elf entering do not trigger") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(you, "Thranduil, the Elvenking")
+        val scout = driver.putCardInHand(you, "Thranduil Test Elf Scout")
+        val dwarf = driver.putCardInHand(you, "Thranduil Test Dwarf Lord")
+
+        var handBefore = driver.getHandSize(you)
+        driver.giveMana(you, Color.GREEN)
+        driver.castSpell(you, scout).isSuccess shouldBe true
+        resolveStack(driver)
+        driver.state.pendingDecision shouldBe null
+        driver.getHandSize(you) shouldBe handBefore - 1
+
+        handBefore = driver.getHandSize(you)
+        driver.giveMana(you, Color.GREEN)
+        driver.castSpell(you, dwarf).isSuccess shouldBe true
+        resolveStack(driver)
+        driver.state.pendingDecision shouldBe null
+        driver.getHandSize(you) shouldBe handBefore - 1
+    }
+
+    test("Thranduil entering does not trigger his own ability (\"another\")") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val thranduil = driver.putCardInHand(you, "Thranduil, the Elvenking")
+
+        val handBefore = driver.getHandSize(you)
+        driver.giveMana(you, Color.BLACK)
+        driver.giveMana(you, Color.GREEN)
+        driver.giveMana(you, Color.BLUE)
+        driver.giveColorlessMana(you, 2)
+        driver.castSpell(you, thranduil).isSuccess shouldBe true
+        resolveStack(driver)
+
+        driver.state.pendingDecision shouldBe null
+        driver.getHandSize(you) shouldBe handBefore - 1
+    }
+})


### PR DESCRIPTION
## What

Thranduil, the Elvenking — "Thranduil has all activated abilities of all **Elf cards in your graveyard**" — needed a third source for the ability-granting static, which until now could only read a permanent's linked-exile or craft-material pile.

Rather than bolt a graveyard case onto a type whose name would then lie, this generalizes the primitive:

| Before | After |
|---|---|
| `ExiledCardsSource` | `DonorCards` |
| `LINKED` / `CRAFTED` | `LINKED_EXILE` / `CRAFT_MATERIALS` / **`YOUR_GRAVEYARD`** |
| `HasAllActivatedAbilitiesOfExiledCards` | `HasAllActivatedAbilitiesOfCards` |
| `filter` | `receivedBy` (which permanents gain the abilities) |
| `creatureCardsOnly: Boolean` | `cardFilter: GameObjectFilter` |

Replacing the baked-in `creatureCardsOnly` flag with a filter is what makes Thranduil expressible at all ("Elf cards", not "creature cards"), and it costs Agatha's Soul Cauldron nothing — `creatureCardsOnly = true` becomes `cardFilter = Filters.Creature`. The two renames follow from SDK reusability rules 3 and 4 (no baked-in constants; a name that lies about what a type does is a bug); with two filters on the type now, `filter` → `receivedBy` disambiguates which one is which.

## Design notes

- **`YOUR_GRAVEYARD` is anchored to the source's projected controller**, not to a component like the two exile pools. A stolen Thranduil therefore reads its *new* controller's graveyard.
- **Fails closed:** a filtered pool with no resolvable controller grants nothing, rather than falling open to every donor card.
- The synthesized once-per-turn `AbilityId` prefix moves with the rename (`exiled_<entity>_<id>` → `donor_<entity>_<id>`).

## Call sites updated

Territory Forge, Agatha's Soul Cauldron, The Enigma Jewel, plus the three engine read sites (`StaticAbilityHandler`'s non-projection list, `CastPermissionUtils`, `ActivateAbilityHandler`), stale cross-references in `GatherCardsExecutor` / `PipelineEffects` / Throne of the Grim Captain, and `docs/card-sdk-language-reference.md`.

**Step 8b (mtgish) not applicable:** the emitter has no entry for this static, so there is no new IR tag to teach it.

## Testing

`ThranduilTheElvenkingScenarioTest` (7 tests) covers:
- an Elf card in your graveyard lends its activated ability, and the granted `{T}` taps **Thranduil** (CR 113.7 source binding)
- a non-Elf card lends nothing (`cardFilter` narrowing)
- an Elf card in an **opponent's** graveyard lends nothing ("your" graveyard)
- the pool is re-read live — the ability appears after a real zone change puts an Elf in the graveyard
- another legendary Elf entering draws two, then discards one
- a nonlegendary Elf and a legendary non-Elf don't trigger; Thranduil's own entry doesn't trigger ("another")

Summoning sickness is cleared explicitly in those tests — without it the negative cases would have passed for the wrong reason (an unusable `{T}` and a missing grant both fail).

Regression: `TerritoryForgeScenarioTest`, `AgathasSoulCauldronScenarioTest`, `TheEnigmaJewelScenarioTest` all pass (the last needed its hardcoded `exiled_` AbilityId prefix updated). Card snapshots re-blessed — the diff is only the four affected cards. `just build` green.

HOB goes to **190/193**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)