### PR TITLE
Add The Eagles Are Coming! to The Hobbit

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -8412,6 +8412,18 @@ Numbers computed at resolution time.
   That is how Nine-Lives Familiar's "with one fewer revival counter" —
   `Subtract(lastKnownSourceCounters(Named(Counters.REVIVAL)), Fixed(1))` — survives to the end step.
 
+  **Pipeline-scoped counts get the same treatment, board-state counts deliberately do not.** A
+  `CreateTokenEffect` scheduled into a delayed trigger has its `count` frozen at scheduling time *only
+  if* the amount reads the pipeline that produced it — `DistinctEntitiesInCollections`,
+  `DistinctCardTypesInCollections`, `ManaValueSumOfCollection`, `StoredCardManaValue`,
+  `VariableReference`, or any arithmetic tree containing one. Those live in the resolving
+  `EffectContext` and would silently read 0 an upkeep later. A *board-state* count
+  (`AggregateBattlefield`, …) is left lazy, because "at the beginning of your end step, create a token
+  for each creature you control" is supposed to count when the trigger fires. The Eagles Are Coming!
+  is the pipeline case: `moveTracked` records what actually reached the hand and
+  `DistinctEntitiesInCollections` counts those ids without looking them up in state, so a *token*
+  creature returned to hand still counts even though it ceased to exist (CR 111.7).
+
 ### Last-known damage dealt to the source (dies/leaves triggers)
 
 - `LastKnownDamageDealtToSource` — the total damage dealt to the source *this turn*, read as last-known

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheEaglesAreComing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheEaglesAreComing.kt
@@ -1,0 +1,116 @@
+package com.wingedsheep.mtg.sets.definitions.hob.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Eagles Are Coming!
+ * {1}{W}
+ * Instant
+ * Kicker {2}{W}{W}
+ *
+ * Choose target creature you own. If this spell was kicked, instead choose any number of target
+ * creatures you own. Return each chosen creature to your hand. At the beginning of the next upkeep,
+ * create a 4/4 white Bird Soldier creature token with flying for each creature returned to your
+ * hand this way.
+ *
+ * The kicked cast swaps only the *targeting* (one creature → any number), never the effect, so this
+ * card sets `kickerTarget` without a `kickerEffect` — the engine falls back to the printed
+ * `spellEffect` when no kicked variant is defined. That works because the effect reads
+ * [CardSource.ChosenTargets], which enumerates however many targets were actually announced. The
+ * shape is Divine Resilience's (FDN), minus the second effect.
+ *
+ * "Creature you **own**" is ownership, not control ([ControllerPredicate.OwnedByYou]): a creature of
+ * yours that an opponent has stolen is a legal target, and returning it puts it in *your* hand,
+ * since a card always returns to its owner's hand.
+ *
+ * The token count is `moveTracked`'s record of what actually reached the hand, not the announced
+ * target list — a target that became illegal is removed on resolution and must not be counted.
+ * [DynamicAmount.DistinctEntitiesInCollections] counts entity ids without looking them up in state,
+ * which is what makes the card's ruling work: a *token* creature returned to hand is counted even
+ * though it ceases to exist (CR 111.7) before the delayed trigger fires.
+ *
+ * That count has to be frozen when the spell resolves, because the pipeline holding the collection
+ * is gone by the next upkeep — `CreateDelayedTriggerExecutor` does that for the pipeline-scoped
+ * amounts it finds in a scheduled `CreateTokenEffect`.
+ *
+ * "The **next** upkeep" is any player's, not specifically yours, so the delayed trigger carries no
+ * `fireOnPlayer` and uses [DelayedTriggerTiming.CURRENT_TURN_OR_LATER] — the next upkeep step to
+ * begin, which on your own turn is your opponent's.
+ */
+val TheEaglesAreComing = card("The Eagles Are Coming!") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Kicker {2}{W}{W} (You may pay an additional {2}{W}{W} as you cast this spell.)\n" +
+        "Choose target creature you own. If this spell was kicked, instead choose any number of " +
+        "target creatures you own. Return each chosen creature to your hand. At the beginning of " +
+        "the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each " +
+        "creature returned to your hand this way."
+
+    keywordAbility(KeywordAbility.kicker("{2}{W}{W}"))
+
+    spell {
+        val creatureYouOwn = TargetFilter(
+            GameObjectFilter.Creature.withControllerPredicate(ControllerPredicate.OwnedByYou)
+        )
+
+        // Unkicked: exactly one target creature you own.
+        target = TargetObject(filter = creatureYouOwn)
+
+        // Kicked: any number of target creatures you own. No kickerEffect — the pipeline below
+        // reads whatever was announced, so both modes share one effect.
+        kickerTarget = TargetObject(unlimited = true, filter = creatureYouOwn)
+
+        effect = Effects.Pipeline {
+            val chosen = gather(CardSource.ChosenTargets, name = "chosen")
+            val returned = moveTracked(
+                chosen,
+                CardDestination.ToZone(Zone.HAND, Player.You),
+                name = "returned"
+            )
+            run(
+                CreateDelayedTriggerEffect(
+                    step = Step.UPKEEP,
+                    timing = DelayedTriggerTiming.CURRENT_TURN_OR_LATER,
+                    effect = Effects.CreateToken(
+                        count = DynamicAmount.DistinctEntitiesInCollections(listOf(returned.key)),
+                        power = 4,
+                        toughness = 4,
+                        colors = setOf(Color.WHITE),
+                        creatureTypes = setOf("Bird", "Soldier"),
+                        keywords = setOf(Keyword.FLYING),
+                        imageUri = "https://cards.scryfall.io/normal/front/9/e/9ed2d2f3-e1b0-41e0-a29d-31624e5e9004.jpg?1785524352"
+                    )
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "12"
+        artist = "Zezhou Chen"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0bda1b62-47fc-42c2-a841-ccad8ea0db48.jpg?1784376936"
+        ruling("2026-06-29", "The kicker ability doesn't let you pay a kicker cost more than once.")
+        ruling("2026-06-29", "Any creature tokens that were returned to your hand are counted by the delayed triggered ability. You'll get a Bird Soldier token for each of them.")
+        ruling("2026-06-29", "If a spell's kicker cost was paid, the spell is \"kicked.\"")
+        ruling("2026-06-29", "If you copy a kicked spell on the stack, the copy is also kicked.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -11807,6 +11807,111 @@
     ]
 }
 
+// The Eagles Are Coming!
+{
+    "name": "The Eagles Are Coming!",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Kicker {2}{W}{W} (You may pay an additional {2}{W}{W} as you cast this spell.)\nChoose target creature you own. If this spell was kicked, instead choose any number of target creatures you own. Return each chosen creature to your hand. At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.",
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "manaCost": "{2}{W}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": "ChosenTargets",
+                    "storeAs": "chosen"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "chosen",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "storeMovedAs": "returned"
+                },
+                {
+                    "type": "CreateDelayedTrigger",
+                    "step": "UPKEEP",
+                    "effect": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "DistinctEntitiesInCollections",
+                            "collections": [
+                                "returned"
+                            ]
+                        },
+                        "power": 4,
+                        "toughness": 4,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Bird",
+                            "Soldier"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9ed2d2f3-e1b0-41e0-a29d-31624e5e9004.jpg?1785524352"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you"
+                }
+            }
+        ],
+        "kickerTargetRequirements": [
+            {
+                "type": "TargetObject",
+                "unlimited": true,
+                "filter": {
+                    "baseFilter": "creature own:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "rarity": "RARE",
+        "artist": "Zezhou Chen",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0bda1b62-47fc-42c2-a841-ccad8ea0db48.jpg?1784376936",
+        "rulings": [
+            {
+                "date": "2026-06-29",
+                "text": "The kicker ability doesn't let you pay a kicker cost more than once."
+            },
+            {
+                "date": "2026-06-29",
+                "text": "Any creature tokens that were returned to your hand are counted by the delayed triggered ability. You'll get a Bird Soldier token for each of them."
+            },
+            {
+                "date": "2026-06-29",
+                "text": "If a spell's kicker cost was paid, the spell is \"kicked.\""
+            },
+            {
+                "date": "2026-06-29",
+                "text": "If you copy a kicked spell on the stack, the copy is also kicked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // The Great Goblin
 {
     "name": "The Great Goblin",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenCopyOfTargetEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
 import com.wingedsheep.sdk.scripting.effects.DelayedTriggerTiming
 import com.wingedsheep.sdk.scripting.effects.DealDamagePerEntityInZoneEffect
@@ -240,6 +241,50 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
     }
 
     /**
+     * Freeze [amount] into a [DynamicAmount.Fixed] **only if** some part of it reads the pipeline
+     * that is running this effect — a stored collection or a stored number. Those live in the
+     * `EffectContext` of the resolution that scheduled the delayed trigger and are gone by the time
+     * it fires, so a lazy read would silently answer 0.
+     *
+     * Anything else is returned untouched. That distinction is the whole point: a *board-state*
+     * amount ("for each creature you control") on a delayed trigger is supposed to be counted when
+     * the trigger fires, and blanket-snapshotting would silently freeze every such card to its
+     * scheduling-time value.
+     *
+     * When the tree does read the pipeline, the *whole* expression is evaluated now rather than
+     * only its pipeline leaves. That is the correct reading for the wording this exists to serve —
+     * "for each creature returned to your hand **this way**" is settled at the moment the returns
+     * happen — and it keeps the substitution a single evaluate rather than a partial rebuild.
+     */
+    private fun snapshotPipelineAmount(
+        amount: DynamicAmount,
+        context: EffectContext,
+        state: GameState
+    ): DynamicAmount {
+        if (!readsPipeline(amount)) return amount
+        return DynamicAmount.Fixed(dynamicAmountEvaluator.evaluate(state, amount, context))
+    }
+
+    /** Whether [amount] anywhere reads a pipeline-scoped collection or stored number. */
+    private fun readsPipeline(amount: DynamicAmount): Boolean = when (amount) {
+        is DynamicAmount.DistinctEntitiesInCollections,
+        is DynamicAmount.DistinctCardTypesInCollections,
+        is DynamicAmount.ManaValueSumOfCollection,
+        is DynamicAmount.StoredCardManaValue,
+        is DynamicAmount.VariableReference -> true
+
+        is DynamicAmount.Add -> readsPipeline(amount.left) || readsPipeline(amount.right)
+        is DynamicAmount.Subtract -> readsPipeline(amount.left) || readsPipeline(amount.right)
+        is DynamicAmount.Max -> readsPipeline(amount.left) || readsPipeline(amount.right)
+        is DynamicAmount.Min -> readsPipeline(amount.left) || readsPipeline(amount.right)
+        is DynamicAmount.Multiply -> readsPipeline(amount.amount)
+        is DynamicAmount.IfPositive -> readsPipeline(amount.amount)
+        is DynamicAmount.Power -> readsPipeline(amount.exponent)
+        is DynamicAmount.Conditional -> readsPipeline(amount.ifTrue) || readsPipeline(amount.ifFalse)
+        else -> false
+    }
+
+    /**
      * Recursively substitute context-dependent target references with concrete SpecificEntity
      * references using the current execution context.
      *
@@ -328,6 +373,17 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             is AddColorlessManaEffect -> {
                 val snapshot = snapshotAmount(effect.amount, context, state)
                 if (snapshot !== effect.amount) effect.copy(amount = snapshot) else effect
+            }
+            // "At the beginning of the next upkeep, create a 4/4 … token **for each creature
+            // returned to your hand this way**" (The Eagles Are Coming!). The count reads the
+            // pipeline collection that ran this effect, and that pipeline is gone by the time the
+            // trigger fires — a lazy read would find no collection and make zero tokens. Only
+            // pipeline-scoped reads are frozen (see [snapshotPipelineAmount]); a board-state count
+            // stays lazy so "at the beginning of your end step, create a token for each …" keeps
+            // counting when the card says to count.
+            is CreateTokenEffect -> {
+                val count = snapshotPipelineAmount(effect.count, context, state)
+                if (count !== effect.count) effect.copy(count = count) else effect
             }
             is DealDamagePerEntityInZoneEffect -> {
                 // Resolve collection name to concrete entity IDs from the pipeline

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheEaglesAreComingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheEaglesAreComingScenarioTest.kt
@@ -1,0 +1,190 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.TheEaglesAreComing
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import com.wingedsheep.engine.core.PaymentStrategy
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Eagles Are Coming! {1}{W} — Instant, Kicker {2}{W}{W}.
+ *
+ * "Choose target creature you own. If this spell was kicked, instead choose any number of target
+ *  creatures you own. Return each chosen creature to your hand. At the beginning of the next upkeep,
+ *  create a 4/4 white Bird Soldier creature token with flying for each creature returned to your
+ *  hand this way."
+ *
+ * Two things are worth pinning. The kicker changes the *target count* — one creature unkicked, any
+ * number kicked — which is a cast-time announcement, not a resolution-time branch. And the token
+ * count is settled when the spell resolves, not when the delayed trigger fires an upkeep later: the
+ * pipeline collection it counts is long gone by then, so the count has to have been frozen.
+ *
+ * Tokens are looked up as "Bird Soldier Token" — `CreateTokenExecutor` derives the name from the
+ * creature types, so the bare type finds nothing.
+ */
+class TheEaglesAreComingScenarioTest : FunSpec({
+
+    val TOKEN = "Bird Soldier Token"
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheEaglesAreComing))
+        return driver
+    }
+
+    fun settleStack(driver: GameTestDriver) {
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass()
+            safety++
+        }
+    }
+
+    fun tokenCount(driver: GameTestDriver, player: EntityId): Int =
+        driver.getPermanents(player).count {
+            driver.state.getEntity(it)?.get<CardComponent>()?.name == TOKEN
+        }
+
+    /** Cast the Eagles at [targets], kicked or not, and let it resolve. */
+    fun castEagles(
+        driver: GameTestDriver,
+        you: EntityId,
+        card: EntityId,
+        targets: List<EntityId>,
+        kicked: Boolean
+    ) {
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = card,
+                targets = targets.map { ChosenTarget.Permanent(it) },
+                declaredCostSlot = if (kicked) ChoiceSlot.KICKED else null,
+                paymentStrategy = PaymentStrategy.AutoPay
+            )
+        ).isSuccess shouldBe true
+        settleStack(driver)
+    }
+
+    /**
+     * Walk forward to the *next* upkeep step and let the delayed trigger resolve. The main-phase hop
+     * first is load-bearing: `passPriorityUntil` returns immediately when the game is already in the
+     * requested step, so calling it with UPKEEP from within an upkeep would silently do nothing.
+     */
+    fun advanceToNextUpkeep(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.passPriorityUntil(Step.UPKEEP)
+        settleStack(driver)
+    }
+
+    /**
+     * Priority does not reliably revert to the active player after a resolution, so normalise it
+     * before acting rather than reasoning about where it landed. With an empty stack a single pass
+     * moves priority across without advancing the step.
+     */
+    fun handPriorityTo(driver: GameTestDriver, player: EntityId) {
+        driver.priorityPlayer?.takeIf { it != player }?.let { driver.passPriority(it) }
+    }
+
+    test("unkicked: returns the one target and makes a single 4/4 flier at the next upkeep") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val bear = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val eagles = driver.putCardInHand(you, "The Eagles Are Coming!")
+        repeat(2) { driver.putLandOnBattlefield(you, "Plains") }
+
+        castEagles(driver, you, eagles, listOf(bear), kicked = false)
+
+        // Returned to hand immediately; the tokens wait for the upkeep.
+        driver.findPermanent(you, "Centaur Courser") shouldBe null
+        driver.findCardInHand(you, "Centaur Courser") shouldBe bear
+        tokenCount(driver, you) shouldBe 0
+
+        advanceToNextUpkeep(driver)
+        tokenCount(driver, you) shouldBe 1
+    }
+
+    test("kicked: any number of targets, one token per creature returned") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val a = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val b = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        val c = driver.putCreatureOnBattlefield(you, "Phantom Warrior")
+        val eagles = driver.putCardInHand(you, "The Eagles Are Coming!")
+        // {1}{W} + kicker {2}{W}{W} = {3}{W}{W}{W} → six Plains cover it.
+        repeat(6) { driver.putLandOnBattlefield(you, "Plains") }
+
+        castEagles(driver, you, eagles, listOf(a, b, c), kicked = true)
+
+        driver.getCreatures(you).isEmpty() shouldBe true
+        listOf(a, b, c).forEach { driver.getHand(you).contains(it) shouldBe true }
+
+        advanceToNextUpkeep(driver)
+        tokenCount(driver, you) shouldBe 3
+    }
+
+    test("unkicked cast may not choose more than one target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val a = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val b = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        val eagles = driver.putCardInHand(you, "The Eagles Are Coming!")
+        repeat(2) { driver.putLandOnBattlefield(you, "Plains") }
+
+        // Without the kicker the spell has exactly one target slot, so a two-target
+        // announcement is illegal.
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = eagles,
+                targets = listOf(a, b).map { ChosenTarget.Permanent(it) },
+                declaredCostSlot = null,
+                paymentStrategy = PaymentStrategy.AutoPay
+            )
+        ).isSuccess shouldBe false
+    }
+
+    test("a token creature returned to hand still counts toward the Bird Soldiers") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        // Cast the Eagles once to manufacture a token creature to bounce.
+        val seed = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        val first = driver.putCardInHand(you, "The Eagles Are Coming!")
+        repeat(8) { driver.putLandOnBattlefield(you, "Plains") }
+        castEagles(driver, you, first, listOf(seed), kicked = false)
+        advanceToNextUpkeep(driver)
+
+        val birdToken = driver.findPermanent(you, TOKEN)!!
+        tokenCount(driver, you) shouldBe 1
+
+        // Bounce the token itself, at instant speed in the opponent's upkeep. It ceases to exist on
+        // reaching the hand (CR 111.7), but the ruling says it is still counted — one new Bird
+        // Soldier next upkeep.
+        handPriorityTo(driver, you)
+        val second = driver.putCardInHand(you, "The Eagles Are Coming!")
+        castEagles(driver, you, second, listOf(birdToken), kicked = false)
+
+        tokenCount(driver, you) shouldBe 0   // the bounced token is gone
+        advanceToNextUpkeep(driver)
+        tokenCount(driver, you) shouldBe 1   // and it earned a replacement
+    }
+})


### PR DESCRIPTION
Implements **The Eagles Are Coming!** `{1}{W}` (HOB 12) — one of the two cards left in The Hobbit. Tom, Bert, and William is the other, in #1824.

> Kicker {2}{W}{W}
> Choose target creature you own. If this spell was kicked, instead choose any number of target creatures you own. Return each chosen creature to your hand. At the beginning of the next upkeep, create a 4/4 white Bird Soldier creature token with flying for each creature returned to your hand this way.

### Targeting

Kicker swaps only the *targeting* (one creature → any number), never the effect, so this sets `kickerTarget` with **no** `kickerEffect` — the engine falls back to the printed `spellEffect`. That works because the effect reads `CardSource.ChosenTargets`, which enumerates however many targets were actually announced. The shape is Divine Resilience's (FDN), minus the second effect.

"Creature you **own**" is ownership, not control: a creature of yours an opponent has stolen is a legal target, and returning it puts it in *your* hand.

The token count comes from `moveTracked`'s record of what actually reached the hand, not the announced target list — a target that became illegal on resolution must not be counted.

### The engine gap

The count reads the pipeline collection that produced it, and that pipeline is gone by the next upkeep — a lazy read would find no collection and silently create **zero** tokens. `CreateDelayedTriggerExecutor` now freezes a scheduled `CreateTokenEffect`'s `count`.

**Scoped deliberately.** Only amounts that actually read the pipeline are frozen — `DistinctEntitiesInCollections`, `DistinctCardTypesInCollections`, `ManaValueSumOfCollection`, `StoredCardManaValue`, `VariableReference`, or any arithmetic tree containing one. A **board-state** count is left lazy on purpose: blanket-snapshotting every `count` would silently freeze existing cards like *"at the beginning of your end step, create a token for each creature you control"*, which are supposed to count when the trigger fires. Same principle as the existing `AddDynamicCountersEffect` / `AddManaEffect` snapshots, but narrowed so it can't regress unrelated cards.

Counting entity ids without looking them up in state is also exactly what makes the card's ruling work: *"Any creature tokens that were returned to your hand are counted"* — a token ceases to exist on reaching the hand (CR 111.7) but still earns a Bird Soldier.

"The **next** upkeep" is any player's, so the delayed trigger carries no `fireOnPlayer`.

### Tests

`TheEaglesAreComingScenarioTest` — unkicked returns one and makes one token; kicked returns three and makes three; an unkicked cast can't announce two targets; and a bounced Bird Soldier token still earns its replacement (the ruling above).

### Verification

- `TheEaglesAreComingScenarioTest` — **4/4 passing** locally, including the "unkicked cast may not choose more than one target" rejection and the bounced-token ruling.
- `CardDefinitionSnapshotTest` — HOB golden reblessed; **only The Eagles Are Coming! moved** (pure addition, no other card touched).

Note: the HOB golden will conflict with #1824, which adds the other card. Whichever merges second needs a rebase and a re-run of `just rebless-cards`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
