### PR TITLE
Add four Murders at Karlov Manor cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CoercedToKill.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/CoercedToKill.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ControlEnchantedPermanent
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Coerced to Kill — Murders at Karlov Manor #192
+ * {3}{U}{B} · Enchantment — Aura
+ *
+ * Enchant creature
+ * You control enchanted creature.
+ * Enchanted creature has base power and toughness 1/1, has deathtouch, and is an Assassin in
+ * addition to its other types.
+ *
+ * Dimir's take on Control Magic: you take the creature *and* shrink it to a 1/1 deathtouch body. The
+ * stolen creature stops being a threat on its own stats and becomes a repeatable trade — a 1/1 that
+ * kills anything it touches, which is exactly what you want from a creature you're going to throw at
+ * its former controller's board.
+ *
+ * Four separate statics because they land in four different layers, and the layer order is what
+ * makes the card work:
+ *  - [ControlEnchantedPermanent] — Layer 2 (CONTROL).
+ *  - [GrantSubtype] "Assassin" — Layer 4 (TYPE), *in addition to* its other types, so a stolen
+ *    Sphinx is a Sphinx Assassin.
+ *  - [GrantKeyword] deathtouch — Layer 6 (ABILITY).
+ *  - [SetBasePowerToughnessStatic] — Layer 7b (SET_BASE_VALUES). Being a *base* P/T set, it is
+ *    applied before Layer 7c modifications, so +1/+1 counters and pump effects still add on top of
+ *    the 1/1 rather than being erased by it.
+ *
+ * [SetBasePowerToughnessStatic] and [GrantKeyword] both default their filter to the attached
+ * creature, which is what an Aura wants. [GrantSubtype] does **not** — it defaults to
+ * `GroupFilter.source()`, which would make the *Aura* an Assassin and leave the creature untouched,
+ * so the attached-creature filter is passed explicitly.
+ */
+val CoercedToKill = card("Coerced to Kill") {
+    manaCost = "{3}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "You control enchanted creature.\n" +
+        "Enchanted creature has base power and toughness 1/1, has deathtouch, and is an Assassin " +
+        "in addition to its other types."
+
+    auraTarget = Targets.Creature
+
+    // "You control enchanted creature." — Layer 2 (CONTROL)
+    staticAbility {
+        ability = ControlEnchantedPermanent
+    }
+
+    // "is an Assassin in addition to its other types" — Layer 4 (TYPE)
+    staticAbility {
+        ability = GrantSubtype("Assassin", GroupFilter.attachedCreature())
+    }
+
+    // "has deathtouch" — Layer 6 (ABILITY)
+    staticAbility {
+        ability = GrantKeyword(Keyword.DEATHTOUCH)
+    }
+
+    // "has base power and toughness 1/1" — Layer 7b (SET_BASE_VALUES)
+    staticAbility {
+        ability = SetBasePowerToughnessStatic(1, 1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "192"
+        artist = "Justyna Dura"
+        flavorText = "\"People are being brainwashed into these attacks. We must find the puppet " +
+            "master.\"\n—Alquist Proft"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2dc9f352-5076-4b5f-9815-cf47abb63d5b.jpg?1783912855"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KarlovWatchdog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/KarlovWatchdog.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeTurnedFaceUp
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EventPattern.YouAttackEvent
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Karlov Watchdog — Murders at Karlov Manor #20
+ * {3}{W} · Creature — Dog · 3/2
+ *
+ * Vigilance
+ * Permanents your opponents control can't be turned face up during your turn.
+ * Whenever you attack with three or more creatures, creatures you control get +1/+1 until end of turn.
+ *
+ * The lock is white's answer to the disguise/cloak deck: on your turn an opponent can't flip a
+ * face-down permanent up, so they can't ambush your attack with a surprise 4/5 in the declare-blockers
+ * step. It's [CantBeTurnedFaceUp] over every permanent they control, wrapped in a
+ * [ConditionalStaticAbility] gated by [Conditions.IsYourTurn] — the static is only *live* during your
+ * turn, and the turn-face-up special action reads the projected flag and is rejected. "Your" resolves
+ * to the Watchdog's projected controller, so a stolen Watchdog locks down its new controller's
+ * opponents instead.
+ *
+ * `CantBeTurnedFaceUp` defaults its filter to the *attached* creature (it's normally an Aura's
+ * ability, as on Unable to Scream), so the opponent-wide filter is passed explicitly.
+ *
+ * The attack payoff is `YouAttackEvent(minAttackers = 3)` bound ANY — the Meddling Youths shape. The
+ * Watchdog need not be among the three attackers (it has vigilance, so it often attacks anyway), and
+ * the trigger fires once per declare-attackers rather than once per attacker. The pump is a plain
+ * Layer 7c modification over every creature you control, including creatures that didn't attack and
+ * any that entered after attackers were declared but before the trigger resolved.
+ */
+val KarlovWatchdog = card("Karlov Watchdog") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog"
+    power = 3
+    toughness = 2
+    oracleText = "Vigilance\n" +
+        "Permanents your opponents control can't be turned face up during your turn.\n" +
+        "Whenever you attack with three or more creatures, creatures you control get +1/+1 until " +
+        "end of turn."
+
+    keywords(Keyword.VIGILANCE)
+
+    // "Permanents your opponents control can't be turned face up during your turn."
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = CantBeTurnedFaceUp(GroupFilter.AllPermanents.opponentControls()),
+            condition = Conditions.IsYourTurn,
+        )
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(YouAttackEvent(minAttackers = 3), TriggerBinding.ANY)
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter.AllCreaturesYouControl,
+            effect = Effects.ModifyStats(1, 1, EffectTarget.Self, Duration.EndOfTurn),
+        )
+        description = "Whenever you attack with three or more creatures, creatures you control " +
+            "get +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "20"
+        artist = "Craig J Spearing"
+        flavorText = "Teysa trusts only those for whom money has no meaning."
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/79cfb366-ae2a-4b3d-9a80-383a32db1509.jpg?1783912924"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LumberingLaundry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/LumberingLaundry.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.LookAtFaceDownCreatures
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lumbering Laundry — Murders at Karlov Manor #253
+ * {5} · Artifact Creature — Golem · 4/5
+ *
+ * {2}: Until end of turn, you may look at face-down creatures you don't control any time.
+ * Disguise {5}
+ *
+ * The colorless disguise mirror-breaker: {2} buys x-ray vision for the turn, so you know whether the
+ * 2/2 across the table is a Culvert Ambusher or a bluffed land before you attack into it.
+ *
+ * [LookAtFaceDownCreatures] is the same printed static Lens of Clarity carries; here it's handed out
+ * for the turn by [Effects.GrantStaticAbility] anchored to the Laundry itself
+ * ([EffectTarget.Self]). Visibility is a pure view concern — `Visibility.hasLookAtFaceDownCreatures`
+ * asks whether the viewing player controls a permanent with the ability, and it scans
+ * `GameState.grantedStaticAbilities` alongside printed ones, so a granted copy reveals exactly like
+ * a printed one and the grant expires in the cleanup step.
+ *
+ * **Known limitation:** the grant is anchored to the Laundry, so it ends early if the Laundry leaves
+ * the battlefield before end of turn. The printed card's effect is unanchored and would persist. The
+ * engine has no player-anchored static grant, and the divergence only shows in the narrow line
+ * "activate, then lose the Laundry, then need to look at a face-down creature the same turn."
+ *
+ * Disguise makes it a 2/2 with ward {2} for {3}, flipping up for {5} — worth it mostly to blank a
+ * removal spell, since the 4/5 body is what you were paying {5} for anyway.
+ */
+val LumberingLaundry = card("Lumbering Laundry") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 4
+    toughness = 5
+    oracleText = "{2}: Until end of turn, you may look at face-down creatures you don't control " +
+        "any time.\n" +
+        "Disguise {5} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. " +
+        "Turn it face up any time for its disguise cost.)"
+
+    disguise = "{5}"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}")
+        effect = Effects.GrantStaticAbility(
+            ability = LookAtFaceDownCreatures,
+            target = EffectTarget.Self,
+            duration = Duration.EndOfTurn,
+        )
+        description = "Until end of turn, you may look at face-down creatures you don't control any time."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "253"
+        artist = "Michal Ivan"
+        flavorText = "A true crime of fashion."
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/080ad039-1669-4735-9864-76f4c61fc59e.jpg?1783912828"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VeinRipper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/VeinRipper.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.mkm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Vein Ripper — Murders at Karlov Manor #110
+ * {3}{B}{B}{B} · Creature — Vampire Assassin · 6/5
+ *
+ * Flying
+ * Ward—Sacrifice a creature.
+ * Whenever a creature dies, target opponent loses 2 life and you gain 2 life.
+ *
+ * The drain trigger is [Triggers.AnyCreatureDies] — *any* creature, either side of the table,
+ * including the Ripper itself. That last case matters and falls out for free: the Ripper dying is a
+ * creature dying, so it drains once on the way out (the trigger is detected from the zone-change
+ * event, which is emitted whether or not the source survives to see it).
+ *
+ * "Target opponent" is chosen when the trigger goes on the stack, so a board wipe puts one trigger
+ * per dead creature on the stack and each picks its own target. [Effects.DrainLife] is the single
+ * "N from them, N to you" primitive — modelling it as separate lose/gain effects would let the gain
+ * happen even when the loss was prevented or the opponent left the game.
+ *
+ * Ward—Sacrifice a creature ([WardCost.Sacrifice]) is the real protection: it isn't a mana tax an
+ * opponent can simply pay through, it's a second creature, which usually means removal on the Ripper
+ * costs them their own board. Ward triggers on becoming a target of an opponent's spell or ability
+ * (CR 702.21b), so it does nothing against edicts or board wipes that never target.
+ */
+val VeinRipper = card("Vein Ripper") {
+    manaCost = "{3}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Assassin"
+    power = 6
+    toughness = 5
+    oracleText = "Flying\n" +
+        "Ward—Sacrifice a creature.\n" +
+        "Whenever a creature dies, target opponent loses 2 life and you gain 2 life."
+
+    keywords(Keyword.FLYING)
+
+    keywordAbility(KeywordAbility.Ward(WardCost.Sacrifice(GameObjectFilter.Creature)))
+
+    triggeredAbility {
+        trigger = Triggers.AnyCreatureDies
+        target = Targets.Opponent
+        effect = Effects.DrainLife(
+            amount = DynamicAmount.Fixed(2),
+            from = EffectTarget.ContextTarget(0),
+            to = EffectTarget.Controller,
+        )
+        description = "Whenever a creature dies, target opponent loses 2 life and you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "110"
+        artist = "Bastien L. Deharme"
+        flavorText = "\"I'm afraid your investigation has reached a dead end.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/078933b3-6d82-45f2-94e8-addf54cf1704.jpg?1783912890"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -1769,6 +1769,53 @@
     ]
 }
 
+// Coerced to Kill
+{
+    "name": "Coerced to Kill",
+    "manaCost": "{3}{U}{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nYou control enchanted creature.\nEnchanted creature has base power and toughness 1/1, has deathtouch, and is an Assassin in addition to its other types.",
+    "script": {
+        "staticAbilities": [
+            "ControlEnchantedPermanent",
+            {
+                "type": "GrantSubtype",
+                "subtype": "Assassin",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEATHTOUCH"
+            },
+            {
+                "type": "SetBasePowerToughnessStatic",
+                "power": 1,
+                "toughness": 1
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "rarity": "UNCOMMON",
+        "artist": "Justyna Dura",
+        "flavorText": "\"People are being brainwashed into these attacks. We must find the puppet master.\"\n—Alquist Proft",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2dc9f352-5076-4b5f-9815-cf47abb63d5b.jpg?1783912855"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Cold Case Cracker
 {
     "name": "Cold Case Cracker",
@@ -6002,6 +6049,77 @@
     ]
 }
 
+// Karlov Watchdog
+{
+    "name": "Karlov Watchdog",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "Vigilance\nPermanents your opponents control can't be turned face up during your turn.\nWhenever you attack with three or more creatures, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "minAttackers": 3
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever you attack with three or more creatures, creatures you control get +1/+1 until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "CantBeTurnedFaceUp",
+                    "filter": {
+                        "baseFilter": "permanent ctrl:opponent"
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "UNCOMMON",
+        "artist": "Craig J Spearing",
+        "flavorText": "Teysa trusts only those for whom money has no meaning.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/79cfb366-ae2a-4b3d-9a80-383a32db1509.jpg?1783912924"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Knife
 {
     "name": "Knife",
@@ -6670,6 +6788,58 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Lumbering Laundry
+{
+    "name": "Lumbering Laundry",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "{2}: Until end of turn, you may look at face-down creatures you don't control any time.\nDisguise {5} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "keywordAbilities": [
+        {
+            "type": "Disguise",
+            "disguiseCost": {
+                "type": "PayAtom",
+                "atom": {
+                    "type": "AtomMana",
+                    "cost": "{5}"
+                }
+            }
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantStaticAbility",
+                    "ability": "LookAtFaceDownCreatures",
+                    "target": "Self"
+                },
+                "descriptionOverride": "Until end of turn, you may look at face-down creatures you don't control any time."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "rarity": "UNCOMMON",
+        "artist": "Michal Ivan",
+        "flavorText": "A true crime of fashion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/080ad039-1669-4735-9864-76f4c61fc59e.jpg?1783912828"
+    },
+    "colorIdentityOverride": []
 }
 
 // Lush Portico
@@ -11881,6 +12051,68 @@
         "artist": "Michal Ivan",
         "flavorText": "Obtaining evidence through the \"proper\" channels can take weeks of paperwork. Sometimes justice just can't wait.",
         "imageUri": "https://cards.scryfall.io/normal/front/3/7/37692f9a-3825-43aa-aacb-1bb92cb5bd07.jpg?1783912890"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vein Ripper
+{
+    "name": "Vein Ripper",
+    "manaCost": "{3}{B}{B}{B}",
+    "typeLine": "Creature — Vampire Assassin",
+    "oracleText": "Flying\nWard—Sacrifice a creature.\nWhenever a creature dies, target opponent loses 2 life and you gain 2 life.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Sacrifice",
+                "filter": "creature"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "from": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": "TargetOpponent",
+                "descriptionOverride": "Whenever a creature dies, target opponent loses 2 life and you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "MYTHIC",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "\"I'm afraid your investigation has reached a dead end.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/078933b3-6d82-45f2-94e8-addf54cf1704.jpg?1783912890"
     },
     "colorIdentityOverride": [
         "BLACK"


### PR DESCRIPTION
Four MKM cards, all composed from existing SDK primitives — no new engine vocabulary.

- **Karlov Watchdog** {3}{W} 3/2 — vigilance; opponents' permanents can't be turned face up during your turn; attack with three or more creatures to pump your team. Composes `CantBeTurnedFaceUp` over an opponent-controlled filter inside a `ConditionalStaticAbility` gated by `Conditions.IsYourTurn`, plus `YouAttackEvent(minAttackers = 3)` (the Meddling Youths shape) over `ForEachInGroup` + `ModifyStats`.
- **Lumbering Laundry** {5} 4/5 — `{2}`: look at face-down creatures you don't control for the turn; disguise {5}. Composes `Effects.GrantStaticAbility` over the existing `LookAtFaceDownCreatures` static (Lens of Clarity's printed ability).
- **Vein Ripper** {3}{B}{B}{B} 6/5 — flying; Ward—Sacrifice a creature; whenever a creature dies, drain 2. Composes `Triggers.AnyCreatureDies` + `Effects.DrainLife` + the existing `WardCost.Sacrifice` atom.
- **Coerced to Kill** {3}{U}{B} Aura — steal it, shrink it to a 1/1 deathtouch Assassin. Four statics across four layers: `ControlEnchantedPermanent` (2), `GrantSubtype` (4), `GrantKeyword` deathtouch (6), `SetBasePowerToughnessStatic` (7b).

All four are MKM-original printings, so each canonical `CardDefinition` belongs in this set.

### Notes for review

**`GrantSubtype` filter trap (Coerced to Kill).** `GrantSubtype` defaults its filter to `GroupFilter.source()`, not the attached creature — the default would make the *Aura* an Assassin and leave the creature untouched, which the SDK doc flags as invisible without a test. The attached-creature filter is passed explicitly. `SetBasePowerToughnessStatic` and `GrantKeyword` already default to `attachedCreature()`.

**Documented limitation (Lumbering Laundry).** The granted static is anchored to the Laundry, so it ends early if the Laundry leaves the battlefield before end of turn; the printed card's effect is unanchored. The engine has no player-anchored static grant. The divergence only shows in "activate, then lose the Laundry, then need to look at a face-down creature the same turn." Called out in the card's doc comment.

### Cards dropped from this batch

Four candidates were cut once they turned out to need new engine vocabulary — each wants its own PR:

- **Goblin Maskmaker** — "face-down spells you cast this turn cost {1} less." `turnSpellCostReductions` matches against the *card definition* with no entity (`CostCalculator`), so a face-down state predicate can't be evaluated there. Needs a durational sibling of `SpellCostTarget.FaceDownYouCast`.
- **Doorkeeper Thrull** — "artifacts and creatures entering don't cause abilities to trigger" (a Hushbringer static).
- **Pompous Gadabout** — "can't be blocked by creatures that don't have a name"; no nameless-object predicate exists.
- **Unyielding Gatekeeper** / **Branch of Vitu-Ghazi** — the first needs a general exile-then-return-tapped blink with a branch on who controlled the permanent; the second needs the retain-unspent-mana marker bound to the color chosen at resolution (`Effects.RetainUnspentMana` takes fixed colors, so it would over-retain unrelated mana).

### Verification

`just rebless-cards` passed and **only these four cards moved in the MKM golden** (232 pure insertions, no unrelated card touched). All four `image_uris.normal` verified HTTP 200, and every mechanical field was re-checked against Scryfall.

The local `just build` was **not** completed: `:mtg-sets:test` passed after the re-bless, but `:rules-engine:compileTestKotlin` died with "Not enough memory to run compilation" against a Kotlin daemon that had been pegged for 3.5 hours by other concurrent agent builds. Rather than kill another agent's daemon, this is left to CI — no engine or test sources changed in this branch, so that task compiles the same code as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)