### PR TITLE
Add Tom, Bert, and William to The Hobbit

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7536,6 +7536,16 @@ answer it and would silently return `false`.
   where the Demon type the card grants itself on return (`Effects.AddCreatureType(..., Duration.Permanent)`)
   is what stops the second death from returning it again. Reads `TriggerContext.lastKnownSubtypes`,
   populated from the `ZoneChangeEvent`'s `EntitySnapshot.subtypes`.
+- `TriggeringEntityHadCardType(cardType)` — the card-type sibling of `TriggeringEntityHadSubtype`:
+  intervening-if for dies/leaves triggers, true when the triggering entity had `cardType` among its
+  **projected** card types the moment it left the battlefield (CR 603.10), so a type set by a
+  continuous effect counts and not just the printed line. Resolution-only; pass `CardType.X.name`
+  (matched case-insensitively). Tom, Bert, and William's `triggerCondition =
+  Conditions.TriggeringEntityHadCardType(CardType.CREATURE.name)` is the self-recursion guard for
+  "if they were a creature, return them … They're an artifact" — the second death is of the artifact
+  they came back as, so the guard fails and the loop stops. Reads
+  `TriggerContext.lastKnownCardTypes`, populated from the `ZoneChangeEvent`'s
+  `EntitySnapshot.typeLine`.
 - `TargetControlsCreature(target)` — target player has a creature.
 - `TargetControlsLand(target)` — target player has a land.
 - `TargetMatchesFilter(filter, targetIndex = 0)` — the context target matches a `GameObjectFilter`.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1958,6 +1958,16 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadSubtype(subtype)
 
     /**
+     * If the triggering entity had [cardType] among its **projected** card types when it left the
+     * battlefield (CR 603.10 last-known information). The card-type sibling of
+     * [TriggeringEntityHadSubtype] — e.g. Tom, Bert, and William's
+     * `TriggeringEntityHadCardType(CardType.CREATURE.name)`, where returning as an artifact is what
+     * stops the death trigger looping.
+     */
+    fun TriggeringEntityHadCardType(cardType: String): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadCardType(cardType)
+
+    /**
      * If the triggering entity was NOT put onto the battlefield by this source's ability.
      * Used to break ETB-trigger loops on cards like Kodama of the East Tree:
      * "if it wasn't put onto the battlefield with this ability". Pair with

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -186,6 +186,25 @@ data class TriggeringEntityHadSubtype(val subtype: String) : Condition {
 }
 
 /**
+ * Condition: "if it was a <card type>" (intervening-if for dies/leaves triggers).
+ * Reads the last-known **projected** card types captured on the triggering entity at the moment it
+ * left the battlefield (Rule 603.10 last-known information), so a type set by a continuous effect —
+ * not just the printed type line — counts.
+ *
+ * The card-type sibling of [TriggeringEntityHadSubtype]. Used by self-recursion loop guards that
+ * turn the returning permanent into something that is no longer a creature: Tom, Bert, and William
+ * ("When this creature dies, if they were a creature, return them to the battlefield. They're an
+ * artifact"), where the second death is of an *artifact*, so the guard fails and the loop stops.
+ * A card in a graveyard has its printed type line back, so asking the live entity would answer
+ * "creature" forever — only the leave-time snapshot can tell the two deaths apart.
+ */
+@SerialName("TriggeringEntityHadCardType")
+@Serializable
+data class TriggeringEntityHadCardType(val cardType: String) : Condition {
+    override val description: String = "if it was a ${cardType.lowercase()}"
+}
+
+/**
  * Condition: "with a single target" — true iff the triggering spell or ability
  * has exactly one target chosen. Reads the triggering entity's TargetsComponent.
  * Used by cards like Spinerock Tyrant whose trigger fires only when you cast an

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TomBertAndWilliam.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TomBertAndWilliam.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.BecomeArtifactEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Tom, Bert, and William
+ * {3}{B}{G}
+ * Legendary Creature — Troll
+ * 5/5
+ *
+ * {1}, Sacrifice another creature: Draw cards equal to the sacrificed creature's power, then
+ * discard a card.
+ * When Tom, Bert, and William die, if they were a creature, return them to the battlefield.
+ * They're an artifact. (They're no longer a creature.)
+ *
+ * The draw count is [EntityReference.Sacrificed] — whose LKI policy is `LIVE_THEN_LKI`, so the
+ * power read is the one the creature last had on the battlefield, per the card's ruling ("use the
+ * sacrificed creature's power as it last existed on the battlefield"). A sacrificed 0-power
+ * creature draws nothing but the discard still happens: "then discard a card" is not conditional.
+ *
+ * The dies trigger is a self-recursion loop guarded by an intervening "if". The guard has to read
+ * *last-known* information: once the trigger is considered, Tom is a card in the graveyard wearing
+ * its printed `Legendary Creature — Troll` type line again, so asking the live entity would answer
+ * "creature" on both deaths and the pair would recur forever. [Conditions.TriggeringEntityHadCardType]
+ * reads the projected card types captured when the permanent left the battlefield (CR 603.10), which
+ * is where [BecomeArtifactEffect]'s type change shows up — so the second death sees `ARTIFACT`, the
+ * guard fails, and the loop stops after exactly one return.
+ *
+ * [BecomeArtifactEffect] sets the card types to ARTIFACT alone, which drops CREATURE and, with it,
+ * the Troll creature type (CR 205.1a). Abilities are kept (`loseAllAbilities = false`) — nothing on
+ * the card takes them away, so the returned artifact still carries the sacrifice outlet and the dies
+ * trigger. Colors are kept too (`colors = null`, against the parameter's colorless default): the
+ * card changes only its type. [Duration.Permanent] lasts until the permanent next leaves the
+ * battlefield, so the type change is still in force at the moment the snapshot for that second
+ * death is taken.
+ */
+val TomBertAndWilliam = card("Tom, Bert, and William") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Troll"
+    power = 5
+    toughness = 5
+    oracleText = "{1}, Sacrifice another creature: Draw cards equal to the sacrificed creature's " +
+        "power, then discard a card.\n" +
+        "When Tom, Bert, and William die, if they were a creature, return them to the battlefield. " +
+        "They're an artifact."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature)
+        )
+        effect = Effects.Composite(
+            Effects.DrawCards(
+                DynamicAmount.EntityProperty(
+                    EntityReference.Sacrificed(),
+                    EntityNumericProperty.Power
+                )
+            ),
+            Effects.Discard(1)
+        )
+        description = "{1}, Sacrifice another creature: Draw cards equal to the sacrificed " +
+            "creature's power, then discard a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerCondition = Conditions.TriggeringEntityHadCardType(CardType.CREATURE.name)
+        effect = Effects.Composite(
+            Effects.Move(
+                target = EffectTarget.Self,
+                destination = Zone.BATTLEFIELD,
+                fromZone = Zone.GRAVEYARD
+            ),
+            BecomeArtifactEffect(
+                target = EffectTarget.Self,
+                cardTypes = setOf(CardType.ARTIFACT.name),
+                subtypes = emptySet(),
+                // `null` keeps the printed colors — the card only changes its type, so the returned
+                // artifact is still black-green. The parameter's default is `emptySet()` (colorless).
+                colors = null,
+                loseAllAbilities = false,
+                duration = Duration.Permanent
+            )
+        )
+        description = "When Tom, Bert, and William die, if they were a creature, return them to " +
+            "the battlefield. They're an artifact."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "169"
+        artist = "Leonardo Borazio"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/211a9764-3c60-46ba-bb53-e6692640ec8f.jpg?1783902784"
+        ruling("2026-06-29", "Use the sacrificed creature's power as it last existed on the battlefield to determine how many cards you draw.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -13608,6 +13608,142 @@
     ]
 }
 
+// Tom, Bert, and William
+{
+    "name": "Tom, Bert, and William",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Legendary Creature — Troll",
+    "oracleText": "{1}, Sacrifice another creature: Draw cards equal to the sacrificed creature's power, then discard a card.\nWhen Tom, Bert, and William die, if they were a creature, return them to the battlefield. They're an artifact.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "BecomeArtifact",
+                            "target": "Self",
+                            "colors": null,
+                            "loseAllAbilities": false
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "TriggeringEntityHadCardType",
+                    "cardType": "CREATURE"
+                },
+                "descriptionOverride": "When Tom, Bert, and William die, if they were a creature, return them to the battlefield. They're an artifact."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "EntityProperty",
+                                "entity": "Sacrificed",
+                                "numericProperty": "Power"
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}, Sacrifice another creature: Draw cards equal to the sacrificed creature's power, then discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "rarity": "RARE",
+        "artist": "Leonardo Borazio",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/211a9764-3c60-46ba-bb53-e6692640ec8f.jpg?1783902784",
+        "rulings": [
+            {
+                "date": "2026-06-29",
+                "text": "Use the sacrificed creature's power as it last existed on the battlefield to determine how many cards you draw."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Troll Negotiations
 {
     "name": "Troll Negotiations",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -61,6 +61,15 @@ data class TriggerContext(
      */
     val lastKnownSubtypes: Set<String>? = null,
     /**
+     * Last-known **projected** card types when the triggering entity left the battlefield
+     * (CR 603.10), so a type set by a continuous effect counts and not just the printed one. Read by
+     * [com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadCardType] as an intervening-if on
+     * dies/leaves triggers (Tom, Bert, and William's "if they were a creature" self-recursion
+     * guard — the second death is of the artifact they came back as). The card-type sibling of
+     * [lastKnownSubtypes]. Null when the trigger's source never left the battlefield.
+     */
+    val lastKnownCardTypes: Set<String>? = null,
+    /**
      * Last-known counter map (counter-type-string → count) when the triggering source left
      * the battlefield. Used by triggers that move every counter onto another permanent
      * (e.g., Essence Channeler's "put its counters on target creature you control").
@@ -209,6 +218,8 @@ data class TriggerContext(
                     lastKnownPower = event.lastKnown?.power,
                     lastKnownToughness = event.lastKnown?.toughness,
                     lastKnownSubtypes = event.lastKnown?.subtypes?.takeIf { it.isNotEmpty() },
+                    lastKnownCardTypes = event.lastKnown?.typeLine?.cardTypes
+                        ?.mapTo(mutableSetOf()) { it.name }?.takeIf { it.isNotEmpty() },
                     lastKnownCounters = event.lastKnown?.counters?.takeIf { it.isNotEmpty() },
                     lastKnownDamageDealtByPlayers =
                         event.lastKnown?.damageDealtByPlayers?.takeIf { it.isNotEmpty() },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1840,6 +1840,7 @@ class TriggerMatcher(
                 // of settling for the +1/+1-only or sum-of-all-kinds scalars above.
                 triggerLastKnownCounters = trigger.triggerContext.lastKnownCounters,
                 triggerLastKnownSubtypes = trigger.triggerContext.lastKnownSubtypes,
+                triggerLastKnownCardTypes = trigger.triggerContext.lastKnownCardTypes,
                 triggerLastKnownPower = trigger.triggerContext.lastKnownPower,
                 triggerLastKnownToughness = trigger.triggerContext.lastKnownToughness,
                 triggerDiedBatchTotalPower = trigger.triggerContext.diedBatchTotalPower,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -601,6 +601,13 @@ class ConditionEvaluator(
                 ifResolution { ctx ->
                     ctx.triggerLastKnownSubtypes.orEmpty().any { it.equals(condition.subtype, ignoreCase = true) }
                 }
+            is com.wingedsheep.sdk.scripting.conditions.TriggeringEntityHadCardType ->
+                // Card-type names are captured from the projected TypeLine's enum names (e.g.
+                // "CREATURE"); compare case-insensitively so card authors can pass either
+                // CardType.X.name or a literal.
+                ifResolution { ctx ->
+                    ctx.triggerLastKnownCardTypes.orEmpty().any { it.equals(condition.cardType, ignoreCase = true) }
+                }
             is TriggeringEntityWasNotPutByThisSource ->
                 ifResolution { evaluateTriggeringEntityWasNotPutByThisSource(state, it) }
             is TriggeringSpellHasSingleTarget -> ifResolution { evaluateTriggeringSpellHasSingleTarget(state, it) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -210,6 +210,12 @@ data class EffectContext(
      * Demon". Null when the trigger wasn't driven by a permanent leaving the battlefield.
      */
     val triggerLastKnownSubtypes: Set<String>? = null,
+    /**
+     * Last-known projected card types from a dies/leaves trigger context (CR 603.10). Read by
+     * `TriggeringEntityHadCardType` as an intervening-if — e.g. Tom, Bert, and William's "if they
+     * were a creature". Null when the trigger wasn't driven by a permanent leaving the battlefield.
+     */
+    val triggerLastKnownCardTypes: Set<String>? = null,
     /** The entity that caused the trigger to fire (e.g., creature that dealt damage for Aurification) */
     val triggeringEntityId: EntityId? = null,
     /** The player associated with the trigger event (e.g., the player who cast a spell for SpellCastEvent) */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ReflexiveTriggerEffectExecutor.kt
@@ -460,6 +460,7 @@ class ReflexiveTriggerEffectExecutor(
                     lastKnownToughness = effectContext.triggerLastKnownToughness,
                     diedBatchTotalPower = effectContext.triggerDiedBatchTotalPower,
                     lastKnownSubtypes = effectContext.triggerLastKnownSubtypes,
+                    lastKnownCardTypes = effectContext.triggerLastKnownCardTypes,
                     lastKnownCounters = effectContext.triggerLastKnownCounters,
                     lastKnownDamageDealtByPlayers = effectContext.triggerLastKnownDamageDealtByPlayers,
                     lastKnownBlockingOrBlockedByIds = effectContext.triggerLastKnownBlockingOrBlockedByIds,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TomBertAndWilliamScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TomBertAndWilliamScenarioTest.kt
@@ -1,0 +1,178 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.TomBertAndWilliam
+import com.wingedsheep.mtg.sets.definitions.lea.cards.Shatter
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tom, Bert, and William {3}{B}{G} — Legendary Creature — Troll 5/5.
+ *
+ * "{1}, Sacrifice another creature: Draw cards equal to the sacrificed creature's power, then
+ *  discard a card."
+ * "When Tom, Bert, and William die, if they were a creature, return them to the battlefield.
+ *  They're an artifact."
+ *
+ * The interesting behaviour is the self-recursion guard. The first death returns Tom as an
+ * *artifact*; the second death must not return him again, and the only thing telling the two deaths
+ * apart is a card type that — by the time the trigger is considered — exists solely as last-known
+ * information on a card sitting in the graveyard wearing its printed `Legendary Creature — Troll`
+ * line again. That is what `Conditions.TriggeringEntityHadCardType` reads.
+ *
+ * Deaths are staged with real removal rather than the blunt `moveToGraveyard` test helper, which by
+ * design skips dies triggers entirely and would make the guard assertions vacuous. Two Lightning
+ * Bolts (3 + 3) are lethal to the printed 5/5; the returned artifact is no longer a creature, so
+ * bolts can't even target it — Shatter is what kills it, which is itself part of the point.
+ */
+class TomBertAndWilliamScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+    val sacOutletId = TomBertAndWilliam.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TomBertAndWilliam, Shatter))
+        return driver
+    }
+
+    fun settleStack(driver: GameTestDriver) {
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass()
+            safety++
+        }
+    }
+
+    /** Bolt [creature] for 3 and let anything that follows resolve. */
+    fun bolt(driver: GameTestDriver, caster: EntityId, creature: EntityId) {
+        driver.giveMana(caster, Color.RED, 1)
+        val boltCard = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.castSpell(caster, boltCard, targets = listOf(creature)).error shouldBe null
+        settleStack(driver)
+    }
+
+    fun tomOnBattlefield(driver: GameTestDriver, player: EntityId): EntityId? =
+        driver.findPermanent(player, "Tom, Bert, and William")
+
+    test("sacrifice outlet draws cards equal to the sacrificed creature's power, then discards one") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val tom = driver.putCreatureOnBattlefield(you, "Tom, Bert, and William")
+        driver.removeSummoningSickness(tom)
+        // Centaur Courser is a 3/3, so this must draw exactly 3.
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+
+        val handBefore = driver.getHandSize(you)
+        driver.giveColorlessMana(you, 1)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = tom,
+                abilityId = sacOutletId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(courser))
+            )
+        ).isSuccess shouldBe true
+        settleStack(driver)
+
+        // The discard is a card selection; pitch the first card in hand.
+        driver.submitCardSelection(you, listOf(driver.getHand(you).first())).error shouldBe null
+        settleStack(driver)
+
+        // Drew 3, discarded 1.
+        driver.getHandSize(you) shouldBe handBefore + 2
+        driver.getGraveyardCardNames(you).contains("Centaur Courser") shouldBe true
+    }
+
+    test("first death: returns to the battlefield as an artifact that is no longer a creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val tom = driver.putCreatureOnBattlefield(you, "Tom, Bert, and William")
+        bolt(driver, you, tom)   // 3 damage — not yet lethal to a 5/5
+        tomOnBattlefield(driver, you) shouldBe tom
+        bolt(driver, you, tom)   // 6 total — lethal
+
+        val returned = tomOnBattlefield(driver, you)
+        (returned != null) shouldBe true
+
+        val projected = projector.project(driver.state)
+        val cardTypes = projected.getTypes(returned!!)
+        cardTypes.contains(CardType.ARTIFACT.name) shouldBe true
+        // "They're no longer a creature." — and losing CREATURE drops the Troll type with it.
+        cardTypes.contains(CardType.CREATURE.name) shouldBe false
+        projected.isCreature(returned) shouldBe false
+        projected.getSubtypes(returned).contains("Troll") shouldBe false
+
+        driver.getGraveyardCardNames(you).contains("Tom, Bert, and William") shouldBe false
+    }
+
+    test("second death: the artifact they came back as does NOT return again") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val tom = driver.putCreatureOnBattlefield(you, "Tom, Bert, and William")
+        bolt(driver, you, tom)
+        bolt(driver, you, tom)
+        val returned = tomOnBattlefield(driver, you)!!
+
+        // They are an artifact now, so this death must NOT trigger the return.
+        driver.giveMana(you, Color.RED, 2)
+        val shatter = driver.putCardInHand(you, "Shatter")
+        driver.castSpell(you, shatter, targets = listOf(returned)).error shouldBe null
+        settleStack(driver)
+
+        tomOnBattlefield(driver, you) shouldBe null
+        driver.getGraveyardCardNames(you).contains("Tom, Bert, and William") shouldBe true
+    }
+
+    test("the returned artifact keeps its abilities, so the sacrifice outlet still works") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val tom = driver.putCreatureOnBattlefield(you, "Tom, Bert, and William")
+        bolt(driver, you, tom)
+        bolt(driver, you, tom)
+        val returned = tomOnBattlefield(driver, you)!!
+
+        val lion = driver.putCreatureOnBattlefield(you, "Savannah Lions")   // 1/1
+        val handBefore = driver.getHandSize(you)
+        driver.giveColorlessMana(you, 1)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = returned,
+                abilityId = sacOutletId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(lion))
+            )
+        ).isSuccess shouldBe true
+        settleStack(driver)
+
+        driver.submitCardSelection(you, listOf(driver.getHand(you).first())).error shouldBe null
+        settleStack(driver)
+
+        // Drew 1 (the Lions' power), discarded 1 — net zero, but the ability resolved.
+        driver.getHandSize(you) shouldBe handBefore
+        driver.getGraveyardCardNames(you).contains("Savannah Lions") shouldBe true
+    }
+})


### PR DESCRIPTION
Implements **Tom, Bert, and William** `{3}{B}{G}` (HOB 169) — one of the two cards left in The Hobbit. The Eagles Are Coming! is the other, in #1825.

### The card

- **`{1}`, Sacrifice another creature: Draw cards equal to the sacrificed creature's power, then discard a card.** Pure composition — `EntityProperty(Sacrificed(), Power)` has LKI policy `LIVE_THEN_LKI`, so it reads the power the creature last had on the battlefield, which is what the card's ruling asks for.
- **When they die, if they were a creature, return them to the battlefield. They're an artifact.** Needed new vocabulary.

### Why the intervening "if" needs new vocabulary

It's a self-recursion loop guard, and it has to read *last-known* information. By the time the trigger is considered, Tom is a card in the graveyard wearing its printed `Legendary Creature — Troll` line again, so asking the live entity would answer "creature" on **both** deaths and the pair would return forever.

The guard is load-bearing rather than cosmetic: `DeathAndLeaveTriggerDetector.detectDeathTriggers` fires a SELF death trigger for **any** battlefield → graveyard move, with no creature check, so the artifact's death really does re-fire the ability.

### `TriggeringEntityHadCardType`

The card-type sibling of the existing `TriggeringEntityHadSubtype` (Infernal Vessel's "if it wasn't a Demon" guard), reading the **projected** type line already captured on the `ZoneChangeEvent`'s `EntitySnapshot` — so a type set by a continuous effect counts, not just the printed one. Wired one-for-one with the subtype field:

| Layer | Change |
|---|---|
| SDK | `TriggeringEntityHadCardType` condition + `Conditions` facade |
| `TriggerContext` | `lastKnownCardTypes`, from `event.lastKnown.typeLine.cardTypes` |
| `EffectContext` | `triggerLastKnownCardTypes` |
| `TriggerMatcher` | pass-through (the site where `triggerCondition` is actually evaluated) |
| `ReflexiveTriggerEffectExecutor` | pass-through |
| `ConditionEvaluator` | evaluation branch, case-insensitive |

`BecomeArtifactEffect` passes `colors = null` against its colorless default — the card changes only its type, so the returned artifact is still black-green — and keeps its abilities.

### Tests

`TomBertAndWilliamScenarioTest` — sacrifice outlet draws by power then discards; first death returns them as a non-creature artifact that has lost the Troll type; second death does **not** return them; the returned artifact still has its abilities. Deaths are staged with real removal (two Bolts, then Shatter), never the `moveToGraveyard` helper, which skips dies triggers and would make the guard assertions vacuous.

### Verification

- `TomBertAndWilliamScenarioTest` — **4/4 passing** locally.
- `CardDefinitionSnapshotTest` — HOB golden reblessed; **only Tom, Bert, and William moved** (pure addition, no other card touched).

Note: the HOB golden will conflict with #1825, which adds the other card. Whichever merges second needs a rebase and a re-run of `just rebless-cards`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
