### PR TITLE
Add four Mirrodin cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ReiverDemonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ReiverDemonReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reiver Demon reprint in CMD. Canonical CardDefinition lives in Mirrodin, its earliest printing.
+ */
+val ReiverDemonReprint = Printing(
+    oracleId = "7dcb95a9-c114-4333-8b45-4380f92d9695",
+    name = "Reiver Demon",
+    setCode = "CMD",
+    collectorNumber = "95",
+    scryfallId = "81a97b45-2a11-493e-9b6a-195844326650",
+    artist = "Brom",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81a97b45-2a11-493e-9b6a-195844326650.jpg?1783941221",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ClockworkDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ClockworkDragon.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Clockwork Dragon — Mirrodin #155
+ * {7} · Artifact Creature — Dragon · 0/0 · Rare
+ *
+ * Flying
+ * This creature enters with six +1/+1 counters on it.
+ * Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat.
+ * {3}: Put a +1/+1 counter on this creature.
+ *
+ * The top of the Mirrodin Clockwork ladder, and modelled exactly like its setmates Clockwork Beetle
+ * and Clockwork Condor (and their Antiquities ancestor Clockwork Avian): printed 0/0 plus six
+ * [EntersWithCounters] +1/+1 counters (CR 613.4c, layer 7d) make a 6/6 on the battlefield, and it
+ * dies as a state-based action once the last counter is shed.
+ *
+ * The counter-shed line is a trigger that *sets up a delayed trigger* ("…remove a counter from it at
+ * end of combat"). [Triggers.EachEndOfCombat] with the intervening-if
+ * [Conditions.SourceAttackedOrBlockedThisCombat] is observationally identical — one counter shed per
+ * combat the Dragon fought in, on any player's turn — because the delayed trigger and the tracker
+ * are keyed to the same object and both go away when it leaves the battlefield.
+ *
+ * Unlike Clockwork Avian, the recharge ability carries **no** timing or ceiling restriction: it is a
+ * plain `{3}` activation usable any time the Dragon's controller has priority, and it can push the
+ * Dragon above six counters.
+ */
+val ClockworkDragon = card("Clockwork Dragon") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Dragon"
+    power = 0
+    toughness = 0
+    oracleText = "Flying\n" +
+        "This creature enters with six +1/+1 counters on it.\n" +
+        "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat.\n" +
+        "{3}: Put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLYING)
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.PlusOnePlusOne,
+            count = 6,
+            selfOnly = true
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EachEndOfCombat
+        triggerCondition = Conditions.SourceAttackedOrBlockedThisCombat
+        effect = Effects.RemoveCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "{3}: Put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "155"
+        artist = "Arnie Swekel"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca6448da-b513-4bea-95f4-47bdfa0df078.jpg?1783944525"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LivingHive.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/LivingHive.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Living Hive — Mirrodin #124
+ * {6}{G}{G} · Creature — Elemental Insect · 6/6 · Rare
+ *
+ * Trample
+ * Whenever this creature deals combat damage to a player, create that many 1/1 green Insect
+ * creature tokens.
+ *
+ * "That many" is the damage in the triggering payload, read with
+ * [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT] — the same primitive Broodhatch Nantuko uses. It is the
+ * damage *actually dealt*, so a pumped or partially-prevented hit makes the matching number of
+ * Insects, and a fully-prevented hit never triggers at all.
+ *
+ * Trample matters here: only the damage assigned to the *player* counts, since the trigger fires off
+ * the player-damage event. A 6/6 trampling over a 2/2 blocker deals 4 to the player and hatches four
+ * Insects, not six.
+ */
+val LivingHive = card("Living Hive") {
+    manaCost = "{6}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental Insect"
+    power = 6
+    toughness = 6
+    oracleText = "Trample\n" +
+        "Whenever this creature deals combat damage to a player, create that many 1/1 green Insect " +
+        "creature tokens."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = CreateTokenEffect(
+            count = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Insect"),
+            // Mirrodin printed no token cards; this is the Magic Player Rewards 2003 Insect, the
+            // contemporary printing.
+            imageUri = "https://cards.scryfall.io/normal/front/a/a/aa47df37-f246-4f80-a944-008cdf347dad.jpg?1783944982"
+        )
+        description = "Whenever this creature deals combat damage to a player, create that many " +
+            "1/1 green Insect creature tokens."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "124"
+        artist = "Anthony S. Waters"
+        flavorText = "In its center is a single red ant, a queen that regulates the hive's movements."
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/407dad3c-d721-412a-8b29-bc15be56d2fe.jpg?1783944534"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MyrIncubator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MyrIncubator.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.EmitLibrarySearchedEventEffect
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Myr Incubator — Mirrodin #212
+ * {6} · Artifact · Rare
+ *
+ * {6}, {T}, Sacrifice this artifact: Search your library for any number of artifact cards, exile
+ * them, then create that many 1/1 colorless Myr artifact creature tokens. Then shuffle.
+ *
+ * One Gather → Select → Move pipeline, no new vocabulary:
+ *
+ *  1. `gather(FromZone(LIBRARY, You, Artifact))` snapshots the artifact cards in your library.
+ *  2. `chooseAnyNumber(...)` is the literal "any number" — zero is a legal search result (CR 701.23b),
+ *     so declining finds nothing, makes no tokens, and still shuffles.
+ *  3. `exile(...)` moves the whole found collection to exile.
+ *  4. "that many" is [DynamicAmount.DistinctEntitiesInCollections] over the found slot, evaluated
+ *     after the move — the collection tracks entity ids, which survive the zone change — so the token
+ *     count is the number of cards *actually* exiled rather than the number asked for.
+ *  5. [ShuffleLibraryEffect] is the trailing "Then shuffle", and
+ *     [EmitLibrarySearchedEventEffect] fires the "whenever a player searches their library" triggers
+ *     (CR 701.23) that every other search primitive emits.
+ *
+ * The exile is a plain one-way exile, not a linked one: nothing on this card ever refers back to the
+ * exiled cards, and the tokens are ordinary tokens rather than copies of them.
+ */
+val MyrIncubator = card("Myr Incubator") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{6}, {T}, Sacrifice this artifact: Search your library for any number of artifact " +
+        "cards, exile them, then create that many 1/1 colorless Myr artifact creature tokens. " +
+        "Then shuffle."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{6}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Pipeline(
+            descriptionOverride = "Search your library for any number of artifact cards, exile " +
+                "them, then create that many 1/1 colorless Myr artifact creature tokens. Then shuffle."
+        ) {
+            val searchable = gather(
+                CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.Artifact),
+                name = "myrIncubatorSearchable"
+            )
+
+            val found = chooseAnyNumber(
+                from = searchable,
+                prompt = "Search your library for any number of artifact cards",
+                name = "myrIncubatorFound"
+            )
+
+            exile(found)
+
+            run(
+                CreateTokenEffect(
+                    count = DynamicAmount.DistinctEntitiesInCollections(listOf(found.key)),
+                    power = 1,
+                    toughness = 1,
+                    colors = emptySet(),
+                    creatureTypes = setOf("Myr"),
+                    artifactToken = true,
+                    // Mirrodin printed no token cards; this is the Magic Player Rewards 2004 Myr,
+                    // the contemporary printing (the same series Pentavus's Pentavite comes from).
+                    imageUri = "https://cards.scryfall.io/normal/front/1/8/187cf6d5-c352-48f2-b8bf-fe1bf946e2ac.jpg?1783944459"
+                )
+            )
+
+            run(ShuffleLibraryEffect())
+            run(EmitLibrarySearchedEventEffect)
+        }
+        description = "{6}, {T}, Sacrifice this artifact: Search your library for any number of " +
+            "artifact cards, exile them, then create that many 1/1 colorless Myr artifact creature " +
+            "tokens. Then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "212"
+        artist = "Alex Horley-Orlandelli"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31b0f9ef-7404-4e05-b759-aaf1ebcfcb31.jpg?1783944512"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ReiverDemon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ReiverDemon.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Reiver Demon — Mirrodin #75
+ * {4}{B}{B}{B}{B} · Creature — Demon · 6/6 · Rare
+ *
+ * Flying
+ * When this creature enters, if you cast it from your hand, destroy all nonartifact, nonblack
+ * creatures. They can't be regenerated.
+ *
+ * The intervening-if is [Conditions.WasCastFromHand] on the enters trigger (CR 603.4) — the same
+ * cast-origin marker Phage the Untouchable reads with the negated form. Reanimating or blinking the
+ * Demon gets a 6/6 flier and no wipe.
+ *
+ * The wipe itself is [Effects.DestroyAll] over `Creature.nonartifact().notColor(BLACK)` with
+ * `noRegenerate = true` for "they can't be regenerated" (functional errata of the printed "bury").
+ * Reiver Demon is black, so it is outside its own filter and never needs an explicit self-exclusion;
+ * an artifact creature or another black creature survives too.
+ */
+val ReiverDemon = card("Reiver Demon") {
+    manaCost = "{4}{B}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\n" +
+        "When this creature enters, if you cast it from your hand, destroy all nonartifact, " +
+        "nonblack creatures. They can't be regenerated."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCastFromHand
+        effect = Effects.DestroyAll(
+            filter = GameObjectFilter.Creature.nonartifact().notColor(Color.BLACK),
+            noRegenerate = true
+        )
+        description = "When this creature enters, if you cast it from your hand, destroy all " +
+            "nonartifact, nonblack creatures. They can't be regenerated."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Brom"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d109abda-982f-4907-8b64-ec63e138bc42.jpg?1783944545"
+        ruling(
+            "2013-09-20",
+            "If a creature (such as Clone) enters the battlefield as a copy of this creature, the " +
+                "copy's \"enters-the-battlefield\" ability will still trigger as long as you cast " +
+                "that creature spell from your hand."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -925,6 +925,97 @@
     "colorIdentityOverride": []
 }
 
+// Clockwork Dragon
+{
+    "name": "Clockwork Dragon",
+    "manaCost": "{7}",
+    "typeLine": "Artifact Creature — Dragon",
+    "oracleText": "Flying\nThis creature enters with six +1/+1 counters on it.\nWhenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat.\n{3}: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END_COMBAT",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "RemoveCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Any",
+                    "conditions": [
+                        {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": {
+                                "statePredicates": [
+                                    "AttackedThisCombat"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "EntityMatches",
+                            "entity": "Self",
+                            "filter": {
+                                "statePredicates": [
+                                    "BlockedThisCombat"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks or blocks, remove a +1/+1 counter from it at end of combat."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "{3}: Put a +1/+1 counter on this creature."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 6,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "RARE",
+        "artist": "Arnie Swekel",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca6448da-b513-4bea-95f4-47bdfa0df078.jpg?1783944525"
+    },
+    "colorIdentityOverride": []
+}
+
 // Clockwork Vorrac
 {
     "name": "Clockwork Vorrac",
@@ -3852,6 +3943,60 @@
     "colorIdentityOverride": []
 }
 
+// Living Hive
+{
+    "name": "Living Hive",
+    "manaCost": "{6}{G}{G}",
+    "typeLine": "Creature — Elemental Insect",
+    "oracleText": "Trample\nWhenever this creature deals combat damage to a player, create that many 1/1 green Insect creature tokens.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Insect"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa47df37-f246-4f80-a944-008cdf347dad.jpg?1783944982"
+                },
+                "descriptionOverride": "Whenever this creature deals combat damage to a player, create that many 1/1 green Insect creature tokens."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "RARE",
+        "artist": "Anthony S. Waters",
+        "flavorText": "In its center is a single red ant, a queen that regulates the hive's movements.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/407dad3c-d721-412a-8b29-bc15be56d2fe.jpg?1783944534"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Lodestone Myr
 {
     "name": "Lodestone Myr",
@@ -4777,6 +4922,92 @@
         "artist": "Greg Staples",
         "flavorText": "Most myr monitor other species. Some myr monitor other myr.",
         "imageUri": "https://cards.scryfall.io/normal/front/e/e/eeeef899-a8b5-4416-a208-3bd5a0c7177b.jpg?1783944512"
+    },
+    "colorIdentityOverride": []
+}
+
+// Myr Incubator
+{
+    "name": "Myr Incubator",
+    "manaCost": "{6}",
+    "typeLine": "Artifact",
+    "oracleText": "{6}, {T}, Sacrifice this artifact: Search your library for any number of artifact cards, exile them, then create that many 1/1 colorless Myr artifact creature tokens. Then shuffle.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{6}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "artifact"
+                            },
+                            "storeAs": "myrIncubatorSearchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "myrIncubatorSearchable",
+                            "selection": "ChooseAnyNumber",
+                            "storeSelected": "myrIncubatorFound",
+                            "prompt": "Search your library for any number of artifact cards"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "myrIncubatorFound",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "DistinctEntitiesInCollections",
+                                "collections": [
+                                    "myrIncubatorFound"
+                                ]
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Myr"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/1/8/187cf6d5-c352-48f2-b8bf-fe1bf946e2ac.jpg?1783944459",
+                            "artifactToken": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ],
+                    "descriptionOverride": "Search your library for any number of artifact cards, exile them, then create that many 1/1 colorless Myr artifact creature tokens. Then shuffle."
+                },
+                "descriptionOverride": "{6}, {T}, Sacrifice this artifact: Search your library for any number of artifact cards, exile them, then create that many 1/1 colorless Myr artifact creature tokens. Then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "rarity": "RARE",
+        "artist": "Alex Horley-Orlandelli",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31b0f9ef-7404-4e05-b759-aaf1ebcfcb31.jpg?1783944512"
     },
     "colorIdentityOverride": []
 }
@@ -6287,6 +6518,81 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Reiver Demon
+{
+    "name": "Reiver Demon",
+    "manaCost": "{4}{B}{B}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Flying\nWhen this creature enters, if you cast it from your hand, destroy all nonartifact, nonblack creatures. They can't be regenerated.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        "IsNonartifact",
+                                        {
+                                            "type": "NotColor",
+                                            "color": "BLACK"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy",
+                            "noRegenerate": true
+                        }
+                    ]
+                },
+                "triggerCondition": "WasCastFromHand",
+                "descriptionOverride": "When this creature enters, if you cast it from your hand, destroy all nonartifact, nonblack creatures. They can't be regenerated."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Brom",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d109abda-982f-4907-8b64-ec63e138bc42.jpg?1783944545",
+        "rulings": [
+            {
+                "date": "2013-09-20",
+                "text": "If a creature (such as Clone) enters the battlefield as a copy of this creature, the copy's \"enters-the-battlefield\" ability will still trigger as long as you cast that creature spell from your hand."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
Four Mirrodin cards, all built from existing `Effects.*` / `Patterns.*` primitives — no new SDK vocabulary.

| Card | What it does | Composed from |
|---|---|---|
| **Clockwork Dragon** {7} | Flying; enters with six +1/+1 counters; sheds one at end of any combat it fought in; `{3}`: put a +1/+1 counter on it | `EntersWithCounters` + `Triggers.EachEndOfCombat` with the `Conditions.SourceAttackedOrBlockedThisCombat` intervening-if — identical to its setmates Clockwork Beetle / Clockwork Condor and their Antiquities ancestor Clockwork Avian. Unlike Avian, the recharge has no upkeep-only or ceiling restriction. |
| **Living Hive** {6}{G}{G} | Trample; combat damage to a player makes that many 1/1 green Insects | `Triggers.DealsCombatDamageToPlayer` + `CreateTokenEffect` counted by `ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT` (Broodhatch Nantuko's primitive). Counts damage *actually dealt to the player*, so trampling over a blocker hatches only what the player was hit for. |
| **Reiver Demon** {4}{B}{B}{B}{B} | Flying; enters → if you cast it from your hand, destroy all nonartifact, nonblack creatures, no regeneration | `Triggers.EntersBattlefield` + `Conditions.WasCastFromHand` (CR 603.4 intervening-if) + `Effects.DestroyAll(Creature.nonartifact().notColor(BLACK), noRegenerate = true)`. Reanimating or blinking it gets the flier and no wipe. The Demon is black, so it sits outside its own filter. |
| **Myr Incubator** {6} | `{6}`, `{T}`, sacrifice: search library for any number of artifacts, exile them, make that many 1/1 Myr tokens, shuffle | One inline `Effects.Pipeline`: gather → `chooseAnyNumber` → `exile` → `CreateTokenEffect` counted by `DynamicAmount.DistinctEntitiesInCollections` → shuffle + `EmitLibrarySearchedEventEffect`. Same exile-then-count-the-slot shape as Hex Magic. Zero is a legal search result (CR 701.23b). |

Also adds the **Commander 2011 `Printing` row for Reiver Demon** — `check-card-printing` flagged it the moment the canonical definition landed in Mirrodin.

Mirrodin goes 213 → 217 of 291.

### Dropped from the batch: Oblivion Stone

Its second ability ends with "*remove all fate counters from all permanents*". There is no `fate` counter type, and more importantly no effect for **"remove all counters of one named kind from every permanent"**:

- `RemoveAllCountersEffect` strips *every* kind from its target — it would eat loyalty and +1/+1 counters off the survivors.
- `RemoveCountersEffect` takes a fixed `Int`, which is wrong as soon as a permanent carries two or more fate counters from repeat activations.

That is genuine new SDK vocabulary, so per the batching rule it leaves this PR and gets its own, with tests for the primitive rather than just for the card.

### Verification

- `just build` — `mtg-sets` clean apart from the expected `CardDefinitionSnapshotTest` diff; `CardLintTest` and `FacadeBoundaryTest` pass.
- `just rebless-cards` — `MRD.json` only, **306 insertions / 0 deletions**, exactly the four new cards. Nothing else moved.
- `just check-card-printing` — clean for all four.
- Disclosure: the full `just build` also reported `QuickGameLobbyCommanderAiTest > "AI quick lobby starts Commander with a generated AI deck"` failing on a 30-second `eventually`. That class took **4,302 seconds** of wall time in that run — the machine was thrashing with three concurrent agent builds. Re-run in isolation, `just test-server` passes in 1m10s with `failures="0"` for that class. The test seats a 99-Plains host deck and waits on the AI's first `StateUpdate`, which none of these cards can reach.
- No scenario tests: nothing here adds engine behaviour, so the snapshot + lint nets are the coverage (per the add-card skill). No client change — the Myr Incubator search routes to the existing `LibrarySearchUI` via `SearchLibraryDecision`, the same path Scouting Trek already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)