### PR TITLE
Add five Mirrodin artifact cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/AssertAuthority.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/AssertAuthority.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Assert Authority — Mirrodin #30
+ * {5}{U}{U} · Instant
+ *
+ * Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)
+ * Counter target spell. If that spell is countered this way, exile it instead of putting it into
+ * its owner's graveyard.
+ *
+ * Two existing primitives, no engine work: [KeywordAbility.Affinity] over [CardType.ARTIFACT]
+ * (Thoughtcast's cost reduction — generic mana only, so the floor is {U}{U}) plus
+ * [Effects.CounterSpellToExile], the Dissipate counter whose `CounterDestination.Exile` sends the
+ * countered spell to exile instead of its owner's graveyard.
+ *
+ * Affinity is a cost reduction, not an alternative cost, so mana value stays 7 in every zone no
+ * matter how many artifacts paid for it.
+ */
+val AssertAuthority = card("Assert Authority") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\n" +
+        "Counter target spell. If that spell is countered this way, exile it instead of putting it " +
+        "into its owner's graveyard."
+
+    keywordAbility(KeywordAbility.Affinity(CardType.ARTIFACT))
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpellToExile()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "30"
+        artist = "Greg Hildebrandt"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc339ed7-e1d4-4fe9-a4c4-b030d3e74c00.jpg?1783944557"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BoshIronGolem.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/BoshIronGolem.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Bosh, Iron Golem — Mirrodin #147
+ * {8} · Legendary Artifact Creature — Golem · 6/7
+ *
+ * Trample
+ * {3}{R}, Sacrifice an artifact: Bosh deals damage equal to the sacrificed artifact's mana value
+ * to any target.
+ *
+ * The textbook sacrifice-cost-feeds-the-effect shape, and it needs no engine work: the
+ * [Costs.Sacrifice] cost binds the sacrificed artifact to [EntityReference.Sacrificed], whose
+ * last-known information is captured at cost payment, and the damage amount reads
+ * [EntityNumericProperty.ManaValue] off that snapshot (same wiring as Priest of Yawgmoth).
+ *
+ * Two rulings ride on that:
+ *  - Bosh is itself an artifact and the filter doesn't exclude the source, so **Bosh can be
+ *    sacrificed to its own ability** — the damage is still dealt, from the graveyard, using
+ *    last-known information (CR 608.2h).
+ *  - An {X} in an artifact's mana cost is 0 on the battlefield (CR 202.3b), so sacrificing an
+ *    X-cost artifact deals damage equal to the rest of its cost only.
+ */
+val BoshIronGolem = card("Bosh, Iron Golem") {
+    manaCost = "{8}"
+    colorIdentity = "R"
+    typeLine = "Legendary Artifact Creature — Golem"
+    power = 6
+    toughness = 7
+    oracleText = "Trample\n" +
+        "{3}{R}, Sacrifice an artifact: Bosh deals damage equal to the sacrificed artifact's " +
+        "mana value to any target."
+
+    keywords(Keyword.TRAMPLE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{R}"), Costs.Sacrifice(GameObjectFilter.Artifact))
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(
+            DynamicAmount.EntityProperty(
+                EntityReference.Sacrificed(0),
+                EntityNumericProperty.ManaValue
+            ),
+            t
+        )
+        description = "{3}{R}, Sacrifice an artifact: Bosh deals damage equal to the sacrificed " +
+            "artifact's mana value to any target."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "147"
+        artist = "Brom"
+        flavorText = "As Glissa searches for the truth about Memnarch, Bosh searches to unearth " +
+            "the secrets of his past."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9bfe325c-8d3d-4543-9fcd-214525d4ab2a.jpg?1783944527"
+        ruling("2020-08-07", "Bosh can be sacrificed to pay the cost of its last ability.")
+        ruling("2020-08-07", "If an artifact on the battlefield has {X} in its mana cost, X is considered to be 0.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ForgeArmor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/ForgeArmor.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Forge Armor — Mirrodin #92
+ * {4}{R} · Instant
+ *
+ * As an additional cost to cast this spell, sacrifice an artifact.
+ * Put X +1/+1 counters on target creature, where X is the sacrificed artifact's mana value.
+ *
+ * The spell-side twin of Bosh, Iron Golem, composed the same way as Eldritch Evolution: the
+ * additional cost binds the sacrificed artifact to [EntityReference.Sacrificed] at cost payment,
+ * and the counter count reads [EntityNumericProperty.ManaValue] off that snapshot at resolution —
+ * mana value is a printed characteristic, so it still reads correctly from the graveyard.
+ *
+ * The additional cost is paid at cast time (CR 601.2h), so an artifact sacrificed to it is gone
+ * before the spell resolves; sacrificing a {0} artifact is legal and simply puts no counters on
+ * the target. An {X} artifact on the battlefield has X = 0 (CR 202.3b).
+ */
+val ForgeArmor = card("Forge Armor") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice an artifact.\n" +
+        "Put X +1/+1 counters on target creature, where X is the sacrificed artifact's mana value."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Artifact))
+
+    spell {
+        target = Targets.Creature
+        effect = Effects.AddDynamicCounters(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            amount = DynamicAmount.EntityProperty(
+                EntityReference.Sacrificed(0),
+                EntityNumericProperty.ManaValue
+            ),
+            target = EffectTarget.ContextTarget(0)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "92"
+        artist = "Tony Szczudlo"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/2873b6d5-af76-498c-bc2d-a26c36be3cbd.jpg?1783944541"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Glimmervoid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Glimmervoid.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+
+/**
+ * Glimmervoid — Mirrodin #281
+ * Land
+ *
+ * At the beginning of the end step, if you control no artifacts, sacrifice this land.
+ * {T}: Add one mana of any color.
+ *
+ * A five-color land with an artifact-shaped leash, composed from two existing primitives.
+ *
+ * The mana half is [Effects.AddAnyColorMana] (one mana, one chosen color), marked
+ * `manaAbility = true` with [TimingRule.ManaAbility] so it never uses the stack (CR 605.1a).
+ *
+ * The upkeep-of-the-drawback half is [Triggers.EachEndStep] — *each* end step, not just yours, so
+ * an opponent's turn kills it just as fast — with the "if you control no artifacts" clause as an
+ * intervening-if [triggerCondition]. That matters twice (CR 603.4): the ability doesn't even
+ * trigger while you control an artifact, and if the last artifact leaves in response to the
+ * trigger, the sacrifice still happens; conversely, deploying an artifact in response to the
+ * trigger saves the land.
+ *
+ * Color identity stays colorless — "any color" adds nothing to identity (CR 903.4).
+ */
+val Glimmervoid = card("Glimmervoid") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "At the beginning of the end step, if you control no artifacts, sacrifice this land.\n" +
+        "{T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        triggerCondition = Conditions.YouControl(GameObjectFilter.Artifact, negate = true)
+        effect = SacrificeSelfEffect
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "281"
+        artist = "Lars Grant-West"
+        flavorText = "An empty canvas holds infinite possibilities."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2ab98a1-664c-4775-a3dd-22a15e2f836b.jpg?1783944493"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MarchOfTheMachines.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/MarchOfTheMachines.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessDynamicStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * March of the Machines — Mirrodin #42
+ * {3}{U} · Enchantment
+ *
+ * Each noncreature artifact is an artifact creature with power and toughness each equal to its
+ * mana value. (Equipment that's a creature can't equip a creature.)
+ *
+ * Titania's Song (ATQ) minus the ability wipe and minus the leaves-the-battlefield linger, so it
+ * is two continuous group statics over noncreature artifacts (CR 613):
+ *  - Layer 4 (TYPE): [GrantCardType] "CREATURE" — they are already artifacts, so this alone makes
+ *    them artifact creatures, and any other card types (an artifact land, an artifact enchantment)
+ *    are kept.
+ *  - Layer 7b (POWER_TOUGHNESS, SET_VALUES): [SetBasePowerToughnessDynamicStatic] fed each
+ *    permanent's own mana value ([EntityReference.AffectedEntity] → [EntityNumericProperty.ManaValue]).
+ *
+ * The `Artifact.notCreature()` filter is locked in at effect-collection time — it is not an
+ * IsCreature-keyed filter the projector re-resolves after Layer 4 — so the same set is animated in
+ * Layer 4 and re-sized in Layer 7b (the Opalescence/Conspiracy locked-set rule).
+ *
+ * Three printed consequences fall out of the layers rather than needing card-specific wiring:
+ * artifact lands have mana value 0 and so die as 0/0s to state-based actions; a later animation
+ * effect (Chimeric Staff) applies in the same layer with a later timestamp and wins; and an
+ * Equipment that becomes a creature is unattached by the CR 301.5c state-based action, which is
+ * exactly what the reminder text describes.
+ */
+val MarchOfTheMachines = card("March of the Machines") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Each noncreature artifact is an artifact creature with power and toughness each " +
+        "equal to its mana value. (Equipment that's a creature can't equip a creature.)"
+
+    val noncreatureArtifacts = GroupFilter(GameObjectFilter.Artifact.notCreature())
+    val manaValue: DynamicAmount = DynamicAmount.EntityProperty(
+        entity = EntityReference.AffectedEntity,
+        numericProperty = EntityNumericProperty.ManaValue
+    )
+
+    staticAbility { ability = GrantCardType(cardType = "CREATURE", filter = noncreatureArtifacts) }
+    staticAbility {
+        ability = SetBasePowerToughnessDynamicStatic(
+            power = manaValue,
+            toughness = manaValue,
+            filter = noncreatureArtifacts
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "42"
+        artist = "Ben Thompson"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9bdcc966-7837-463f-ae26-1096f34ac8c0.jpg?1783944553"
+        ruling(
+            "2004-12-01",
+            "If an Equipment becomes a creature, it can no longer equip a creature. If it's " +
+                "currently attached to a creature, it becomes unattached (but remains on the " +
+                "battlefield). You can activate the Equipment's equip ability, but it won't do anything."
+        )
+        ruling(
+            "2004-12-01",
+            "Each artifact land has a mana value of 0. March of the Machines makes them 0/0 " +
+                "creatures, which are put into the graveyard as a state-based action."
+        )
+        ruling(
+            "2007-07-15",
+            "If a noncreature artifact becomes an artifact creature this way and then another " +
+                "effect animates it, the new effect overrides March of the Machines's effect."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -161,6 +161,47 @@
     ]
 }
 
+// Assert Authority
+{
+    "name": "Assert Authority",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Affinity for artifacts (This spell costs {1} less to cast for each artifact you control.)\nCounter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Affinity",
+            "forType": "ARTIFACT"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Counter",
+            "counterDestination": "CounterDestination.Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Hildebrandt",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc339ed7-e1d4-4fe9-a4c4-b030d3e74c00.jpg?1783944557"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Auriok Bladewarden
 {
     "name": "Auriok Bladewarden",
@@ -658,6 +699,86 @@
         "imageUri": "https://cards.scryfall.io/normal/front/4/6/465a7990-c9f9-4716-a833-fd41458b9cee.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Bosh, Iron Golem
+{
+    "name": "Bosh, Iron Golem",
+    "manaCost": "{8}",
+    "typeLine": "Legendary Artifact Creature — Golem",
+    "oracleText": "Trample\n{3}{R}, Sacrifice an artifact: Bosh deals damage equal to the sacrificed artifact's mana value to any target.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 7
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Sacrificed",
+                        "numericProperty": "ManaValue"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{3}{R}, Sacrifice an artifact: Bosh deals damage equal to the sacrificed artifact's mana value to any target."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "RARE",
+        "artist": "Brom",
+        "flavorText": "As Glissa searches for the truth about Memnarch, Bosh searches to unearth the secrets of his past.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9bfe325c-8d3d-4543-9fcd-214525d4ab2a.jpg?1783944527",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "Bosh can be sacrificed to pay the cost of its last ability."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "If an artifact on the battlefield has {X} in its mana cost, X is considered to be 0."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Broodstar
@@ -2376,6 +2497,55 @@
     ]
 }
 
+// Forge Armor
+{
+    "name": "Forge Armor",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice an artifact.\nPut X +1/+1 counters on target creature, where X is the sacrificed artifact's mana value.",
+    "script": {
+        "spellEffect": {
+            "type": "AddDynamicCounters",
+            "counterType": "+1/+1",
+            "amount": {
+                "type": "EntityProperty",
+                "entity": "Sacrificed",
+                "numericProperty": "ManaValue"
+            },
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                }
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "92",
+        "rarity": "UNCOMMON",
+        "artist": "Tony Szczudlo",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/2873b6d5-af76-498c-bc2d-a26c36be3cbd.jpg?1783944541"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Frogmite
 {
     "name": "Frogmite",
@@ -2489,6 +2659,53 @@
         "artist": "Martina Pilcerova",
         "flavorText": "Over such beauty, wars are fought. With such power, wars are won.",
         "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1d5e4c8-dfd0-45bc-8000-ebfaccfefec3.jpg?1783944521"
+    },
+    "colorIdentityOverride": []
+}
+
+// Glimmervoid
+{
+    "name": "Glimmervoid",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "At the beginning of the end step, if you control no artifacts, sacrifice this land.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": "SacrificeSelf",
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact",
+                    "negate": true
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "281",
+        "rarity": "RARE",
+        "artist": "Lars Grant-West",
+        "flavorText": "An empty canvas holds infinite possibilities.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2ab98a1-664c-4775-a3dd-22a15e2f836b.jpg?1783944493"
     },
     "colorIdentityOverride": []
 }
@@ -4438,6 +4655,80 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// March of the Machines
+{
+    "name": "March of the Machines",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Each noncreature artifact is an artifact creature with power and toughness each equal to its mana value. (Equipment that's a creature can't equip a creature.)",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantCardType",
+                "cardType": "CREATURE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsArtifact",
+                            {
+                                "type": "Not",
+                                "predicate": "IsCreature"
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "SetBasePowerToughnessDynamicStatic",
+                "power": {
+                    "type": "EntityProperty",
+                    "entity": "AffectedEntity",
+                    "numericProperty": "ManaValue"
+                },
+                "toughness": {
+                    "type": "EntityProperty",
+                    "entity": "AffectedEntity",
+                    "numericProperty": "ManaValue"
+                },
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsArtifact",
+                            {
+                                "type": "Not",
+                                "predicate": "IsCreature"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "RARE",
+        "artist": "Ben Thompson",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9bdcc966-7837-463f-ae26-1096f34ac8c0.jpg?1783944553",
+        "rulings": [
+            {
+                "date": "2004-12-01",
+                "text": "If an Equipment becomes a creature, it can no longer equip a creature. If it's currently attached to a creature, it becomes unattached (but remains on the battlefield). You can activate the Equipment's equip ability, but it won't do anything."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "Each artifact land has a mana value of 0. March of the Machines makes them 0/0 creatures, which are put into the graveyard as a state-based action."
+            },
+            {
+                "date": "2007-07-15",
+                "text": "If a noncreature artifact becomes an artifact creature this way and then another effect animates it, the new effect overrides March of the Machines's effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlimmervoidScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlimmervoidScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Glimmervoid (MRD #281):
+ *
+ *   Land
+ *   "At the beginning of the end step, if you control no artifacts, sacrifice this land.
+ *    {T}: Add one mana of any color."
+ *
+ * The interesting half is the intervening-if end-step trigger (CR 603.4): it must not even
+ * trigger while its controller holds an artifact, and it must fire on *each* end step — including
+ * an opponent's — when they don't.
+ */
+class GlimmervoidScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Glimmervoid") {
+
+            test("is sacrificed at the end step when its controller controls no artifacts") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Glimmervoid")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("Glimmervoid starts on the battlefield") {
+                    game.isOnBattlefield("Glimmervoid") shouldBe true
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("with no artifacts, the end-step trigger sacrifices it") {
+                    game.isOnBattlefield("Glimmervoid") shouldBe false
+                }
+            }
+
+            test("survives the end step while its controller controls an artifact") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Glimmervoid")
+                    .withCardOnBattlefield(1, "Bonesplitter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("the intervening-if clause is false, so the ability never triggers") {
+                    game.isOnBattlefield("Glimmervoid") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarchOfTheMachinesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarchOfTheMachinesScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for March of the Machines (MRD #42):
+ *
+ *   {3}{U} Enchantment
+ *   "Each noncreature artifact is an artifact creature with power and toughness each equal to its
+ *    mana value."
+ *
+ * The distinguishing behaviour against its Antiquities cousin Titania's Song is that March does
+ * *not* strip abilities, and the printed rulings that fall out of the layer system: an artifact
+ * land has mana value 0 and so dies as a 0/0 to state-based actions, and an artifact that is
+ * already a creature is untouched.
+ */
+class MarchOfTheMachinesScenarioTest : ScenarioTestBase() {
+
+    // A {3} noncreature artifact with an activated ability — proves the ability survives (unlike
+    // Titania's Song) and that its mana value drives the animated P/T.
+    private val cogwheelEngine = card("Cogwheel Engine") {
+        manaCost = "{3}"
+        typeLine = "Artifact"
+        oracleText = "{T}: Draw a card."
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    // A {2} artifact that is already a creature — March's filter must skip it.
+    private val brassSoldier = card("Brass Soldier") {
+        manaCost = "{2}"
+        typeLine = "Artifact Creature — Soldier"
+        power = 1
+        toughness = 4
+    }
+
+    init {
+        cardRegistry.register(cogwheelEngine)
+        cardRegistry.register(brassSoldier)
+
+        context("March of the Machines") {
+
+            test("a noncreature artifact becomes an MV/MV creature and keeps its abilities") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Cogwheel Engine")
+                    .withCardOnBattlefield(1, "March of the Machines")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val engine = game.findPermanent("Cogwheel Engine")!!
+                val projected = game.state.projectedState
+
+                withClue("a {3} noncreature artifact becomes a creature") {
+                    projected.isCreature(engine) shouldBe true
+                }
+                withClue("its base power and toughness each equal its mana value (3)") {
+                    projected.getPower(engine) shouldBe 3
+                    projected.getToughness(engine) shouldBe 3
+                }
+                withClue("unlike Titania's Song, March does not strip abilities") {
+                    projected.hasLostAllAbilities(engine) shouldBe false
+                }
+            }
+
+            test("an artifact that is already a creature keeps its printed power and toughness") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Brass Soldier")
+                    .withCardOnBattlefield(1, "March of the Machines")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val soldier = game.findPermanent("Brass Soldier")!!
+                val projected = game.state.projectedState
+
+                withClue("the noncreature-artifact filter skips an artifact creature") {
+                    projected.getPower(soldier) shouldBe 1
+                    projected.getToughness(soldier) shouldBe 4
+                }
+            }
+
+            test("an artifact land is a 0/0 and dies to state-based actions") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ancient Den")
+                    .withCardOnBattlefield(1, "March of the Machines")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val den = game.findPermanent("Ancient Den")!!
+                val projected = game.state.projectedState
+
+                withClue("an artifact land is animated too, at its mana value of 0") {
+                    projected.isCreature(den) shouldBe true
+                    projected.getPower(den) shouldBe 0
+                    projected.getToughness(den) shouldBe 0
+                }
+
+                // The builder seeds permanents without ever handing out priority, so SBAs have
+                // not run yet.
+                game.checkStateBasedActions()
+
+                withClue("a 0-toughness creature is put into the graveyard by CR 704.5f") {
+                    game.isOnBattlefield("Ancient Den") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Five artifact-matters cards from Mirrodin, all built from existing primitives — no new SDK vocabulary, so no SDK reference changes.

- **Assert Authority** ({5}{U}{U} Instant) — affinity for artifacts + counter target spell, exiling it. `KeywordAbility.Affinity(ARTIFACT)` (Thoughtcast) + `Effects.CounterSpellToExile()` (Dissipate).
- **Bosh, Iron Golem** ({8} 6/7 Legendary Artifact Creature) — trample + `{3}{R}, Sacrifice an artifact:` damage equal to the sacrificed artifact's mana value to any target. The sacrifice cost binds the artifact to `EntityReference.Sacrificed`, and the damage reads `ManaValue` off that snapshot — the Priest of Yawgmoth template, whose doc comment already cites Bosh as the canonical example. Bosh can be sacrificed to its own ability, per the printed ruling.
- **Forge Armor** ({4}{R} Instant) — sacrifice-an-artifact additional cost, then X +1/+1 counters on target creature. Same `EntityReference.Sacrificed` → `AddDynamicCounters` chain as Eldritch Evolution.
- **Glimmervoid** (Land) — `Effects.AddAnyColorMana(1)` mana ability plus an intervening-if `Triggers.EachEndStep` that sacrifices the land when you control no artifacts (CR 603.4 — checked at trigger *and* at resolution).
- **March of the Machines** ({3}{U} Enchantment) — two continuous group statics over noncreature artifacts: Layer 4 `GrantCardType("CREATURE")` and Layer 7b `SetBasePowerToughnessDynamicStatic` fed each permanent's own mana value. Titania's Song (ATQ) minus the ability wipe and the leaves-the-battlefield linger.

### Tests

Two scenario tests, one file per card, for the two cards whose behaviour is a rules claim rather than a straight facade call:

- `GlimmervoidScenarioTest` — both branches of the intervening-if (sacrificed with no artifacts; never triggers while an artifact is out).
- `MarchOfTheMachinesScenarioTest` — a {3} noncreature artifact becomes a 3/3 and *keeps* its abilities (the difference from Titania's Song), an artifact creature is skipped by the filter, and an artifact land is a 0/0 that dies to state-based actions.

The MRD card snapshot golden is re-blessed; the diff is purely additive — only these five cards appear, no existing entry moved.

### Dropped from the batch

**Arc-Slogger** was in the original pick and was dropped: `{R}, Exile the top ten cards of your library:` needs an *exile the top N of your library* cost atom, which doesn't exist (`CostAtom.ExileFrom` is a player-chosen selection, not the top N). That's new engine vocabulary and belongs in its own PR.

### Verification

`just build` passed apart from the expected `CardDefinitionSnapshotTest` MRD mismatch, which `just rebless-cards` then resolved. `GlimmervoidScenarioTest` passed locally. `MarchOfTheMachinesScenarioTest`'s first two cases passed locally; the third was edited afterwards to drive state-based actions through `checkStateBasedActions()` (the scenario builder seeds permanents without ever handing out priority) and has not been re-run locally — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
