### PR TITLE
Add 240 vanilla cards

### DIFF
--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/CombatAdvisorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/CombatAdvisorTest.kt
@@ -95,18 +95,26 @@ class CombatAdvisorTest : FunSpec({
 
     // ── Helper: set up a game, place creatures, and get combat advisor ──
 
+    /**
+     * `TestCards.all` is the *whole* card corpus (`MtgSetCatalog.all` + the test-only cards), so it
+     * is registered **first** and the test's own [allCards] second: `CardRegistry.register` is
+     * last-write-wins by name, and a test that hand-builds a creature to get exact P/T must win over
+     * a real card that happens to share its name. Registering the corpus last silently swapped this
+     * suite's 4/4 "Pillarfield Ox" and 2/3 "Nessian Courser" for the printed 2/4 and 3/3 the moment
+     * those cards were implemented, which broke the gang-block arithmetic the tests assert on.
+     */
     fun setup(allCards: List<CardDefinition>): Triple<GameTestDriver, CardRegistry, CombatAdvisor> {
         val driver = GameTestDriver()
-        driver.registerCards(allCards)
         driver.registerCards(TestCards.all)
+        driver.registerCards(allCards)
         driver.initMirrorMatch(
             deck = Deck.of("Plains" to 20, "Forest" to 20),
             startingLife = 20
         )
 
         val registry = CardRegistry()
-        registry.register(allCards)
         registry.register(TestCards.all)
+        registry.register(allCards)
         val simulator = GameSimulator(registry)
         val evaluator = AIPlayer.defaultEvaluator()
         val advisor = CombatAdvisor(simulator, evaluator)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/GoblinHero.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/GoblinHero.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Hero
+ * {2}{R}
+ * Creature — Goblin
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val GoblinHero = card("Goblin Hero") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Mark Tedin"
+        flavorText = "They attacked in an orgy of rage and madness, but only one seemed as focused on killing us as on the sheer joy of battle."
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/7135a569-e5d3-4a1f-924b-bdb86926b4e1.jpg?1783947934"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/ScarwoodGoblins.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/ScarwoodGoblins.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scarwood Goblins
+ * {R}{G}
+ * Creature — Goblin
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val ScarwoodGoblins = card("Scarwood Goblins") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Goblin"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Ron Spencer"
+        flavorText = "Larger and more cunning than most Goblins, Scarwood Goblins are thankfully found only in isolated pockets."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/5542d236-af43-43b8-b30f-8980d74bbdd0.jpg?1783947928"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Squire.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/drk/cards/Squire.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.drk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Squire
+ * {1}{W}
+ * Creature — Human Soldier
+ * 1/2
+ *
+ * Vanilla — no rules text.
+ */
+val Squire = card("Squire") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Dennis Detwiller"
+        flavorText = "\"Of twenty yeer of age he was, I gesse.\nOf his stature he was of even lengthe,\nAnd wonderly deliver, and greete of strengthe.\"\n—Geoffrey Chaucer, *The Canterbury Tales*"
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/374df061-ebd2-4f1f-9a6e-7940a49197a9.jpg?1783947948"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fem/cards/VodalianSoldiers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fem/cards/VodalianSoldiers.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.fem.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vodalian Soldiers
+ * {1}{U}
+ * Creature — Merfolk Soldier
+ * 1/2
+ *
+ * Vanilla — no rules text.
+ */
+val VodalianSoldiers = card("Vodalian Soldiers") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Soldier"
+    power = 1
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31a"
+        artist = "Melissa A. Benson"
+        flavorText = "\"Vodalian Soldiers had some unique advantages. Often they would ride into battle on war machines rumored to have come from the far northern oceans.\"\n—*Sarpadian Empires, vol. V*"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7eb50256-9113-4b03-bcef-9aea24be8493.jpg?1783947907"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hml/cards/DwarvenTrader.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hml/cards/DwarvenTrader.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.hml.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dwarven Trader
+ * {R}
+ * Creature — Dwarf
+ * 1/1
+ *
+ * Vanilla — no rules text.
+ */
+val DwarvenTrader = card("Dwarven Trader") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf"
+    power = 1
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72a"
+        artist = "Margaret Organ-Kean"
+        flavorText = "\"Their definition of 'fair profit' is certainly novel.\"\n—Reveka, Wizard Savant"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4db9aa47-f42b-41e9-948c-8b012c3809fb.jpg?1783947283"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/BalduvianBears.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/BalduvianBears.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Balduvian Bears
+ * {1}{G}
+ * Creature — Bear
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val BalduvianBears = card("Balduvian Bears") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "226"
+        artist = "Quinton Hoover"
+        flavorText = "\"They're a hardy bunch, but I'd still bet that they just slept through the worst of the cold times.\"\n—Disa the Restless, journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef5297cb-e763-4871-9cd3-0e2dbcc52095.jpg?1783947481"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ScaledWurm.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/ScaledWurm.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scaled Wurm
+ * {7}{G}
+ * Creature — Wurm
+ * 7/6
+ *
+ * Vanilla — no rules text.
+ */
+val ScaledWurm = card("Scaled Wurm") {
+    manaCost = "{7}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 7
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "262"
+        artist = "Daniel Gelon"
+        flavorText = "\"Flourishing during the Ice Age, these Wurms were the bane of all Kjeldorans. Their great size and ferocity made them the subject of countless nightmares—they embodied the worst of the Ice Age.\"\n—*Kjeldor: Ice Civilization*"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/499cd7fa-c86c-4a5f-b36d-8160e8a6af1f.jpg?1783947472"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/TorGiant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/TorGiant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tor Giant
+ * {3}{R}
+ * Creature — Giant
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val TorGiant = card("Tor Giant") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "220"
+        artist = "Douglas Shuler"
+        flavorText = "\"What do you do then? Run. Run very fast. Don't stop until you see the camp—or a bigger Giant.\"\n—Toothlicker Harj, Orcish Captain"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7ef8f279-1a10-4685-99d6-bc971a7f922b.jpg?1783947482"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/BarbaryApes.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/BarbaryApes.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barbary Apes
+ * {1}{G}
+ * Creature — Ape
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val BarbaryApes = card("Barbary Apes") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ape"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "176"
+        artist = "Bryon Wackwitz"
+        flavorText = "Unpredictable in the extreme, these carnivorous apes will prey even upon their own kind."
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df25ffdd-995d-46ae-856b-f6368f9438ed.jpg?1783948049"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/BarktoothWarbeard.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/BarktoothWarbeard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barktooth Warbeard
+ * {4}{B}{R}{R}
+ * Legendary Creature — Human Warrior
+ * 6/5
+ *
+ * Vanilla — no rules text.
+ */
+val BarktoothWarbeard = card("Barktooth Warbeard") {
+    manaCost = "{4}{B}{R}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 6
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Andi Rusu"
+        flavorText = "He is devious and cunning, in both appearance and deed. Beware the Warbeard, for this brute bites as well as he barks!"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0ea52228-f8ad-4623-9e05-f162473bfc03.jpg?1783948041"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CrimsonKobolds.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CrimsonKobolds.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crimson Kobolds
+ * {0}
+ * Creature — Kobold
+ * 0/1
+ *
+ * Vanilla — no rules text.
+ */
+val CrimsonKobolds = card("Crimson Kobolds") {
+    manaCost = "{0}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kobold"
+    power = 0
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Anson Maddocks"
+        flavorText = "\"Kobolds are harmless.\" —Bearand the Bold, epitaph"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13696657-aeef-4add-9a3b-8137fce01fe3.jpg?1783948057"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CrookshankKobolds.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/CrookshankKobolds.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crookshank Kobolds
+ * {0}
+ * Creature — Kobold
+ * 0/1
+ *
+ * Vanilla — no rules text.
+ */
+val CrookshankKobolds = card("Crookshank Kobolds") {
+    manaCost = "{0}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kobold"
+    power = 0
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "141"
+        artist = "Christopher Rush"
+        flavorText = "The Crookshank military boasts a standing army of nearly twenty-four million, give or take twenty-two million."
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7af6b119-7db4-49dd-aaa4-044b8c133f13.jpg?1783948058"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DurkwoodBoars.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/DurkwoodBoars.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Durkwood Boars
+ * {4}{G}
+ * Creature — Boar
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val DurkwoodBoars = card("Durkwood Boars") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Mike Kimble"
+        flavorText = "\"And the unclean spirits went out, and entered the swine; and the herd ran violently . . .\" —Mark 5:13"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d41f08b-68fb-45f2-bdc9-488baedc7d6f.jpg?1783948049"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HeadlessHorseman.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/HeadlessHorseman.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Headless Horseman
+ * {2}{B}
+ * Creature — Zombie Knight
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val HeadlessHorseman = card("Headless Horseman") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Knight"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Quinton Hoover"
+        flavorText = "\". . . [T]he ghost rides forth to the scene of battle in nightly quest of his head . . . he sometimes passes along the Hollow, like a midnight blast . . .\"\n—Washington Irving, The Legend of Sleepy Hollow"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1aa37c8-98fa-4984-b09b-cf65ad84e97b.jpg?1783948066"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/JasmineBoreal.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/JasmineBoreal.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jasmine Boreal
+ * {3}{G}{W}
+ * Legendary Creature — Human
+ * 4/5
+ *
+ * Vanilla — no rules text.
+ */
+val JasmineBoreal = card("Jasmine Boreal") {
+    manaCost = "{3}{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Legendary Creature — Human"
+    power = 4
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Richard Kane Ferguson"
+        flavorText = "\"Peace must prevail, even if the wicked must die.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db6ef678-4ce9-48d6-aa4f-2afd9a1ad724.jpg?1783948038"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/JeditOjanen.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/JeditOjanen.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jedit Ojanen
+ * {4}{W}{W}{U}
+ * Legendary Creature — Cat Warrior
+ * 5/5
+ *
+ * Vanilla — no rules text.
+ */
+val JeditOjanen = card("Jedit Ojanen") {
+    manaCost = "{4}{W}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Cat Warrior"
+    power = 5
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "234"
+        artist = "Mark Poole"
+        flavorText = "Mightiest of the Cat Warriors, Jedit Ojanen forsook the forests of his tribe and took service with the Robaran Mercenaries, rising through their ranks to lead them in the battle for Efrava."
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/97b80124-2b59-425c-93cc-9b032e631c6e.jpg?1783948038"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/JerrardOfTheClosedFist.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/JerrardOfTheClosedFist.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jerrard of the Closed Fist
+ * {3}{R}{G}{G}
+ * Legendary Creature — Human Knight
+ * 6/5
+ *
+ * Vanilla — no rules text.
+ */
+val JerrardOfTheClosedFist = card("Jerrard of the Closed Fist") {
+    manaCost = "{3}{R}{G}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Human Knight"
+    power = 6
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "235"
+        artist = "Andi Rusu"
+        flavorText = "Once, the order of the Closed Fist reached throughout the Kb'Briann Highlands. Now, Jerrard alone remains to uphold their standard."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f841918-813b-4784-ab57-907185b0a355.jpg?1783948038"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KasimirTheLoneWolf.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KasimirTheLoneWolf.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kasimir the Lone Wolf
+ * {4}{W}{U}
+ * Legendary Creature — Human Warrior
+ * 5/3
+ *
+ * Vanilla — no rules text.
+ */
+val KasimirTheLoneWolf = card("Kasimir the Lone Wolf") {
+    manaCost = "{4}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 5
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Richard Kane Ferguson"
+        flavorText = "Popular indeed is the tale of how Kasimir was once a Holy man who renounced his order to take up the sword. But this tale is no more likely than any other."
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45b1e60d-54dd-41cd-b9a2-00890725a3df.jpg?1783948037"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KeepersOfTheFaith.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KeepersOfTheFaith.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Keepers of the Faith
+ * {1}{W}{W}
+ * Creature — Human Cleric
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val KeepersOfTheFaith = card("Keepers of the Faith") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Daniel Gelon"
+        flavorText = "And then the Archangel Anthius spoke to them, saying, \"Fear shall be vanquished by the Sword of Faith.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b63a69ae-99ce-4d26-88b7-784793c43cd4.jpg?1783948083"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KoboldsOfKherKeep.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/KoboldsOfKherKeep.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kobolds of Kher Keep
+ * {0}
+ * Creature — Kobold
+ * 0/1
+ *
+ * Vanilla — no rules text.
+ */
+val KoboldsOfKherKeep = card("Kobolds of Kher Keep") {
+    manaCost = "{0}"
+    colorIdentity = "R"
+    typeLine = "Creature — Kobold"
+    power = 0
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "157"
+        artist = "Julie Baroh"
+        flavorText = "Kher Keep is unique among fortresses: impervious to aerial assault but defenseless from the ground."
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df0320d9-7c2a-456a-9159-1b4fae67bfb5.jpg?1783948054"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/LadyOrca.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/LadyOrca.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lady Orca
+ * {5}{B}{R}
+ * Legendary Creature — Demon
+ * 7/4
+ *
+ * Vanilla — no rules text.
+ */
+val LadyOrca = card("Lady Orca") {
+    manaCost = "{5}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Demon"
+    power = 7
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "241"
+        artist = "Sandra Everingham"
+        flavorText = "\"I do not remember what he said to her. I remember her fiery eyes, fixed upon him for an instant. I remember a flash, and the hot breath of sudden flames made me turn away. When I looked again, Angus was gone.\" —A Wayfarer, on meeting Lady Orca"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2779553-74eb-42ba-97d0-96269f48c269.jpg?1783948036"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/RagingBull.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/RagingBull.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raging Bull
+ * {2}{R}
+ * Creature — Ox
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val RagingBull = card("Raging Bull") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ox"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Randy Asplund-Faith"
+        flavorText = "\"Sometimes the bulls win, and sometimes the bears win. But the bulls have more fun.\"\n—Anonymous"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec10a51c-d2c3-4d14-9a71-9e59155bf980.jpg?1783948052"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SirShandlarOfEberyn.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SirShandlarOfEberyn.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sir Shandlar of Eberyn
+ * {4}{G}{W}
+ * Legendary Creature — Human Knight
+ * 4/7
+ *
+ * Vanilla — no rules text.
+ */
+val SirShandlarOfEberyn = card("Sir Shandlar of Eberyn") {
+    manaCost = "{4}{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Legendary Creature — Human Knight"
+    power = 4
+    toughness = 7
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "257"
+        artist = "Andi Rusu"
+        flavorText = "\"Remember Sir Shandlar! Remember and stand firm!\" —rallying cry of the Eberyn militia"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31570ded-f5e3-44c4-b95f-294ac10b2cd2.jpg?1783948033"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SivitriScarzam.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/SivitriScarzam.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sivitri Scarzam
+ * {5}{U}{B}
+ * Legendary Creature — Human
+ * 6/4
+ *
+ * Vanilla — no rules text.
+ */
+val SivitriScarzam = card("Sivitri Scarzam") {
+    manaCost = "{5}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human"
+    power = 6
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "258"
+        artist = "NéNé Thomas"
+        flavorText = "Even the brave have cause to tremble at the sight of Sivitri Scarzam. Who else has tamed Scarzam's Dragon?"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c12ee9e-db13-4b4d-a061-b6566f538f09.jpg?1783948032"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TheLadyOfTheMountain.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TheLadyOfTheMountain.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * The Lady of the Mountain
+ * {4}{R}{G}
+ * Legendary Creature — Giant
+ * 5/5
+ *
+ * Vanilla — no rules text.
+ */
+val TheLadyOfTheMountain = card("The Lady of the Mountain") {
+    manaCost = "{4}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Giant"
+    power = 5
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "263"
+        artist = "Richard Kane Ferguson"
+        flavorText = "Her given name has been lost in the mists of time. Legend says that her silent vigil will one day be ended by the one who, pure of heart and spirit, calls out that name again."
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83717eb2-220e-4086-be09-dee9174798b8.jpg?1783948032"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TobiasAndrion.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TobiasAndrion.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tobias Andrion
+ * {3}{W}{U}
+ * Legendary Creature — Human Advisor
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val TobiasAndrion = card("Tobias Andrion") {
+    manaCost = "{3}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "264"
+        artist = "Andi Rusu"
+        flavorText = "Administrator of the military state of Sheoltun, Tobias is the military right arm of the empire and the figurehead of its freedom."
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/cac56eda-5ed3-4abd-beec-f5063fbf930a.jpg?1783948031"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TorstenVonUrsus.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/leg/cards/TorstenVonUrsus.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.leg.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Torsten Von Ursus
+ * {3}{G}{G}{W}
+ * Legendary Creature — Human Soldier
+ * 5/5
+ *
+ * Vanilla — no rules text.
+ */
+val TorstenVonUrsus = card("Torsten Von Ursus") {
+    manaCost = "{3}{G}{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 5
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "266"
+        artist = "Mark Poole"
+        flavorText = "\"How can you accuse me of evil? Though these deeds be unsavory, no one will argue: good shall follow from them.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fd99522-4a91-4ccd-91bf-5f32a6ac3510.jpg?1783948031"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/FreshVolunteers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/FreshVolunteers.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fresh Volunteers
+ * {1}{W}
+ * Creature — Human Rebel
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val FreshVolunteers = card("Fresh Volunteers") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Rebel"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Jeff Miracola"
+        flavorText = "Every Cho-Arrim villager is a potential warrior; when they are called, they abandon their peaceful way of life and take up arms to defend it."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e070ea4a-c417-405f-b788-78fb7ca2eaa5.jpg?1783945981"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/WildJhovall.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/WildJhovall.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wild Jhovall
+ * {3}{R}
+ * Creature — Cat
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val WildJhovall = card("Wild Jhovall") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cat"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "227"
+        artist = "Daren Bader"
+        flavorText = "Jhovalls sharpen their claws on trees—or on Mercadians, if no trees are handy."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/64bcc06a-de86-4387-882d-ead33e9c9e01.jpg?1783945930"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornTrooper.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/AlabornTrooper.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alaborn Trooper
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val AlabornTrooper = card("Alaborn Trooper") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Lubov"
+        flavorText = "\"I dedicate my body to my country And my life to my King.\"\n—Alaborn Soldier's Oath"
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1cd30b4-4ed8-467e-808e-b0caf4196d90.jpg?1783946495"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/BarbtoothWurm.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/BarbtoothWurm.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barbtooth Wurm
+ * {5}{G}
+ * Creature — Wurm
+ * 6/4
+ *
+ * Vanilla — no rules text.
+ */
+val BarbtoothWurm = card("Barbtooth Wurm") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 6
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Rebecca Guay"
+        flavorText = "In its lair lies a carpet of bones."
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f627db9-c63e-4353-94f4-3e28db7b222a.jpg?1783946458"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DakmorScorpion.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/DakmorScorpion.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dakmor Scorpion
+ * {1}{B}
+ * Creature — Scorpion
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val DakmorScorpion = card("Dakmor Scorpion") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Scorpion"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Randy Gallegos"
+        flavorText = "A scorpion this big you won't find curled up in your boot. Maybe *around* your boot, but not *in* it."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d860dee-93a9-48e5-ba7a-80ad8cdc84e4.jpg?1783946477"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinCavaliers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoblinCavaliers.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Cavaliers
+ * {2}{R}
+ * Creature — Goblin
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val GoblinCavaliers = card("Goblin Cavaliers") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "DiTerlizzi"
+        flavorText = "They get along so well with their goats because they're practically goats themselves."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edc6ea02-0642-4fc5-b50c-543dc393bfdd.jpg?1783946467"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoldenBear.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/GoldenBear.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Golden Bear
+ * {3}{G}
+ * Creature — Bear
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val GoldenBear = card("Golden Bear") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Una Fricker"
+        flavorText = "The elvish scout was scrupulous about the truth. She told the traders that gold lay nearby."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7dfc789-7ea0-4eb8-8c3b-2c50fd52cbab.jpg?1783946455"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ObsidianGiant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/ObsidianGiant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Obsidian Giant
+ * {4}{R}
+ * Creature — Giant
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val ObsidianGiant = card("Obsidian Giant") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "109"
+        artist = "David A. Cherry"
+        flavorText = "After a while, ships stopped sailing within his reach."
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aad8a194-cee7-4671-8310-19357fc1a450.jpg?1783946462"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/OgreWarrior.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/OgreWarrior.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ogre Warrior
+ * {3}{R}
+ * Creature — Ogre Warrior
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val OgreWarrior = card("Ogre Warrior") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Warrior"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "113"
+        artist = "Jeff Miracola"
+        flavorText = "Assault and battery included."
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66e72970-df1f-4ded-a686-036008555a76.jpg?1783946462"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/PlatedWurm.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/PlatedWurm.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plated Wurm
+ * {4}{G}
+ * Creature — Wurm
+ * 4/5
+ *
+ * Vanilla — no rules text.
+ */
+val PlatedWurm = card("Plated Wurm") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 4
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "141"
+        artist = "Daniel Gelon"
+        flavorText = "\"I'd hate to see the bird that could get *this* wurm!\"\n—Alaborn soldier"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b51f8724-8f26-4a9d-b586-4223354ae7fc.jpg?1783946449"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasMerchant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TalasMerchant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Talas Merchant
+ * {1}{U}
+ * Creature — Human Pirate
+ * 1/3
+ *
+ * Vanilla — no rules text.
+ */
+val TalasMerchant = card("Talas Merchant") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    power = 1
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Lubov"
+        flavorText = "The trader let loose a laugh that made all around him check their purses."
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f779d7e-6e37-49bc-b76d-3bb490ff142b.jpg?1783946482"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TrokinHighGuard.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/TrokinHighGuard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trokin High Guard
+ * {3}{W}
+ * Creature — Human Knight
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val TrokinHighGuard = card("Trokin High Guard") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "26"
+        artist = "Ron Spencer"
+        flavorText = "Battle tempers soldiers as fire tempers steel."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c2b9302-fca6-43ca-a01c-03aec51acd0d.jpg?1783946490"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/VolunteerMilitia.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/p02/cards/VolunteerMilitia.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.p02.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volunteer Militia
+ * {W}
+ * Creature — Human Soldier
+ * 1/2
+ *
+ * Vanilla — no rules text.
+ */
+val VolunteerMilitia = card("Volunteer Militia") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Keith Parkinson"
+        flavorText = "People fight hardest on their own soil."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/de307b2e-9a1c-4f95-887f-14c9d99577aa.jpg?1783946489"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BarbarianHorde.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/BarbarianHorde.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barbarian Horde
+ * {3}{R}
+ * Creature — Human Barbarian Soldier
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val BarbarianHorde = card("Barbarian Horde") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Barbarian Soldier"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Kuang Sheng"
+        flavorText = "Only twenty years after the Sima clan united the empire, invading barbarians divided it again."
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1f930c2-e828-4566-b2df-3b054f311be5.jpg?1783946109"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ForestBear.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ForestBear.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forest Bear
+ * {1}{G}
+ * Creature — Bear
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val ForestBear = card("Forest Bear") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Wang Yuqun"
+        flavorText = "Fish and bear paws—one can't have both.\n—Chinese idiom meaning \"you can't have it both ways\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fae9abc7-ecd3-4042-a5b0-5f2b24491fa6.jpg?1783946101"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/IndependentTroops.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/IndependentTroops.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Independent Troops
+ * {1}{R}
+ * Creature — Human Soldier
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val IndependentTroops = card("Independent Troops") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Kuang Sheng"
+        flavorText = "\"The empire, long united, must divide, and long divided, must unite.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff7a4769-7a64-4016-8db0-b56c6b98aff3.jpg?1783946106"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/MengHuosHorde.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/MengHuosHorde.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meng Huo's Horde
+ * {4}{G}
+ * Creature — Human Soldier
+ * 4/5
+ *
+ * Vanilla — no rules text.
+ */
+val MengHuosHorde = card("Meng Huo's Horde") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Soldier"
+    power = 4
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Li Tie"
+        flavorText = "Through his allies, Meng Huo commanded several hundred thousand troops composed of cavalry, rattan-armored warriors, infantry, naked men with swords, and wild animals."
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e1642802-055e-44d2-a261-c2a45ad515e8.jpg?1783946099"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuEliteInfantry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuEliteInfantry.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shu Elite Infantry
+ * {3}{W}
+ * Creature — Human Soldier
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val ShuEliteInfantry = card("Shu Elite Infantry") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Song Shikai"
+        flavorText = "Kongming's first campaign against the Wei kingdom was a rousing success until an arrogant Shu general, Ma Su, foolishly lost the city of Jieting."
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36bcd751-1142-4e72-9d87-7a25c74c038b.jpg?1783946128"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuFootSoldiers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/ShuFootSoldiers.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shu Foot Soldiers
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val ShuFootSoldiers = card("Shu Foot Soldiers") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Xu Tan"
+        flavorText = "Liu Bei lost many men at the battle of Runan because of his lack of strategy. It wasn't until he met Kongming that he began to truly succeed as a leader."
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd4268d5-f27b-44a5-91f6-6c90521825fd.jpg?1783946127"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SouthernElephant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/SouthernElephant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Southern Elephant
+ * {3}{G}
+ * Creature — Elephant
+ * 3/4
+ *
+ * Vanilla — no rules text.
+ */
+val SouthernElephant = card("Southern Elephant") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elephant"
+    power = 3
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Wang Yuqun"
+        flavorText = "While defending their southern borders, both the Wu and Shu kingdoms fought against the barbarians' trained elephants."
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87e138c7-1166-4e20-b039-e94c1319ad42.jpg?1783946098"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/StrawSoldiers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/StrawSoldiers.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Straw Soldiers
+ * {1}{U}
+ * Creature — Scarecrow Soldier
+ * 1/3
+ *
+ * Vanilla — no rules text.
+ */
+val StrawSoldiers = card("Straw Soldiers") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Scarecrow Soldier"
+    power = 1
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Cai Tingting"
+        flavorText = "The overnight appearance of miles of \"armed\" Wu forts at Guangling frightened a much vaster Wei force into fleeing for their lives."
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8ae5ba21-eb8e-4663-bfd8-3e19a0c10774.jpg?1783946120"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TrainedJackal.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/TrainedJackal.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trained Jackal
+ * {G}
+ * Creature — Jackal
+ * 1/2
+ *
+ * Vanilla — no rules text.
+ */
+val TrainedJackal = card("Trained Jackal") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Jackal"
+    power = 1
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Yang Jun Kwon"
+        flavorText = "To taunt a man into action, call him a coward. To insult him beyond forgiveness, call him a jackal."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01deb3cc-91e8-4ef3-964f-f36c6a21207c.jpg?1783946096"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/VolunteerMilitia.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/VolunteerMilitia.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volunteer Militia reprint in PTK.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * P02's `cards/` package (the card's earliest real printing). This file
+ * contributes only the PTK-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val VolunteerMilitiaReprint = Printing(
+    oracleId = "4f598459-b776-4ac1-bc69-8fde21674451",
+    name = "Volunteer Militia",
+    setCode = "PTK",
+    collectorNumber = "30",
+    artist = "Lin Yan",
+    imageUri = "https://cards.scryfall.io/normal/front/0/a/0af243f6-ef28-49d1-afeb-ac03d568ed6a.jpg?1783946126",
+    releaseDate = "1999-05-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiInfantry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WeiInfantry.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wei Infantry
+ * {1}{B}
+ * Creature — Human Soldier
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val WeiInfantry = card("Wei Infantry") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "88"
+        artist = "LHQ"
+        flavorText = "Wei won the battle of Hefei when Zhang Liao defeated Sun Quan and then foiled a Wu scheme to incite rebellion."
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72c6465f-3144-4faf-b248-a9fb941dc002.jpg?1783946112"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuInfantry.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/WuInfantry.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wu Infantry
+ * {1}{U}
+ * Creature — Human Soldier
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val WuInfantry = card("Wu Infantry") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Xu Xiaoming"
+        flavorText = "The first battle of Hefei was Sun Quan's last as a field general. From then on he let his generals command in the field while he directed battle from behind the front lines."
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/ebe4115e-7ca3-4996-a390-133c2e6d09b7.jpg?1783946119"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/BarbtoothWurm.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/BarbtoothWurm.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barbtooth Wurm reprint in S99.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * P02's `cards/` package (the card's earliest real printing). This file
+ * contributes only the S99-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BarbtoothWurmReprint = Printing(
+    oracleId = "03ad624e-71f6-4f72-8ce0-7700e83458d9",
+    name = "Barbtooth Wurm",
+    setCode = "S99",
+    collectorNumber = "125",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e85fbc25-412a-4367-8209-258ff638dcc6.jpg?1783946024",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DakmorScorpion.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DakmorScorpion.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dakmor Scorpion reprint in S99.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * P02's `cards/` package (the card's earliest real printing). This file
+ * contributes only the S99-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val DakmorScorpionReprint = Printing(
+    oracleId = "008290c2-499d-425b-9a6c-c4aeb47c33ff",
+    name = "Dakmor Scorpion",
+    setCode = "S99",
+    collectorNumber = "73",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6ed84268-92f7-4790-99b2-f2982b6e0893.jpg?1783946035",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DurkwoodBoars.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/DurkwoodBoars.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Durkwood Boars reprint in S99.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * LEG's `cards/` package (the card's earliest real printing). This file
+ * contributes only the S99-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val DurkwoodBoarsReprint = Printing(
+    oracleId = "8bb2ac6c-20aa-46dd-883f-b629855cabb0",
+    name = "Durkwood Boars",
+    setCode = "S99",
+    collectorNumber = "127",
+    artist = "Mike Kimble",
+    imageUri = "https://cards.scryfall.io/normal/front/3/e/3e2275b3-08ea-48d4-8781-7e64f2b94d72.jpg?1783946023",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinCavaliers.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinCavaliers.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Cavaliers reprint in S99.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * P02's `cards/` package (the card's earliest real printing). This file
+ * contributes only the S99-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val GoblinCavaliersReprint = Printing(
+    oracleId = "be77e3f8-76a3-4d03-a8be-ad4b0b72f929",
+    name = "Goblin Cavaliers",
+    setCode = "S99",
+    collectorNumber = "98",
+    artist = "DiTerlizzi",
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4d81d6c-b45a-4565-89ef-a6ba20a1e9e7.jpg?1783946030",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinHero.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/GoblinHero.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Hero reprint in S99.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * DRK's `cards/` package (the card's earliest real printing). This file
+ * contributes only the S99-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val GoblinHeroReprint = Printing(
+    oracleId = "ee969637-a20e-4163-97c0-9fd5cb17b741",
+    name = "Goblin Hero",
+    setCode = "S99",
+    collectorNumber = "103",
+    artist = "Pete Venters",
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c3ed9cd3-5e6a-4e86-b120-ff27b744311d.jpg?1783946031",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/OgreWarrior.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/OgreWarrior.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ogre Warrior reprint in S99.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * P02's `cards/` package (the card's earliest real printing). This file
+ * contributes only the S99-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val OgreWarriorReprint = Printing(
+    oracleId = "31426e08-bfd1-44f1-8473-5e982cb8e841",
+    name = "Ogre Warrior",
+    setCode = "S99",
+    collectorNumber = "113",
+    artist = "Jeff Miracola",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/3760dc16-6d36-4355-902e-44c1333bf049.jpg?1783946027",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/SouthernElephant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/SouthernElephant.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Southern Elephant reprint in S99.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * PTK's `cards/` package (the card's earliest real printing). This file
+ * contributes only the S99-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SouthernElephantReprint = Printing(
+    oracleId = "79de2319-078d-46db-9044-0088c623b73f",
+    name = "Southern Elephant",
+    setCode = "S99",
+    collectorNumber = "142",
+    artist = "Wang Yuqun",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/77c3a2b3-5ad8-4b16-a7a8-8344b78ca77b.jpg?1783946020",
+    releaseDate = "1999-07-01",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/TrainedOrgg.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/TrainedOrgg.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trained Orgg
+ * {6}{R}
+ * Creature — Orgg
+ * 6/6
+ *
+ * Vanilla — no rules text.
+ */
+val TrainedOrgg = card("Trained Orgg") {
+    manaCost = "{6}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Orgg"
+    power = 6
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "120"
+        artist = "Eric Peterson"
+        flavorText = "All orggs know how to kill; training teaches them *what* to kill."
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/425540b0-c826-4814-b0df-032264b1c237.jpg?1783946025"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/WillowElf.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/s99/cards/WillowElf.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.s99.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Willow Elf
+ * {G}
+ * Creature — Elf
+ * 1/1
+ *
+ * Vanilla — no rules text.
+ */
+val WillowElf = card("Willow Elf") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf"
+    power = 1
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "DiTerlizzi"
+        flavorText = "The forest lives in the elf as the elf lives in the forest."
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8f0750c-1cce-4088-a848-f11fe3694d89.jpg?1783946018"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/LowlandGiant.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/LowlandGiant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lowland Giant
+ * {2}{R}{R}
+ * Creature — Giant
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val LowlandGiant = card("Lowland Giant") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "187"
+        artist = "Paolo Parente"
+        flavorText = "\"Faugh!\" snorted Tahngarth. \"Why would it make a meal of something like you?\" Squee looked relieved. \"No,\" he continued, \"you'd make a much better toothpick.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/7398dec7-5e60-43c0-81a0-ab49beb37077.jpg?1783946627"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MetallicSliver.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/MetallicSliver.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Metallic Sliver
+ * {1}
+ * Artifact Creature — Sliver
+ * 1/1
+ *
+ * Vanilla — no rules text.
+ */
+val MetallicSliver = card("Metallic Sliver") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Sliver"
+    power = 1
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "297"
+        artist = "Allen Williams"
+        flavorText = "When the clever counterfeit was accepted by the hive, Volrath's influence upon the slivers grew even stronger."
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/30143f4f-9846-448d-8797-8fe0bc0cc5df.jpg?1783946602"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/PhyrexianWalker.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/PhyrexianWalker.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.vis.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Walker
+ * {0}
+ * Artifact Creature — Phyrexian Construct
+ * 0/3
+ *
+ * Vanilla — no rules text.
+ */
+val PhyrexianWalker = card("Phyrexian Walker") {
+    manaCost = "{0}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Phyrexian Construct"
+    power = 0
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Bryan Talbot"
+        flavorText = "\"I have heard terrible tales of black rains, ashen fields, and metal that screams. I have consoled myself that the tales were a myth of some fevered mind. But today I saw a walker—and now I fear the truth.\"\n—Kasib Ibn Naji, Letters"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f8a3979-2947-4692-8b2f-d4c07c534777.jpg?1783946973"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bok/BetrayersOfKamigawaSet.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bok/BetrayersOfKamigawaSet.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bok
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Betrayers of Kamigawa (2005)
+ *
+ * The second set of the Kamigawa block, between Champions and Saviors.
+ * Scaffolded here as the canonical home for cards whose earliest real printing is
+ * BOK. Intentionally incomplete relative to the official set — only cards
+ * relocated here as their canonical earliest printing live in this package.
+ *
+ * Set Code: BOK
+ * Release Date: 2005-02-04
+ */
+object BetrayersOfKamigawaSet : MtgSet {
+
+    override val code = "BOK"
+    override val displayName = "Betrayers of Kamigawa"
+    override val releaseDate = "2005-02-04"
+    override val block = "Kamigawa"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.bok.cards"
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bok/cards/FrostOgre.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bok/cards/FrostOgre.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.bok.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frost Ogre
+ * {3}{R}{R}
+ * Creature — Ogre Warrior
+ * 5/3
+ *
+ * Vanilla — no rules text.
+ */
+val FrostOgre = card("Frost Ogre") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Warrior"
+    power = 5
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Dan Murayama Scott"
+        flavorText = "Mountain ogres allowed blizzards to sheathe them in ice, both to reinforce their armor and to hide their pungent musk from potential prey."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a91e5f1-9179-4763-b7c9-b7ad5451f6d0.jpg?1783944191"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bok/cards/GnarledMass.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bok/cards/GnarledMass.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.bok.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gnarled Mass
+ * {1}{G}{G}
+ * Creature — Spirit
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val GnarledMass = card("Gnarled Mass") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Tony Szczudlo"
+        flavorText = "\"On the fifty-seventh day of the Battle of Silk, the bell again tolled in hopes of summoning mortal aid. This time, a new breed of kami rose to answer its call.\"\n—*Great Battles of Kamigawa*"
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c28728d-4839-4cdf-91d4-b9fb4b5d0449.jpg?1783944185"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/KrovikanScoundrel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/KrovikanScoundrel.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.csp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Krovikan Scoundrel
+ * {1}{B}
+ * Creature — Human Rogue
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val KrovikanScoundrel = card("Krovikan Scoundrel") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Rogue"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "64"
+        artist = "Ralph Horsley"
+        flavorText = "The few surviving humans of Krov would have welcomed the return of winter and its sterilizing cold. They often peered northward, hoping that the snow's edge had reached their infested city-tomb."
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd9f046c-b416-4d80-8998-047b98361352.jpg?1783943348"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/BladeOfTheSixthPride.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/BladeOfTheSixthPride.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.fut.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blade of the Sixth Pride
+ * {1}{W}
+ * Creature — Cat Rebel
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val BladeOfTheSixthPride = card("Blade of the Sixth Pride") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Rebel"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Justin Sweet"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f6ccfe28-ec08-4751-b65c-c40b2bafa955.jpg?1783943127"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/BlindPhantasm.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/BlindPhantasm.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.fut.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blind Phantasm
+ * {2}{U}
+ * Creature — Illusion
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val BlindPhantasm = card("Blind Phantasm") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Illusion"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Khang Le"
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b26ee7b-de1a-4a39-9580-89941c3d0f21.jpg?1783943118"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/FomoriNomad.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/FomoriNomad.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.fut.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fomori Nomad
+ * {4}{R}
+ * Creature — Nomad Giant
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val FomoriNomad = card("Fomori Nomad") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Nomad Giant"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Raymond Swanland"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/8216b3f3-b9b6-4d90-a624-c1b9b7bdf953.jpg?1783943103"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/NessianCourser.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fut/cards/NessianCourser.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.fut.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nessian Courser
+ * {2}{G}
+ * Creature — Centaur Warrior
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val NessianCourser = card("Nessian Courser") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Warrior"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Vance Kovacs"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88b18b70-f656-4426-a3e5-69cf61fdaad1.jpg?1783943095"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AxegrinderGiant.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/AxegrinderGiant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Axegrinder Giant
+ * {4}{R}{R}
+ * Creature — Giant Warrior
+ * 6/4
+ *
+ * Vanilla — no rules text.
+ */
+val AxegrinderGiant = card("Axegrinder Giant") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior"
+    power = 6
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "151"
+        artist = "Warren Mahy"
+        flavorText = "The angriest of giants are often the most skillful weaponsmiths. Their grudges fuel endless sessions at the forge, all the while growling ferociously to themselves."
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/8595e9a1-010e-48a7-91e4-3d2722c8dbc0.jpg?1783942880"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/VensersSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/VensersSliver.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Venser's Sliver
+ * {5}
+ * Artifact Creature — Sliver
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val VensersSliver = card("Venser's Sliver") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Sliver"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "267"
+        artist = "Carl Critchlow"
+        flavorText = "Venser admired his handiwork and smiled. His first prototype had joined with the hive mind all too well, running with the brood and becoming a predator itself. This one, he thought, would be accepted into the hive but still obey his commands."
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e3c5a64-453b-4477-853a-9514ba326f16.jpg?1783943196"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CylianElf.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/CylianElf.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cylian Elf
+ * {1}{G}
+ * Creature — Elf Scout
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val CylianElf = card("Cylian Elf") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Scout"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Steve Prescott"
+        flavorText = "From her sunsail tent high above the forest floor, an elf harkener can hear the footfalls of a single creature through the cacophony of Naya's jungle sounds."
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3afaab6-4768-4852-a0b6-4e6a0295bde7.jpg?1783942555"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DregReaver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DregReaver.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dreg Reaver
+ * {4}{B}
+ * Creature — Zombie Beast
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val DregReaver = card("Dreg Reaver") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Beast"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Thomas M. Baxa"
+        flavorText = "\"On our thirty-fourth day of digging, we unearthed a chamber that contained the intact remains of several species long extinct from Grixis. One in particular should make a fine siege engine . . . .\"\n—Last notes of Shungus Nod, fleshcrafter"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e7771eba-bc2d-40f2-bab4-5e9cc4fe8f34.jpg?1783942567"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/IncurableOgre.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/IncurableOgre.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Incurable Ogre
+ * {3}{R}
+ * Creature — Ogre Mutant
+ * 5/1
+ *
+ * Vanilla — no rules text.
+ */
+val IncurableOgre = card("Incurable Ogre") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Mutant"
+    power = 5
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Carl Critchlow"
+        flavorText = "Each mutation causes the incurables to look vastly different from one another. They are left with only one thing in common: their insatiable lust for the slaughter."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5ad3381e-ae2f-40cf-8a7b-62375e9f453e.jpg?1783942560"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JhessianLookout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/JhessianLookout.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jhessian Lookout
+ * {1}{U}
+ * Creature — Human Scout
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val JhessianLookout = card("Jhessian Lookout") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Scout"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "46"
+        artist = "Donato Giancola"
+        flavorText = "She stands ready, always watchful, knowing that weeks of peace and serenity can be overturned by a single distant sail."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f55b1b92-575e-4b6f-9179-21d0bc1acd11.jpg?1783942574"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/WoollyThoctar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/WoollyThoctar.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woolly Thoctar
+ * {R}{G}{W}
+ * Creature — Beast
+ * 5/4
+ *
+ * Vanilla — no rules text.
+ */
+val WoollyThoctar = card("Woolly Thoctar") {
+    manaCost = "{R}{G}{W}"
+    colorIdentity = "WRG"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "209"
+        artist = "Wayne Reynolds"
+        flavorText = "One of the most ferocious and deadly gargantuans, the thoctar never sees its worshippers, but it often awakens surrounded by gifts and sacrifices."
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7d5907d5-ae5c-4c9d-a5df-61f1c94f979d.jpg?1783942536"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/GrizzledLeotau.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/GrizzledLeotau.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grizzled Leotau
+ * {G}{W}
+ * Creature — Cat
+ * 1/5
+ *
+ * Vanilla — no rules text.
+ */
+val GrizzledLeotau = card("Grizzled Leotau") {
+    manaCost = "{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Creature — Cat"
+    power = 1
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Lars Grant-West"
+        flavorText = "\"There is no glory in a death of age, as even the leotau know. As winter steals into their coats, they seek the deadliest lands, that they may die as they lived.\"\n—Aarsil the Blessed"
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2b388381-9e13-4ce7-b5b3-56a74cc23d93.jpg?1783942427"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/RhoxBrute.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arb/cards/RhoxBrute.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.arb.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rhox Brute
+ * {2}{R}{G}
+ * Creature — Rhino Warrior
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val RhoxBrute = card("Rhox Brute") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Rhino Warrior"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Raymond Swanland"
+        flavorText = "\"In this new world, I have seen the once-devout rhoxes take up arms with the savages of Jund. I would be offended, but I see the wisdom in their choice.\"\n—Gernan, Dawnray archer"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/237de286-5bf0-4c8e-8504-2d01d3133b55.jpg?1783942429"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/NettleSwine.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/NettleSwine.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nettle Swine
+ * {3}{G}
+ * Creature — Boar
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val NettleSwine = card("Nettle Swine") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "186"
+        artist = "Christopher Moeller"
+        flavorText = "\"I killed one and found bricks and bones in its belly. It had eaten a whole cottage, thatch and all.\"\n—Paulin, Somberwald trapper"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75935f0e-9086-485b-b3e6-1a958fd0f2af.jpg?1783940664"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RagingPoltergeist.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RagingPoltergeist.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raging Poltergeist
+ * {4}{R}
+ * Creature — Spirit
+ * 6/1
+ *
+ * Vanilla — no rules text.
+ */
+val RagingPoltergeist = card("Raging Poltergeist") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Spirit"
+    power = 6
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Slawomir Maniak"
+        flavorText = "Some tried cremating their dead to stop the ghoulcallers. But the dead returned, furious about their fate."
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78833788-ffb2-43fc-9345-975f1cd46f38.jpg?1783940678"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RenegadeDemon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/RenegadeDemon.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Renegade Demon
+ * {3}{B}{B}
+ * Creature — Demon
+ * 5/3
+ *
+ * Vanilla — no rules text.
+ */
+val RenegadeDemon = card("Renegade Demon") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 5
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Tomasz Jedruszek"
+        flavorText = "\"Have you ever cornered a wounded vampire? That's a walk in the cathedral garden in comparison.\"\n—Tristen, Cathar Marshal"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/395696f8-9be2-4925-852f-b783850e1ca2.jpg?1783940692"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Vorstclaw.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/Vorstclaw.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vorstclaw
+ * {4}{G}{G}
+ * Creature — Elemental Horror
+ * 7/7
+ *
+ * Vanilla — no rules text.
+ */
+val Vorstclaw = card("Vorstclaw") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental Horror"
+    power = 7
+    toughness = 7
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "Lucas Graciano"
+        flavorText = "\"Where'd the werewolves go? Maybe *that* got hungry.\"\n—Halana of Ulvenwald"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/7591ee4f-9bfe-4419-84df-abf35d85bb94.jpg?1783940659"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BroodhunterWurm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/BroodhunterWurm.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broodhunter Wurm
+ * {3}{G}
+ * Creature — Wurm
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val BroodhunterWurm = card("Broodhunter Wurm") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Svetlin Velinov"
+        flavorText = "The native creatures of Zendikar have adapted to live under rocks and crawl through underbrush in order to avoid the most voracious predators. The Eldrazi have yet to make such adjustments."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c11c852d-9c7c-4d9b-8e79-70ea5ac865df.jpg?1783938188"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ExpeditionEnvoy.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/ExpeditionEnvoy.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Expedition Envoy
+ * {W}
+ * Creature — Human Scout Ally
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val ExpeditionEnvoy = card("Expedition Envoy") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout Ally"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "24"
+        artist = "David Palumbo"
+        flavorText = "The unofficial motto of every expedition house is \"ready for anything,\" a phrase whose significance has been amplified since the emergence of the Eldrazi."
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/41193ef1-1619-4448-9905-26b05079c79a.jpg?1783938221"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/CyclopsOfOneEyedPass.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/CyclopsOfOneEyedPass.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cyclops of One-Eyed Pass
+ * {2}{R}{R}
+ * Creature — Cyclops
+ * 5/2
+ *
+ * Vanilla — no rules text.
+ */
+val CyclopsOfOneEyedPass = card("Cyclops of One-Eyed Pass") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cyclops"
+    power = 5
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "90"
+        artist = "Kev Walker"
+        flavorText = "The Champion armed herself to face the cyclops, heedless of her companions' despair. \"How will you defeat it with only one spear?\" asked young Althemone. The Champion raised her weapon. \"It has but one eye.\"\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71a25c69-8e57-4a44-955a-da1541bbe0fe.jpg?1783939550"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/GreatHart.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/GreatHart.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Great Hart
+ * {3}{W}
+ * Creature — Elk
+ * 2/4
+ *
+ * Vanilla — no rules text.
+ */
+val GreatHart = card("Great Hart") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elk"
+    power = 2
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Christopher Moeller"
+        flavorText = "The great hart stood like a statue, its hide painted gold by the dawn. The Champion laid down her weapons and stepped forward within an arm's length of the beast. The hart, sacred to Heliod and bathed in the god's own light, bowed to the Champion, marking her as the Chosen of the Sun God.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70cd7d2b-e9c4-4900-89a0-f6eb0c6cb22b.jpg?1783939581"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/SwordwiseCentaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bng/cards/SwordwiseCentaur.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.bng.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Swordwise Centaur
+ * {G}{G}
+ * Creature — Centaur Warrior
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val SwordwiseCentaur = card("Swordwise Centaur") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Warrior"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Slawomir Maniak"
+        flavorText = "The girl who would become the Champion of the Sun hacked furiously at the practice dummy. At last she stopped, breathing heavily, and looked up at her instructor. \"So much anger,\" said the centaur. \"I will teach you the ways of war, child. But first you must make peace with yourself.\"\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/1/7/1776ebd7-91fc-49e1-a978-f2012162d1cf.jpg?1783939527"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/CanyonMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/CanyonMinotaur.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canyon Minotaur
+ * {3}{R}
+ * Creature — Minotaur Warrior
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val CanyonMinotaur = card("Canyon Minotaur") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Warrior"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Steve Prescott"
+        flavorText = "On Jund, the deep canyons were the best places to hide. When the goblins wandered into Naya, they found that was not so true."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b200790-43c7-42ae-9edf-89c8198a385b.jpg?1783942480"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/FusionElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/FusionElemental.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fusion Elemental
+ * {W}{U}{B}{R}{G}
+ * Creature — Elemental
+ * 8/8
+ *
+ * Vanilla — no rules text.
+ */
+val FusionElemental = card("Fusion Elemental") {
+    manaCost = "{W}{U}{B}{R}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Creature — Elemental"
+    power = 8
+    toughness = 8
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "107"
+        artist = "Michael Komarck"
+        flavorText = "As the shards merged into the Maelstrom, their mana energies fused into new monstrosities."
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6712dbd-ee54-4fb7-93ab-64f8f07350f1.jpg?1783942469"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ValiantGuard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/ValiantGuard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Valiant Guard
+ * {W}
+ * Creature — Human Soldier
+ * 0/3
+ *
+ * Vanilla — no rules text.
+ */
+val ValiantGuard = card("Valiant Guard") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 0
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Chris Rahn"
+        flavorText = "As the outsiders invaded Bant, soldiers who once saw sigils as the highest marks of glory began to see the scars of battle as tokens of equal worth."
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83ec1486-900b-4763-9b5b-390cb00aff02.jpg?1783942490"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/ArmoredWolfRider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/ArmoredWolfRider.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.dgm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Wolf-Rider
+ * {3}{G}{W}
+ * Creature — Elf Knight
+ * 4/6
+ *
+ * Vanilla — no rules text.
+ */
+val ArmoredWolfRider = card("Armored Wolf-Rider") {
+    manaCost = "{3}{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Creature — Elf Knight"
+    power = 4
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Matt Stewart"
+        flavorText = "Wolf-riders of Selesnya apprentice from a young age. Each rider raises a wolf pup from birth to serve as a mount, hoping that one day the two will share the honor of guarding the Great Concourse."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e43d959f-6055-4578-a69a-0ec93e993e21.jpg?1783940033"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/BaneAlleyBlackguard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/BaneAlleyBlackguard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.dgm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bane Alley Blackguard
+ * {1}{B}
+ * Creature — Human Rogue
+ * 1/3
+ *
+ * Vanilla — no rules text.
+ */
+val BaneAlleyBlackguard = card("Bane Alley Blackguard") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Rogue"
+    power = 1
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "21"
+        artist = "Mike Bierek"
+        flavorText = "\"I'm in the field of procurement, and business is good. The guilds want all kinds of maps and relics these days, though what they want them for I'm not quite sure.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/15fcad03-4567-4f96-976e-01a07d8ab050.jpg?1783940040"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/HollowhengeBeast.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/HollowhengeBeast.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hollowhenge Beast
+ * {3}{G}{G}
+ * Creature — Beast
+ * 5/5
+ *
+ * Vanilla — no rules text.
+ */
+val HollowhengeBeast = card("Hollowhenge Beast") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Dave Kendall"
+        flavorText = "In a world of monsters, it's the stuff of nightmares."
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/052ab91f-ac01-43f4-9276-9af35dbfbf71.jpg?1783940805"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/RussetWolves.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/RussetWolves.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Russet Wolves
+ * {3}{R}
+ * Creature — Wolf
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val RussetWolves = card("Russet Wolves") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wolf"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Christopher Moeller"
+        flavorText = "\"The wolves of our valley are bred to detest the scent of ghouls. For centuries they have kept our estates clear of such carrion.\"\n—Olivia Voldaren"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3c7c972-5a11-4709-b3ef-e2acb3b51dd9.jpg?1783940814"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/SanctuaryCat.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/SanctuaryCat.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sanctuary Cat
+ * {W}
+ * Creature — Cat
+ * 1/2
+ *
+ * Vanilla — no rules text.
+ */
+val SanctuaryCat = card("Sanctuary Cat") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 1
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "David Palumbo"
+        flavorText = "Cats prowl the corridors of Avacyn's churches in search of devils or signs of their mischief."
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96865440-01ad-40f2-90d7-9ecd0b4efecc.jpg?1783940850"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/WanderingTombshell.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/WanderingTombshell.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wandering Tombshell
+ * {3}{B}
+ * Creature — Zombie Turtle
+ * 1/6
+ *
+ * Vanilla — no rules text.
+ */
+val WanderingTombshell = card("Wandering Tombshell") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Turtle"
+    power = 1
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Yeong-Hao Han"
+        flavorText = "The crumbling temples on the tortoise's back are monuments to the decadence of the ancient Sultai. Though it harkens back to the era of the khans, Silumgar allows it to walk his territory as a warning to those who would oppose him."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e66e1d97-d676-471a-a140-deb39600a7a9.jpg?1783938592"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/FalkenrathReaver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/FalkenrathReaver.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Falkenrath Reaver
+ * {1}{R}
+ * Creature — Vampire
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val FalkenrathReaver = card("Falkenrath Reaver") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Daarken"
+        flavorText = "\"Each day there are new reports of homes along Getander Pass and Hofsaddel falling to vampires of a more savage nature. I've even heard tell that Anje Falkenrath has returned. Please send whatever help you can.\"\n—Sterin Gorn, letter to Thalia"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd2023b3-5999-44b1-a67f-3f2a76cb2d14.jpg?1783937462"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/FieldCreeper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/FieldCreeper.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Field Creeper
+ * {2}
+ * Artifact Creature — Scarecrow
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val FieldCreeper = card("Field Creeper") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Anthony Palumbo"
+        flavorText = "As it walks across the fallow field, its awkward, loping gait matches the rattling in its head to create a haunting rhythm that chills the bones."
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b92b162-f51d-4138-8d9b-e5eb929ad87e.jpg?1783937424"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/FeralKrushok.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/FeralKrushok.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.frf.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Feral Krushok
+ * {4}{G}
+ * Creature — Beast
+ * 5/4
+ *
+ * Vanilla — no rules text.
+ */
+val FeralKrushok = card("Feral Krushok") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 5
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Kev Walker"
+        flavorText = "In a stunning act of diplomacy, Yasova Dragonclaw ceded a portion of Temur lands to the Sultai. Her clan protested until they saw she had given the Sultai the breeding grounds of the krushoks. They hadn't realized she had a sense of humor."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/5041996b-c265-4c4f-a52c-dfe29b2e282d.jpg?1783938681"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/GoreSwine.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/GoreSwine.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.frf.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gore Swine
+ * {2}{R}
+ * Creature — Boar
+ * 4/1
+ *
+ * Vanilla — no rules text.
+ */
+val GoreSwine = card("Gore Swine") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Boar"
+    power = 4
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "103"
+        artist = "Jack Wang"
+        flavorText = "\"The Mardu are like the gore swine. We are wild, hunt in packs, and rarely clean the blood from our blades.\"\n—Vallash, Mardu warrior"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31c36d53-1173-4a55-8fb8-63a624fde7de.jpg?1783938688"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/GreatHornKrushok.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/frf/cards/GreatHornKrushok.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.frf.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Great-Horn Krushok
+ * {4}{W}
+ * Creature — Beast
+ * 3/5
+ *
+ * Vanilla — no rules text.
+ */
+val GreatHornKrushok = card("Great-Horn Krushok") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Beast"
+    power = 3
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "13"
+        artist = "YW Tang"
+        flavorText = "Perfectly suited for life in the Shifting Wastes, the krushok is well protected by its horn, its hide, and its temper."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/122e08cb-407b-4b3d-8af0-077ff96bf160.jpg?1783938713"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/GutterSkulk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/GutterSkulk.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gutter Skulk
+ * {1}{B}
+ * Creature — Zombie Rat
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val GutterSkulk = card("Gutter Skulk") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Rat"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Mark Winters"
+        flavorText = "Upon finding his warehouse infested, Gaven didn't know whether to get an exterminator or an exorcist."
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/830c7c77-20c4-429f-88c7-b85ab7a0e38b.jpg?1783940131"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/RuinationWurm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/RuinationWurm.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ruination Wurm
+ * {4}{R}{G}
+ * Creature — Wurm
+ * 7/6
+ *
+ * Vanilla — no rules text.
+ */
+val RuinationWurm = card("Ruination Wurm") {
+    manaCost = "{4}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Wurm"
+    power = 7
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Dave Kendall"
+        flavorText = "When the architects of Ravnica claim a structure will stand against a wurm, they never mention for how long."
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce04d1ee-2605-472d-b3ee-24800342e9af.jpg?1783940101"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/OreskosSwiftclaw.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/OreskosSwiftclaw.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oreskos Swiftclaw
+ * {1}{W}
+ * Creature — Cat Warrior
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val OreskosSwiftclaw = card("Oreskos Swiftclaw") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Warrior"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "James Ryman"
+        flavorText = "After the Battle of Pharagax Bridge, the Champion spent many months among the leonin of Oreskos. She found that they were quick to take offense, not because they were thin-skinned, but because they were always eager for a fight.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03c67b91-7f05-44b1-9e99-3e2094434f6a.jpg?1783939456"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/PensiveMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/PensiveMinotaur.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pensive Minotaur
+ * {2}{R}
+ * Creature — Minotaur Warrior
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val PensiveMinotaur = card("Pensive Minotaur") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Warrior"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Svetlin Velinov"
+        flavorText = "The Champion and her companions marched through the night, but the battle was over before they arrived. In the middle of the carnage sat a solitary minotaur, lost in what seemed to the Champion to be thought.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/902b462a-a552-42d4-91f0-bd33cd9cb719.jpg?1783939421"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/RottedHulk.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/RottedHulk.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rotted Hulk
+ * {3}{B}
+ * Creature — Elemental
+ * 2/5
+ *
+ * Vanilla — no rules text.
+ */
+val RottedHulk = card("Rotted Hulk") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "81"
+        artist = "Raymond Swanland"
+        flavorText = "The hulk rose from the sea and loomed over the Champion. Pinned beneath the twisting, rotted planks of wood was the body of Kaliaros, the helmsman of her former crew, and beside him the captain, Photine.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/1066644a-ac62-4809-805c-607c645613c5.jpg?1783939431"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/CowlProwler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/CowlProwler.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cowl Prowler
+ * {4}{G}{G}
+ * Creature — Wurm
+ * 6/6
+ *
+ * Vanilla — no rules text.
+ */
+val CowlProwler = card("Cowl Prowler") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 6
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Tomasz Jedruszek"
+        flavorText = "Consulate guards who pursue fleeing renegades into the Cowl often become lost—occasionally permanently—in the city's wildest greenbelt."
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a1b25f4-f50c-4210-a03f-080a5e4e5708.jpg?1783937183"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/CurioVendor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/CurioVendor.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Curio Vendor
+ * {1}{U}
+ * Creature — Vedalken
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val CurioVendor = card("Curio Vendor") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Vedalken"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "42"
+        artist = "Igor Kieryluk"
+        flavorText = "\"Step right up! Try your hand! It'll thrill the senses and boggle the mind!\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c598054a-26fa-40e7-8497-3da8eaf12aac.jpg?1783937222"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/PrakhataClubSecurity.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/PrakhataClubSecurity.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prakhata Club Security
+ * {3}{B}
+ * Creature — Aetherborn Warrior
+ * 3/4
+ *
+ * Vanilla — no rules text.
+ */
+val PrakhataClubSecurity = card("Prakhata Club Security") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Aetherborn Warrior"
+    power = 3
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "98"
+        artist = "Igor Kieryluk"
+        flavorText = "It's rare that the Prakhata Club closes its doors. It's also rare that Lord Gonti meets with Consul Kambal. What are the odds the two would occur on the same day?"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c32b73ce-cb25-4104-bccd-6b6a131790a9.jpg?1783937200"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/TasseledDromedary.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/TasseledDromedary.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tasseled Dromedary
+ * {W}
+ * Creature — Camel
+ * 0/4
+ *
+ * Vanilla — no rules text.
+ */
+val TasseledDromedary = card("Tasseled Dromedary") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Camel"
+    power = 0
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Raoul Vitale"
+        flavorText = "There is no dress code for the Inventors' Fair, but you'll be hard-pressed to find anyone or anything not done up in their finest."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cef3bf2-55cf-4f42-9ec0-fa921ef22311.jpg?1783937227"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/TerrainElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/TerrainElemental.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Terrain Elemental
+ * {1}{G}
+ * Creature — Elemental
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val TerrainElemental = card("Terrain Elemental") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "272"
+        artist = "Magali Villeneuve"
+        flavorText = "\"You tread upon the land all the time, yet you seem dismayed when it moves to step on you.\"\n—Nissa Revane"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32b89e5c-ffb4-406f-99d1-ec2797aca061.jpg?1783937136"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/TerrorOfTheFairgrounds.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/TerrorOfTheFairgrounds.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Terror of the Fairgrounds
+ * {3}{R}
+ * Creature — Gremlin
+ * 5/2
+ *
+ * Vanilla — no rules text.
+ */
+val TerrorOfTheFairgrounds = card("Terror of the Fairgrounds") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Gremlin"
+    power = 5
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Filip Burburan"
+        flavorText = "\"Consider this a high alert, people. Permission to destroy on sight. Either we take it down or it'll take down the Fair.\"\n—Pav, gremlin watch"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04623df9-8fa9-44cc-b528-c2c484626d1f.jpg?1783937185"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/CanyonMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/CanyonMinotaur.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canyon Minotaur reprint in M10.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * CON's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M10-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CanyonMinotaurReprint = Printing(
+    oracleId = "0c7163e6-f5a1-45a5-88c2-19dd9ef0a587",
+    name = "Canyon Minotaur",
+    setCode = "M10",
+    collectorNumber = "130",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/b/8/b85b682f-f526-45a8-9a12-db3fe8c3c8c3.jpg?1783942375",
+    releaseDate = "2009-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/CentaurCourser.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/CentaurCourser.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Centaur Courser
+ * {2}{G}
+ * Creature — Centaur Warrior
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val CentaurCourser = card("Centaur Courser") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Warrior"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "172"
+        artist = "Vance Kovacs"
+        flavorText = "\"The centaurs are truly free. Never will they be tamed by temptation or controlled by fear. They live in total harmony, a feat not yet achieved by our kind.\"\n—Ramal, sage of Westgate"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/03354b67-7df2-4b4b-a996-a37550e58561.jpg?1783942365"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/EliteVanguard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/EliteVanguard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elite Vanguard
+ * {W}
+ * Creature — Human Soldier
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val EliteVanguard = card("Elite Vanguard") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Mark Tedin"
+        flavorText = "The vanguard is skilled at waging war alone. The enemy is often defeated before its reinforcements reach the front."
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6bda0b4b-ab5a-4d91-9dd1-7a5a145b67f5.jpg?1783942403"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/RuneclawBear.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/RuneclawBear.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Runeclaw Bear
+ * {1}{G}
+ * Creature — Bear
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val RuneclawBear = card("Runeclaw Bear") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Bear"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "203"
+        artist = "Jesper Ejsing"
+        flavorText = "Bears aren't always as strong and as mean as you imagine. Some are even stronger and meaner."
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/268bd9d5-4da1-4cbf-83f9-47f7aac1cfc3.jpg?1783942358"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/SiegeMastodon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/SiegeMastodon.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Siege Mastodon
+ * {4}{W}
+ * Creature — Elephant
+ * 3/5
+ *
+ * Vanilla — no rules text.
+ */
+val SiegeMastodon = card("Siege Mastodon") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant"
+    power = 3
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Matt Cavotta"
+        flavorText = "\"Defending the citadel is easy. I just take these big fellows outside the main gate and let the enemy take a good long look.\"\n—Mastodon keeper"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/287d4c56-1b75-4ac4-8be8-333b1aba982a.jpg?1783942399"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/SilvercoatLion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/SilvercoatLion.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silvercoat Lion
+ * {1}{W}
+ * Creature — Cat
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val SilvercoatLion = card("Silvercoat Lion") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Terese Nielsen"
+        flavorText = "Hunters of every species on the savannah, silvercoats disdain camouflage in favor of total dominance of the food chain."
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea82996f-a05f-4831-9bbd-3281ebca9a61.jpg?1783942398"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/WarpathGhoul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/WarpathGhoul.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Warpath Ghoul
+ * {2}{B}
+ * Creature — Zombie
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val WarpathGhoul = card("Warpath Ghoul") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "rk post"
+        flavorText = "The battle was over, but the carnage continued for days."
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c6cc262-ba0c-4cca-ae9c-24a1824753e4.jpg?1783942377"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ZombieGoliath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/ZombieGoliath.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombie Goliath
+ * {4}{B}
+ * Creature — Zombie Giant
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val ZombieGoliath = card("Zombie Goliath") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Giant"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "E. M. Gist"
+        flavorText = "\"Phirax of Blood Ridge has sent a war giant at us? What, do I have to spell it out for you? Kill the giant, scoop out its skull, and drive it back to Blood Ridge. Honestly, what kind of necromancer minions are you?\"\n—Keren-Dur, necromancer lord"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc295834-af33-45ae-be4d-7a1987f85561.jpg?1783942376"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/ArmoredCancrix.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/ArmoredCancrix.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Cancrix
+ * {4}{U}
+ * Creature — Crab
+ * 2/5
+ *
+ * Vanilla — no rules text.
+ */
+val ArmoredCancrix = card("Armored Cancrix") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab"
+    power = 2
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Tomasz Jedruszek"
+        flavorText = "Creatures displaced from time still turn up every year, stranded by the temporal disaster that once swept across Dominaria."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53ef0757-8eb0-4384-bf8e-9a7340144dfa.jpg?1783941828"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/BaronyVampire.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/BaronyVampire.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barony Vampire
+ * {2}{B}
+ * Creature — Vampire
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val BaronyVampire = card("Barony Vampire") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Daarken"
+        flavorText = "\"Poor little sun-dweller out past curfew. And to think, you might have survived if it wasn't so close to suppertime.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88583170-7b0e-4c02-b270-4859ba05d82b.jpg?1783941820"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/CanyonMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/CanyonMinotaur.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canyon Minotaur reprint in M11.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * CON's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M11-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CanyonMinotaurReprint = Printing(
+    oracleId = "0c7163e6-f5a1-45a5-88c2-19dd9ef0a587",
+    name = "Canyon Minotaur",
+    setCode = "M11",
+    collectorNumber = "126",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/b/6/b670dcc2-e8e3-4fd7-a1db-c3152b005d39.jpg?1783941809",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/EliteVanguard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/EliteVanguard.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elite Vanguard reprint in M11.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M11-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val EliteVanguardReprint = Printing(
+    oracleId = "b3b9a87d-cb95-435c-90b6-037406cab32e",
+    name = "Elite Vanguard",
+    setCode = "M11",
+    collectorNumber = "13",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/8969be61-afed-4483-902f-739acf57c43c.jpg?1783941835",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/MaritimeGuard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/MaritimeGuard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Maritime Guard
+ * {1}{U}
+ * Creature — Merfolk Soldier
+ * 1/3
+ *
+ * Vanilla — no rules text.
+ */
+val MaritimeGuard = card("Maritime Guard") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Soldier"
+    power = 1
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Allen Williams"
+        flavorText = "Once common in the Kapsho Seas, merfolk were hunted almost to extinction. They survived those dark days and emerged calculating and determined to endure."
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f365d82a-88a3-403b-92a6-91c9ccb3421f.jpg?1783941824"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/NetherHorror.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/NetherHorror.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nether Horror
+ * {3}{B}
+ * Creature — Horror
+ * 4/2
+ *
+ * Vanilla — no rules text.
+ */
+val NetherHorror = card("Nether Horror") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 4
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "108"
+        artist = "Allen Williams"
+        flavorText = "\"My dreams darkened and seeped into my waking hours. Spellcraft and nightmare merged to create this monstrosity.\"\n—Sunniva, witch of Holm Hollow"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c217b672-c724-4fc2-936c-b3f0feaf6ea0.jpg?1783941813"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/RuneclawBear.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/RuneclawBear.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Runeclaw Bear reprint in M11.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M11-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val RuneclawBearReprint = Printing(
+    oracleId = "ec49dfcf-d16d-4621-af4b-4a6f09043221",
+    name = "Runeclaw Bear",
+    setCode = "M11",
+    collectorNumber = "195",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b8ef778-2acf-40f0-9a64-6415d2109093.jpg?1783941793",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/SiegeMastodon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/SiegeMastodon.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Siege Mastodon reprint in M11.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M11-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SiegeMastodonReprint = Printing(
+    oracleId = "b4c404d8-9f2d-4429-ac36-449ae319abb7",
+    name = "Siege Mastodon",
+    setCode = "M11",
+    collectorNumber = "29",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/296d7ce0-866a-43eb-939e-3287ff00234d.jpg?1783941831",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/SilvercoatLion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/SilvercoatLion.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silvercoat Lion reprint in M11.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M11-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SilvercoatLionReprint = Printing(
+    oracleId = "e3c0b11e-7340-4e0a-98b7-91b38439d4f9",
+    name = "Silvercoat Lion",
+    setCode = "M11",
+    collectorNumber = "31",
+    artist = "Terese Nielsen",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e37523d3-7719-48e1-9b3e-2670772a509b.jpg?1783941831",
+    releaseDate = "2010-07-16",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/StoneGolem.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/StoneGolem.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Golem
+ * {5}
+ * Artifact Creature — Golem
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val StoneGolem = card("Stone Golem") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Martina Pilcerova"
+        flavorText = "The sculptor, like most artists, put his heart and soul in his work. But the newly awakened golem decided he wanted his creator's other, more tangible parts."
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/37d0876b-5026-4a0a-bf2f-e831593643a7.jpg?1783941788"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AmphinCutthroat.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AmphinCutthroat.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Amphin Cutthroat
+ * {3}{U}
+ * Creature — Salamander Rogue
+ * 2/4
+ *
+ * Vanilla — no rules text.
+ */
+val AmphinCutthroat = card("Amphin Cutthroat") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Salamander Rogue"
+    power = 2
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Howard Lyon"
+        flavorText = "\"The amphin have long built their society in secret. While surface dwellers squabbled over trivial borders, they patiently expanded, building their ammonite temple-caves. Now amphin priests eye the shore, and amphin hunters gird for war.\"\n—Gor Muldrak, *Cryptohistories*"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd169064-9c7b-40bd-8be0-a89fcb28ae2f.jpg?1783941096"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ArmoredWarhorse.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ArmoredWarhorse.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Warhorse
+ * {W}{W}
+ * Creature — Horse
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val ArmoredWarhorse = card("Armored Warhorse") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Horse"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "rk post"
+        flavorText = "\"When we of the Northern Verge claim a mount, no peasant's nag will do. It must be as strong as our virtue, and must join us of its own will.\"\n—Sarlena, paladin of the Northern Verge"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52daf505-d436-4ea6-a157-4268af2ff7a8.jpg?1783941106"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/BonebreakerGiant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/BonebreakerGiant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bonebreaker Giant
+ * {4}{R}
+ * Creature — Giant
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val BonebreakerGiant = card("Bonebreaker Giant") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Kev Walker"
+        flavorText = "One thing's for sure—his fists are harder than your skull."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc17e5c1-a6b4-401b-95eb-1c01cd1da570.jpg?1783941073"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/EliteVanguard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/EliteVanguard.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elite Vanguard reprint in M12.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M12-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val EliteVanguardReprint = Printing(
+    oracleId = "b3b9a87d-cb95-435c-90b6-037406cab32e",
+    name = "Elite Vanguard",
+    setCode = "M12",
+    collectorNumber = "15",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f03487e9-f584-4bbd-8335-4dd001a88b52.jpg?1783941103",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/RuneclawBear.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/RuneclawBear.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Runeclaw Bear reprint in M12.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M12-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val RuneclawBearReprint = Printing(
+    oracleId = "ec49dfcf-d16d-4621-af4b-4a6f09043221",
+    name = "Runeclaw Bear",
+    setCode = "M12",
+    collectorNumber = "193",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/6/c/6caf2b93-1971-4702-9aa5-bd223eb37a39.jpg?1783941055",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/SiegeMastodon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/SiegeMastodon.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Siege Mastodon reprint in M12.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M12-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SiegeMastodonReprint = Printing(
+    oracleId = "b4c404d8-9f2d-4429-ac36-449ae319abb7",
+    name = "Siege Mastodon",
+    setCode = "M12",
+    collectorNumber = "34",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39c340a3-0118-48d3-99ab-f4a0e7099325.jpg?1783941098",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/VastwoodGorger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/VastwoodGorger.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vastwood Gorger reprint in M12.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * ZEN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M12-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val VastwoodGorgerReprint = Printing(
+    oracleId = "a17a86a3-9f9c-4e09-93e6-e543a70733bc",
+    name = "Vastwood Gorger",
+    setCode = "M12",
+    collectorNumber = "200",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cdd9d448-ebd5-4e01-af88-e755833c2451.jpg?1783941056",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/WarpathGhoul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/WarpathGhoul.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Warpath Ghoul reprint in M12.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M12-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val WarpathGhoulReprint = Printing(
+    oracleId = "17ae652c-b1c7-4dde-ae9e-50b9e286776c",
+    name = "Warpath Ghoul",
+    setCode = "M12",
+    collectorNumber = "117",
+    artist = "rk post",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/94785274-fa79-47cc-9896-0f5f695abb21.jpg?1783941076",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ZombieGoliath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/ZombieGoliath.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombie Goliath reprint in M12.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M12-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ZombieGoliathReprint = Printing(
+    oracleId = "eadd88b6-e75a-4482-8382-561718121772",
+    name = "Zombie Goliath",
+    setCode = "M12",
+    collectorNumber = "119",
+    artist = "E. M. Gist",
+    imageUri = "https://cards.scryfall.io/normal/front/1/9/1985e0bd-05b9-4eaf-9333-6262cf677acd.jpg?1783941077",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/CanyonMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/CanyonMinotaur.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canyon Minotaur reprint in M13.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * CON's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M13-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CanyonMinotaurReprint = Printing(
+    oracleId = "0c7163e6-f5a1-45a5-88c2-19dd9ef0a587",
+    name = "Canyon Minotaur",
+    setCode = "M13",
+    collectorNumber = "122",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f8dc0efb-5847-4061-b386-9b4099361a58.jpg?1783940487",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/CentaurCourser.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/CentaurCourser.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Centaur Courser reprint in M13.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M13-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CentaurCourserReprint = Printing(
+    oracleId = "2f5bf099-2e01-4e1c-9ebf-0ce0ac66939e",
+    name = "Centaur Courser",
+    setCode = "M13",
+    collectorNumber = "164",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/44a5f7db-ea4e-4af5-9d4a-0335db6ea0e9.jpg?1783940475",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/KrakenHatchling.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/KrakenHatchling.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kraken Hatchling reprint in M13.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * ZEN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M13-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val KrakenHatchlingReprint = Printing(
+    oracleId = "08e6c786-d553-4c23-9137-cfad84146739",
+    name = "Kraken Hatchling",
+    setCode = "M13",
+    collectorNumber = "58",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/5/9/59a50590-9091-4632-bf8c-792e1e0a75a8.jpg?1783940505",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/PillarfieldOx.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/PillarfieldOx.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pillarfield Ox reprint in M13.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * ZEN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M13-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val PillarfieldOxReprint = Printing(
+    oracleId = "0f7c70c4-9795-4c76-8b27-043942a963c6",
+    name = "Pillarfield Ox",
+    setCode = "M13",
+    collectorNumber = "25",
+    artist = "Andrew Robinson",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/33e2f3ae-bf92-478b-9c63-acc3f175f02a.jpg?1783940516",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/SilvercoatLion.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/SilvercoatLion.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silvercoat Lion reprint in M13.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M13-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SilvercoatLionReprint = Printing(
+    oracleId = "e3c0b11e-7340-4e0a-98b7-91b38439d4f9",
+    name = "Silvercoat Lion",
+    setCode = "M13",
+    collectorNumber = "35",
+    artist = "Terese Nielsen",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9d33e866-cfd8-44e6-8070-df8df1ce965d.jpg?1783940511",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/VastwoodGorger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/VastwoodGorger.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vastwood Gorger reprint in M13.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * ZEN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M13-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val VastwoodGorgerReprint = Printing(
+    oracleId = "a17a86a3-9f9c-4e09-93e6-e543a70733bc",
+    name = "Vastwood Gorger",
+    setCode = "M13",
+    collectorNumber = "196",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/70fc4a5f-1c59-4139-a506-72baebb1168f.jpg?1783940463",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/ZombieGoliath.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/ZombieGoliath.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zombie Goliath reprint in M13.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M13-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ZombieGoliathReprint = Printing(
+    oracleId = "eadd88b6-e75a-4482-8382-561718121772",
+    name = "Zombie Goliath",
+    setCode = "M13",
+    collectorNumber = "119",
+    artist = "E. M. Gist",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/8638edec-ddcd-4f50-9c2f-2e1668e3d175.jpg?1783940490",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ArmoredCancrix.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ArmoredCancrix.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Cancrix reprint in M14.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M11's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M14-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ArmoredCancrixReprint = Printing(
+    oracleId = "445bb343-9758-459b-970f-47f1705f1e55",
+    name = "Armored Cancrix",
+    setCode = "M14",
+    collectorNumber = "44",
+    artist = "Tomasz Jedruszek",
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3b455b0f-a69c-43b4-bbf5-605ed41f10e0.jpg?1783939937",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/CanyonMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/CanyonMinotaur.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canyon Minotaur reprint in M14.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * CON's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M14-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CanyonMinotaurReprint = Printing(
+    oracleId = "0c7163e6-f5a1-45a5-88c2-19dd9ef0a587",
+    name = "Canyon Minotaur",
+    setCode = "M14",
+    collectorNumber = "131",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/3469d73e-6de1-4b91-83e3-b1714ac29268.jpg?1783939915",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/KalonianTusker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/KalonianTusker.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kalonian Tusker
+ * {G}{G}
+ * Creature — Beast
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val KalonianTusker = card("Kalonian Tusker") {
+    manaCost = "{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "182"
+        artist = "Svetlin Velinov"
+        flavorText = "\"And all this time I thought *we* were tracking *it*.\"\n—Juruk, Kalonian tracker"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/135946fc-fe67-401f-821d-d7145c63f030.jpg?1783939902"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/MinotaurAbomination.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/MinotaurAbomination.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Minotaur Abomination
+ * {4}{B}{B}
+ * Creature — Zombie Minotaur
+ * 4/6
+ *
+ * Vanilla — no rules text.
+ */
+val MinotaurAbomination = card("Minotaur Abomination") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Minotaur"
+    power = 4
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Karl Kopinski"
+        flavorText = "\"Look at that. Shuffling, wobbling, entrails placed haphazardly. It's shameful. Who would let that kind of work flap about for all to see?\"\n—Lestin, necromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9dca75a1-443d-4f8e-b12b-2aada3a8e3e4.jpg?1783939921"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PillarfieldOx.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/PillarfieldOx.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pillarfield Ox reprint in M14.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * ZEN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M14-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val PillarfieldOxReprint = Printing(
+    oracleId = "0f7c70c4-9795-4c76-8b27-043942a963c6",
+    name = "Pillarfield Ox",
+    setCode = "M14",
+    collectorNumber = "28",
+    artist = "Andrew Robinson",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f79d3bba-18b0-4c56-a90b-8e28935a6a7a.jpg?1783939941",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/RegathanFirecat.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/RegathanFirecat.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Regathan Firecat
+ * {2}{R}
+ * Creature — Elemental Cat
+ * 4/1
+ *
+ * Vanilla — no rules text.
+ */
+val RegathanFirecat = card("Regathan Firecat") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Cat"
+    power = 4
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Eric Velhagen"
+        flavorText = "It stalks the Regathan highlands, leaving behind melted snow, scorched earth, and the charred corpses of would-be temple robbers."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b4df1dd-886d-4fe7-b3f7-2dca044de41c.jpg?1783939911"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/RumblingBaloth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/RumblingBaloth.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rumbling Baloth
+ * {2}{G}{G}
+ * Creature — Beast
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val RumblingBaloth = card("Rumbling Baloth") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Jesper Ejsing"
+        flavorText = "In the dim light beneath the vast trees of Deepglade, baloths prowl in search of prey. Their guttural calls are more felt than heard, but their attack scream carries for miles."
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d8610ff1-064b-4c75-a8df-d3b076370d1e.jpg?1783939900"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SiegeMastodon.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SiegeMastodon.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Siege Mastodon reprint in M14.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M14-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SiegeMastodonReprint = Printing(
+    oracleId = "b4c404d8-9f2d-4429-ac36-449ae319abb7",
+    name = "Siege Mastodon",
+    setCode = "M14",
+    collectorNumber = "34",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40e7a30f-bb29-4c6b-bf70-53e9e4292814.jpg?1783939940",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SliverConstruct.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/SliverConstruct.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sliver Construct
+ * {3}
+ * Artifact Creature — Sliver Construct
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val SliverConstruct = card("Sliver Construct") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Sliver Construct"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "218"
+        artist = "Mathias Kollros"
+        flavorText = "Slivers destroy those who come close to the Skep, the central hive. Shards of torn metal litter the ground as a warning to any artificers inquisitive about the hive's inner workings."
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/3129645a-221c-4eb5-88fd-12cc742a1dfe.jpg?1783939893"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/UndeadMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/UndeadMinotaur.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Undead Minotaur
+ * {2}{B}
+ * Creature — Zombie Minotaur
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val UndeadMinotaur = card("Undead Minotaur") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Minotaur"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Karl Kopinski"
+        flavorText = "\"The work that went into creating this magnificent specimen. Horrific, deadly, well-balanced. Not all necromancers do elegant work like this.\"\n—Lestin, necromancer"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e5ae910-ee1d-4958-92d9-0b06872913c6.jpg?1783939918"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/BronzeSable.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/BronzeSable.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bronze Sable reprint in M15.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * THS's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M15-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BronzeSableReprint = Printing(
+    oracleId = "f27e5e11-0ad0-448b-8760-75ed1b97e7d8",
+    name = "Bronze Sable",
+    setCode = "M15",
+    collectorNumber = "214",
+    artist = "Jasper Sandner",
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e8ba6d7d-fad0-4af1-be12-44be326a031e.jpg?1783939159",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/CentaurCourser.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/CentaurCourser.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Centaur Courser reprint in M15.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M15-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CentaurCourserReprint = Printing(
+    oracleId = "2f5bf099-2e01-4e1c-9ebf-0ce0ac66939e",
+    name = "Centaur Courser",
+    setCode = "M15",
+    collectorNumber = "282",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3b625203-6c50-4b14-928c-6b0aec1375a2.jpg?1783939144",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/GoblinRoughrider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/GoblinRoughrider.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Roughrider reprint in M15.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * WWK's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M15-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val GoblinRoughriderReprint = Printing(
+    oracleId = "a920d37e-e172-41f7-bfbf-c18821dcbed7",
+    name = "Goblin Roughrider",
+    setCode = "M15",
+    collectorNumber = "146",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/9097ec4a-6c0e-4c27-8910-29ac47612031.jpg?1783939173",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/OreskosSwiftclaw.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/OreskosSwiftclaw.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oreskos Swiftclaw reprint in M15.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * JOU's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M15-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val OreskosSwiftclawReprint = Printing(
+    oracleId = "014d00fc-434a-4b06-84b2-afd930677d61",
+    name = "Oreskos Swiftclaw",
+    setCode = "M15",
+    collectorNumber = "22",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/2/d/2d32e198-8ddd-44bc-be57-17e1ff72d666.jpg?1783939200",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/RuneclawBear.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/RuneclawBear.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Runeclaw Bear reprint in M15.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M15-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val RuneclawBearReprint = Printing(
+    oracleId = "ec49dfcf-d16d-4621-af4b-4a6f09043221",
+    name = "Runeclaw Bear",
+    setCode = "M15",
+    collectorNumber = "197",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d1995238-79cc-4381-9595-71ef11ea1e36.jpg?1783939162",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/WitchsFamiliar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/WitchsFamiliar.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Witch's Familiar
+ * {2}{B}
+ * Creature — Frog
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val WitchsFamiliar = card("Witch's Familiar") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Frog"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "123"
+        artist = "Jack Wang"
+        flavorText = "Some bog witches practice the strange art of batrachomancy, reading portents in the number, size, and color of warts on a toad's hide."
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c9f3b3b-de16-4ae5-844e-1373e0f84469.jpg?1783939178"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/HexplateGolem.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/HexplateGolem.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hexplate Golem
+ * {7}
+ * Artifact Creature — Golem
+ * 5/7
+ *
+ * Vanilla — no rules text.
+ */
+val HexplateGolem = card("Hexplate Golem") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 5
+    toughness = 7
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Matt Cavotta"
+        flavorText = "\"Use everything. Iron, rust, scrap . . . even the ground must join our cause.\"\n—Ezuri, renegade leader"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/49b913f3-6581-45ae-9cdb-274c2ccd8899.jpg?1783941369"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/OgreResister.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/OgreResister.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ogre Resister
+ * {2}{R}{R}
+ * Creature — Ogre
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val OgreResister = card("Ogre Resister") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Efrem Palacios"
+        flavorText = "He didn't have a word for \"home,\" but he knew it was something to be defended."
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60b7407d-f677-403b-893c-361df456009a.jpg?1783941377"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/QuilledSlagwurm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/QuilledSlagwurm.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quilled Slagwurm
+ * {4}{G}{G}{G}
+ * Creature — Phyrexian Wurm
+ * 8/8
+ *
+ * Vanilla — no rules text.
+ */
+val QuilledSlagwurm = card("Quilled Slagwurm") {
+    manaCost = "{4}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Wurm"
+    power = 8
+    toughness = 8
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Matt Stewart"
+        flavorText = "Vorinclex removed its teeth so it wouldn't waste time chewing before moving to the next kill."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12c597b9-5024-42bd-b500-5ef6a3accda6.jpg?1783941373"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/IndomitableAncients.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/IndomitableAncients.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.mor.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Indomitable Ancients
+ * {2}{W}{W}
+ * Creature — Treefolk Warrior
+ * 2/10
+ *
+ * Vanilla — no rules text.
+ */
+val IndomitableAncients = card("Indomitable Ancients") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Treefolk Warrior"
+    power = 2
+    toughness = 10
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "13"
+        artist = "Pete Venters"
+        flavorText = "\"Odum and Broadbark were the only beings mighty enough to challenge the giant Moran the Destroyer. Their battle lasted a hundred dawns, until Moran became so exhausted that he fell into namesleep. He awoke as Moran the Gardener.\"\n—*The Tale of Odum and Broadbark*"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddf33cb6-d159-4af3-8403-d0ac10af9894.jpg?1783942804"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/FlamebornViron.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/FlamebornViron.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.nph.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flameborn Viron
+ * {4}{R}{R}
+ * Creature — Phyrexian Insect
+ * 6/4
+ *
+ * Vanilla — no rules text.
+ */
+val FlamebornViron = card("Flameborn Viron") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Phyrexian Insect"
+    power = 6
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Large or small, all will toil for the Great Work.\"\n—Decree of Urabrask"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/9601ea62-a609-4bc5-a2f0-f7615b4dd5fa.jpg?1783941308"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/LoxodonConvert.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/LoxodonConvert.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.nph.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Loxodon Convert
+ * {3}{W}
+ * Creature — Phyrexian Elephant Soldier
+ * 4/2
+ *
+ * Vanilla — no rules text.
+ */
+val LoxodonConvert = card("Loxodon Convert") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Phyrexian Elephant Soldier"
+    power = 4
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Adrian Smith"
+        flavorText = "Just one drop of the glistening oil can eventually stain even a soul as stalwart as a loxodon's beyond redemption."
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/00c050c3-4f50-4bb6-8477-6737887ca10d.jpg?1783941325"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/RottedHystrix.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/nph/cards/RottedHystrix.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.nph.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rotted Hystrix
+ * {4}{G}
+ * Creature — Phyrexian Beast
+ * 3/6
+ *
+ * Vanilla — no rules text.
+ */
+val RottedHystrix = card("Rotted Hystrix") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Phyrexian Beast"
+    power = 3
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "120"
+        artist = "Dave Allsop"
+        flavorText = "Vorinclex had no grand plan. The oil did its own work, evolving creatures into worthy predators."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7bcae97d-468a-4e16-bfed-d2946f64784c.jpg?1783941299"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/AncientCrab.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/AncientCrab.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ancient Crab
+ * {1}{U}{U}
+ * Creature — Crab
+ * 1/5
+ *
+ * Vanilla — no rules text.
+ */
+val AncientCrab = card("Ancient Crab") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab"
+    power = 1
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Steve Prescott"
+        flavorText = "After the fall of Sea Gate and the draining of the Halimar basin, the crab set off to find a new home."
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/783794e3-fe0c-4014-ae5a-6c249af23ddc.jpg?1783937919"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/CanopyGorger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/CanopyGorger.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canopy Gorger
+ * {4}{G}{G}
+ * Creature — Wurm
+ * 6/5
+ *
+ * Vanilla — no rules text.
+ */
+val CanopyGorger = card("Canopy Gorger") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 6
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Lake Hurwitz"
+        flavorText = "The settlement's defenders were glad to have such a massive, ferocious creature join the fight—but less glad to see it flatten their homes along the way."
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cbc8957d-769c-4630-9544-56cea8c847c2.jpg?1783937902"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CatacombSlug.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CatacombSlug.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Catacomb Slug reprint in ORI.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * RTR's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ORI-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CatacombSlugReprint = Printing(
+    oracleId = "1b0b5264-2810-4ac5-8b2e-8abbf4016287",
+    name = "Catacomb Slug",
+    setCode = "ORI",
+    collectorNumber = "86",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d30d6df7-6199-4b06-9d45-785ee1e2ed3b.jpg?1783938344",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/Cobblebrute.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/Cobblebrute.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cobblebrute reprint in ORI.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * RTR's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ORI-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CobblebruteReprint = Printing(
+    oracleId = "6d4ed1f2-0918-444c-95ef-d58beb5aa216",
+    name = "Cobblebrute",
+    setCode = "ORI",
+    collectorNumber = "138",
+    artist = "Eytan Zana",
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/ffa87a70-c9fb-4ab3-ac16-367888aa775b.jpg?1783938331",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MaritimeGuard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/MaritimeGuard.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Maritime Guard reprint in ORI.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M11's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ORI-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val MaritimeGuardReprint = Printing(
+    oracleId = "0bb1c704-47f1-4d0c-8158-cfcd0b5e4d06",
+    name = "Maritime Guard",
+    setCode = "ORI",
+    collectorNumber = "63",
+    artist = "Allen Williams",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/1008ff1b-7fb0-4570-b23e-9fda14b97640.jpg?1783938350",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VastwoodGorger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/VastwoodGorger.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vastwood Gorger reprint in ORI.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * ZEN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ORI-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val VastwoodGorgerReprint = Printing(
+    oracleId = "a17a86a3-9f9c-4e09-93e6-e543a70733bc",
+    name = "Vastwood Gorger",
+    setCode = "ORI",
+    collectorNumber = "204",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/72f53dc9-5397-49e1-97d4-3b0b6858f2b2.jpg?1783938318",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/YokedOx.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/YokedOx.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yoked Ox reprint in ORI.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * THS's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ORI-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val YokedOxReprint = Printing(
+    oracleId = "19b4cf0b-e1e4-4e50-80bc-673bc6ef8bb8",
+    name = "Yoked Ox",
+    setCode = "ORI",
+    collectorNumber = "42",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/431069f2-3eba-42f3-b42d-05a7d066b665.jpg?1783938356",
+    releaseDate = "2015-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/FusionElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pc2/cards/FusionElemental.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.pc2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fusion Elemental reprint in PC2.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * CON's `cards/` package (the card's earliest real printing). This file
+ * contributes only the PC2-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val FusionElementalReprint = Printing(
+    oracleId = "a152674f-be29-40ab-8dd9-376fd4eb3bb8",
+    name = "Fusion Elemental",
+    setCode = "PC2",
+    collectorNumber = "93",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/de5a1e9e-ac2b-4db7-8d6e-554c4c65f1cb.jpg?1783940599",
+    releaseDate = "2012-06-01",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/ArmoredWhirlTurtle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/ArmoredWhirlTurtle.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Whirl Turtle reprint in PZ2.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * GS1's `cards/` package (the card's earliest real printing). This file
+ * contributes only the PZ2-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ArmoredWhirlTurtleReprint = Printing(
+    oracleId = "51a886f2-9b0a-4964-9d59-99dc1a68a97c",
+    name = "Armored Whirl Turtle",
+    setCode = "PZ2",
+    collectorNumber = "70809",
+    artist = "Tingting Yeh",
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/ca7c3c99-cebf-4b2e-882f-3bd60aaef840.jpg?1783933905",
+    releaseDate = "2018-12-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/FerociousZheng.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/FerociousZheng.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ferocious Zheng reprint in PZ2.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * GS1's `cards/` package (the card's earliest real printing). This file
+ * contributes only the PZ2-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val FerociousZhengReprint = Printing(
+    oracleId = "a45e0854-28c7-41f5-a9fe-5b76a8070c5b",
+    name = "Ferocious Zheng",
+    setCode = "PZ2",
+    collectorNumber = "70847",
+    artist = "Yutaka Li",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/012e05ec-e429-45ba-814c-3789673fe311.jpg?1783933892",
+    releaseDate = "2018-12-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/LeopardSpottedJiao.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/pz2/cards/LeopardSpottedJiao.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.pz2.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leopard-Spotted Jiao reprint in PZ2.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * GS1's `cards/` package (the card's earliest real printing). This file
+ * contributes only the PZ2-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val LeopardSpottedJiaoReprint = Printing(
+    oracleId = "0056e07b-416b-487e-9e6c-3697db402dd4",
+    name = "Leopard-Spotted Jiao",
+    setCode = "PZ2",
+    collectorNumber = "70789",
+    artist = "Shinchuen Chen",
+    imageUri = "https://cards.scryfall.io/normal/front/c/7/c7761133-59df-4a5e-8c28-deb2ad213986.jpg?1783933910",
+    releaseDate = "2018-12-06",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/JwariScuttler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/JwariScuttler.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Jwari Scuttler
+ * {2}{U}
+ * Creature — Crab
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val JwariScuttler = card("Jwari Scuttler") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Andrew Robinson"
+        flavorText = "\"Yeah, they've got a lot of meat. The only downside to eating 'em is that you often find human bones and body parts inside.\"\n—Jaby, Silundi Sea nomad"
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04129038-3b02-418a-862a-229e9dde339b.jpg?1783941995"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LagacLizard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/LagacLizard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lagac Lizard
+ * {3}{R}
+ * Creature — Lizard
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val LagacLizard = card("Lagac Lizard") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Svetlin Velinov"
+        flavorText = "Tracing their ancestry back to Zendikar's earliest forms of life, lagac lizards have seen the comings and goings of planeswalkers and the Eldrazi, and the rise of the vampire clans, none of which has changed them one bit."
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b47e9cfa-5547-4ef3-9e36-8d0f36dfa59a.jpg?1783941974"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/NemaSiltlurker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/roe/cards/NemaSiltlurker.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.roe.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nema Siltlurker
+ * {4}{G}
+ * Creature — Lizard
+ * 3/5
+ *
+ * Vanilla — no rules text.
+ */
+val NemaSiltlurker = card("Nema Siltlurker") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Lizard"
+    power = 3
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "200"
+        artist = "Wayne Reynolds"
+        flavorText = "In one gargantuan bite, it will swallow not only you but also the riverbank you were standing on."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a477e081-949f-4cf0-b0d2-b9bdff6c760d.jpg?1783941961"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AxebaneStag.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/AxebaneStag.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Axebane Stag
+ * {6}{G}
+ * Creature — Elk
+ * 6/7
+ *
+ * Vanilla — no rules text.
+ */
+val AxebaneStag = card("Axebane Stag") {
+    manaCost = "{6}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elk"
+    power = 6
+    toughness = 7
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Martina Pilcerova"
+        flavorText = "\"When the spires have burned and the cobblestones are dust, he will take his rightful place as king of the wilds.\"\n—Kirce, Axebane guardian"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bfce7c02-ccc3-44cd-8087-627eaa6a072e.jpg?1783940351"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CatacombSlug.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/CatacombSlug.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Catacomb Slug
+ * {4}{B}
+ * Creature — Slug
+ * 2/6
+ *
+ * Vanilla — no rules text.
+ */
+val CatacombSlug = card("Catacomb Slug") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Slug"
+    power = 2
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "58"
+        artist = "Nils Hamm"
+        flavorText = "\"The entire murder scene was covered in dripping, oozing slime. No need for a soothsayer to solve that one.\"\n—Pel Javya, Wojek investigator"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53b36fba-6a0e-4f03-8bee-03919062537f.jpg?1783940365"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Cobblebrute.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/Cobblebrute.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cobblebrute
+ * {3}{R}
+ * Creature — Elemental
+ * 5/2
+ *
+ * Vanilla — no rules text.
+ */
+val Cobblebrute = card("Cobblebrute") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 5
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Eytan Zana"
+        flavorText = "The most ancient streets take on a life of their own. A few have decided to move to nicer neighborhoods."
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e038376-801f-454e-a635-0e2d58ccbf7c.jpg?1783940356"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/GolgariLonglegs.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/GolgariLonglegs.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Golgari Longlegs
+ * {3}{B/G}{B/G}
+ * Creature — Insect
+ * 5/4
+ *
+ * Vanilla — no rules text.
+ */
+val GolgariLonglegs = card("Golgari Longlegs") {
+    manaCost = "{3}{B/G}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Insect"
+    power = 5
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Volkan Baǵa"
+        flavorText = "Despite its enormous stature, it can fold itself into a tunnel with startling quickness, vanishing back into the undercity."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d44058ba-3419-4777-8d59-05dea5e864e1.jpg?1783940327"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/LoamdraggerGiant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/LoamdraggerGiant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Loamdragger Giant
+ * {4}{R/G}{R/G}{R/G}
+ * Creature — Giant Warrior
+ * 7/6
+ *
+ * Vanilla — no rules text.
+ */
+val LoamdraggerGiant = card("Loamdragger Giant") {
+    manaCost = "{4}{R/G}{R/G}{R/G}"
+    colorIdentity = "RG"
+    typeLine = "Creature — Giant Warrior"
+    power = 7
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Pete Venters"
+        flavorText = "Giants sleep soundly and long, sometimes for long enough that a crust of earth and moss grows over them. But inevitably something disturbs their slumber, and they wake unhappy."
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0a27bbe4-5341-4b2b-9ae8-eb56585a9c3a.jpg?1783942721"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/OldGhastbark.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/shm/cards/OldGhastbark.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.shm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Old Ghastbark
+ * {3}{G/W}{G/W}
+ * Creature — Treefolk Warrior
+ * 3/6
+ *
+ * Vanilla — no rules text.
+ */
+val OldGhastbark = card("Old Ghastbark") {
+    manaCost = "{3}{G/W}{G/W}"
+    colorIdentity = "WG"
+    typeLine = "Creature — Treefolk Warrior"
+    power = 3
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "232"
+        artist = "Thomas M. Baxa"
+        flavorText = "\"Beware of trees that talk. Their words are threats. And mind the ones that sway and creak. They too threaten us, but in a foreign tongue.\"\n—*The Book of Other Folk*"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b5ab941-89cc-4fdd-a916-3a54651f6478.jpg?1783942716"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DevilthornFox.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/DevilthornFox.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Devilthorn Fox
+ * {1}{W}
+ * Creature — Fox
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val DevilthornFox = card("Devilthorn Fox") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Fox"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Filip Burburan"
+        flavorText = "On expeditions through Ashmouth, the hunters of Devilthorn Lodge rely on the cleverness of foxes to counteract the mischief of devils."
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/57bea4c2-7a15-4f31-938d-c4c906e4ebe7.jpg?1783937821"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HulkingDevil.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/HulkingDevil.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hulking Devil
+ * {3}{R}
+ * Creature — Devil
+ * 5/2
+ *
+ * Vanilla — no rules text.
+ */
+val HulkingDevil = card("Hulking Devil") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    power = 5
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Joseph Meehan"
+        flavorText = "Fear the patient devil, the one who is calm in the midst of chaos. Beware the silent devil, the one whose cackle does not mingle with the others."
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/031ecfc4-cc84-4f74-8eb1-3eaa234d8093.jpg?1783937750"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SeagrafSkaab.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/SeagrafSkaab.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seagraf Skaab
+ * {1}{U}
+ * Creature — Zombie
+ * 1/3
+ *
+ * Vanilla — no rules text.
+ */
+val SeagrafSkaab = card("Seagraf Skaab") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Jama Jurabaev"
+        flavorText = "\"Your recent work is an inspiration. I have the utmost respect for your approach, and your craft is impeccable. At your convenience, I would be honored to collaborate on a project.\"\n—Ludevic, letter to Geralf"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/065d497d-5cfd-43c9-8c86-9a1da3d7e17e.jpg?1783937788"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ThornhideWolves.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/ThornhideWolves.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thornhide Wolves
+ * {4}{G}
+ * Creature — Wolf
+ * 4/5
+ *
+ * Vanilla — no rules text.
+ */
+val ThornhideWolves = card("Thornhide Wolves") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 4
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "232"
+        artist = "Scott Murphy"
+        flavorText = "\"Halana grew brambles to create a barricade around our camp, hoping that it would keep the wolves out. That was a mistake for which we almost paid dearly.\"\n—Alena, trapper of Kessig"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c699b5f-a2de-4c87-a7bc-16be4bc0a8cd.jpg?1783937720"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VampireNoble.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/VampireNoble.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vampire Noble
+ * {2}{B}
+ * Creature — Vampire Noble
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val VampireNoble = card("Vampire Noble") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Noble"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Ryan Alexander Lee"
+        flavorText = "\"No emergency is so dire that it cannot be dealt with elegantly.\"\n—Olivia Voldaren"
+        imageUri = "https://cards.scryfall.io/normal/front/b/2/b2435f17-0378-4480-8d56-d256245c7ced.jpg?1783937761"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/WickerWitch.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/WickerWitch.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wicker Witch
+ * {3}
+ * Artifact Creature — Scarecrow
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val WickerWitch = card("Wicker Witch") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Scarecrow"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "268"
+        artist = "Izzy"
+        flavorText = "When there were no more crows to scare, it focused its efforts elsewhere."
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae115587-012d-40ff-a20d-270fabf2f8c6.jpg?1783937699"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AlphaTyrranax.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/AlphaTyrranax.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alpha Tyrranax
+ * {4}{G}{G}
+ * Creature — Dinosaur Beast
+ * 6/5
+ *
+ * Vanilla — no rules text.
+ */
+val AlphaTyrranax = card("Alpha Tyrranax") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur Beast"
+    power = 6
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Dave Kendall"
+        flavorText = "Hunger seized the tyrranax, and the Sylvok's vision quest ended in disaster."
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a2e5279-f28c-4a78-9f8a-16c9f72f8d38.jpg?1783941720"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/LoxodonWayfarer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/LoxodonWayfarer.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Loxodon Wayfarer
+ * {2}{W}
+ * Creature — Elephant Monk
+ * 1/5
+ *
+ * Vanilla — no rules text.
+ */
+val LoxodonWayfarer = card("Loxodon Wayfarer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Monk"
+    power = 1
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Steven Belledin"
+        flavorText = "The Mirran elders vanished with Memnarch, leaving behind a generation of wayward orphans."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/356c5e6a-c0bd-43f7-bc84-a6ae8718a7a2.jpg?1783941744"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Memnite.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/Memnite.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Memnite
+ * {0}
+ * Artifact Creature — Construct
+ * 1/1
+ *
+ * Vanilla — no rules text.
+ */
+val Memnite = card("Memnite") {
+    manaCost = "{0}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 1
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "174"
+        artist = "Svetlin Velinov"
+        flavorText = "Reminders of Memnarch's reign still skirr across Mirrodin, reminiscent of his form if not his power."
+        imageUri = "https://cards.scryfall.io/normal/front/4/6/469cc4e0-49c0-4009-97ea-28e44addec69.jpg?1783941703"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/MoriokReaver.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/MoriokReaver.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moriok Reaver
+ * {2}{B}
+ * Creature — Human Warrior
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val MoriokReaver = card("Moriok Reaver") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Warrior"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Marc Simonetti"
+        flavorText = "\"The Moriok are fools. They try so hard to gain my favor. All I want is for them to die quickly, to join the ranks of the nim.\"\n—Geth, Lord of the Vault"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2a0410f-95c5-49bf-856d-dea796c96e3b.jpg?1783941730"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/PlatedSeastrider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/PlatedSeastrider.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plated Seastrider
+ * {U}{U}
+ * Creature — Beast
+ * 1/4
+ *
+ * Vanilla — no rules text.
+ */
+val PlatedSeastrider = card("Plated Seastrider") {
+    manaCost = "{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Beast"
+    power = 1
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Izzy"
+        flavorText = "The Neurok buried entangling cables just under the Quicksilver Sea. One seastrider harvest can provide an army's worth of armor and shields."
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/97171611-c677-48a6-b081-98a27ecef979.jpg?1783941738"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/RazorfieldThresher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/RazorfieldThresher.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Razorfield Thresher
+ * {7}
+ * Artifact Creature — Construct
+ * 6/4
+ *
+ * Vanilla — no rules text.
+ */
+val RazorfieldThresher = card("Razorfield Thresher") {
+    manaCost = "{7}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 6
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Karl Kopinski"
+        flavorText = "DANGER! Keep appendages clear of front of machine. And rear of machine. And side of machine. And top of machine."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0a74203-d342-489d-a584-bca78ef3331d.jpg?1783941698"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ScoriaElemental.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/ScoriaElemental.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scoria Elemental
+ * {4}{R}
+ * Creature — Elemental
+ * 6/1
+ *
+ * Vanilla — no rules text.
+ */
+val ScoriaElemental = card("Scoria Elemental") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 6
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Karl Kopinski"
+        flavorText = "A single molten cord links it to the subterranean furnaces, drawing heat and metal from beneath Kuldotha. Until that bond is cut, it carves a swath of raw destruction."
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca4d9198-52a7-4dfe-8f7f-4fa6e19a2479.jpg?1783941723"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/BorderlandMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/BorderlandMinotaur.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Borderland Minotaur
+ * {2}{R}{R}
+ * Creature — Minotaur Warrior
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val BorderlandMinotaur = card("Borderland Minotaur") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Warrior"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Greg Staples"
+        flavorText = "\"You have led us to triumph over the forces of Mogis!\" said Brygus the Brave, clapping the Champion on the back. The Champion wiped the sweat and blood from her brow. \"I count eight graves,\" she said. \"Too many to call this a victory.\"\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c7f6eb2-feae-4dc9-a009-0ad60f89a592.jpg?1783939766"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/BronzeSable.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/BronzeSable.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bronze Sable
+ * {2}
+ * Artifact Creature — Sable
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val BronzeSable = card("Bronze Sable") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Sable"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "212"
+        artist = "Jasper Sandner"
+        flavorText = "The Champion stood alone between the horde of the Returned and the shrine to Karametra, cutting down scores among hundreds. She would have been overcome if not for the aid of the temple guardians whom Karametra awakened.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba7e563d-964c-4afd-9e21-9d400f8719d4.jpg?1783939721"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FelhideMinotaur.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/FelhideMinotaur.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Felhide Minotaur
+ * {2}{B}
+ * Creature — Minotaur
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val FelhideMinotaur = card("Felhide Minotaur") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Minotaur"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Kev Walker"
+        flavorText = "With spear held high, the Champion came to meet Thyrogog of the Ashlands, who wore the old king's skin as a cloak and fed on the flesh of innocents. The foul minotaur raised the great axe called Goremaster and charged.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4e424de-81be-4f90-a7a2-4102c8ba8989.jpg?1783939779"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/NessianCourser.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/NessianCourser.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nessian Courser reprint in THS.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * FUT's `cards/` package (the card's earliest real printing). This file
+ * contributes only the THS-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val NessianCourserReprint = Printing(
+    oracleId = "e876d1fc-3acd-41a3-a34b-2bfa83204393",
+    name = "Nessian Courser",
+    setCode = "THS",
+    collectorNumber = "165",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/4697f3aa-abde-4379-af82-f30115f59be0.jpg?1783939743",
+    releaseDate = "2013-09-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PheresBandCentaurs.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/PheresBandCentaurs.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pheres-Band Centaurs
+ * {4}{G}
+ * Creature — Centaur Warrior
+ * 3/7
+ *
+ * Vanilla — no rules text.
+ */
+val PheresBandCentaurs = card("Pheres-Band Centaurs") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Centaur Warrior"
+    power = 3
+    toughness = 7
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Mark Winters"
+        flavorText = "\"Poets speak of your unrivaled speed,\" the Champion said to the assembled centaurs, \"but it is plain to see that your true strength lies in your unwavering loyalty to one another.\"\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/2168fcf4-cf87-4ab8-9710-6ec672750a9a.jpg?1783939739"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SilentArtisan.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/SilentArtisan.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silent Artisan
+ * {3}{W}{W}
+ * Creature — Giant
+ * 3/5
+ *
+ * Vanilla — no rules text.
+ */
+val SilentArtisan = card("Silent Artisan") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Giant"
+    power = 3
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Anthony Palumbo"
+        flavorText = "On the fourth day they passed through a forest of immense stacked stones. Althemone, youngest of the companions, called these pillars the work of a god, but the Champion knew better. She quickened her pace.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dce5647d-1546-4eff-a2a2-9e9ef26db533.jpg?1783939806"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TravelingPhilosopher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TravelingPhilosopher.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Traveling Philosopher
+ * {1}{W}
+ * Creature — Human Advisor
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val TravelingPhilosopher = card("Traveling Philosopher") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Advisor"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "James Ryman"
+        flavorText = "The Champion and the philosopher Olexa returned from the opposing camp at dusk. Behind them, the enemy raised sail and departed, breaking the siege. When asked what the two had done, the Champion replied, \"We spoke to them.\"\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edad0276-45d1-45e5-a6b1-1cd2a99b4f2c.jpg?1783939808"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TritonShorethief.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/TritonShorethief.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Triton Shorethief
+ * {U}
+ * Creature — Merfolk Rogue
+ * 1/2
+ *
+ * Vanilla — no rules text.
+ */
+val TritonShorethief = card("Triton Shorethief") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Rogue"
+    power = 1
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Howard Lyon"
+        flavorText = "At sunrise, the Champion and her companions awoke to find their supplies gone and Brygus, their sentry, dead. Carefully arranged piles of ornamental shells gave a clear warning: go no further.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d8f0fe22-dc89-4ad8-b5f6-6d91b61f1385.jpg?1783939787"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/YokedOx.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/YokedOx.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yoked Ox
+ * {W}
+ * Creature — Ox
+ * 0/4
+ *
+ * Vanilla — no rules text.
+ */
+val YokedOx = card("Yoked Ox") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Ox"
+    power = 0
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Ryan Yee"
+        flavorText = "It was in fields of grain, not fields of battle, that the Champion learned to bear the yoke of duty to the gods. She worked the land long before she was called on to defend it.\n—*The Theriad*"
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12fc09d4-e6ce-428b-818b-b465093af88e.jpg?1783939803"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/GoblinRoughrider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/GoblinRoughrider.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.wwk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Roughrider
+ * {2}{R}
+ * Creature — Goblin Knight
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val GoblinRoughrider = card("Goblin Roughrider") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Knight"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "82"
+        artist = "Jesper Ejsing"
+        flavorText = "Astride the bucking creature, Gribble hurtled down the mountainside while his Grotag brethren cheered. It was at that moment that legend of the Skrill Tamer was born."
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e79787dd-6d2f-4773-aefe-16a4eb93d3cc.jpg?1783942050"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/LeatherbackBaloth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/LeatherbackBaloth.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.wwk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leatherback Baloth
+ * {G}{G}{G}
+ * Creature — Beast
+ * 4/5
+ *
+ * Vanilla — no rules text.
+ */
+val LeatherbackBaloth = card("Leatherback Baloth") {
+    manaCost = "{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "107"
+        artist = "Dave Kendall"
+        flavorText = "Heavy enough to withstand the Roil, leatherback skeletons are havens for travelers in storms and landshifts."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55f97b4c-42c7-4986-a150-0b8de11f0537.jpg?1783942043"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/KrakenHatchling.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/KrakenHatchling.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kraken Hatchling
+ * {U}
+ * Creature — Kraken
+ * 0/4
+ *
+ * Vanilla — no rules text.
+ */
+val KrakenHatchling = card("Kraken Hatchling") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Kraken"
+    power = 0
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Jason Felix"
+        flavorText = "A spike and a maul are needed to crack their shells, but the taste is worth the effort."
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45d100a3-93f2-428c-8f54-8807e71f2638.jpg?1783942164"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/PillarfieldOx.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/PillarfieldOx.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pillarfield Ox
+ * {3}{W}
+ * Creature — Ox
+ * 2/4
+ *
+ * Vanilla — no rules text.
+ */
+val PillarfieldOx = card("Pillarfield Ox") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Ox"
+    power = 2
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Andrew Robinson"
+        flavorText = "These stubborn and unpredictable oxen inspire the plains nomads' most colorful curses."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d70a8ff1-f0cf-4aef-ad90-06902f98d434.jpg?1783942168"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/ShatterskullGiant.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/ShatterskullGiant.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shatterskull Giant
+ * {2}{R}{R}
+ * Creature — Giant Warrior
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val ShatterskullGiant = card("Shatterskull Giant") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Giant Warrior"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Kekai Kotaki"
+        flavorText = "\"Now I know why they call it Shatterskull Pass. Rocks fell all night like hammers smashing an anvil. It's no wonder the giants are angry all the time.\"\n—Mitra, Bala Ged missionary"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9cfbb4dd-56a2-4a94-9b15-b3ef8b2f1d0b.jpg?1783942140"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/StoneworkPuma.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/StoneworkPuma.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stonework Puma
+ * {3}
+ * Artifact Creature — Cat Ally
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val StoneworkPuma = card("Stonework Puma") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Cat Ally"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "207"
+        artist = "Christopher Moeller"
+        flavorText = "\"We suffer uneasy ground, unstable alliances, and unpredictable magic. Something you can truly trust is worth more than a chest of gold.\"\n—Nikou, Joraga bard"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/05460615-4c24-487f-841a-ca14106e5688.jpg?1783942125"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/VastwoodGorger.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/VastwoodGorger.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vastwood Gorger
+ * {5}{G}
+ * Creature — Wurm
+ * 5/6
+ *
+ * Vanilla — no rules text.
+ */
+val VastwoodGorger = card("Vastwood Gorger") {
+    manaCost = "{5}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 5
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Kieran Yanner"
+        flavorText = "\"I've known true ferocity and power. Those brazen 'planar-walkers' have no idea what wild really means.\"\n—Chadir the Navigator"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc5daf96-ceae-4c9a-95cd-f6d706e9b1fa.jpg?1783942129"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/BastionEnforcer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/BastionEnforcer.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bastion Enforcer
+ * {2}{W}
+ * Creature — Dwarf Soldier
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val BastionEnforcer = card("Bastion Enforcer") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Soldier"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Matt Stewart"
+        flavorText = "Headquartered at the Bastion of the Honorable, the Consulate's enforcers are charged with the impossible task of keeping the peace."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88b9c0f7-d49b-4d74-9038-44954054ce21.jpg?1783936782"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/LathnuSailback.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/LathnuSailback.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lathnu Sailback
+ * {4}{R}
+ * Creature — Lizard
+ * 5/4
+ *
+ * Vanilla — no rules text.
+ */
+val LathnuSailback = card("Lathnu Sailback") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Lizard"
+    power = 5
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Christopher Burdett"
+        flavorText = "Travelers to Lathnu, high on the Devra Cliffs, need not fear the political strife of Ghirapur . . . but they have other dangers to worry about."
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33998799-f31b-4522-93b2-0c34c570ebf7.jpg?1783936752"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/PrizefighterConstruct.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/PrizefighterConstruct.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prizefighter Construct
+ * {5}
+ * Artifact Creature — Construct
+ * 6/2
+ *
+ * Vanilla — no rules text.
+ */
+val PrizefighterConstruct = card("Prizefighter Construct") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 6
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "172"
+        artist = "Daniel Ljunggren"
+        flavorText = "The Scrappers, an underground group with a passion for automaton brawls, had renegade leanings even before the Consulate's crackdown. It didn't take long for them to lend their best brawlers to the conflict."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e389c92-b54b-46b3-a7ab-b8a5a2a7d380.jpg?1783936720"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/AncientCrab.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/AncientCrab.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ancient Crab reprint in AKH.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * OGW's `cards/` package (the card's earliest real printing). This file
+ * contributes only the AKH-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val AncientCrabReprint = Printing(
+    oracleId = "6bab6d0a-cd06-45e3-b780-d5354ee2a032",
+    name = "Ancient Crab",
+    setCode = "AKH",
+    collectorNumber = "40",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c2ca68b-15fb-4691-b549-268df92ca413.jpg?1783936527",
+    releaseDate = "2017-04-28",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/Colossapede.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/Colossapede.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Colossapede
+ * {4}{G}
+ * Creature — Insect
+ * 5/5
+ *
+ * Vanilla — no rules text.
+ */
+val Colossapede = card("Colossapede") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 5
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Jason Kang"
+        flavorText = "\"If it is bigger, you must be faster. If it is stronger, you must be sharper. Anything less, and you will never seize a place in our God-Pharaoh's perfect afterlife.\"\n—Rhonas, god of strength"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/7642bfc5-ace8-419e-b57b-2b881bfe023e.jpg?1783936478"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DuneBeetle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/DuneBeetle.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dune Beetle
+ * {1}{B}
+ * Creature — Insect
+ * 1/4
+ *
+ * Vanilla — no rules text.
+ */
+val DuneBeetle = card("Dune Beetle") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    power = 1
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Grzegorz Rutkowski"
+        flavorText = "The scouring sands of Shefet polish its carapace, and the ranks of the cursed fill its belly."
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/923cb904-c725-4d57-bc17-7aa87a7cd8e0.jpg?1783936506"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HyenaPack.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HyenaPack.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hyena Pack
+ * {2}{R}{R}
+ * Creature — Hyena
+ * 3/4
+ *
+ * Vanilla — no rules text.
+ */
+val HyenaPack = card("Hyena Pack") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Hyena"
+    power = 3
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Winona Nelson"
+        flavorText = "With carrion a rarity in the Broken Lands, the hyenas that stalk the deserts hunt in packs."
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9fa8351-567e-4ef4-8346-c58e50c778a6.jpg?1783936487"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ThoseWhoServe.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/ThoseWhoServe.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Those Who Serve
+ * {2}{W}
+ * Creature — Zombie
+ * 2/4
+ *
+ * Vanilla — no rules text.
+ */
+val ThoseWhoServe = card("Those Who Serve") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Volkan Baǵa"
+        flavorText = "\"The dead perform all the work here—farming, building, teaching, even embalming their fellow mummies. The living need do nothing but train. What system could be more perfect?\"\n—Temmet, vizier of Naktamun"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4f27dd9-7ee4-4cdc-8f65-a4349b6aa47f.jpg?1783936530"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/ArenaBeginnerSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/ArenaBeginnerSet.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.anb
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Arena Beginner Set (2020)
+ *
+ * MTG Arena's beginner set, which succeeded the New Player Experience cards.
+ * Scaffolded here as the canonical home for cards whose earliest real printing is
+ * ANB. Intentionally incomplete relative to the official set — only cards
+ * relocated here as their canonical earliest printing live in this package.
+ *
+ * Set Code: ANB
+ * Release Date: 2020-08-13
+ */
+object ArenaBeginnerSet : MtgSet {
+
+    override val code = "ANB"
+    override val displayName = "Arena Beginner Set"
+    override val releaseDate = "2020-08-13"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.anb.cards"
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/ArmoredWhirlTurtle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/ArmoredWhirlTurtle.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Whirl Turtle reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * GS1's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ArmoredWhirlTurtleReprint = Printing(
+    oracleId = "51a886f2-9b0a-4964-9d59-99dc1a68a97c",
+    name = "Armored Whirl Turtle",
+    setCode = "ANB",
+    collectorNumber = "24",
+    artist = "Tingting Yeh",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/44a783f2-04d3-42fc-acc1-5f2974f9aca2.jpg?1783929839",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/FearlessHalberdier.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/FearlessHalberdier.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fearless Halberdier reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * GRN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val FearlessHalberdierReprint = Printing(
+    oracleId = "2ef2f417-2061-4796-974a-92f800ef05e4",
+    name = "Fearless Halberdier",
+    setCode = "ANB",
+    collectorNumber = "69",
+    artist = "Suzanne Helmigh",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/ef9351dc-9af0-48d1-9012-7c478fdc34e1.jpg?1783929807",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/KrovikanScoundrel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/KrovikanScoundrel.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Krovikan Scoundrel reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * CSP's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val KrovikanScoundrelReprint = Printing(
+    oracleId = "44c437ca-5d36-4bb3-9450-baf0c93ff4ce",
+    name = "Krovikan Scoundrel",
+    setCode = "ANB",
+    collectorNumber = "50",
+    artist = "Ralph Horsley",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b672836-dba8-4a32-ac04-616644268534.jpg?1783929827",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/LoxodonLineBreaker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/LoxodonLineBreaker.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Loxodon Line Breaker reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M19's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val LoxodonLineBreakerReprint = Printing(
+    oracleId = "57f0f55d-4cf9-4a35-96dd-05c24c2a9a4f",
+    name = "Loxodon Line Breaker",
+    setCode = "ANB",
+    collectorNumber = "14",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/087f35cc-ccb4-479a-baf2-8249a58e4a68.jpg?1783929843",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/RumblingBaloth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/RumblingBaloth.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rumbling Baloth reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M14's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val RumblingBalothReprint = Printing(
+    oracleId = "3191c6ca-4d25-4ba3-bfe1-4aeab1295573",
+    name = "Rumbling Baloth",
+    setCode = "ANB",
+    collectorNumber = "103",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c28b7565-3da0-4878-bf5d-188f7019d47f.jpg?1783929787",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/SanctuaryCat.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/SanctuaryCat.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sanctuary Cat reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * DKA's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SanctuaryCatReprint = Printing(
+    oracleId = "c623bc4b-7fc1-4bc1-84e9-71c301dd402f",
+    name = "Sanctuary Cat",
+    setCode = "ANB",
+    collectorNumber = "17",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/61170c40-1e85-4fc2-804a-7fdc7062ac55.jpg?1783929839",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/ShorecomberCrab.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/ShorecomberCrab.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shorecomber Crab
+ * {U}
+ * Creature — Crab
+ * 0/4
+ *
+ * Vanilla — no rules text.
+ */
+val ShorecomberCrab = card("Shorecomber Crab") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab"
+    power = 0
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32a"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0d899e1-bded-4e16-8ecc-cc07784af4bb.jpg?1783929831"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/ShrineKeeper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/ShrineKeeper.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shrine Keeper reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * OANA's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ShrineKeeperReprint = Printing(
+    oracleId = "c3319f74-1771-4679-bdad-0ab4b34e9106",
+    name = "Shrine Keeper",
+    setCode = "ANB",
+    collectorNumber = "19",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6f2d3642-3eda-4b15-96dd-b0f0f9680bd7.jpg?1783929840",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/SwornGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/SwornGuardian.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sworn Guardian reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * RIX's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SwornGuardianReprint = Printing(
+    oracleId = "9f63ab29-b86e-4337-b9dd-2b35c8415f90",
+    name = "Sworn Guardian",
+    setCode = "ANB",
+    collectorNumber = "35",
+    artist = "Sara Winters",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a32a86fb-3652-4ac7-a879-c78899c493d6.jpg?1783929829",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/TreetopWarden.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/TreetopWarden.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Treetop Warden reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * OANA's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val TreetopWardenReprint = Printing(
+    oracleId = "8bb63574-6e8e-499b-8e61-843f06b19313",
+    name = "Treetop Warden",
+    setCode = "ANB",
+    collectorNumber = "107",
+    artist = "Colin Boyer",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22c42e1a-9a4d-4630-b6c2-749d76c4cafb.jpg?1783929784",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/WitchsFamiliar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/anb/cards/WitchsFamiliar.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.anb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Witch's Familiar reprint in ANB.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M15's `cards/` package (the card's earliest real printing). This file
+ * contributes only the ANB-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val WitchsFamiliarReprint = Printing(
+    oracleId = "abe06b4d-e7f0-4125-8cfc-e36296e8bacd",
+    name = "Witch's Familiar",
+    setCode = "ANB",
+    collectorNumber = "66",
+    artist = "Jack Wang",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1f1f9bd-2891-4338-bcce-c55e55e6c933.jpg?1783929809",
+    releaseDate = "2020-08-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DouserOfLights.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/DouserOfLights.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Douser of Lights
+ * {4}{B}
+ * Creature — Horror
+ * 4/5
+ *
+ * Vanilla — no rules text.
+ */
+val DouserOfLights = card("Douser of Lights") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 4
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Darek Zabrocki"
+        flavorText = "The party of Rakdos revelers cackled and capered as the thing approached. It hissed, and they jabbed their torches at it, giggling when it recoiled. Then, one by one, the torches went out—and the screaming began."
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c554be7-6fd4-4642-aaa0-2781d9c388e4.jpg?1783934175"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/FearlessHalberdier.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/FearlessHalberdier.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fearless Halberdier
+ * {2}{R}
+ * Creature — Human Warrior
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val FearlessHalberdier = card("Fearless Halberdier") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Suzanne Helmigh"
+        flavorText = "\"I spent some time in the Legion, but I'm done taking orders all day.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/30e04f16-89d0-4e75-a3cd-4dd64414050c.jpg?1783934164"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WildCeratok.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WildCeratok.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wild Ceratok
+ * {3}{G}
+ * Creature — Rhino
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val WildCeratok = card("Wild Ceratok") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Svetlin Velinov"
+        flavorText = "Once part of a wealthy merchant's private zoo, the herd roams feral throughout the Tenth, where it will remain until the guilds can agree to relocate, cull, or befriend it."
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/4464e11a-c5b9-40ea-8be0-dab29d14e289.jpg?1783934143"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WishcoinCrab.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/grn/cards/WishcoinCrab.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.grn.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wishcoin Crab
+ * {3}{U}
+ * Creature — Crab
+ * 2/5
+ *
+ * Vanilla — no rules text.
+ */
+val WishcoinCrab = card("Wishcoin Crab") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab"
+    power = 2
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "James Paick"
+        flavorText = "\"What wishes do they grant? Mostly pinching-related ones.\"\n—Omik, superintendent of waterworks"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/6580d6a2-ee21-4442-9842-18c65a172f49.jpg?1783934181"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/ArmoredWhirlTurtle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/ArmoredWhirlTurtle.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.gs1.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Armored Whirl Turtle
+ * {2}{U}
+ * Creature — Turtle
+ * 0/5
+ *
+ * Vanilla — no rules text.
+ */
+val ArmoredWhirlTurtle = card("Armored Whirl Turtle") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Turtle"
+    power = 0
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Tingting Yeh"
+        flavorText = "Not all enormous beasts are quick to anger."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fcc87fdf-6473-4b91-a8b9-2986e57dc071.jpg?1783934633"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/FerociousZheng.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/FerociousZheng.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.gs1.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ferocious Zheng
+ * {2}{G}{G}
+ * Creature — Cat Beast
+ * 4/4
+ *
+ * Vanilla — no rules text.
+ */
+val FerociousZheng = card("Ferocious Zheng") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Beast"
+    power = 4
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Yutaka Li"
+        flavorText = "Known for their glowing horn and stone-rattling roar, zheng are the fiercest predators in the forest. Few survived before Jiang Yanggu came."
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a6d1184-15e0-4b41-ba2d-4f68e91c61d4.jpg?1783934626"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/LeopardSpottedJiao.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gs1/cards/LeopardSpottedJiao.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.gs1.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leopard-Spotted Jiao
+ * {1}{R}
+ * Creature — Beast
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val LeopardSpottedJiao = card("Leopard-Spotted Jiao") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Beast"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Shinchuen Chen"
+        flavorText = "This strange beast has the hide of a leopard, the howl of a dog, and the horns of an ox."
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/91df110f-85d2-41cb-96b6-6c79cebfada7.jpg?1783934627"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/DefiantKhenra.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/DefiantKhenra.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Defiant Khenra
+ * {1}{R}
+ * Creature — Jackal Warrior
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val DefiantKhenra = card("Defiant Khenra") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Jackal Warrior"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "David Palumbo"
+        flavorText = "There were those who saw the death of the gods and the city's collapse as a final test of worth. Some believed it meant the God-Pharaoh had been killed. Only a few realized they had been deceived."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67e3983d-b1ed-46a9-9ab0-96c4d0d77050.jpg?1783936030"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/DutifulServants.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/DutifulServants.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dutiful Servants
+ * {3}{W}
+ * Creature — Zombie
+ * 2/5
+ *
+ * Vanilla — no rules text.
+ */
+val DutifulServants = card("Dutiful Servants") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Volkan Baǵa"
+        flavorText = "Buildings crumbled and monuments fell. The river bled and the sky wept tears of fire. All the while, servants silently continued their work, oblivious to it all."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/7684db4c-6eff-4da1-a410-48d707fb5bf1.jpg?1783936063"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/HarrierNaga.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/HarrierNaga.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Harrier Naga
+ * {2}{G}
+ * Creature — Snake Warrior
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val HarrierNaga = card("Harrier Naga") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Snake Warrior"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Filip Burburan"
+        flavorText = "She trusts that the potent poisons of her darts will reach the enemy before the enemy reaches her."
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bcdc68c9-f5f3-4c5b-80df-85508cf15f84.jpg?1783936019"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FrenziedRaptor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/FrenziedRaptor.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frenzied Raptor reprint in IKO.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * XLN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the IKO-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val FrenziedRaptorReprint = Printing(
+    oracleId = "655c59d5-8666-476c-b494-411fa2e243a7",
+    name = "Frenzied Raptor",
+    setCode = "IKO",
+    collectorNumber = "120",
+    artist = "Jonathan Kuo",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5fb22ac0-3863-4165-8c93-f2ec1775474f.jpg?1783931050",
+    releaseDate = "2020-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/GloomPangolin.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/GloomPangolin.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gloom Pangolin
+ * {2}{B}
+ * Creature — Nightmare Pangolin
+ * 1/5
+ *
+ * Vanilla — no rules text.
+ */
+val GloomPangolin = card("Gloom Pangolin") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Nightmare Pangolin"
+    power = 1
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "YW Tang"
+        flavorText = "\"They say it survives on a purely bioluminescent diet. It's only active during the darkest of Indatha nights, making verification highly challenging.\"\n—Gannet, Skysail zoologist"
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f135dd7-2a4f-4c83-9a90-76bcab3cc33d.jpg?1783931061"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SavaiSabertooth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/SavaiSabertooth.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savai Sabertooth
+ * {1}{W}
+ * Creature — Cat
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val SavaiSabertooth = card("Savai Sabertooth") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Ilse Gort"
+        flavorText = "The giant tigers of Savai prefer to hunt at daybreak, when the crystals' warning glow is masked by the light of dawn."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d46702b0-7e10-462a-9aac-7564efe91804.jpg?1783931085"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DuneBeetle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DuneBeetle.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dune Beetle reprint in J22.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * AKH's `cards/` package (the card's earliest real printing). This file
+ * contributes only the J22-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val DuneBeetleReprint = Printing(
+    oracleId = "3f79603a-3173-404e-8c69-b2254c1270dc",
+    name = "Dune Beetle",
+    setCode = "J22",
+    collectorNumber = "407",
+    artist = "Grzegorz Rutkowski",
+    imageUri = "https://cards.scryfall.io/normal/front/3/b/3bd4f7da-5200-4c1b-8c42-95d601952995.jpg?1783919009",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RenegadeDemon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RenegadeDemon.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Renegade Demon reprint in J22.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * AVR's `cards/` package (the card's earliest real printing). This file
+ * contributes only the J22-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val RenegadeDemonReprint = Printing(
+    oracleId = "5f444efc-3bc2-4ca8-986c-f804f9e1a95e",
+    name = "Renegade Demon",
+    setCode = "J22",
+    collectorNumber = "126",
+    artist = "Alexandre Honoré",
+    imageUri = "https://cards.scryfall.io/normal/front/2/c/2cee747f-4a9e-4752-815a-dc7ebabccd6b.jpg?1783919142",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BorderlandMinotaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/BorderlandMinotaur.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Borderland Minotaur reprint in JMP.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * THS's `cards/` package (the card's earliest real printing). This file
+ * contributes only the JMP-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BorderlandMinotaurReprint = Printing(
+    oracleId = "03a9ac3f-f6e4-4ade-9770-cf723434b7e8",
+    name = "Borderland Minotaur",
+    setCode = "JMP",
+    collectorNumber = "301",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/8/b/8b8c80ea-7b29-4335-ba7b-3e51a5a104a9.jpg?1783930400",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FusionElemental.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/FusionElemental.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fusion Elemental reprint in JMP.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * CON's `cards/` package (the card's earliest real printing). This file
+ * contributes only the JMP-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val FusionElementalReprint = Printing(
+    oracleId = "a152674f-be29-40ab-8dd9-376fd4eb3bb8",
+    name = "Fusion Elemental",
+    setCode = "JMP",
+    collectorNumber = "451",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/5538bc51-e320-437e-867d-0d01621e31fb.jpg?1783930345",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/OrazcaFrillback.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/OrazcaFrillback.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Orazca Frillback reprint in JMP.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * RIX's `cards/` package (the card's earliest real printing). This file
+ * contributes only the JMP-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val OrazcaFrillbackReprint = Printing(
+    oracleId = "2da32ec3-f42f-4edc-b5b3-e5f39fcf370c",
+    name = "Orazca Frillback",
+    setCode = "JMP",
+    collectorNumber = "416",
+    artist = "Simon Dominic",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/20471a3b-90f9-4463-9b43-fc7b9b28f5d1.jpg?1783930358",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RumblingBaloth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/RumblingBaloth.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rumbling Baloth reprint in JMP.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M14's `cards/` package (the card's earliest real printing). This file
+ * contributes only the JMP-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val RumblingBalothReprint = Printing(
+    oracleId = "3191c6ca-4d25-4ba3-bfe1-4aeab1295573",
+    name = "Rumbling Baloth",
+    setCode = "JMP",
+    collectorNumber = "426",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/93a56610-482b-4ddf-88e1-e4a2edf4fa0f.jpg?1783930355",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GrizzledOutrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/GrizzledOutrider.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grizzled Outrider
+ * {4}{G}
+ * Creature — Elf Warrior
+ * 5/5
+ *
+ * Vanilla — no rules text.
+ */
+val GrizzledOutrider = card("Grizzled Outrider") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 5
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "173"
+        artist = "Cristi Balanescu"
+        flavorText = "\"Sure, a horse might be faster. But I'd like to see a horse take the head clean off a troll in one swipe!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a1d4473-5317-4bdd-9cb9-93670acf52e9.jpg?1783928213"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/Bogstomper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/Bogstomper.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bogstomper
+ * {4}{B}{B}
+ * Creature — Beast
+ * 6/5
+ *
+ * Vanilla — no rules text.
+ */
+val Bogstomper = card("Bogstomper") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Beast"
+    power = 6
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Jason Felix"
+        flavorText = "\"They are gentle herbivores, despite their size. Approach cautiously, and hum a tune to let them know you mean no harm.\"\n—Vivien Reid"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/05145a8d-0bfb-4f07-87cf-65875310bdb4.jpg?1783934576"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CentaurCourser.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CentaurCourser.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Centaur Courser reprint in M19.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M19-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CentaurCourserReprint = Printing(
+    oracleId = "2f5bf099-2e01-4e1c-9ebf-0ce0ac66939e",
+    name = "Centaur Courser",
+    setCode = "M19",
+    collectorNumber = "171",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/bae6eb55-4bf9-4418-b667-a9a761f91ef9.jpg?1783934541",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FieldCreeper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/FieldCreeper.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Field Creeper reprint in M19.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * EMN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M19-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val FieldCreeperReprint = Printing(
+    oracleId = "e6584e39-099c-437f-9239-fa718cac85af",
+    name = "Field Creeper",
+    setCode = "M19",
+    collectorNumber = "234",
+    artist = "Anthony Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e148c1bf-84a2-48cd-882e-ad0fd74b8f0f.jpg?1783934513",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LoxodonLineBreaker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LoxodonLineBreaker.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Loxodon Line Breaker
+ * {2}{W}
+ * Creature — Elephant Soldier
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val LoxodonLineBreaker = card("Loxodon Line Breaker") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Elephant Soldier"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Jesper Ejsing"
+        flavorText = "Loxodons are firm in stature and spirit. No matter the odds, they are always first into battle."
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/928d4250-c379-4134-a263-7811c80a8760.jpg?1783934603"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OnakkeOgre.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OnakkeOgre.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Onakke Ogre
+ * {2}{R}
+ * Creature — Ogre Warrior
+ * 4/2
+ *
+ * Vanilla — no rules text.
+ */
+val OnakkeOgre = card("Onakke Ogre") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Warrior"
+    power = 4
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Mathias Kollros"
+        flavorText = "The ogres you know are nothing like the Onakke. Possessing both intellect and industry, they had brute strength without being brutish."
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e016da6-8800-47b4-9b96-1887677c795c.jpg?1783934548"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OreskosSwiftclaw.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/OreskosSwiftclaw.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oreskos Swiftclaw reprint in M19.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * JOU's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M19-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val OreskosSwiftclawReprint = Printing(
+    oracleId = "014d00fc-434a-4b06-84b2-afd930677d61",
+    name = "Oreskos Swiftclaw",
+    setCode = "M19",
+    collectorNumber = "31",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0ea1dfb4-1983-41f7-956c-f2a1d1489b54.jpg?1783934600",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ThornhideWolves.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ThornhideWolves.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thornhide Wolves reprint in M19.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * SOI's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M19-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ThornhideWolvesReprint = Printing(
+    oracleId = "c5c221e6-dafe-4661-b920-3faed9551802",
+    name = "Thornhide Wolves",
+    setCode = "M19",
+    collectorNumber = "204",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc0f3812-bb6c-4d99-b505-9dfd84e3fd95.jpg?1783934527",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BaronyVampire.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BaronyVampire.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barony Vampire reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M11's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BaronyVampireReprint = Printing(
+    oracleId = "e886756a-298d-4f79-8699-8bfc9345352e",
+    name = "Barony Vampire",
+    setCode = "M20",
+    collectorNumber = "85",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b0130d04-05f2-44f5-bd6c-8b11f798b69e.jpg?1783933000",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BastionEnforcer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BastionEnforcer.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bastion Enforcer reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * AER's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BastionEnforcerReprint = Printing(
+    oracleId = "87449f64-9500-4967-a073-cde19824e087",
+    name = "Bastion Enforcer",
+    setCode = "M20",
+    collectorNumber = "303",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7cbf17a0-2dbc-4e79-9cfa-ea49b1605105.jpg?1783932914",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/Bogstomper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/Bogstomper.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bogstomper reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M19's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BogstomperReprint = Printing(
+    oracleId = "7c2f1915-8d91-47c6-bab4-be325348673a",
+    name = "Bogstomper",
+    setCode = "M20",
+    collectorNumber = "320",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/ad005eef-d4e4-4f46-81a5-9bbce87014ce.jpg?1783932908",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/CentaurCourser.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/CentaurCourser.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Centaur Courser reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val CentaurCourserReprint = Printing(
+    oracleId = "2f5bf099-2e01-4e1c-9ebf-0ce0ac66939e",
+    name = "Centaur Courser",
+    setCode = "M20",
+    collectorNumber = "168",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e8b67ee8-3189-4426-8b1a-b540267768fd.jpg?1783932966",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/FearlessHalberdier.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/FearlessHalberdier.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fearless Halberdier reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * GRN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val FearlessHalberdierReprint = Printing(
+    oracleId = "2ef2f417-2061-4796-974a-92f800ef05e4",
+    name = "Fearless Halberdier",
+    setCode = "M20",
+    collectorNumber = "329",
+    artist = "Suzanne Helmigh",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89f08297-f477-4330-a99e-3f0847c31364.jpg?1783932904",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ImperialOutrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ImperialOutrider.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Imperial Outrider
+ * {3}{W}
+ * Creature — Human Knight
+ * 1/5
+ *
+ * Vanilla — no rules text.
+ */
+val ImperialOutrider = card("Imperial Outrider") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 1
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "307"
+        artist = "Scott Murphy"
+        flavorText = "Her mount's hollow crest can produce a trumpeting warning that carries for miles, summoning more knights to her aid."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0dd3aca5-516f-4500-9d7f-95630401d3ae.jpg?1783932913"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/IroncladKrovod.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/IroncladKrovod.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ironclad Krovod reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * WAR's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val IroncladKrovodReprint = Printing(
+    oracleId = "bd1c9b5f-3b70-457c-8dd8-2420ce1c0d7c",
+    name = "Ironclad Krovod",
+    setCode = "M20",
+    collectorNumber = "308",
+    artist = "Sam Rowan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e5d57e98-e05a-4a89-900e-20fe675a62ef.jpg?1783932912",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ProwlingCaracal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/ProwlingCaracal.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prowling Caracal reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * RNA's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ProwlingCaracalReprint = Printing(
+    oracleId = "0eabe5e9-cb03-4481-9360-5e79eccd0631",
+    name = "Prowling Caracal",
+    setCode = "M20",
+    collectorNumber = "309",
+    artist = "Jonathan Kuo",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e689e4a-fc54-46f4-b0c5-c0e65d88340e.jpg?1783932912",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/SiegeMastodon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/SiegeMastodon.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Siege Mastodon reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M10's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SiegeMastodonReprint = Printing(
+    oracleId = "b4c404d8-9f2d-4429-ac36-449ae319abb7",
+    name = "Siege Mastodon",
+    setCode = "M20",
+    collectorNumber = "312",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/7/1/71fd27a8-2de6-454f-8174-a60918bfe60e.jpg?1783932912",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/StoneGolem.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/StoneGolem.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Stone Golem reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M11's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val StoneGolemReprint = Printing(
+    oracleId = "7cfb32af-ac59-4459-ac9e-2762488e9180",
+    name = "Stone Golem",
+    setCode = "M20",
+    collectorNumber = "240",
+    artist = "Martina Pilcerova",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b4de70a-729b-4566-b6f3-c76f551405a5.jpg?1783932939",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/Vorstclaw.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/Vorstclaw.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vorstclaw reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * AVR's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val VorstclawReprint = Printing(
+    oracleId = "aa944cbe-fdba-4001-97d5-c722fe744dcc",
+    name = "Vorstclaw",
+    setCode = "M20",
+    collectorNumber = "201",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/79719ed0-468d-4946-8dfc-fb7e2b2e305e.jpg?1783932954",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/YokedOx.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/YokedOx.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yoked Ox reprint in M20.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * THS's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M20-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val YokedOxReprint = Printing(
+    oracleId = "19b4cf0b-e1e4-4e50-80bc-673bc6ef8bb8",
+    name = "Yoked Ox",
+    setCode = "M20",
+    collectorNumber = "41",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/a/7/a73f186b-c897-4a98-bc25-8e4aa348d8c9.jpg?1783933018",
+    releaseDate = "2019-07-12",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/GarruksGorehorn.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/GarruksGorehorn.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Garruk's Gorehorn
+ * {4}{G}
+ * Creature — Beast
+ * 7/3
+ *
+ * Vanilla — no rules text.
+ */
+val GarruksGorehorn = card("Garruk's Gorehorn") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 7
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "184"
+        artist = "Svetlin Velinov"
+        flavorText = "\"It certainly takes after its master: big and brutish, and you can smell it from a mile away.\"\n—Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/3928bbce-87b7-4b28-9af4-20362935c909.jpg?1783930677"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/OnakkeOgre.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/OnakkeOgre.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Onakke Ogre reprint in M21.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * M19's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M21-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val OnakkeOgreReprint = Printing(
+    oracleId = "fa10cacb-ab14-447a-b411-9d74bc3772fb",
+    name = "Onakke Ogre",
+    setCode = "M21",
+    collectorNumber = "155",
+    artist = "Mathias Kollros",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/76e42d07-57d9-4de4-8d41-eb42dd1573ed.jpg?1783930686",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/StaunchShieldmate.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/StaunchShieldmate.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Staunch Shieldmate
+ * {W}
+ * Creature — Dwarf Soldier
+ * 1/3
+ *
+ * Vanilla — no rules text.
+ */
+val StaunchShieldmate = card("Staunch Shieldmate") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Soldier"
+    power = 1
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Bartłomiej Gaweł"
+        flavorText = "\"Gilded with gold from a dragon's trove, it is! And etched with the image of the dragon I slew to take it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db17f25a-32d1-469b-bb5f-f1761e227990.jpg?1783930733"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/WishcoinCrab.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/WishcoinCrab.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wishcoin Crab reprint in M21.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * GRN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the M21-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val WishcoinCrabReprint = Printing(
+    oracleId = "abc519b8-82de-4559-be03-ddb1ddaab993",
+    name = "Wishcoin Crab",
+    setCode = "M21",
+    collectorNumber = "86",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/348955a0-e988-48d7-a6a0-a8045fcffd25.jpg?1783930713",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/ArenaNewPlayerExperienceSet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/ArenaNewPlayerExperienceSet.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.oana
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Arena New Player Experience Cards (2018)
+ *
+ * MTG Arena's original new-player tutorial set; the earliest printing of a handful of simple creatures.
+ * Scaffolded here as the canonical home for cards whose earliest real printing is
+ * OANA. Intentionally incomplete relative to the official set — only cards
+ * relocated here as their canonical earliest printing live in this package.
+ *
+ * Set Code: OANA
+ * Release Date: 2018-07-14
+ */
+object ArenaNewPlayerExperienceSet : MtgSet {
+
+    override val code = "OANA"
+    override val displayName = "Arena New Player Experience Cards"
+    override val releaseDate = "2018-07-14"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.oana.cards"
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/cards/SanctuaryCat.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/cards/SanctuaryCat.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.oana.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sanctuary Cat reprint in OANA.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * DKA's `cards/` package (the card's earliest real printing). This file
+ * contributes only the OANA-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SanctuaryCatReprint = Printing(
+    oracleId = "c623bc4b-7fc1-4bc1-84e9-71c301dd402f",
+    name = "Sanctuary Cat",
+    setCode = "OANA",
+    collectorNumber = "8",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/a/f/af79c8fb-9189-48c2-a7b8-a1097dbaf138.jpg?1783934411",
+    releaseDate = "2018-07-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/cards/ShrineKeeper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/cards/ShrineKeeper.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.oana.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shrine Keeper
+ * {W}{W}
+ * Creature — Human Cleric
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val ShrineKeeper = card("Shrine Keeper") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Craig J Spearing"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74f04961-c42e-41fb-a770-62c7d3d2b83a.jpg?1783934410"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/cards/TreetopWarden.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/oana/cards/TreetopWarden.kt
@@ -1,0 +1,27 @@
+package com.wingedsheep.mtg.sets.definitions.oana.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Treetop Warden
+ * {1}{G}
+ * Creature — Elf Warrior
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val TreetopWarden = card("Treetop Warden") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Warrior"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Colin Boyer"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/771341f5-11b2-4edc-aa41-088e852c058e.jpg?1783934405"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/CanalMonitor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/CanalMonitor.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canal Monitor
+ * {4}{B}
+ * Creature — Lizard
+ * 5/3
+ *
+ * Vanilla — no rules text.
+ */
+val CanalMonitor = card("Canal Monitor") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Lizard"
+    power = 5
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Zezhou Chen"
+        flavorText = "The first goblin tried to swim the canal. The second built a raft. The last and craftiest goblin launched herself from a firecannon and soared over the canal, trailing smoke. All were eaten, but only one was cooked."
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78226edc-87dd-4c38-987c-52aefe0f9531.jpg?1783935316"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/OrazcaFrillback.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/OrazcaFrillback.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Orazca Frillback
+ * {2}{G}
+ * Creature — Dinosaur
+ * 4/2
+ *
+ * Vanilla — no rules text.
+ */
+val OrazcaFrillback = card("Orazca Frillback") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 4
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Simon Dominic"
+        flavorText = "The frillbacks of Orazca soak up the sun on their tall spinal fins. They look slow and sleepy—until they catch the scent of prey."
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/00c81160-192c-4077-8ed1-3643919a2025.jpg?1783935284"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/OrazcaRaptor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/OrazcaRaptor.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Orazca Raptor
+ * {2}{R}{R}
+ * Creature — Dinosaur
+ * 3/4
+ *
+ * Vanilla — no rules text.
+ */
+val OrazcaRaptor = card("Orazca Raptor") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur"
+    power = 3
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "108"
+        artist = "Jakub Kasper"
+        flavorText = "\"If you come across a raptor in the city, stay perfectly still. At least then you'll be well rested when you die.\"\n—Captain Brandis Thorn"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7080f86-0a9f-4471-a52b-0d44d19e6e59.jpg?1783935296"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/RaptorCompanion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/RaptorCompanion.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raptor Companion reprint in RIX.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (types, P/T) lives in
+ * XLN's `cards/` package (the card's earliest real printing). This file
+ * contributes only the RIX-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val RaptorCompanionReprint = Printing(
+    oracleId = "20e65887-c68c-4dc0-b74b-9ce093f40b06",
+    name = "Raptor Companion",
+    setCode = "RIX",
+    collectorNumber = "19",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e16f2ffb-2780-47d2-bcdf-9cef82716b20.jpg?1783935335",
+    releaseDate = "2018-01-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/SwornGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/SwornGuardian.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sworn Guardian
+ * {1}{U}
+ * Creature — Merfolk Warrior
+ * 1/3
+ *
+ * Vanilla — no rules text.
+ */
+val SwornGuardian = card("Sworn Guardian") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Warrior"
+    power = 1
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "58"
+        artist = "Sara Winters"
+        flavorText = "For the River Heralds, the Immortal Sun is an object of terror and devastation. The idea that anyone would retrieve it for their own use is utterly abhorrent."
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/6452ba94-6bb0-409c-99f7-71e6457c3f2a.jpg?1783935317"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AxebaneBeast.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/AxebaneBeast.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Axebane Beast
+ * {3}{G}
+ * Creature — Beast
+ * 3/4
+ *
+ * Vanilla — no rules text.
+ */
+val AxebaneBeast = card("Axebane Beast") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 3
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "121"
+        artist = "Sam Rowan"
+        flavorText = "\"Imagine a gigantic pine cone that's extremely territorial and always in a foul mood.\"\n—Zhosmir, urban huntmaster"
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f420b35-1f73-41c8-a15f-1aee4af0999c.jpg?1783933673"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/CatacombCrocodile.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/CatacombCrocodile.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Catacomb Crocodile
+ * {4}{B}
+ * Creature — Crocodile
+ * 3/7
+ *
+ * Vanilla — no rules text.
+ */
+val CatacombCrocodile = card("Catacomb Crocodile") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Crocodile"
+    power = 3
+    toughness = 7
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "67"
+        artist = "Nils Hamm"
+        flavorText = "\"I am sewer-king!\" said Rat. \"I am quick and cunning and I know every tunnel.\"\n\"No, I am king!\" said Zombie. \"I am cold and deadly and no rot can harm me.\"\nThen Croc came and ate them both."
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/440c53f0-7922-4e14-802d-d7a22f8fed85.jpg?1783933696"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/CoralCommando.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/CoralCommando.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Coral Commando
+ * {2}{U}
+ * Creature — Merfolk Warrior
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val CoralCommando = card("Coral Commando") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Warrior"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Alex Konstad"
+        flavorText = "Few Ravnicans are aware of the vast reefs in their world's hidden ocean. Far beneath the great sinkholes, where the light is blue and dim, merfolk tend the coral labyrinths that feed the benthic ecosystem."
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/889cc2a0-d9a6-4368-92e0-055a7d7bf9d1.jpg?1783933710"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FeralMaaka.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/FeralMaaka.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Feral Maaka
+ * {1}{R}
+ * Creature — Cat
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val FeralMaaka = card("Feral Maaka") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Cat"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Jonathan Kuo"
+        flavorText = "\"Lost are the lush meadows and verdant forests, where maaka prowled and lammasu soared. Lost are the wilds, where our hearts were free.\"\n—Daiva, Gruul storyteller"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c969aa0-b0e5-42cd-abba-0a3c7266142c.jpg?1783933682"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ProwlingCaracal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/ProwlingCaracal.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prowling Caracal
+ * {1}{W}
+ * Creature — Cat
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val ProwlingCaracal = card("Prowling Caracal") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "17"
+        artist = "Jonathan Kuo"
+        flavorText = "A hunter in the city requires the utmost cunning to survive. It must pounce only if the kill is certain, and leave the remains where no one will see."
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5382fc4-3384-449e-a83f-43a59158d55b.jpg?1783933719"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/AgelessGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/AgelessGuardian.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ageless Guardian
+ * {1}{W}
+ * Creature — Spirit Soldier
+ * 1/4
+ *
+ * Vanilla — no rules text.
+ */
+val AgelessGuardian = card("Ageless Guardian") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Soldier"
+    power = 1
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Nicholas Gregory"
+        flavorText = "Ancient ruins dot the world of Arcavios, most older than Strixhaven itself and many still guarded by soldiers from the Blood Age, centuries after their deaths."
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a5ff6af-402f-4bf6-a75b-dc1e0e40aff6.jpg?1783927397"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SpinedKarok.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/SpinedKarok.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spined Karok
+ * {2}{G}
+ * Creature — Crocodile
+ * 2/4
+ *
+ * Vanilla — no rules text.
+ */
+val SpinedKarok = card("Spined Karok") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Crocodile"
+    power = 2
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Filip Burburan"
+        flavorText = "\"The bogs are deeper than you realize. Most of the space beneath the surface is taken up by these enormous karoks. You might think your feet are touching the bottom. They're probably not.\"\n—Gyome, Witherbloom chef"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c37ae6b5-225a-410e-ab22-13e923bdfb65.jpg?1783927338"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornBrute.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornBrute.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nyxborn Brute
+ * {3}{R}{R}
+ * Enchantment Creature — Cyclops
+ * 7/3
+ *
+ * Vanilla — no rules text.
+ */
+val NyxbornBrute = card("Nyxborn Brute") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment Creature — Cyclops"
+    power = 7
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Zoltan Boros"
+        flavorText = "\"One-eyed and frightful, the cyclops\nlifted a boulder and hurled it\nseaward from cliff's edge, shattering\nmasts and scattering sailors.\"\n—*The Callapheia*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/05bc4236-566f-401b-b9d7-f58126fa228b.jpg?1783931550"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornColossus.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornColossus.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nyxborn Colossus
+ * {3}{G}{G}{G}
+ * Enchantment Creature — Giant
+ * 6/7
+ *
+ * Vanilla — no rules text.
+ */
+val NyxbornColossus = card("Nyxborn Colossus") {
+    manaCost = "{3}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment Creature — Giant"
+    power = 6
+    toughness = 7
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "191"
+        artist = "Mathias Kollros"
+        flavorText = "\"Tree-tall giants confronted her, fiercely demanding her tribute;\nFox-cunning Callaphe's slippery speaking entangled their senses...\"\n—*The Callapheia*"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b4f003c-1e99-4e53-ad6d-81ff3c592b2c.jpg?1783931531"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornCourser.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornCourser.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nyxborn Courser
+ * {1}{W}{W}
+ * Enchantment Creature — Centaur Scout
+ * 2/4
+ *
+ * Vanilla — no rules text.
+ */
+val NyxbornCourser = card("Nyxborn Courser") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment Creature — Centaur Scout"
+    power = 2
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Bastien L. Deharme"
+        flavorText = "\"Storms drove them westward to Ketaphos; wide plains shimmered in starlight.\nCentaurs greeted them, offering gold-hued apples and grain-cakes.\"\n—*The Callapheia*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0fd32240-c003-4e18-adf1-e2e992c702b1.jpg?1783931593"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornMarauder.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornMarauder.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nyxborn Marauder
+ * {2}{B}{B}
+ * Enchantment Creature — Minotaur
+ * 4/3
+ *
+ * Vanilla — no rules text.
+ */
+val NyxbornMarauder = card("Nyxborn Marauder") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment Creature — Minotaur"
+    power = 4
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "109"
+        artist = "Steve Prescott"
+        flavorText = "\"Callaphe guided them into the\ndarkness of Hetos, the bleak mire;\nBlood-horned minotaurs circled them,\naxes aglimmer in shadow.\"\n—*The Callapheia*"
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd2a923a-1f9c-4a29-9c6b-344ae4d5ae8f.jpg?1783931562"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornSeaguard.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/NyxbornSeaguard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nyxborn Seaguard
+ * {2}{U}{U}
+ * Enchantment Creature — Merfolk Soldier
+ * 2/5
+ *
+ * Vanilla — no rules text.
+ */
+val NyxbornSeaguard = card("Nyxborn Seaguard") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Merfolk Soldier"
+    power = 2
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Simon Dominic"
+        flavorText = "\"Storm-tossed and broken, Callaphe cried out to deep-dwelling Thassa.\nTritons came swiftly to save her, bringing her north to the Lindus.\"\n—*The Callapheia*"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9ad0c7d7-0e44-496f-a2fc-fafc604cb1f1.jpg?1783931581"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/IroncladKrovod.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/IroncladKrovod.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ironclad Krovod
+ * {3}{W}
+ * Creature — Beast
+ * 2/5
+ *
+ * Vanilla — no rules text.
+ */
+val IroncladKrovod = card("Ironclad Krovod") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Sam Rowan"
+        flavorText = "\"We need to block the exits from the plaza! What's big, heavy, and available?\"\n—Gideon Jura"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afb16895-6542-405e-9793-154ffc439f23.jpg?1783933481"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/LazotepBehemoth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/LazotepBehemoth.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lazotep Behemoth
+ * {4}{B}
+ * Creature — Zombie Hippo
+ * 5/4
+ *
+ * Vanilla — no rules text.
+ */
+val LazotepBehemoth = card("Lazotep Behemoth") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Hippo"
+    power = 5
+    toughness = 4
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Zezhou Chen"
+        flavorText = "\"I know I should be more concerned. But a big, blue zombie-potamus from beyond the stars? This is what they're invading us with?\"\n—Mileva, Boros legionnaire"
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b4be6f22-e9e8-462a-956b-e1c78bbadacc.jpg?1783933444"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/NagaEternal.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/NagaEternal.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Naga Eternal
+ * {2}{U}
+ * Creature — Zombie Snake
+ * 3/2
+ *
+ * Vanilla — no rules text.
+ */
+val NagaEternal = card("Naga Eternal") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Snake"
+    power = 3
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Johann Bodin"
+        flavorText = "\"I recognize that headdress. This one was feared even by her fellow initiates.\"\n—Samut"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f244233-f2e8-48f8-9106-e7cd186efd51.jpg?1783933461"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/AncientBrontodon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/AncientBrontodon.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ancient Brontodon
+ * {6}{G}{G}
+ * Creature — Dinosaur
+ * 9/9
+ *
+ * Vanilla — no rules text.
+ */
+val AncientBrontodon = card("Ancient Brontodon") {
+    manaCost = "{6}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 9
+    toughness = 9
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "175"
+        artist = "Jakub Kasper"
+        flavorText = "It is taller than all but the tallest trees, and older than all but the oldest."
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39421ce8-86d5-4739-b6fd-78d63c0bb258.jpg?1783935731"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/FrenziedRaptor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/FrenziedRaptor.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frenzied Raptor
+ * {2}{R}
+ * Creature — Dinosaur
+ * 4/2
+ *
+ * Vanilla — no rules text.
+ */
+val FrenziedRaptor = card("Frenzied Raptor") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur"
+    power = 4
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Jesper Ejsing"
+        flavorText = "Sun Empire warriors are taught to emulate the fearless raptors that fling themselves against towers of horn and muscle a hundred times their size."
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a7c3a1c9-ffa2-4990-aa4b-db9d688f1ed4.jpg?1783935745"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GildedSentinel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/GildedSentinel.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gilded Sentinel
+ * {4}
+ * Artifact Creature — Golem
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val GildedSentinel = card("Gilded Sentinel") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "239"
+        artist = "Izzy"
+        flavorText = "The River Heralds fight to keep all others from reaching the golden city. The city has its own defenses."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01cc1a59-76bf-4721-b4a7-ef746f3d3990.jpg?1783935702"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/HeadwaterSentries.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/HeadwaterSentries.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Headwater Sentries
+ * {3}{U}
+ * Creature — Merfolk Warrior
+ * 2/5
+ *
+ * Vanilla — no rules text.
+ */
+val HeadwaterSentries = card("Headwater Sentries") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Warrior"
+    power = 2
+    toughness = 5
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "58"
+        artist = "Naomi Baker"
+        flavorText = "\"The elders say that if the intruders discovered the secret of the golden city, it would mean an end to our people.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2af2c338-f5e9-4596-9435-c6aa965ae541.jpg?1783935781"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/LoomingAltisaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/LoomingAltisaur.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Looming Altisaur
+ * {3}{W}
+ * Creature — Dinosaur
+ * 1/7
+ *
+ * Vanilla — no rules text.
+ */
+val LoomingAltisaur = card("Looming Altisaur") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur"
+    power = 1
+    toughness = 7
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Lars Grant-West"
+        flavorText = "Nature can't be tamed, but the Sun Empire believes that humans are made stronger when they test themselves against the wild strength of the dinosaurs."
+        imageUri = "https://cards.scryfall.io/normal/front/c/f/cfcff1c6-0db6-4ff6-b4af-d7048b426368.jpg?1783935797"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/QueensBaySoldier.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/QueensBaySoldier.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Queen's Bay Soldier
+ * {1}{B}
+ * Creature — Vampire Soldier
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val QueensBaySoldier = card("Queen's Bay Soldier") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Soldier"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Jesper Ejsing"
+        flavorText = "The soldiers of the Legion of Dusk have come to the colonies at Queen's Bay in search of glory and riches. They are veterans of centuries of warfare, and they thirst for conquest."
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce2ca2e6-f920-4529-88d2-d984bdb7490a.jpg?1783935757"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RaptorCompanion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RaptorCompanion.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raptor Companion
+ * {1}{W}
+ * Creature — Dinosaur
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val RaptorCompanion = card("Raptor Companion") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "31"
+        artist = "Slawomir Maniak"
+        flavorText = "A raptor will follow any order as long as that order is \"hunt,\" \"kill,\" or \"go for the guts.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d37fc42-0a7c-46b3-9270-333d370e479f.jpg?1783935794"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/CliffhavenSellSword.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/CliffhavenSellSword.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cliffhaven Sell-Sword
+ * {1}{W}
+ * Creature — Kor Warrior
+ * 3/1
+ *
+ * Vanilla — no rules text.
+ */
+val CliffhavenSellSword = card("Cliffhaven Sell-Sword") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kor Warrior"
+    power = 3
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Jason Rainville"
+        flavorText = "\"I swing a sword. It's a simple life. A lot of adventurers just see me as some cheap muscle, but if my steel lets them return home with their lives and limbs intact, then I've done my job.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f334767-4353-4379-a934-fa67075db439.jpg?1783929421"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/MurasaBrute.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/MurasaBrute.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Murasa Brute
+ * {2}{G}
+ * Creature — Troll Warrior
+ * 3/3
+ *
+ * Vanilla — no rules text.
+ */
+val MurasaBrute = card("Murasa Brute") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Troll Warrior"
+    power = 3
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Caio Monteiro"
+        flavorText = "Some adventuring parties are made up of old friends, their common bonds bolstering them in the face of peril. Other parties simply hire the biggest, meanest muscle they can find."
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efe1c5b2-4356-41ae-ab7e-ad9fc835a911.jpg?1783929336"
+    }
+}

--- a/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/YargleAndMultani.kt
+++ b/mtg-sets/2023/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mom/cards/YargleAndMultani.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.mom.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yargle and Multani
+ * {3}{B}{B}{G}
+ * Legendary Creature — Frog Spirit Elemental
+ * 18/6
+ *
+ * Vanilla — no rules text.
+ */
+val YargleAndMultani = card("Yargle and Multani") {
+    manaCost = "{3}{B}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Frog Spirit Elemental"
+    power = 18
+    toughness = 6
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "256"
+        artist = "Slawomir Maniak"
+        flavorText = "\"I've heard much about you from my daughter,\" Multani rumbled. \"There was a time when I'd balk at your aid, phantom, but she has shown me the merit in Urborg's strange ways.\"\n\"Gnshhagghkkapphribbit,\" replied Yargle."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c15e244-14cc-46a5-abd4-66a58d1c0dd0.jpg?1783916936"
+    }
+}

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/AvatarTheLastAirbenderEternalSet.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/AvatarTheLastAirbenderEternalSet.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.tle
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Avatar: The Last Airbender Eternal (2025)
+ *
+ * The Eternal companion product to Avatar: The Last Airbender.
+ * Scaffolded here as the canonical home for cards whose earliest real printing is
+ * TLE. Intentionally incomplete relative to the official set — only cards
+ * relocated here as their canonical earliest printing live in this package.
+ *
+ * Set Code: TLE
+ * Release Date: 2025-11-21
+ */
+object AvatarTheLastAirbenderEternalSet : MtgSet {
+
+    override val code = "TLE"
+    override val displayName = "Avatar: The Last Airbender Eternal"
+    override val releaseDate = "2025-11-21"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.tle.cards"
+}

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/CapitalGuard.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/CapitalGuard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Capital Guard
+ * {1}{R}
+ * Creature — Human Soldier
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val CapitalGuard = card("Capital Guard") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "234"
+        artist = "Nathaniel Himawan"
+        flavorText = "Fire Nation guards rely more on fear than fire."
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/91cbed11-3b5c-4e7a-9b13-125c1fe5f22f.jpg?1783904780"
+    }
+}

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/KyoshiWarriorGuard.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/KyoshiWarriorGuard.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kyoshi Warrior Guard
+ * {1}{W}
+ * Creature — Human Warrior Ally
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val KyoshiWarriorGuard = card("Kyoshi Warrior Guard") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Warrior Ally"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Yunomachi"
+        flavorText = "Kyoshi Warrior drills are designed to encourage individual discipline as well as uncompromising trust in their fellow warriors."
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a2acb28-c0e2-492b-a227-ef49e905e0fb.jpg?1783904787"
+    }
+}

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/WarshipScout.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tle/cards/WarshipScout.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.tle.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Warship Scout
+ * {R}
+ * Creature — Human Scout
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val WarshipScout = card("Warship Scout") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Scout"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "244"
+        artist = "Brandon L. Hunt"
+        flavorText = "\"For the glory of the Fire Nation!\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1a95982-be16-465a-9c1b-1f4d875c0c40.jpg?1783904777"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/MarvelSuperHeroesCommanderSet.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/MarvelSuperHeroesCommanderSet.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.msc
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Marvel Super Heroes Commander (2026)
+ *
+ * The Marvel Super Heroes Universes Beyond Commander decks.
+ * Scaffolded here as the canonical home for cards whose earliest real printing is
+ * MSC. Intentionally incomplete relative to the official set — only cards
+ * relocated here as their canonical earliest printing live in this package.
+ *
+ * Set Code: MSC
+ * Release Date: 2026-06-26
+ */
+object MarvelSuperHeroesCommanderSet : MtgSet {
+
+    override val code = "MSC"
+    override val displayName = "Marvel Super Heroes Commander"
+    override val releaseDate = "2026-06-26"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.msc.cards"
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/BlackWidowNatashaRomanoff.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/BlackWidowNatashaRomanoff.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Black Widow, Natasha Romanoff
+ * {1}{R}
+ * Legendary Creature — Human Assassin Hero
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val BlackWidowNatashaRomanoff = card("Black Widow, Natasha Romanoff") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Assassin Hero"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "846"
+        artist = "Julia Vasilyeva"
+        flavorText = "\"They tell me now that I'm an Avenger I can't kill anyone. You want to put that to the test?\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/f/2f3e2f33-9c31-4107-b9b4-a7e1d2d43bab.jpg?1783902994"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/HappyHoganDauntlessDriver.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/msc/cards/HappyHoganDauntlessDriver.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.msc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Happy Hogan, Dauntless Driver
+ * {R}
+ * Legendary Creature — Human Pilot
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val HappyHoganDauntlessDriver = card("Happy Hogan, Dauntless Driver") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Pilot"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "545"
+        artist = "Ivan Shavrin"
+        flavorText = "\"Traffic is a little heavy this morning, Tony, but we'll get you there on time.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/4174e5fa-8e28-41c5-ba5c-4ec27b7cd4a3.jpg?1783903100"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/trc/StarTrekCommanderSet.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/trc/StarTrekCommanderSet.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.trc
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Star Trek Commander (2026)
+ *
+ * The Star Trek Universes Beyond Commander decks.
+ * Scaffolded here as the canonical home for cards whose earliest real printing is
+ * TRC. Intentionally incomplete relative to the official set — only cards
+ * relocated here as their canonical earliest printing live in this package.
+ *
+ * Set Code: TRC
+ * Release Date: 2026-01-23
+ */
+object StarTrekCommanderSet : MtgSet {
+
+    override val code = "TRC"
+    override val displayName = "Star Trek Commander"
+    override val releaseDate = "2026-01-23"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.trc.cards"
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/trc/cards/DefenseForceAggressor.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/trc/cards/DefenseForceAggressor.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.trc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Defense Force Aggressor
+ * {R}
+ * Creature — Klingon Warrior
+ * 2/1
+ *
+ * Vanilla — no rules text.
+ */
+val DefenseForceAggressor = card("Defense Force Aggressor") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Klingon Warrior"
+    power = 2
+    toughness = 1
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Josu Hernaiz"
+        flavorText = "\"You play games with death, little warrior. I like it!\"\n—Captain Ma'ah"
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67380a35-1a15-4c45-8a24-3c6077af85db.jpg?1785981114"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/trc/cards/StarfleetCrew.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/trc/cards/StarfleetCrew.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.trc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Starfleet Crew
+ * {1}{W}
+ * Creature — Officer
+ * 2/3
+ *
+ * Vanilla — no rules text.
+ */
+val StarfleetCrew = card("Starfleet Crew") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Officer"
+    power = 2
+    toughness = 3
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "139"
+        artist = "Runa I. Rosenberger"
+        flavorText = "\"The first duty of every Starfleet officer is to the truth, whether it's scientific truth, or historical truth, or personal truth. It is the guiding principle on which Starfleet is based.\"\n—Captain Jean-Luc Picard"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ecf2358f-542d-45c9-b5c5-c57b2b0c1122.jpg?1785981010"
+    }
+}

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/trc/cards/WarshipFlightCrew.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/trc/cards/WarshipFlightCrew.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.mtg.sets.definitions.trc.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Warship Flight Crew
+ * {1}{R}
+ * Creature — Klingon Pilot
+ * 2/2
+ *
+ * Vanilla — no rules text.
+ */
+val WarshipFlightCrew = card("Warship Flight Crew") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Klingon Pilot"
+    power = 2
+    toughness = 2
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Johann Bodin"
+        flavorText = "Opponents write off Klingons as unthinking brutes at their own peril. When the Klingon Empire developed warp drive, humanity still relied on horse-drawn carts."
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b6d130a-60f7-410a-b45f-ad81dd203c8c.jpg?1785981141"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AER.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AER.json
@@ -1,3 +1,23 @@
+// Bastion Enforcer
+{
+    "name": "Bastion Enforcer",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Dwarf Soldier",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Matt Stewart",
+        "flavorText": "Headquartered at the Bastion of the Honorable, the Consulate's enforcers are charged with the impossible task of keeping the peace.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88b9c0f7-d49b-4d74-9038-44954054ce21.jpg?1783936782"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Druid of the Cowl
 {
     "name": "Druid of the Cowl",
@@ -30,6 +50,26 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Lathnu Sailback
+{
+    "name": "Lathnu Sailback",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Lizard",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Christopher Burdett",
+        "flavorText": "Travelers to Lathnu, high on the Devra Cliffs, need not fear the political strife of Ghirapur . . . but they have other dangers to worry about.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33998799-f31b-4522-93b2-0c34c570ebf7.jpg?1783936752"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -93,6 +133,24 @@
                 "text": "Creatures of the chosen type that enter the battlefield at the same time as Metallic Mimic won't enter with an additional +1/+1 counter."
             }
         ]
+    },
+    "colorIdentityOverride": []
+}
+
+// Prizefighter Construct
+{
+    "name": "Prizefighter Construct",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Construct",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "artist": "Daniel Ljunggren",
+        "flavorText": "The Scrappers, an underground group with a passion for automaton brawls, had renegade leanings even before the Consulate's crackdown. It didn't take long for them to lend their best brawlers to the conflict.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e389c92-b54b-46b3-a7ab-b8a5a2a7d380.jpg?1783936720"
     },
     "colorIdentityOverride": []
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -1,3 +1,23 @@
+// Colossapede
+{
+    "name": "Colossapede",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Insect",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Jason Kang",
+        "flavorText": "\"If it is bigger, you must be faster. If it is stronger, you must be sharper. Anything less, and you will never seize a place in our God-Pharaoh's perfect afterlife.\"\n—Rhonas, god of strength",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/7642bfc5-ace8-419e-b57b-2b881bfe023e.jpg?1783936478"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Doomed Dissenter
 {
     "name": "Doomed Dissenter",
@@ -37,6 +57,26 @@
         "artist": "Tony Foti",
         "flavorText": "There is only one fate left to those banished from the God-Pharaoh's city.",
         "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1c0b645-de43-46d0-84c1-03f295def217.jpg?1783936508"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dune Beetle
+{
+    "name": "Dune Beetle",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Insect",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Grzegorz Rutkowski",
+        "flavorText": "The scouring sands of Shefet polish its carapace, and the ranks of the cursed fill its belly.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/923cb904-c725-4d57-bc17-7aa87a7cd8e0.jpg?1783936506"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -123,6 +163,26 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Hyena Pack
+{
+    "name": "Hyena Pack",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Hyena",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Winona Nelson",
+        "flavorText": "With carrion a rarity in the Broken Lands, the hyenas that stalk the deserts hunt in packs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9fa8351-567e-4ef4-8346-c58e50c778a6.jpg?1783936487"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -247,6 +307,26 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Those Who Serve
+{
+    "name": "Those Who Serve",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Zombie",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"The dead perform all the work here—farming, building, teaching, even embalming their fellow mummies. The living need do nothing but train. What system could be more perfect?\"\n—Temmet, vizier of Naktamun",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4f27dd9-7ee4-4cdc-8f65-a4349b6aa47f.jpg?1783936530"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -1,3 +1,23 @@
+// Cylian Elf
+{
+    "name": "Cylian Elf",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Scout",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Steve Prescott",
+        "flavorText": "From her sunsail tent high above the forest floor, an elf harkener can hear the footfalls of a single creature through the cacophony of Naya's jungle sounds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3afaab6-4768-4852-a0b6-4e6a0295bde7.jpg?1783942555"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Death Baron
 {
     "name": "Death Baron",
@@ -132,6 +152,26 @@
     ]
 }
 
+// Dreg Reaver
+{
+    "name": "Dreg Reaver",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Zombie Beast",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Thomas M. Baxa",
+        "flavorText": "\"On our thirty-fourth day of digging, we unearthed a chamber that contained the intact remains of several species long extinct from Grixis. One in particular should make a fine siege engine . . . .\"\n—Last notes of Shungus Nod, fleshcrafter",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e7771eba-bc2d-40f2-bab4-5e9cc4fe8f34.jpg?1783942567"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Elvish Visionary
 {
     "name": "Elvish Visionary",
@@ -167,6 +207,69 @@
         "imageUri": "https://cards.scryfall.io/normal/front/f/a/faccfa5f-4d89-4a86-92d7-36cb5a16c5c9.jpg"
     },
     "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Incurable Ogre
+{
+    "name": "Incurable Ogre",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Ogre Mutant",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Carl Critchlow",
+        "flavorText": "Each mutation causes the incurables to look vastly different from one another. They are left with only one thing in common: their insatiable lust for the slaughter.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5ad3381e-ae2f-40cf-8a7b-62375e9f453e.jpg?1783942560"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Jhessian Lookout
+{
+    "name": "Jhessian Lookout",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Scout",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "artist": "Donato Giancola",
+        "flavorText": "She stands ready, always watchful, knowing that weeks of peace and serenity can be overturned by a single distant sail.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f55b1b92-575e-4b6f-9179-21d0bc1acd11.jpg?1783942574"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Woolly Thoctar
+{
+    "name": "Woolly Thoctar",
+    "manaCost": "{R}{G}{W}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "flavorText": "One of the most ferocious and deadly gargantuans, the thoctar never sees its worshippers, but it often awakens surrounded by gifts and sacrifices.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7d5907d5-ae5c-4c9d-a5df-61f1c94f979d.jpg?1783942536"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED",
         "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ANB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ANB.json
@@ -1,0 +1,18 @@
+// Shorecomber Crab
+{
+    "name": "Shorecomber Crab",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Crab",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "32a",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0d899e1-bded-4e16-8ecc-cc07784af4bb.jpg?1783929831"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ARB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARB.json
@@ -1,3 +1,24 @@
+// Grizzled Leotau
+{
+    "name": "Grizzled Leotau",
+    "manaCost": "{G}{W}",
+    "typeLine": "Creature — Cat",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Lars Grant-West",
+        "flavorText": "\"There is no glory in a death of age, as even the leotau know. As winter steals into their coats, they seek the deadliest lands, that they may die as they lived.\"\n—Aarsil the Blessed",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2b388381-9e13-4ce7-b5b3-56a74cc23d93.jpg?1783942427"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Maelstrom Pulse
 {
     "name": "Maelstrom Pulse",
@@ -62,6 +83,27 @@
     },
     "colorIdentityOverride": [
         "BLACK",
+        "GREEN"
+    ]
+}
+
+// Rhox Brute
+{
+    "name": "Rhox Brute",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Creature — Rhino Warrior",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Raymond Swanland",
+        "flavorText": "\"In this new world, I have seen the once-devout rhoxes take up arms with the savages of Jund. I would be offended, but I see the wisdom in their choice.\"\n—Gernan, Dawnray archer",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/237de286-5bf0-4c8e-8504-2d01d3133b55.jpg?1783942429"
+    },
+    "colorIdentityOverride": [
+        "RED",
         "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -1766,6 +1766,46 @@
     ]
 }
 
+// Nettle Swine
+{
+    "name": "Nettle Swine",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Boar",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"I killed one and found bricks and bones in its belly. It had eaten a whole cottage, thatch and all.\"\n—Paulin, Somberwald trapper",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75935f0e-9086-485b-b3e6-1a958fd0f2af.jpg?1783940664"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Raging Poltergeist
+{
+    "name": "Raging Poltergeist",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Spirit",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "artist": "Slawomir Maniak",
+        "flavorText": "Some tried cremating their dead to stop the ghoulcallers. But the dead returned, furious about their fate.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78833788-ffb2-43fc-9345-975f1cd46f38.jpg?1783940678"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Reforge the Soul
 {
     "name": "Reforge the Soul",
@@ -1833,6 +1873,26 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Renegade Demon
+{
+    "name": "Renegade Demon",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "\"Have you ever cornered a wounded vampire? That's a walk in the cathedral garden in comparison.\"\n—Tristen, Cathar Marshal",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/395696f8-9be2-4925-852f-b783850e1ca2.jpg?1783940692"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -2381,6 +2441,27 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Vorstclaw
+{
+    "name": "Vorstclaw",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Elemental Horror",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "UNCOMMON",
+        "artist": "Lucas Graciano",
+        "flavorText": "\"Where'd the werewolves go? Maybe *that* got hungry.\"\n—Halana of Ulvenwald",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/7591ee4f-9bfe-4419-84df-abf35d85bb94.jpg?1783940659"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
@@ -86,6 +86,26 @@
     ]
 }
 
+// Broodhunter Wurm
+{
+    "name": "Broodhunter Wurm",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Svetlin Velinov",
+        "flavorText": "The native creatures of Zendikar have adapted to live under rocks and crawl through underbrush in order to avoid the most voracious predators. The Eldrazi have yet to make such adjustments.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c11c852d-9c7c-4d9b-8e79-70ea5ac865df.jpg?1783938188"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cinder Glade
 {
     "name": "Cinder Glade",
@@ -122,6 +142,27 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Expedition Envoy
+{
+    "name": "Expedition Envoy",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Scout Ally",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "rarity": "UNCOMMON",
+        "artist": "David Palumbo",
+        "flavorText": "The unofficial motto of every expedition house is \"ready for anything,\" a phrase whose significance has been amplified since the emergence of the Eldrazi.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/41193ef1-1619-4448-9905-26b05079c79a.jpg?1783938221"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/BNG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BNG.json
@@ -1,3 +1,63 @@
+// Cyclops of One-Eyed Pass
+{
+    "name": "Cyclops of One-Eyed Pass",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Cyclops",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "artist": "Kev Walker",
+        "flavorText": "The Champion armed herself to face the cyclops, heedless of her companions' despair. \"How will you defeat it with only one spear?\" asked young Althemone. The Champion raised her weapon. \"It has but one eye.\"\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71a25c69-8e57-4a44-955a-da1541bbe0fe.jpg?1783939550"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Great Hart
+{
+    "name": "Great Hart",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Elk",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Christopher Moeller",
+        "flavorText": "The great hart stood like a statue, its hide painted gold by the dawn. The Champion laid down her weapons and stepped forward within an arm's length of the beast. The hart, sacred to Heliod and bathed in the god's own light, bowed to the Champion, marking her as the Chosen of the Sun God.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70cd7d2b-e9c4-4900-89a0-f6eb0c6cb22b.jpg?1783939581"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Swordwise Centaur
+{
+    "name": "Swordwise Centaur",
+    "manaCost": "{G}{G}",
+    "typeLine": "Creature — Centaur Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Slawomir Maniak",
+        "flavorText": "The girl who would become the Champion of the Sun hacked furiously at the practice dummy. At last she stopped, breathing heavily, and looked up at her instructor. \"So much anger,\" said the centaur. \"I will teach you the ways of war, child. But first you must make peace with yourself.\"\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/7/1776ebd7-91fc-49e1-a978-f2012162d1cf.jpg?1783939527"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Temple of Enlightenment
 {
     "name": "Temple of Enlightenment",

--- a/mtg-sets/src/test/resources/snapshots/cards/BOK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BOK.json
@@ -1,0 +1,39 @@
+// Frost Ogre
+{
+    "name": "Frost Ogre",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Ogre Warrior",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Mountain ogres allowed blizzards to sheathe them in ice, both to reinforce their armor and to hide their pungent musk from potential prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a91e5f1-9179-4763-b7c9-b7ad5451f6d0.jpg?1783944191"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Gnarled Mass
+{
+    "name": "Gnarled Mass",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Creature — Spirit",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Tony Szczudlo",
+        "flavorText": "\"On the fifty-seventh day of the Battle of Silk, the bell again tolled in hopes of summoning mortal aid. This time, a new breed of kami rose to answer its call.\"\n—*Great Battles of Kamigawa*",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c28728d-4839-4cdf-91d4-b9fb4b5d0449.jpg?1783944185"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/CON_.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CON_.json
@@ -71,6 +71,26 @@
     "colorIdentityOverride": []
 }
 
+// Canyon Minotaur
+{
+    "name": "Canyon Minotaur",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Minotaur Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Steve Prescott",
+        "flavorText": "On Jund, the deep canyons were the best places to hide. When the goblins wandered into Naya, they found that was not so true.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b200790-43c7-42ae-9edf-89c8198a385b.jpg?1783942480"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Exotic Orchard
 {
     "name": "Exotic Orchard",
@@ -102,6 +122,31 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/a/6aae6480-4e71-4d94-a648-f80d3849d792.jpg?1562801539"
     },
     "colorIdentityOverride": []
+}
+
+// Fusion Elemental
+{
+    "name": "Fusion Elemental",
+    "manaCost": "{W}{U}{B}{R}{G}",
+    "typeLine": "Creature — Elemental",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "rarity": "UNCOMMON",
+        "artist": "Michael Komarck",
+        "flavorText": "As the shards merged into the Maelstrom, their mana energies fused into new monstrosities.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6712dbd-ee54-4fb7-93ab-64f8f07350f1.jpg?1783942469"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
 }
 
 // Progenitus
@@ -237,4 +282,24 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/6/568df642-3ad7-401c-a133-edb56970c3a1.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Valiant Guard
+{
+    "name": "Valiant Guard",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Chris Rahn",
+        "flavorText": "As the outsiders invaded Bant, soldiers who once saw sigils as the highest marks of glory began to see the scars of battle as tokens of equal worth.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83ec1486-900b-4763-9b5b-390cb00aff02.jpg?1783942490"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/CSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CSP.json
@@ -110,6 +110,26 @@
     ]
 }
 
+// Krovikan Scoundrel
+{
+    "name": "Krovikan Scoundrel",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Rogue",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "artist": "Ralph Horsley",
+        "flavorText": "The few surviving humans of Krov would have welcomed the return of winter and its sterilizing cold. They often peered northward, hoping that the snow's edge had reached their infested city-tomb.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd9f046c-b416-4d80-8998-047b98361352.jpg?1783943348"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Zur the Enchanter
 {
     "name": "Zur the Enchanter",

--- a/mtg-sets/src/test/resources/snapshots/cards/DGM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DGM.json
@@ -1,3 +1,44 @@
+// Armored Wolf-Rider
+{
+    "name": "Armored Wolf-Rider",
+    "manaCost": "{3}{G}{W}",
+    "typeLine": "Creature — Elf Knight",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Matt Stewart",
+        "flavorText": "Wolf-riders of Selesnya apprentice from a young age. Each rider raises a wolf pup from birth to serve as a mount, hoping that one day the two will share the honor of guarding the Great Concourse.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e43d959f-6055-4578-a69a-0ec93e993e21.jpg?1783940033"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
+// Bane Alley Blackguard
+{
+    "name": "Bane Alley Blackguard",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Rogue",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "artist": "Mike Bierek",
+        "flavorText": "\"I'm in the field of procurement, and business is good. The guilds want all kinds of maps and relics these days, though what they want them for I'm not quite sure.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/15fcad03-4567-4f96-976e-01a07d8ab050.jpg?1783940040"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Maze's End
 {
     "name": "Maze's End",

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -748,6 +748,26 @@
     "colorIdentityOverride": []
 }
 
+// Hollowhenge Beast
+{
+    "name": "Hollowhenge Beast",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Dave Kendall",
+        "flavorText": "In a world of monsters, it's the stuff of nightmares.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/052ab91f-ac01-43f4-9276-9af35dbfbf71.jpg?1783940805"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Huntmaster of the Fells
 {
     "name": "Huntmaster of the Fells",
@@ -1213,6 +1233,46 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Russet Wolves
+{
+    "name": "Russet Wolves",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Wolf",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"The wolves of our valley are bred to detest the scent of ghouls. For centuries they have kept our estates clear of such carrion.\"\n—Olivia Voldaren",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3c7c972-5a11-4709-b3ef-e2acb3b51dd9.jpg?1783940814"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sanctuary Cat
+{
+    "name": "Sanctuary Cat",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Cat",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "David Palumbo",
+        "flavorText": "Cats prowl the corridors of Avacyn's churches in search of devils or signs of their mischief.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96865440-01ad-40f2-90d7-9ecd0b4efecc.jpg?1783940850"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/DRK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DRK.json
@@ -103,6 +103,26 @@
     "colorIdentityOverride": []
 }
 
+// Goblin Hero
+{
+    "name": "Goblin Hero",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Mark Tedin",
+        "flavorText": "They attacked in an orgy of rage and madness, but only one seemed as focused on killing us as on the sheer joy of battle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/7135a569-e5d3-4a1f-924b-bdb86926b4e1.jpg?1783947934"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Inferno
 {
     "name": "Inferno",
@@ -160,6 +180,27 @@
     ]
 }
 
+// Scarwood Goblins
+{
+    "name": "Scarwood Goblins",
+    "manaCost": "{R}{G}",
+    "typeLine": "Creature — Goblin",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Ron Spencer",
+        "flavorText": "Larger and more cunning than most Goblins, Scarwood Goblins are thankfully found only in isolated pockets.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/5542d236-af43-43b8-b30f-8980d74bbdd0.jpg?1783947928"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Skull of Orm
 {
     "name": "Skull of Orm",
@@ -212,4 +253,24 @@
         "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa1d9bb5-972a-4705-bf22-0fa1e974dd26.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Squire
+{
+    "name": "Squire",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Dennis Detwiller",
+        "flavorText": "\"Of twenty yeer of age he was, I gesse.\nOf his stature he was of even lengthe,\nAnd wonderly deliver, and greete of strengthe.\"\n—Geoffrey Chaucer, *The Canterbury Tales*",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/374df061-ebd2-4f1f-9a6e-7940a49197a9.jpg?1783947948"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/DTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DTK.json
@@ -771,3 +771,23 @@
         "RED"
     ]
 }
+
+// Wandering Tombshell
+{
+    "name": "Wandering Tombshell",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie Turtle",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "The crumbling temples on the tortoise's back are monuments to the decadence of the ancient Sultai. Though it harkens back to the era of the khans, Silumgar allows it to walk his territory as a warning to those who would oppose him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e66e1d97-d676-471a-a140-deb39600a7a9.jpg?1783938592"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -2058,6 +2058,44 @@
     ]
 }
 
+// Falkenrath Reaver
+{
+    "name": "Falkenrath Reaver",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Vampire",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Daarken",
+        "flavorText": "\"Each day there are new reports of homes along Getander Pass and Hofsaddel falling to vampires of a more savage nature. I've even heard tell that Anje Falkenrath has returned. Please send whatever help you can.\"\n—Sterin Gorn, letter to Thalia",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd2023b3-5999-44b1-a67f-3f2a76cb2d14.jpg?1783937462"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Field Creeper
+{
+    "name": "Field Creeper",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Anthony Palumbo",
+        "flavorText": "As it walks across the fallow field, its awkward, loping gait matches the rattling in its head to create a haunting rhythm that chills the bones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b92b162-f51d-4138-8d9b-e5eb929ad87e.jpg?1783937424"
+    },
+    "colorIdentityOverride": []
+}
+
 // Furyblade Vampire
 {
     "name": "Furyblade Vampire",

--- a/mtg-sets/src/test/resources/snapshots/cards/FEM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FEM.json
@@ -57,3 +57,23 @@
         "WHITE"
     ]
 }
+
+// Vodalian Soldiers
+{
+    "name": "Vodalian Soldiers",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Soldier",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "31a",
+        "artist": "Melissa A. Benson",
+        "flavorText": "\"Vodalian Soldiers had some unique advantages. Often they would ride into battle on war machines rumored to have come from the far northern oceans.\"\n—*Sarpadian Empires, vol. V*",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7eb50256-9113-4b03-bcef-9aea24be8493.jpg?1783947907"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FRF.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FRF.json
@@ -1,3 +1,23 @@
+// Feral Krushok
+{
+    "name": "Feral Krushok",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Kev Walker",
+        "flavorText": "In a stunning act of diplomacy, Yasova Dragonclaw ceded a portion of Temur lands to the Sultai. Her clan protested until they saw she had given the Sultai the breeding grounds of the krushoks. They hadn't realized she had a sense of humor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/5041996b-c265-4c4f-a52c-dfe29b2e282d.jpg?1783938681"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Flamewake Phoenix
 {
     "name": "Flamewake Phoenix",
@@ -59,6 +79,46 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Gore Swine
+{
+    "name": "Gore Swine",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Boar",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "artist": "Jack Wang",
+        "flavorText": "\"The Mardu are like the gore swine. We are wild, hunt in packs, and rarely clean the blood from our blades.\"\n—Vallash, Mardu warrior",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31c36d53-1173-4a55-8fb8-63a624fde7de.jpg?1783938688"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Great-Horn Krushok
+{
+    "name": "Great-Horn Krushok",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "artist": "YW Tang",
+        "flavorText": "Perfectly suited for life in the Shifting Wastes, the krushok is well protected by its horn, its hide, and its temper.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/122e08cb-407b-4b3d-8af0-077ff96bf160.jpg?1783938713"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/FUT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FUT.json
@@ -1,3 +1,60 @@
+// Blade of the Sixth Pride
+{
+    "name": "Blade of the Sixth Pride",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Rebel",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Justin Sweet",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f6ccfe28-ec08-4751-b65c-c40b2bafa955.jpg?1783943127"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Blind Phantasm
+{
+    "name": "Blind Phantasm",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Illusion",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Khang Le",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b26ee7b-de1a-4a39-9580-89941c3d0f21.jpg?1783943118"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Fomori Nomad
+{
+    "name": "Fomori Nomad",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Nomad Giant",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Raymond Swanland",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/8216b3f3-b9b6-4d90-a624-c1b9b7bdf953.jpg?1783943103"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Mass of Ghouls
 {
     "name": "Mass of Ghouls",
@@ -14,6 +71,25 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Nessian Courser
+{
+    "name": "Nessian Courser",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Centaur Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Vance Kovacs",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88b18b70-f656-4426-a3e5-69cf61fdaad1.jpg?1783943095"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/GRN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GRN.json
@@ -196,6 +196,46 @@
     ]
 }
 
+// Douser of Lights
+{
+    "name": "Douser of Lights",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Horror",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Darek Zabrocki",
+        "flavorText": "The party of Rakdos revelers cackled and capered as the thing approached. It hissed, and they jabbed their torches at it, giggling when it recoiled. Then, one by one, the torches went out—and the screaming began.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c554be7-6fd4-4642-aaa0-2781d9c388e4.jpg?1783934175"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Fearless Halberdier
+{
+    "name": "Fearless Halberdier",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Suzanne Helmigh",
+        "flavorText": "\"I spent some time in the Legion, but I'm done taking orders all day.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/30e04f16-89d0-4e75-a3cd-4dd64414050c.jpg?1783934164"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Healer's Hawk
 {
     "name": "Healer's Hawk",
@@ -391,5 +431,45 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Wild Ceratok
+{
+    "name": "Wild Ceratok",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Rhino",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Once part of a wealthy merchant's private zoo, the herd roams feral throughout the Tenth, where it will remain until the guilds can agree to relocate, cull, or befriend it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/4464e11a-c5b9-40ea-8be0-dab29d14e289.jpg?1783934143"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wishcoin Crab
+{
+    "name": "Wishcoin Crab",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Crab",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "James Paick",
+        "flavorText": "\"What wishes do they grant? Mostly pinching-related ones.\"\n—Omik, superintendent of waterworks",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/6580d6a2-ee21-4442-9842-18c65a172f49.jpg?1783934181"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/GS1.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GS1.json
@@ -39,3 +39,63 @@
         "WHITE"
     ]
 }
+
+// Armored Whirl Turtle
+{
+    "name": "Armored Whirl Turtle",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Turtle",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Tingting Yeh",
+        "flavorText": "Not all enormous beasts are quick to anger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fcc87fdf-6473-4b91-a8b9-2986e57dc071.jpg?1783934633"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Ferocious Zheng
+{
+    "name": "Ferocious Zheng",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Cat Beast",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Yutaka Li",
+        "flavorText": "Known for their glowing horn and stone-rattling roar, zheng are the fiercest predators in the forest. Few survived before Jiang Yanggu came.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a6d1184-15e0-4b41-ba2d-4f68e91c61d4.jpg?1783934626"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Leopard-Spotted Jiao
+{
+    "name": "Leopard-Spotted Jiao",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Shinchuen Chen",
+        "flavorText": "This strange beast has the hide of a leopard, the howl of a dog, and the horns of an ox.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/91df110f-85d2-41cb-96b6-6c79cebfada7.jpg?1783934627"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/GTC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GTC.json
@@ -478,6 +478,26 @@
     ]
 }
 
+// Gutter Skulk
+{
+    "name": "Gutter Skulk",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Rat",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "artist": "Mark Winters",
+        "flavorText": "Upon finding his warehouse infested, Gaven didn't know whether to get an exterminator or an exorcist.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/830c7c77-20c4-429f-88c7-b85ab7a0e38b.jpg?1783940131"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Ivy Lane Denizen
 {
     "name": "Ivy Lane Denizen",
@@ -664,6 +684,27 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Ruination Wurm
+{
+    "name": "Ruination Wurm",
+    "manaCost": "{4}{R}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Dave Kendall",
+        "flavorText": "When the architects of Ravnica claim a structure will stand against a wurm, they never mention for how long.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce04d1ee-2605-472d-b3ee-24800342e9af.jpg?1783940101"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/HML.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HML.json
@@ -135,6 +135,26 @@
     ]
 }
 
+// Dwarven Trader
+{
+    "name": "Dwarven Trader",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Dwarf",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "72a",
+        "artist": "Margaret Organ-Kean",
+        "flavorText": "\"Their definition of 'fair profit' is certainly novel.\"\n—Reveka, Wizard Savant",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4db9aa47-f42b-41e9-948c-8b012c3809fb.jpg?1783947283"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Merchant Scroll
 {
     "name": "Merchant Scroll",

--- a/mtg-sets/src/test/resources/snapshots/cards/HOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOU.json
@@ -112,6 +112,46 @@
     ]
 }
 
+// Defiant Khenra
+{
+    "name": "Defiant Khenra",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Jackal Warrior",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "David Palumbo",
+        "flavorText": "There were those who saw the death of the gods and the city's collapse as a final test of worth. Some believed it meant the God-Pharaoh had been killed. Only a few realized they had been deceived.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67e3983d-b1ed-46a9-9ab0-96c4d0d77050.jpg?1783936030"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Dutiful Servants
+{
+    "name": "Dutiful Servants",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Zombie",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Volkan Baǵa",
+        "flavorText": "Buildings crumbled and monuments fell. The river bled and the sky wept tears of fire. All the while, servants silently continued their work, oblivious to it all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/7684db4c-6eff-4da1-a410-48d707fb5bf1.jpg?1783936063"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Firebrand Archer
 {
     "name": "Firebrand Archer",
@@ -157,5 +197,25 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Harrier Naga
+{
+    "name": "Harrier Naga",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Snake Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Filip Burburan",
+        "flavorText": "She trusts that the potent poisons of her darts will reach the enemy before the enemy reaches her.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bcdc68c9-f5f3-4c5b-80df-85508cf15f84.jpg?1783936019"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ICE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ICE.json
@@ -105,6 +105,26 @@
     ]
 }
 
+// Balduvian Bears
+{
+    "name": "Balduvian Bears",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Bear",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "artist": "Quinton Hoover",
+        "flavorText": "\"They're a hardy bunch, but I'd still bet that they just slept through the worst of the cold times.\"\n—Disa the Restless, journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef5297cb-e763-4871-9cd3-0e2dbcc52095.jpg?1783947481"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Brainstorm
 {
     "name": "Brainstorm",
@@ -615,6 +635,26 @@
     ]
 }
 
+// Scaled Wurm
+{
+    "name": "Scaled Wurm",
+    "manaCost": "{7}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "262",
+        "artist": "Daniel Gelon",
+        "flavorText": "\"Flourishing during the Ice Age, these Wurms were the bane of all Kjeldorans. Their great size and ferocity made them the subject of countless nightmares—they embodied the worst of the Ice Age.\"\n—*Kjeldor: Ice Civilization*",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/499cd7fa-c86c-4a5f-b36d-8160e8a6af1f.jpg?1783947472"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Sulfurous Springs
 {
     "name": "Sulfurous Springs",
@@ -698,6 +738,26 @@
     },
     "colorIdentityOverride": [
         "BLACK",
+        "RED"
+    ]
+}
+
+// Tor Giant
+{
+    "name": "Tor Giant",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Giant",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "artist": "Douglas Shuler",
+        "flavorText": "\"What do you do then? Run. Run very fast. Don't stop until you see the camp—or a bigger Giant.\"\n—Toothlicker Harj, Orcish Captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7ef8f279-1a10-4685-99d6-bc971a7f922b.jpg?1783947482"
+    },
+    "colorIdentityOverride": [
         "RED"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/IKO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/IKO.json
@@ -18,6 +18,46 @@
     ]
 }
 
+// Gloom Pangolin
+{
+    "name": "Gloom Pangolin",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Nightmare Pangolin",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "YW Tang",
+        "flavorText": "\"They say it survives on a purely bioluminescent diet. It's only active during the darkest of Indatha nights, making verification highly challenging.\"\n—Gannet, Skysail zoologist",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f135dd7-2a4f-4c83-9a90-76bcab3cc33d.jpg?1783931061"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Savai Sabertooth
+{
+    "name": "Savai Sabertooth",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Ilse Gort",
+        "flavorText": "The giant tigers of Savai prefer to hunt at daybreak, when the crystals' warning glow is masked by the light of dawn.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d46702b0-7e10-462a-9aac-7564efe91804.jpg?1783931085"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Voracious Greatshark
 {
     "name": "Voracious Greatshark",

--- a/mtg-sets/src/test/resources/snapshots/cards/JOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JOU.json
@@ -203,6 +203,66 @@
     "colorIdentityOverride": []
 }
 
+// Oreskos Swiftclaw
+{
+    "name": "Oreskos Swiftclaw",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "James Ryman",
+        "flavorText": "After the Battle of Pharagax Bridge, the Champion spent many months among the leonin of Oreskos. She found that they were quick to take offense, not because they were thin-skinned, but because they were always eager for a fight.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03c67b91-7f05-44b1-9e99-3e2094434f6a.jpg?1783939456"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Pensive Minotaur
+{
+    "name": "Pensive Minotaur",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Minotaur Warrior",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Svetlin Velinov",
+        "flavorText": "The Champion and her companions marched through the night, but the battle was over before they arrived. In the middle of the carnage sat a solitary minotaur, lost in what seemed to the Champion to be thought.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/902b462a-a552-42d4-91f0-bd33cd9cb719.jpg?1783939421"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Rotted Hulk
+{
+    "name": "Rotted Hulk",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Elemental",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "artist": "Raymond Swanland",
+        "flavorText": "The hulk rose from the sea and loomed over the Champion. Pinned beneath the twisting, rotted planks of wood was the body of Kaliaros, the helmsman of her former crew, and beside him the captain, Photine.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/1066644a-ac62-4809-805c-607c645613c5.jpg?1783939431"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Temple of Epiphany
 {
     "name": "Temple of Epiphany",

--- a/mtg-sets/src/test/resources/snapshots/cards/KHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KHM.json
@@ -243,6 +243,26 @@
     "colorIdentityOverride": []
 }
 
+// Grizzled Outrider
+{
+    "name": "Grizzled Outrider",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "artist": "Cristi Balanescu",
+        "flavorText": "\"Sure, a horse might be faster. But I'd like to see a horse take the head clean off a troll in one swipe!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a1d4473-5317-4bdd-9cb9-93670acf52e9.jpg?1783928213"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Immersturm Predator
 {
     "name": "Immersturm Predator",

--- a/mtg-sets/src/test/resources/snapshots/cards/KLD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KLD.json
@@ -378,6 +378,26 @@
     ]
 }
 
+// Cowl Prowler
+{
+    "name": "Cowl Prowler",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "Consulate guards who pursue fleeing renegades into the Cowl often become lost—occasionally permanently—in the city's wildest greenbelt.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a1b25f4-f50c-4210-a03f-080a5e4e5708.jpg?1783937183"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cultivator's Caravan
 {
     "name": "Cultivator's Caravan",
@@ -416,6 +436,26 @@
         "imageUri": "https://cards.scryfall.io/normal/front/b/4/b46b3726-4bc8-4e3a-bc6d-402c81663712.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Curio Vendor
+{
+    "name": "Curio Vendor",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Vedalken",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"Step right up! Try your hand! It'll thrill the senses and boggle the mind!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c598054a-26fa-40e7-8497-3da8eaf12aac.jpg?1783937222"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Filigree Familiar
@@ -651,6 +691,26 @@
     ]
 }
 
+// Prakhata Club Security
+{
+    "name": "Prakhata Club Security",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Aetherborn Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "artist": "Igor Kieryluk",
+        "flavorText": "It's rare that the Prakhata Club closes its doors. It's also rare that Lord Gonti meets with Consul Kambal. What are the odds the two would occur on the same day?",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c32b73ce-cb25-4104-bccd-6b6a131790a9.jpg?1783937200"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Spirebluff Canal
 {
     "name": "Spirebluff Canal",
@@ -717,6 +777,66 @@
     },
     "colorIdentityOverride": [
         "BLUE",
+        "RED"
+    ]
+}
+
+// Tasseled Dromedary
+{
+    "name": "Tasseled Dromedary",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Camel",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Raoul Vitale",
+        "flavorText": "There is no dress code for the Inventors' Fair, but you'll be hard-pressed to find anyone or anything not done up in their finest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cef3bf2-55cf-4f42-9ec0-fa921ef22311.jpg?1783937227"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Terrain Elemental
+{
+    "name": "Terrain Elemental",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elemental",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "272",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"You tread upon the land all the time, yet you seem dismayed when it moves to step on you.\"\n—Nissa Revane",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32b89e5c-ffb4-406f-99d1-ec2797aca061.jpg?1783937136"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Terror of the Fairgrounds
+{
+    "name": "Terror of the Fairgrounds",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Gremlin",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Filip Burburan",
+        "flavorText": "\"Consider this a high alert, people. Permission to destroy on sight. Either we take it down or it'll take down the Fair.\"\n—Pav, gremlin watch",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04623df9-8fa9-44cc-b528-c2c484626d1f.jpg?1783937185"
+    },
+    "colorIdentityOverride": [
         "RED"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/LEG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEG.json
@@ -1,3 +1,45 @@
+// Barbary Apes
+{
+    "name": "Barbary Apes",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Ape",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "artist": "Bryon Wackwitz",
+        "flavorText": "Unpredictable in the extreme, these carnivorous apes will prey even upon their own kind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df25ffdd-995d-46ae-856b-f6368f9438ed.jpg?1783948049"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Barktooth Warbeard
+{
+    "name": "Barktooth Warbeard",
+    "manaCost": "{4}{B}{R}{R}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "UNCOMMON",
+        "artist": "Andi Rusu",
+        "flavorText": "He is devious and cunning, in both appearance and deed. Beware the Warbeard, for this brute bites as well as he barks!",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0ea52228-f8ad-4623-9e05-f162473bfc03.jpg?1783948041"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Boomerang
 {
     "name": "Boomerang",
@@ -31,6 +73,66 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Crimson Kobolds
+{
+    "name": "Crimson Kobolds",
+    "manaCost": "{0}",
+    "typeLine": "Creature — Kobold",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Anson Maddocks",
+        "flavorText": "\"Kobolds are harmless.\" —Bearand the Bold, epitaph",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13696657-aeef-4add-9a3b-8137fce01fe3.jpg?1783948057"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Crookshank Kobolds
+{
+    "name": "Crookshank Kobolds",
+    "manaCost": "{0}",
+    "typeLine": "Creature — Kobold",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "artist": "Christopher Rush",
+        "flavorText": "The Crookshank military boasts a standing army of nearly twenty-four million, give or take twenty-two million.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7af6b119-7db4-49dd-aaa4-044b8c133f13.jpg?1783948058"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Durkwood Boars
+{
+    "name": "Durkwood Boars",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Boar",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Mike Kimble",
+        "flavorText": "\"And the unclean spirits went out, and entered the swine; and the herd ran violently . . .\" —Mark 5:13",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d41f08b-68fb-45f2-bdc9-488baedc7d6f.jpg?1783948049"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -84,6 +186,26 @@
     ]
 }
 
+// Headless Horseman
+{
+    "name": "Headless Horseman",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie Knight",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Quinton Hoover",
+        "flavorText": "\". . . [T]he ghost rides forth to the scene of battle in nightly quest of his head . . . he sometimes passes along the Hollow, like a midnight blast . . .\"\n—Washington Irving, The Legend of Sleepy Hollow",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1aa37c8-98fa-4984-b09b-cf65ad84e97b.jpg?1783948066"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Holy Day
 {
     "name": "Holy Day",
@@ -106,6 +228,156 @@
     ]
 }
 
+// Jasmine Boreal
+{
+    "name": "Jasmine Boreal",
+    "manaCost": "{3}{G}{W}",
+    "typeLine": "Legendary Creature — Human",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Kane Ferguson",
+        "flavorText": "\"Peace must prevail, even if the wicked must die.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db6ef678-4ce9-48d6-aa4f-2afd9a1ad724.jpg?1783948038"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
+// Jedit Ojanen
+{
+    "name": "Jedit Ojanen",
+    "manaCost": "{4}{W}{W}{U}",
+    "typeLine": "Legendary Creature — Cat Warrior",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Poole",
+        "flavorText": "Mightiest of the Cat Warriors, Jedit Ojanen forsook the forests of his tribe and took service with the Robaran Mercenaries, rising through their ranks to lead them in the battle for Efrava.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/97b80124-2b59-425c-93cc-9b032e631c6e.jpg?1783948038"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Jerrard of the Closed Fist
+{
+    "name": "Jerrard of the Closed Fist",
+    "manaCost": "{3}{R}{G}{G}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "UNCOMMON",
+        "artist": "Andi Rusu",
+        "flavorText": "Once, the order of the Closed Fist reached throughout the Kb'Briann Highlands. Now, Jerrard alone remains to uphold their standard.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f841918-813b-4784-ab57-907185b0a355.jpg?1783948038"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Kasimir the Lone Wolf
+{
+    "name": "Kasimir the Lone Wolf",
+    "manaCost": "{4}{W}{U}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Kane Ferguson",
+        "flavorText": "Popular indeed is the tale of how Kasimir was once a Holy man who renounced his order to take up the sword. But this tale is no more likely than any other.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45b1e60d-54dd-41cd-b9a2-00890725a3df.jpg?1783948037"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Keepers of the Faith
+{
+    "name": "Keepers of the Faith",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Daniel Gelon",
+        "flavorText": "And then the Archangel Anthius spoke to them, saying, \"Fear shall be vanquished by the Sword of Faith.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b63a69ae-99ce-4d26-88b7-784793c43cd4.jpg?1783948083"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Kobolds of Kher Keep
+{
+    "name": "Kobolds of Kher Keep",
+    "manaCost": "{0}",
+    "typeLine": "Creature — Kobold",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "artist": "Julie Baroh",
+        "flavorText": "Kher Keep is unique among fortresses: impervious to aerial assault but defenseless from the ground.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df0320d9-7c2a-456a-9159-1b4fae67bfb5.jpg?1783948054"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lady Orca
+{
+    "name": "Lady Orca",
+    "manaCost": "{5}{B}{R}",
+    "typeLine": "Legendary Creature — Demon",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "UNCOMMON",
+        "artist": "Sandra Everingham",
+        "flavorText": "\"I do not remember what he said to her. I remember her fiery eyes, fixed upon him for an instant. I remember a flash, and the hot breath of sudden flames made me turn away. When I looked again, Angus was gone.\" —A Wayfarer, on meeting Lady Orca",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b2779553-74eb-42ba-97d0-96269f48c269.jpg?1783948036"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Moss Monster
 {
     "name": "Moss Monster",
@@ -123,6 +395,26 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Raging Bull
+{
+    "name": "Raging Bull",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Ox",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "artist": "Randy Asplund-Faith",
+        "flavorText": "\"Sometimes the bulls win, and sometimes the bears win. But the bulls have more fun.\"\n—Anonymous",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec10a51c-d2c3-4d14-9a71-9e59155bf980.jpg?1783948052"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -192,6 +484,116 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Sir Shandlar of Eberyn
+{
+    "name": "Sir Shandlar of Eberyn",
+    "manaCost": "{4}{G}{W}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 7
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "UNCOMMON",
+        "artist": "Andi Rusu",
+        "flavorText": "\"Remember Sir Shandlar! Remember and stand firm!\" —rallying cry of the Eberyn militia",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31570ded-f5e3-44c4-b95f-294ac10b2cd2.jpg?1783948033"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
+// Sivitri Scarzam
+{
+    "name": "Sivitri Scarzam",
+    "manaCost": "{5}{U}{B}",
+    "typeLine": "Legendary Creature — Human",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "UNCOMMON",
+        "artist": "NéNé Thomas",
+        "flavorText": "Even the brave have cause to tremble at the sight of Sivitri Scarzam. Who else has tamed Scarzam's Dragon?",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c12ee9e-db13-4b4d-a061-b6566f538f09.jpg?1783948032"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// The Lady of the Mountain
+{
+    "name": "The Lady of the Mountain",
+    "manaCost": "{4}{R}{G}",
+    "typeLine": "Legendary Creature — Giant",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "263",
+        "rarity": "UNCOMMON",
+        "artist": "Richard Kane Ferguson",
+        "flavorText": "Her given name has been lost in the mists of time. Legend says that her silent vigil will one day be ended by the one who, pure of heart and spirit, calls out that name again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83717eb2-220e-4086-be09-dee9174798b8.jpg?1783948032"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Tobias Andrion
+{
+    "name": "Tobias Andrion",
+    "manaCost": "{3}{W}{U}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "264",
+        "rarity": "UNCOMMON",
+        "artist": "Andi Rusu",
+        "flavorText": "Administrator of the military state of Sheoltun, Tobias is the military right arm of the empire and the figurehead of its freedom.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/cac56eda-5ed3-4abd-beec-f5063fbf930a.jpg?1783948031"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
+// Torsten Von Ursus
+{
+    "name": "Torsten Von Ursus",
+    "manaCost": "{3}{G}{G}{W}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Poole",
+        "flavorText": "\"How can you accuse me of evil? Though these deeds be unsavory, no one will argue: good shall follow from them.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5fd99522-4a91-4ccd-91bf-5f32a6ac3510.jpg?1783948031"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -1,3 +1,23 @@
+// Axegrinder Giant
+{
+    "name": "Axegrinder Giant",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "artist": "Warren Mahy",
+        "flavorText": "The angriest of giants are often the most skillful weaponsmiths. Their grudges fuel endless sessions at the forge, all the while growling ferociously to themselves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/8595e9a1-010e-48a7-91e4-3d2722c8dbc0.jpg?1783942880"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Crib Swap
 {
     "name": "Crib Swap",

--- a/mtg-sets/src/test/resources/snapshots/cards/M10.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M10.json
@@ -1,3 +1,44 @@
+// Centaur Courser
+{
+    "name": "Centaur Courser",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Centaur Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "artist": "Vance Kovacs",
+        "flavorText": "\"The centaurs are truly free. Never will they be tamed by temptation or controlled by fear. They live in total harmony, a feat not yet achieved by our kind.\"\n—Ramal, sage of Westgate",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/03354b67-7df2-4b4b-a996-a37550e58561.jpg?1783942365"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Elite Vanguard
+{
+    "name": "Elite Vanguard",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Tedin",
+        "flavorText": "The vanguard is skilled at waging war alone. The enemy is often defeated before its reinforcements reach the front.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6bda0b4b-ab5a-4d91-9dd1-7a5a145b67f5.jpg?1783942403"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Elvish Archdruid
 {
     "name": "Elvish Archdruid",
@@ -202,5 +243,105 @@
     "colorIdentityOverride": [
         "RED",
         "GREEN"
+    ]
+}
+
+// Runeclaw Bear
+{
+    "name": "Runeclaw Bear",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Bear",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Bears aren't always as strong and as mean as you imagine. Some are even stronger and meaner.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/268bd9d5-4da1-4cbf-83f9-47f7aac1cfc3.jpg?1783942358"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Siege Mastodon
+{
+    "name": "Siege Mastodon",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Elephant",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Matt Cavotta",
+        "flavorText": "\"Defending the citadel is easy. I just take these big fellows outside the main gate and let the enemy take a good long look.\"\n—Mastodon keeper",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/287d4c56-1b75-4ac4-8be8-333b1aba982a.jpg?1783942399"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Silvercoat Lion
+{
+    "name": "Silvercoat Lion",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Terese Nielsen",
+        "flavorText": "Hunters of every species on the savannah, silvercoats disdain camouflage in favor of total dominance of the food chain.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea82996f-a05f-4831-9bbd-3281ebca9a61.jpg?1783942398"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Warpath Ghoul
+{
+    "name": "Warpath Ghoul",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "rk post",
+        "flavorText": "The battle was over, but the carnage continued for days.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c6cc262-ba0c-4cca-ae9c-24a1824753e4.jpg?1783942377"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Zombie Goliath
+{
+    "name": "Zombie Goliath",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Zombie Giant",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "E. M. Gist",
+        "flavorText": "\"Phirax of Blood Ridge has sent a war giant at us? What, do I have to spell it out for you? Kill the giant, scoop out its skull, and drive it back to Blood Ridge. Honestly, what kind of necromancer minions are you?\"\n—Keren-Dur, necromancer lord",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc295834-af33-45ae-be4d-7a1987f85561.jpg?1783942376"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -35,6 +35,46 @@
     ]
 }
 
+// Armored Cancrix
+{
+    "name": "Armored Cancrix",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Crab",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Tomasz Jedruszek",
+        "flavorText": "Creatures displaced from time still turn up every year, stranded by the temporal disaster that once swept across Dominaria.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53ef0757-8eb0-4384-bf8e-9a7340144dfa.jpg?1783941828"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Barony Vampire
+{
+    "name": "Barony Vampire",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Daarken",
+        "flavorText": "\"Poor little sun-dweller out past curfew. And to think, you might have survived if it wasn't so close to suppertime.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88583170-7b0e-4c02-b270-4859ba05d82b.jpg?1783941820"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Captivating Vampire
 {
     "name": "Captivating Vampire",
@@ -280,4 +320,63 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Maritime Guard
+{
+    "name": "Maritime Guard",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Soldier",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Allen Williams",
+        "flavorText": "Once common in the Kapsho Seas, merfolk were hunted almost to extinction. They survived those dark days and emerged calculating and determined to endure.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f365d82a-88a3-403b-92a6-91c9ccb3421f.jpg?1783941824"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Nether Horror
+{
+    "name": "Nether Horror",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Horror",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "artist": "Allen Williams",
+        "flavorText": "\"My dreams darkened and seeped into my waking hours. Spellcraft and nightmare merged to create this monstrosity.\"\n—Sunniva, witch of Holm Hollow",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c217b672-c724-4fc2-936c-b3f0feaf6ea0.jpg?1783941813"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Stone Golem
+{
+    "name": "Stone Golem",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Golem",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Martina Pilcerova",
+        "flavorText": "The sculptor, like most artists, put his heart and soul in his work. But the newly awakened golem decided he wanted his creator's other, more tangible parts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/37d0876b-5026-4a0a-bf2f-e831593643a7.jpg?1783941788"
+    },
+    "colorIdentityOverride": []
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -39,6 +39,26 @@
     "colorIdentityOverride": []
 }
 
+// Amphin Cutthroat
+{
+    "name": "Amphin Cutthroat",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Salamander Rogue",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Howard Lyon",
+        "flavorText": "\"The amphin have long built their society in secret. While surface dwellers squabbled over trivial borders, they patiently expanded, building their ammonite temple-caves. Now amphin priests eye the shore, and amphin hunters gird for war.\"\n—Gor Muldrak, *Cryptohistories*",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd169064-9c7b-40bd-8be0-a89fcb28ae2f.jpg?1783941096"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Angelic Destiny
 {
     "name": "Angelic Destiny",
@@ -110,6 +130,46 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Armored Warhorse
+{
+    "name": "Armored Warhorse",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Horse",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "rk post",
+        "flavorText": "\"When we of the Northern Verge claim a mount, no peasant's nag will do. It must be as strong as our virtue, and must join us of its own will.\"\n—Sarlena, paladin of the Northern Verge",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52daf505-d436-4ea6-a157-4268af2ff7a8.jpg?1783941106"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Bonebreaker Giant
+{
+    "name": "Bonebreaker Giant",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Giant",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "Kev Walker",
+        "flavorText": "One thing's for sure—his fists are harder than your skull.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc17e5c1-a6b4-401b-95eb-1c01cd1da570.jpg?1783941073"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -66,6 +66,27 @@
     "colorIdentityOverride": []
 }
 
+// Kalonian Tusker
+{
+    "name": "Kalonian Tusker",
+    "manaCost": "{G}{G}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"And all this time I thought *we* were tracking *it*.\"\n—Juruk, Kalonian tracker",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/135946fc-fe67-401f-821d-d7145c63f030.jpg?1783939902"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mindsparker
 {
     "name": "Mindsparker",
@@ -134,6 +155,26 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Minotaur Abomination
+{
+    "name": "Minotaur Abomination",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Zombie Minotaur",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"Look at that. Shuffling, wobbling, entrails placed haphazardly. It's shameful. Who would let that kind of work flap about for all to see?\"\n—Lestin, necromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9dca75a1-443d-4f8e-b12b-2aada3a8e3e4.jpg?1783939921"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -232,6 +273,26 @@
     ]
 }
 
+// Regathan Firecat
+{
+    "name": "Regathan Firecat",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Elemental Cat",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "artist": "Eric Velhagen",
+        "flavorText": "It stalks the Regathan highlands, leaving behind melted snow, scorched earth, and the charred corpses of would-be temple robbers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b4df1dd-886d-4fe7-b3f7-2dca044de41c.jpg?1783939911"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Rise of the Dark Realms
 {
     "name": "Rise of the Dark Realms",
@@ -273,6 +334,44 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Rumbling Baloth
+{
+    "name": "Rumbling Baloth",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Jesper Ejsing",
+        "flavorText": "In the dim light beneath the vast trees of Deepglade, baloths prowl in search of prey. Their guttural calls are more felt than heard, but their attack scream carries for miles.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d8610ff1-064b-4c75-a8df-d3b076370d1e.jpg?1783939900"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sliver Construct
+{
+    "name": "Sliver Construct",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Sliver Construct",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "artist": "Mathias Kollros",
+        "flavorText": "Slivers destroy those who come close to the Skep, the central hive. Shards of torn metal litter the ground as a warning to any artificers inquisitive about the hive's inner workings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/3129645a-221c-4eb5-88fd-12cc742a1dfe.jpg?1783939893"
+    },
+    "colorIdentityOverride": []
 }
 
 // Sporemound
@@ -317,5 +416,25 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Undead Minotaur
+{
+    "name": "Undead Minotaur",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie Minotaur",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Karl Kopinski",
+        "flavorText": "\"The work that went into creating this magnificent specimen. Horrific, deadly, well-balanced. Not all necromancers do elegant work like this.\"\n—Lestin, necromancer",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e5ae910-ee1d-4958-92d9-0b06872913c6.jpg?1783939918"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M15.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M15.json
@@ -47,3 +47,23 @@
         "GREEN"
     ]
 }
+
+// Witch's Familiar
+{
+    "name": "Witch's Familiar",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Frog",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "artist": "Jack Wang",
+        "flavorText": "Some bog witches practice the strange art of batrachomancy, reading portents in the number, size, and color of warts on a toad's hide.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c9f3b3b-de16-4ae5-844e-1373e0f84469.jpg?1783939178"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -101,6 +101,26 @@
     ]
 }
 
+// Bogstomper
+{
+    "name": "Bogstomper",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Jason Felix",
+        "flavorText": "\"They are gentle herbivores, despite their size. Approach cautiously, and hum a tune to let them know you mean no harm.\"\n—Vivien Reid",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/05145a8d-0bfb-4f07-87cf-65875310bdb4.jpg?1783934576"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Diamond Mare
 {
     "name": "Diamond Mare",
@@ -528,6 +548,26 @@
     ]
 }
 
+// Loxodon Line Breaker
+{
+    "name": "Loxodon Line Breaker",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Elephant Soldier",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Loxodons are firm in stature and spirit. No matter the odds, they are always first into battle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/928d4250-c379-4134-a263-7811c80a8760.jpg?1783934603"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Meteor Golem
 {
     "name": "Meteor Golem",
@@ -615,6 +655,26 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Onakke Ogre
+{
+    "name": "Onakke Ogre",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Ogre Warrior",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Mathias Kollros",
+        "flavorText": "The ogres you know are nothing like the Onakke. Possessing both intellect and industry, they had brute strength without being brutish.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e016da6-8800-47b4-9b96-1887677c795c.jpg?1783934548"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -443,6 +443,26 @@
     ]
 }
 
+// Imperial Outrider
+{
+    "name": "Imperial Outrider",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "307",
+        "artist": "Scott Murphy",
+        "flavorText": "Her mount's hollow crest can produce a trumpeting warning that carries for miles, summoning more knights to her aid.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0dd3aca5-516f-4500-9d7f-95630401d3ae.jpg?1783932913"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Rapacious Dragon
 {
     "name": "Rapacious Dragon",

--- a/mtg-sets/src/test/resources/snapshots/cards/M21.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M21.json
@@ -1,3 +1,23 @@
+// Garruk's Gorehorn
+{
+    "name": "Garruk's Gorehorn",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"It certainly takes after its master: big and brutish, and you can smell it from a mile away.\"\n—Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/3928bbce-87b7-4b28-9af4-20362935c909.jpg?1783930677"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Garruk's Uprising
 {
     "name": "Garruk's Uprising",
@@ -493,6 +513,26 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Staunch Shieldmate
+{
+    "name": "Staunch Shieldmate",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Dwarf Soldier",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Bartłomiej Gaweł",
+        "flavorText": "\"Gilded with gold from a dragon's trove, it is! And etched with the image of the dragon I slew to take it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db17f25a-32d1-469b-bb5f-f1761e227990.jpg?1783930733"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/MBS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MBS.json
@@ -1,3 +1,21 @@
+// Hexplate Golem
+{
+    "name": "Hexplate Golem",
+    "manaCost": "{7}",
+    "typeLine": "Artifact Creature — Golem",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 7
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Matt Cavotta",
+        "flavorText": "\"Use everything. Iron, rust, scrap . . . even the ground must join our cause.\"\n—Ezuri, renegade leader",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/49b913f3-6581-45ae-9cdb-274c2ccd8899.jpg?1783941369"
+    },
+    "colorIdentityOverride": []
+}
+
 // Lumengrid Gargoyle
 {
     "name": "Lumengrid Gargoyle",
@@ -92,6 +110,47 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Ogre Resister
+{
+    "name": "Ogre Resister",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Ogre",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Efrem Palacios",
+        "flavorText": "He didn't have a word for \"home,\" but he knew it was something to be defended.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60b7407d-f677-403b-893c-361df456009a.jpg?1783941377"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Quilled Slagwurm
+{
+    "name": "Quilled Slagwurm",
+    "manaCost": "{4}{G}{G}{G}",
+    "typeLine": "Creature — Phyrexian Wurm",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Stewart",
+        "flavorText": "Vorinclex removed its teeth so it wouldn't waste time chewing before moving to the next kill.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12c597b9-5024-42bd-b500-5ef6a3accda6.jpg?1783941373"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
@@ -298,6 +298,26 @@
     ]
 }
 
+// Fresh Volunteers
+{
+    "name": "Fresh Volunteers",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Rebel",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Jeff Miracola",
+        "flavorText": "Every Cho-Arrim villager is a potential warrior; when they are called, they abandon their peaceful way of life and take up arms to defend it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e070ea4a-c417-405f-b788-78fb7ca2eaa5.jpg?1783945981"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Groundskeeper
 {
     "name": "Groundskeeper",
@@ -716,5 +736,25 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Wild Jhovall
+{
+    "name": "Wild Jhovall",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Cat",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "artist": "Daren Bader",
+        "flavorText": "Jhovalls sharpen their claws on trees—or on Mercadians, if no trees are handy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/64bcc06a-de86-4387-882d-ead33e9c9e01.jpg?1783945930"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/MOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOM.json
@@ -395,3 +395,25 @@
         "GREEN"
     ]
 }
+
+// Yargle and Multani
+{
+    "name": "Yargle and Multani",
+    "manaCost": "{3}{B}{B}{G}",
+    "typeLine": "Legendary Creature — Frog Spirit Elemental",
+    "creatureStats": {
+        "power": 18,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "256",
+        "rarity": "RARE",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"I've heard much about you from my daughter,\" Multani rumbled. \"There was a time when I'd balk at your aid, phantom, but she has shown me the merit in Urborg's strange ways.\"\n\"Gnshhagghkkapphribbit,\" replied Yargle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c15e244-14cc-46a5-abd4-66a58d1c0dd0.jpg?1783916936"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MOR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOR.json
@@ -34,6 +34,27 @@
     ]
 }
 
+// Indomitable Ancients
+{
+    "name": "Indomitable Ancients",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Treefolk Warrior",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 10
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "RARE",
+        "artist": "Pete Venters",
+        "flavorText": "\"Odum and Broadbark were the only beings mighty enough to challenge the giant Moran the Destroyer. Their battle lasted a hundred dawns, until Moran became so exhausted that he fell into namesleep. He awoke as Moran the Gardener.\"\n—*The Tale of Odum and Broadbark*",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/ddf33cb6-d159-4af3-8403-d0ac10af9894.jpg?1783942804"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Kindled Fury
 {
     "name": "Kindled Fury",

--- a/mtg-sets/src/test/resources/snapshots/cards/MSC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSC.json
@@ -1,0 +1,39 @@
+// Black Widow, Natasha Romanoff
+{
+    "name": "Black Widow, Natasha Romanoff",
+    "manaCost": "{1}{R}",
+    "typeLine": "Legendary Creature — Human Assassin Hero",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "846",
+        "artist": "Julia Vasilyeva",
+        "flavorText": "\"They tell me now that I'm an Avenger I can't kill anyone. You want to put that to the test?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f3e2f33-9c31-4107-b9b4-a7e1d2d43bab.jpg?1783902994"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Happy Hogan, Dauntless Driver
+{
+    "name": "Happy Hogan, Dauntless Driver",
+    "manaCost": "{R}",
+    "typeLine": "Legendary Creature — Human Pilot",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "545",
+        "artist": "Ivan Shavrin",
+        "flavorText": "\"Traffic is a little heavy this morning, Tony, but we'll get you there on time.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/4174e5fa-8e28-41c5-ba5c-4ec27b7cd4a3.jpg?1783903100"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/NPH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NPH.json
@@ -1,3 +1,63 @@
+// Flameborn Viron
+{
+    "name": "Flameborn Viron",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Phyrexian Insect",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Large or small, all will toil for the Great Work.\"\n—Decree of Urabrask",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/9601ea62-a609-4bc5-a2f0-f7615b4dd5fa.jpg?1783941308"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Loxodon Convert
+{
+    "name": "Loxodon Convert",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Phyrexian Elephant Soldier",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Adrian Smith",
+        "flavorText": "Just one drop of the glistening oil can eventually stain even a soul as stalwart as a loxodon's beyond redemption.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/00c050c3-4f50-4bb6-8477-6737887ca10d.jpg?1783941325"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Rotted Hystrix
+{
+    "name": "Rotted Hystrix",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Phyrexian Beast",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "artist": "Dave Allsop",
+        "flavorText": "Vorinclex had no grand plan. The oil did its own work, evolving creatures into worthy predators.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7bcae97d-468a-4e16-bfed-d2946f64784c.jpg?1783941299"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Torpor Orb
 {
     "name": "Torpor Orb",

--- a/mtg-sets/src/test/resources/snapshots/cards/OANA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OANA.json
@@ -1,0 +1,37 @@
+// Shrine Keeper
+{
+    "name": "Shrine Keeper",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Craig J Spearing",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74f04961-c42e-41fb-a770-62c7d3d2b83a.jpg?1783934410"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Treetop Warden
+{
+    "name": "Treetop Warden",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Warrior",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Colin Boyer",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/771341f5-11b2-4edc-aa41-088e852c058e.jpg?1783934405"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/OGW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OGW.json
@@ -1,3 +1,23 @@
+// Ancient Crab
+{
+    "name": "Ancient Crab",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Crab",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Steve Prescott",
+        "flavorText": "After the fall of Sea Gate and the draining of the Halimar basin, the crab set off to find a new home.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/783794e3-fe0c-4014-ae5a-6c249af23ddc.jpg?1783937919"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ayli, Eternal Pilgrim
 {
     "name": "Ayli, Eternal Pilgrim",
@@ -121,6 +141,26 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Canopy Gorger
+{
+    "name": "Canopy Gorger",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Lake Hurwitz",
+        "flavorText": "The settlement's defenders were glad to have such a massive, ferocious creature join the fight—but less glad to see it flatten their homes along the way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cbc8957d-769c-4630-9544-56cea8c847c2.jpg?1783937902"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/P02.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/P02.json
@@ -1,3 +1,23 @@
+// Alaborn Trooper
+{
+    "name": "Alaborn Trooper",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Lubov",
+        "flavorText": "\"I dedicate my body to my country And my life to my King.\"\n—Alaborn Soldier's Oath",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1cd30b4-4ed8-467e-808e-b0caf4196d90.jpg?1783946495"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Angel of Mercy
 {
     "name": "Angel of Mercy",
@@ -65,6 +85,26 @@
     ]
 }
 
+// Barbtooth Wurm
+{
+    "name": "Barbtooth Wurm",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Rebecca Guay",
+        "flavorText": "In its lair lies a carpet of bones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f627db9-c63e-4353-94f4-3e28db7b222a.jpg?1783946458"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Bear Cub
 {
     "name": "Bear Cub",
@@ -115,6 +155,46 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Dakmor Scorpion
+{
+    "name": "Dakmor Scorpion",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Scorpion",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Randy Gallegos",
+        "flavorText": "A scorpion this big you won't find curled up in your boot. Maybe *around* your boot, but not *in* it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d860dee-93a9-48e5-ba7a-80ad8cdc84e4.jpg?1783946477"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Goblin Cavaliers
+{
+    "name": "Goblin Cavaliers",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "DiTerlizzi",
+        "flavorText": "They get along so well with their goats because they're practically goats themselves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edc6ea02-0642-4fc5-b50c-543dc393bfdd.jpg?1783946467"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -190,6 +270,26 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Golden Bear
+{
+    "name": "Golden Bear",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Bear",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Una Fricker",
+        "flavorText": "The elvish scout was scrupulous about the truth. She told the traders that gold lay nearby.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7dfc789-7ea0-4eb8-8c3b-2c50fd52cbab.jpg?1783946455"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -282,6 +382,27 @@
     ]
 }
 
+// Obsidian Giant
+{
+    "name": "Obsidian Giant",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Giant",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "rarity": "UNCOMMON",
+        "artist": "David A. Cherry",
+        "flavorText": "After a while, ships stopped sailing within his reach.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aad8a194-cee7-4671-8310-19357fc1a450.jpg?1783946462"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ogre Taskmaster
 {
     "name": "Ogre Taskmaster",
@@ -306,6 +427,46 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Ogre Warrior
+{
+    "name": "Ogre Warrior",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Ogre Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "artist": "Jeff Miracola",
+        "flavorText": "Assault and battery included.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66e72970-df1f-4ded-a686-036008555a76.jpg?1783946462"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Plated Wurm
+{
+    "name": "Plated Wurm",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "artist": "Daniel Gelon",
+        "flavorText": "\"I'd hate to see the bird that could get *this* wurm!\"\n—Alaborn soldier",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b51f8724-8f26-4a9d-b586-4223354ae7fc.jpg?1783946449"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -454,6 +615,46 @@
     ]
 }
 
+// Talas Merchant
+{
+    "name": "Talas Merchant",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Lubov",
+        "flavorText": "The trader let loose a laugh that made all around him check their purses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f779d7e-6e37-49bc-b76d-3bb490ff142b.jpg?1783946482"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Trokin High Guard
+{
+    "name": "Trokin High Guard",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "artist": "Ron Spencer",
+        "flavorText": "Battle tempers soldiers as fire tempers steel.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c2b9302-fca6-43ca-a01c-03aec51acd0d.jpg?1783946490"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Vampiric Spirit
 {
     "name": "Vampiric Spirit",
@@ -494,6 +695,26 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Volunteer Militia
+{
+    "name": "Volunteer Militia",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Keith Parkinson",
+        "flavorText": "People fight hardest on their own soil.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de307b2e-9a1c-4f95-887f-14c9d99577aa.jpg?1783946489"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/PTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PTK.json
@@ -38,6 +38,26 @@
     ]
 }
 
+// Barbarian Horde
+{
+    "name": "Barbarian Horde",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Barbarian Soldier",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Kuang Sheng",
+        "flavorText": "Only twenty years after the Sima clan united the empire, invading barbarians divided it again.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1f930c2-e828-4566-b2df-3b054f311be5.jpg?1783946109"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Corrupt Court Official
 {
     "name": "Corrupt Court Official",
@@ -118,6 +138,66 @@
     ]
 }
 
+// Forest Bear
+{
+    "name": "Forest Bear",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Bear",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Wang Yuqun",
+        "flavorText": "Fish and bear paws—one can't have both.\n—Chinese idiom meaning \"you can't have it both ways\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fae9abc7-ecd3-4042-a5b0-5f2b24491fa6.jpg?1783946101"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Independent Troops
+{
+    "name": "Independent Troops",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Kuang Sheng",
+        "flavorText": "\"The empire, long united, must divide, and long divided, must unite.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff7a4769-7a64-4016-8db0-b56c6b98aff3.jpg?1783946106"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Meng Huo's Horde
+{
+    "name": "Meng Huo's Horde",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Li Tie",
+        "flavorText": "Through his allies, Meng Huo commanded several hundred thousand troops composed of cavalry, rattan-armored warriors, infantry, naked men with swords, and wild animals.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e1642802-055e-44d2-a261-c2a45ad515e8.jpg?1783946099"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Peach Garden Oath
 {
     "name": "Peach Garden Oath",
@@ -147,6 +227,66 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Shu Elite Infantry
+{
+    "name": "Shu Elite Infantry",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "Song Shikai",
+        "flavorText": "Kongming's first campaign against the Wei kingdom was a rousing success until an arrogant Shu general, Ma Su, foolishly lost the city of Jieting.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36bcd751-1142-4e72-9d87-7a25c74c038b.jpg?1783946128"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Shu Foot Soldiers
+{
+    "name": "Shu Foot Soldiers",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Xu Tan",
+        "flavorText": "Liu Bei lost many men at the battle of Runan because of his lack of strategy. It wasn't until he met Kongming that he began to truly succeed as a leader.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd4268d5-f27b-44a5-91f6-6c90521825fd.jpg?1783946127"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Southern Elephant
+{
+    "name": "Southern Elephant",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Elephant",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Wang Yuqun",
+        "flavorText": "While defending their southern borders, both the Wu and Shu kingdoms fought against the barbarians' trained elephants.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87e138c7-1166-4e20-b039-e94c1319ad42.jpg?1783946098"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -217,6 +357,26 @@
     ]
 }
 
+// Straw Soldiers
+{
+    "name": "Straw Soldiers",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Scarecrow Soldier",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Cai Tingting",
+        "flavorText": "The overnight appearance of miles of \"armed\" Wu forts at Guangling frightened a much vaster Wei force into fleeing for their lives.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8ae5ba21-eb8e-4663-bfd8-3e19a0c10774.jpg?1783946120"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Three Visits
 {
     "name": "Three Visits",
@@ -269,5 +429,65 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Trained Jackal
+{
+    "name": "Trained Jackal",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Jackal",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Yang Jun Kwon",
+        "flavorText": "To taunt a man into action, call him a coward. To insult him beyond forgiveness, call him a jackal.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/01deb3cc-91e8-4ef3-964f-f36c6a21207c.jpg?1783946096"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Wei Infantry
+{
+    "name": "Wei Infantry",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "artist": "LHQ",
+        "flavorText": "Wei won the battle of Hefei when Zhang Liao defeated Sun Quan and then foiled a Wu scheme to incite rebellion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72c6465f-3144-4faf-b248-a9fb941dc002.jpg?1783946112"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Wu Infantry
+{
+    "name": "Wu Infantry",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Xu Xiaoming",
+        "flavorText": "The first battle of Hefei was Sun Quan's last as a field general. From then on he let his generals command in the field while he directed battle from behind the front lines.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/ebe4115e-7ca3-4996-a390-133c2e6d09b7.jpg?1783946119"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/RIX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RIX.json
@@ -63,6 +63,26 @@
     ]
 }
 
+// Canal Monitor
+{
+    "name": "Canal Monitor",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Lizard",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Zezhou Chen",
+        "flavorText": "The first goblin tried to swim the canal. The second built a raft. The last and craftiest goblin launched herself from a firecannon and soared over the canal, trailing smoke. All were eaten, but only one was cooked.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78226edc-87dd-4c38-987c-52aefe0f9531.jpg?1783935316"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Fanatical Firebrand
 {
     "name": "Fanatical Firebrand",
@@ -331,6 +351,46 @@
     ]
 }
 
+// Orazca Frillback
+{
+    "name": "Orazca Frillback",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Simon Dominic",
+        "flavorText": "The frillbacks of Orazca soak up the sun on their tall spinal fins. They look slow and sleepy—until they catch the scent of prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/00c81160-192c-4077-8ed1-3643919a2025.jpg?1783935284"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Orazca Raptor
+{
+    "name": "Orazca Raptor",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Dinosaur",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "artist": "Jakub Kasper",
+        "flavorText": "\"If you come across a raptor in the city, stay perfectly still. At least then you'll be well rested when you die.\"\n—Captain Brandis Thorn",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b7080f86-0a9f-4471-a52b-0d44d19e6e59.jpg?1783935296"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Path of Discovery
 {
     "name": "Path of Discovery",
@@ -388,6 +448,26 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Sworn Guardian
+{
+    "name": "Sworn Guardian",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Warrior",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "artist": "Sara Winters",
+        "flavorText": "For the River Heralds, the Immortal Sun is an object of terror and devastation. The idea that anyone would retrieve it for their own use is utterly abhorrent.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/6452ba94-6bb0-409c-99f7-71e6457c3f2a.jpg?1783935317"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/RNA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RNA.json
@@ -46,6 +46,26 @@
     ]
 }
 
+// Axebane Beast
+{
+    "name": "Axebane Beast",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "artist": "Sam Rowan",
+        "flavorText": "\"Imagine a gigantic pine cone that's extremely territorial and always in a foul mood.\"\n—Zhosmir, urban huntmaster",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/f/2f420b35-1f73-41c8-a15f-1aee4af0999c.jpg?1783933673"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Biogenic Upgrade
 {
     "name": "Biogenic Upgrade",
@@ -125,6 +145,66 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Catacomb Crocodile
+{
+    "name": "Catacomb Crocodile",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Crocodile",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 7
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "artist": "Nils Hamm",
+        "flavorText": "\"I am sewer-king!\" said Rat. \"I am quick and cunning and I know every tunnel.\"\n\"No, I am king!\" said Zombie. \"I am cold and deadly and no rot can harm me.\"\nThen Croc came and ate them both.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/440c53f0-7922-4e14-802d-d7a22f8fed85.jpg?1783933696"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Coral Commando
+{
+    "name": "Coral Commando",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Merfolk Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Alex Konstad",
+        "flavorText": "Few Ravnicans are aware of the vast reefs in their world's hidden ocean. Far beneath the great sinkholes, where the light is blue and dim, merfolk tend the coral labyrinths that feed the benthic ecosystem.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/889cc2a0-d9a6-4368-92e0-055a7d7bf9d1.jpg?1783933710"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Feral Maaka
+{
+    "name": "Feral Maaka",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Cat",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Jonathan Kuo",
+        "flavorText": "\"Lost are the lush meadows and verdant forests, where maaka prowled and lammasu soared. Lost are the wilds, where our hearts were free.\"\n—Daiva, Gruul storyteller",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c969aa0-b0e5-42cd-abba-0a3c7266142c.jpg?1783933682"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -399,6 +479,26 @@
     "colorIdentityOverride": [
         "GREEN",
         "BLUE"
+    ]
+}
+
+// Prowling Caracal
+{
+    "name": "Prowling Caracal",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "artist": "Jonathan Kuo",
+        "flavorText": "A hunter in the city requires the utmost cunning to survive. It must pounce only if the kill is certain, and leave the remains where no one will see.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5382fc4-3384-449e-a83f-43a59158d55b.jpg?1783933719"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -232,6 +232,66 @@
     ]
 }
 
+// Jwari Scuttler
+{
+    "name": "Jwari Scuttler",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Crab",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Andrew Robinson",
+        "flavorText": "\"Yeah, they've got a lot of meat. The only downside to eating 'em is that you often find human bones and body parts inside.\"\n—Jaby, Silundi Sea nomad",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04129038-3b02-418a-862a-229e9dde339b.jpg?1783941995"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Lagac Lizard
+{
+    "name": "Lagac Lizard",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Lizard",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Tracing their ancestry back to Zendikar's earliest forms of life, lagac lizards have seen the comings and goings of planeswalkers and the Eldrazi, and the rise of the vampire clans, none of which has changed them one bit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b47e9cfa-5547-4ef3-9e36-8d0f36dfa59a.jpg?1783941974"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Nema Siltlurker
+{
+    "name": "Nema Siltlurker",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Lizard",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "artist": "Wayne Reynolds",
+        "flavorText": "In one gargantuan bite, it will swallow not only you but also the riverbank you were standing on.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a477e081-949f-4cf0-b0d2-b9bdff6c760d.jpg?1783941961"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Pelakka Wurm
 {
     "name": "Pelakka Wurm",

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -1,3 +1,23 @@
+// Axebane Stag
+{
+    "name": "Axebane Stag",
+    "manaCost": "{6}{G}",
+    "typeLine": "Creature — Elk",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 7
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Martina Pilcerova",
+        "flavorText": "\"When the spires have burned and the cobblestones are dust, he will take his rightful place as king of the wilds.\"\n—Kirce, Axebane guardian",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bfce7c02-ccc3-44cd-8087-627eaa6a072e.jpg?1783940351"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Azorius Guildgate
 {
     "name": "Azorius Guildgate",
@@ -40,6 +60,46 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLUE"
+    ]
+}
+
+// Catacomb Slug
+{
+    "name": "Catacomb Slug",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Slug",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "artist": "Nils Hamm",
+        "flavorText": "\"The entire murder scene was covered in dripping, oozing slime. No need for a soothsayer to solve that one.\"\n—Pel Javya, Wojek investigator",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53b36fba-6a0e-4f03-8bee-03919062537f.jpg?1783940365"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cobblebrute
+{
+    "name": "Cobblebrute",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Eytan Zana",
+        "flavorText": "The most ancient streets take on a life of their own. A few have decided to move to nicer neighborhoods.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e038376-801f-454e-a635-0e2d58ccbf7c.jpg?1783940356"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -205,6 +265,27 @@
         "artist": "Eytan Zana",
         "flavorText": "Enter those who are starving and sick. You are welcome among the Swarm when the rest of Ravnica rejects you.",
         "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fe2fd1a-f7d3-48b4-bad8-be5ee45d6121.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Golgari Longlegs
+{
+    "name": "Golgari Longlegs",
+    "manaCost": "{3}{B/G}{B/G}",
+    "typeLine": "Creature — Insect",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Volkan Baǵa",
+        "flavorText": "Despite its enormous stature, it can fold itself into a tunnel with startling quickness, vanishing back into the undercity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d44058ba-3419-4777-8d59-05dea5e864e1.jpg?1783940327"
     },
     "colorIdentityOverride": [
         "BLACK",

--- a/mtg-sets/src/test/resources/snapshots/cards/S99.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/S99.json
@@ -114,6 +114,27 @@
     ]
 }
 
+// Trained Orgg
+{
+    "name": "Trained Orgg",
+    "manaCost": "{6}{R}",
+    "typeLine": "Creature — Orgg",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "RARE",
+        "artist": "Eric Peterson",
+        "flavorText": "All orggs know how to kill; training teaches them *what* to kill.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/425540b0-c826-4814-b0df-032264b1c237.jpg?1783946025"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Vizzerdrix
 {
     "name": "Vizzerdrix",
@@ -132,5 +153,25 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Willow Elf
+{
+    "name": "Willow Elf",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Elf",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "DiTerlizzi",
+        "flavorText": "The forest lives in the elf as the elf lives in the forest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8f0750c-1cce-4088-a848-f11fe3694d89.jpg?1783946018"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/SHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SHM.json
@@ -68,6 +68,48 @@
     ]
 }
 
+// Loamdragger Giant
+{
+    "name": "Loamdragger Giant",
+    "manaCost": "{4}{R/G}{R/G}{R/G}",
+    "typeLine": "Creature — Giant Warrior",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Pete Venters",
+        "flavorText": "Giants sleep soundly and long, sometimes for long enough that a crust of earth and moss grows over them. But inevitably something disturbs their slumber, and they wake unhappy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0a27bbe4-5341-4b2b-9ae8-eb56585a9c3a.jpg?1783942721"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Old Ghastbark
+{
+    "name": "Old Ghastbark",
+    "manaCost": "{3}{G/W}{G/W}",
+    "typeLine": "Creature — Treefolk Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "artist": "Thomas M. Baxa",
+        "flavorText": "\"Beware of trees that talk. Their words are threats. And mind the ones that sway and creak. They too threaten us, but in a foreign tongue.\"\n—*The Book of Other Folk*",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b5ab941-89cc-4fdd-a916-3a54651f6478.jpg?1783942716"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Wilt-Leaf Liege
 {
     "name": "Wilt-Leaf Liege",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1154,6 +1154,26 @@
     ]
 }
 
+// Devilthorn Fox
+{
+    "name": "Devilthorn Fox",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Fox",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Filip Burburan",
+        "flavorText": "On expeditions through Ashmouth, the hunters of Devilthorn Lodge rely on the cleverness of foxes to counteract the mischief of devils.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/57bea4c2-7a15-4f31-938d-c4c906e4ebe7.jpg?1783937821"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Drunau Corpse Trawler
 {
     "name": "Drunau Corpse Trawler",
@@ -2114,6 +2134,26 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Hulking Devil
+{
+    "name": "Hulking Devil",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Devil",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Joseph Meehan",
+        "flavorText": "Fear the patient devil, the one who is calm in the midst of chaos. Beware the silent devil, the one whose cackle does not mingle with the others.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/031ecfc4-cc84-4f74-8eb1-3eaa234d8093.jpg?1783937750"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -3293,6 +3333,26 @@
     ]
 }
 
+// Seagraf Skaab
+{
+    "name": "Seagraf Skaab",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Zombie",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Jama Jurabaev",
+        "flavorText": "\"Your recent work is an inspiration. I have the utmost respect for your approach, and your craft is impeccable. At your convenience, I would be honored to collaborate on a project.\"\n—Ludevic, letter to Geralf",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/065d497d-5cfd-43c9-8c86-9a1da3d7e17e.jpg?1783937788"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Second Harvest
 {
     "name": "Second Harvest",
@@ -3914,6 +3974,26 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Thornhide Wolves
+{
+    "name": "Thornhide Wolves",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Wolf",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "artist": "Scott Murphy",
+        "flavorText": "\"Halana grew brambles to create a barricade around our camp, hoping that it would keep the wolves out. That was a mistake for which we almost paid dearly.\"\n—Alena, trapper of Kessig",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c699b5f-a2de-4c87-a7bc-16be4bc0a8cd.jpg?1783937720"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -4563,6 +4643,26 @@
     ]
 }
 
+// Vampire Noble
+{
+    "name": "Vampire Noble",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire Noble",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Ryan Alexander Lee",
+        "flavorText": "\"No emergency is so dire that it cannot be dealt with elegantly.\"\n—Olivia Voldaren",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/2/b2435f17-0378-4480-8d56-d256245c7ced.jpg?1783937761"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Village Messenger
 {
     "name": "Village Messenger",
@@ -4851,6 +4951,24 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Wicker Witch
+{
+    "name": "Wicker Witch",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Scarecrow",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "artist": "Izzy",
+        "flavorText": "When there were no more crows to scare, it focused its efforts elsewhere.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae115587-012d-40ff-a20d-270fabf2f8c6.jpg?1783937699"
+    },
+    "colorIdentityOverride": []
 }
 
 // Wild-Field Scarecrow

--- a/mtg-sets/src/test/resources/snapshots/cards/SOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOM.json
@@ -1,3 +1,23 @@
+// Alpha Tyrranax
+{
+    "name": "Alpha Tyrranax",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Dinosaur Beast",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Dave Kendall",
+        "flavorText": "Hunger seized the tyrranax, and the Sylvok's vision quest ended in disaster.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a2e5279-f28c-4a78-9f8a-16c9f72f8d38.jpg?1783941720"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Blackcleave Cliffs
 {
     "name": "Blackcleave Cliffs",
@@ -327,6 +347,65 @@
     ]
 }
 
+// Loxodon Wayfarer
+{
+    "name": "Loxodon Wayfarer",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Elephant Monk",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Steven Belledin",
+        "flavorText": "The Mirran elders vanished with Memnarch, leaving behind a generation of wayward orphans.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/356c5e6a-c0bd-43f7-bc84-a6ae8718a7a2.jpg?1783941744"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Memnite
+{
+    "name": "Memnite",
+    "manaCost": "{0}",
+    "typeLine": "Artifact Creature — Construct",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Reminders of Memnarch's reign still skirr across Mirrodin, reminiscent of his form if not his power.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/6/469cc4e0-49c0-4009-97ea-28e44addec69.jpg?1783941703"
+    },
+    "colorIdentityOverride": []
+}
+
+// Moriok Reaver
+{
+    "name": "Moriok Reaver",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Marc Simonetti",
+        "flavorText": "\"The Moriok are fools. They try so hard to gain my favor. All I want is for them to die quickly, to join the ranks of the nim.\"\n—Geth, Lord of the Vault",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2a0410f-95c5-49bf-856d-dea796c96e3b.jpg?1783941730"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Painful Quandary
 {
     "name": "Painful Quandary",
@@ -377,6 +456,44 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Plated Seastrider
+{
+    "name": "Plated Seastrider",
+    "manaCost": "{U}{U}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "Izzy",
+        "flavorText": "The Neurok buried entangling cables just under the Quicksilver Sea. One seastrider harvest can provide an army's worth of armor and shields.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/97171611-c677-48a6-b081-98a27ecef979.jpg?1783941738"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Razorfield Thresher
+{
+    "name": "Razorfield Thresher",
+    "manaCost": "{7}",
+    "typeLine": "Artifact Creature — Construct",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "artist": "Karl Kopinski",
+        "flavorText": "DANGER! Keep appendages clear of front of machine. And rear of machine. And side of machine. And top of machine.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0a74203-d342-489d-a584-bca78ef3331d.jpg?1783941698"
+    },
+    "colorIdentityOverride": []
 }
 
 // Razorverge Thicket
@@ -447,6 +564,26 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Scoria Elemental
+{
+    "name": "Scoria Elemental",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Elemental",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Karl Kopinski",
+        "flavorText": "A single molten cord links it to the subterranean furnaces, drawing heat and metal from beneath Kuldotha. Until that bond is cut, it carves a swath of raw destruction.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca4d9198-52a7-4dfe-8f7f-4fa6e19a2479.jpg?1783941723"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -1,3 +1,23 @@
+// Ageless Guardian
+{
+    "name": "Ageless Guardian",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Spirit Soldier",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Nicholas Gregory",
+        "flavorText": "Ancient ruins dot the world of Arcavios, most older than Strixhaven itself and many still guarded by soldiers from the Blood Age, centuries after their deaths.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a5ff6af-402f-4bf6-a75b-dc1e0e40aff6.jpg?1783927397"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Burrog Befuddler
 {
     "name": "Burrog Befuddler",
@@ -313,6 +333,26 @@
             },
             "imageUri": "https://cards.scryfall.io/normal/back/0/d/0dba25e3-2b4f-45d4-965f-3834bcb359ee.jpg?1739656768"
         }
+    ]
+}
+
+// Spined Karok
+{
+    "name": "Spined Karok",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Crocodile",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Filip Burburan",
+        "flavorText": "\"The bogs are deeper than you realize. Most of the space beneath the surface is taken up by these enormous karoks. You might think your feet are touching the bottom. They're probably not.\"\n—Gyome, Witherbloom chef",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c37ae6b5-225a-410e-ab22-13e923bdfb65.jpg?1783927338"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/THB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THB.json
@@ -44,6 +44,106 @@
     ]
 }
 
+// Nyxborn Brute
+{
+    "name": "Nyxborn Brute",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Enchantment Creature — Cyclops",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"One-eyed and frightful, the cyclops\nlifted a boulder and hurled it\nseaward from cliff's edge, shattering\nmasts and scattering sailors.\"\n—*The Callapheia*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/05bc4236-566f-401b-b9d7-f58126fa228b.jpg?1783931550"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Nyxborn Colossus
+{
+    "name": "Nyxborn Colossus",
+    "manaCost": "{3}{G}{G}{G}",
+    "typeLine": "Enchantment Creature — Giant",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 7
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"Tree-tall giants confronted her, fiercely demanding her tribute;\nFox-cunning Callaphe's slippery speaking entangled their senses...\"\n—*The Callapheia*",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b4f003c-1e99-4e53-ad6d-81ff3c592b2c.jpg?1783931531"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Nyxborn Courser
+{
+    "name": "Nyxborn Courser",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Enchantment Creature — Centaur Scout",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "\"Storms drove them westward to Ketaphos; wide plains shimmered in starlight.\nCentaurs greeted them, offering gold-hued apples and grain-cakes.\"\n—*The Callapheia*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0fd32240-c003-4e18-adf1-e2e992c702b1.jpg?1783931593"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Nyxborn Marauder
+{
+    "name": "Nyxborn Marauder",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Enchantment Creature — Minotaur",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "109",
+        "artist": "Steve Prescott",
+        "flavorText": "\"Callaphe guided them into the\ndarkness of Hetos, the bleak mire;\nBlood-horned minotaurs circled them,\naxes aglimmer in shadow.\"\n—*The Callapheia*",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd2a923a-1f9c-4a29-9c6b-344ae4d5ae8f.jpg?1783931562"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Nyxborn Seaguard
+{
+    "name": "Nyxborn Seaguard",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Enchantment Creature — Merfolk Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "artist": "Simon Dominic",
+        "flavorText": "\"Storm-tossed and broken, Callaphe cried out to deep-dwelling Thassa.\nTritons came swiftly to save her, bringing her north to the Lindus.\"\n—*The Callapheia*",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9ad0c7d7-0e44-496f-a2fc-fafc604cb1f1.jpg?1783931581"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Soul-Guide Lantern
 {
     "name": "Soul-Guide Lantern",

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -1,3 +1,41 @@
+// Borderland Minotaur
+{
+    "name": "Borderland Minotaur",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Minotaur Warrior",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Greg Staples",
+        "flavorText": "\"You have led us to triumph over the forces of Mogis!\" said Brygus the Brave, clapping the Champion on the back. The Champion wiped the sweat and blood from her brow. \"I count eight graves,\" she said. \"Too many to call this a victory.\"\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c7f6eb2-feae-4dc9-a009-0ad60f89a592.jpg?1783939766"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bronze Sable
+{
+    "name": "Bronze Sable",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Sable",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "artist": "Jasper Sandner",
+        "flavorText": "The Champion stood alone between the horde of the Returned and the shrine to Karametra, cutting down scores among hundreds. She would have been overcome if not for the aid of the temple guardians whom Karametra awakened.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba7e563d-964c-4afd-9e21-9d400f8719d4.jpg?1783939721"
+    },
+    "colorIdentityOverride": []
+}
+
 // Burnished Hart
 {
     "name": "Burnished Hart",
@@ -73,6 +111,26 @@
         "imageUri": "https://cards.scryfall.io/normal/front/7/7/772cbcba-9efa-4894-9b57-e73fd296333d.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Felhide Minotaur
+{
+    "name": "Felhide Minotaur",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Minotaur",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Kev Walker",
+        "flavorText": "With spear held high, the Champion came to meet Thyrogog of the Ashlands, who wore the old king's skin as a cloak and fed on the flesh of innocents. The foul minotaur raised the great axe called Goremaster and charged.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4e424de-81be-4f90-a7a2-4102c8ba8989.jpg?1783939779"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
 }
 
 // Hero's Downfall
@@ -181,6 +239,46 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Pheres-Band Centaurs
+{
+    "name": "Pheres-Band Centaurs",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Centaur Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 7
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Mark Winters",
+        "flavorText": "\"Poets speak of your unrivaled speed,\" the Champion said to the assembled centaurs, \"but it is plain to see that your true strength lies in your unwavering loyalty to one another.\"\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/2168fcf4-cf87-4ab8-9710-6ec672750a9a.jpg?1783939739"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Silent Artisan
+{
+    "name": "Silent Artisan",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Giant",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Anthony Palumbo",
+        "flavorText": "On the fourth day they passed through a forest of immense stacked stones. Althemone, youngest of the companions, called these pillars the work of a god, but the Champion knew better. She quickened her pace.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dce5647d-1546-4eff-a2a2-9e9ef26db533.jpg?1783939806"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -474,6 +572,46 @@
     ]
 }
 
+// Traveling Philosopher
+{
+    "name": "Traveling Philosopher",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Advisor",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "James Ryman",
+        "flavorText": "The Champion and the philosopher Olexa returned from the opposing camp at dusk. Behind them, the enemy raised sail and departed, breaking the siege. When asked what the two had done, the Champion replied, \"We spoke to them.\"\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edad0276-45d1-45e5-a6b1-1cd2a99b4f2c.jpg?1783939808"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Triton Shorethief
+{
+    "name": "Triton Shorethief",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Merfolk Rogue",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Howard Lyon",
+        "flavorText": "At sunrise, the Champion and her companions awoke to find their supplies gone and Brygus, their sentry, dead. Carefully arranged piles of ornamental shells gave a clear warning: go no further.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d8f0fe22-dc89-4ad8-b5f6-6d91b61f1385.jpg?1783939787"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Wild Celebrants
 {
     "name": "Wild Celebrants",
@@ -520,5 +658,25 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Yoked Ox
+{
+    "name": "Yoked Ox",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Ox",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Ryan Yee",
+        "flavorText": "It was in fields of grain, not fields of battle, that the Champion learned to bear the yoke of duty to the gods. She worked the land long before she was called on to defend it.\n—*The Theriad*",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12fc09d4-e6ce-428b-818b-b465093af88e.jpg?1783939803"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TLE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLE.json
@@ -1,0 +1,59 @@
+// Capital Guard
+{
+    "name": "Capital Guard",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "artist": "Nathaniel Himawan",
+        "flavorText": "Fire Nation guards rely more on fear than fire.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/91cbed11-3b5c-4e7a-9b13-125c1fe5f22f.jpg?1783904780"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Kyoshi Warrior Guard
+{
+    "name": "Kyoshi Warrior Guard",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Warrior Ally",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Yunomachi",
+        "flavorText": "Kyoshi Warrior drills are designed to encourage individual discipline as well as uncompromising trust in their fellow warriors.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a2acb28-c0e2-492b-a227-ef49e905e0fb.jpg?1783904787"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Warship Scout
+{
+    "name": "Warship Scout",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Scout",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "artist": "Brandon L. Hunt",
+        "flavorText": "\"For the glory of the Fire Nation!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1a95982-be16-465a-9c1b-1f4d875c0c40.jpg?1783904777"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -1349,6 +1349,26 @@
     ]
 }
 
+// Lowland Giant
+{
+    "name": "Lowland Giant",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Giant",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "artist": "Paolo Parente",
+        "flavorText": "\"Faugh!\" snorted Tahngarth. \"Why would it make a meal of something like you?\" Squee looked relieved. \"No,\" he continued, \"you'd make a much better toothpick.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/7398dec7-5e60-43c0-81a0-ab49beb37077.jpg?1783946627"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Manta Riders
 {
     "name": "Manta Riders",
@@ -1510,6 +1530,24 @@
         "artist": "D. Alexander Gregory",
         "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba69c3d3-6fb5-478d-93ba-341dd3ace97d.jpg?1562056379"
     }
+}
+
+// Metallic Sliver
+{
+    "name": "Metallic Sliver",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Sliver",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "297",
+        "artist": "Allen Williams",
+        "flavorText": "When the clever counterfeit was accepted by the hive, Volrath's influence upon the slivers grew even stronger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/30143f4f-9846-448d-8797-8fe0bc0cc5df.jpg?1783946602"
+    },
+    "colorIdentityOverride": []
 }
 
 // Mindwhip Sliver

--- a/mtg-sets/src/test/resources/snapshots/cards/TRC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TRC.json
@@ -1,0 +1,59 @@
+// Defense Force Aggressor
+{
+    "name": "Defense Force Aggressor",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Klingon Warrior",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"You play games with death, little warrior. I like it!\"\n—Captain Ma'ah",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67380a35-1a15-4c45-8a24-3c6077af85db.jpg?1785981114"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Starfleet Crew
+{
+    "name": "Starfleet Crew",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Officer",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "artist": "Runa I. Rosenberger",
+        "flavorText": "\"The first duty of every Starfleet officer is to the truth, whether it's scientific truth, or historical truth, or personal truth. It is the guiding principle on which Starfleet is based.\"\n—Captain Jean-Luc Picard",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ecf2358f-542d-45c9-b5c5-c57b2b0c1122.jpg?1785981010"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Warship Flight Crew
+{
+    "name": "Warship Flight Crew",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Klingon Pilot",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Johann Bodin",
+        "flavorText": "Opponents write off Klingons as unthinking brutes at their own peril. When the Klingon Empire developed warp drive, humanity still relied on horse-drawn carts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b6d130a-60f7-410a-b45f-ad81dd203c8c.jpg?1785981141"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TSP.json
@@ -521,3 +521,21 @@
         "BLUE"
     ]
 }
+
+// Venser's Sliver
+{
+    "name": "Venser's Sliver",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Sliver",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "267",
+        "artist": "Carl Critchlow",
+        "flavorText": "Venser admired his handiwork and smiled. His first prototype had joined with the hive mind all too well, running with the brood and becoming a predator itself. This one, he thought, would be accepted into the hive but still obey his commands.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e3c5a64-453b-4477-853a-9514ba326f16.jpg?1783943196"
+    },
+    "colorIdentityOverride": []
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VIS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VIS.json
@@ -402,6 +402,24 @@
     ]
 }
 
+// Phyrexian Walker
+{
+    "name": "Phyrexian Walker",
+    "manaCost": "{0}",
+    "typeLine": "Artifact Creature — Phyrexian Construct",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Bryan Talbot",
+        "flavorText": "\"I have heard terrible tales of black rains, ashen fields, and metal that screams. I have consoled myself that the tales were a myth of some fevered mind. But today I saw a walker—and now I fear the truth.\"\n—Kasib Ibn Naji, Letters",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f8a3979-2947-4692-8b2f-d4c07c534777.jpg?1783946973"
+    },
+    "colorIdentityOverride": []
+}
+
 // Prosperity
 {
     "name": "Prosperity",

--- a/mtg-sets/src/test/resources/snapshots/cards/WAR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WAR.json
@@ -287,6 +287,46 @@
     ]
 }
 
+// Ironclad Krovod
+{
+    "name": "Ironclad Krovod",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Sam Rowan",
+        "flavorText": "\"We need to block the exits from the plaza! What's big, heavy, and available?\"\n—Gideon Jura",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afb16895-6542-405e-9793-154ffc439f23.jpg?1783933481"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Lazotep Behemoth
+{
+    "name": "Lazotep Behemoth",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Zombie Hippo",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Zezhou Chen",
+        "flavorText": "\"I know I should be more concerned. But a big, blue zombie-potamus from beyond the stars? This is what they're invading us with?\"\n—Mileva, Boros legionnaire",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b4be6f22-e9e8-462a-956b-e1c78bbadacc.jpg?1783933444"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Liliana, Dreadhorde General
 {
     "name": "Liliana, Dreadhorde General",
@@ -462,6 +502,26 @@
     "startingLoyalty": 6,
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Naga Eternal
+{
+    "name": "Naga Eternal",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Zombie Snake",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Johann Bodin",
+        "flavorText": "\"I recognize that headdress. This one was feared even by her fellow initiates.\"\n—Samut",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f244233-f2e8-48f8-9106-e7cd186efd51.jpg?1783933461"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -118,6 +118,26 @@
     ]
 }
 
+// Goblin Roughrider
+{
+    "name": "Goblin Roughrider",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Knight",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "82",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Astride the bucking creature, Gribble hurtled down the mountainside while his Grotag brethren cheered. It was at that moment that legend of the Skrill Tamer was born.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e79787dd-6d2f-4773-aefe-16a4eb93d3cc.jpg?1783942050"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Kalastria Highborn
 {
     "name": "Kalastria Highborn",
@@ -188,6 +208,27 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Leatherback Baloth
+{
+    "name": "Leatherback Baloth",
+    "manaCost": "{G}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Kendall",
+        "flavorText": "Heavy enough to withstand the Roil, leatherback skeletons are havens for travelers in storms and landshifts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55f97b4c-42c7-4986-a150-0b8de11f0537.jpg?1783942043"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -1,3 +1,23 @@
+// Ancient Brontodon
+{
+    "name": "Ancient Brontodon",
+    "manaCost": "{6}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "creatureStats": {
+        "power": 9,
+        "toughness": 9
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "artist": "Jakub Kasper",
+        "flavorText": "It is taller than all but the tallest trees, and older than all but the oldest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/39421ce8-86d5-4739-b6fd-78d63c0bb258.jpg?1783935731"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Bishop's Soldier
 {
     "name": "Bishop's Soldier",
@@ -270,6 +290,44 @@
     ]
 }
 
+// Frenzied Raptor
+{
+    "name": "Frenzied Raptor",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Dinosaur",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Jesper Ejsing",
+        "flavorText": "Sun Empire warriors are taught to emulate the fearless raptors that fling themselves against towers of horn and muscle a hundred times their size.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7c3a1c9-ffa2-4990-aa4b-db9d688f1ed4.jpg?1783935745"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Gilded Sentinel
+{
+    "name": "Gilded Sentinel",
+    "manaCost": "{4}",
+    "typeLine": "Artifact Creature — Golem",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "artist": "Izzy",
+        "flavorText": "The River Heralds fight to keep all others from reaching the golden city. The city has its own defenses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/01cc1a59-76bf-4721-b4a7-ef746f3d3990.jpg?1783935702"
+    },
+    "colorIdentityOverride": []
+}
+
 // Gishath, Sun's Avatar
 {
     "name": "Gishath, Sun's Avatar",
@@ -500,6 +558,46 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Headwater Sentries
+{
+    "name": "Headwater Sentries",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Merfolk Warrior",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "artist": "Naomi Baker",
+        "flavorText": "\"The elders say that if the intruders discovered the secret of the golden city, it would mean an end to our people.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2af2c338-f5e9-4596-9435-c6aa965ae541.jpg?1783935781"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Looming Altisaur
+{
+    "name": "Looming Altisaur",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Dinosaur",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 7
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Lars Grant-West",
+        "flavorText": "Nature can't be tamed, but the Sun Empire believes that humans are made stronger when they test themselves against the wild strength of the dinosaurs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/f/cfcff1c6-0db6-4ff6-b4af-d7048b426368.jpg?1783935797"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -749,6 +847,46 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Queen's Bay Soldier
+{
+    "name": "Queen's Bay Soldier",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Soldier",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Jesper Ejsing",
+        "flavorText": "The soldiers of the Legion of Dusk have come to the colonies at Queen's Bay in search of glory and riches. They are veterans of centuries of warfare, and they thirst for conquest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce2ca2e6-f920-4529-88d2-d984bdb7490a.jpg?1783935757"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Raptor Companion
+{
+    "name": "Raptor Companion",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Dinosaur",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Slawomir Maniak",
+        "flavorText": "A raptor will follow any order as long as that order is \"hunt,\" \"kill,\" or \"go for the guts.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d37fc42-0a7c-46b3-9270-333d370e479f.jpg?1783935794"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -615,6 +615,26 @@
     ]
 }
 
+// Kraken Hatchling
+{
+    "name": "Kraken Hatchling",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Kraken",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Jason Felix",
+        "flavorText": "A spike and a maul are needed to crack their shells, but the taste is worth the effort.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45d100a3-93f2-428c-8f54-8807e71f2638.jpg?1783942164"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Marsh Flats
 {
     "name": "Marsh Flats",
@@ -757,6 +777,26 @@
         "imageUri": "https://cards.scryfall.io/normal/front/2/4/24a5cc2c-0fbf-4a5f-b175-6e0ffd0d0787.jpg?1783942123"
     },
     "colorIdentityOverride": []
+}
+
+// Pillarfield Ox
+{
+    "name": "Pillarfield Ox",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Ox",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "artist": "Andrew Robinson",
+        "flavorText": "These stubborn and unpredictable oxen inspire the plains nomads' most colorful curses.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d70a8ff1-f0cf-4aef-ad90-06902f98d434.jpg?1783942168"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Rampaging Baloths
@@ -1034,6 +1074,44 @@
     "colorIdentityOverride": []
 }
 
+// Shatterskull Giant
+{
+    "name": "Shatterskull Giant",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Giant Warrior",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Kekai Kotaki",
+        "flavorText": "\"Now I know why they call it Shatterskull Pass. Rocks fell all night like hammers smashing an anvil. It's no wonder the giants are angry all the time.\"\n—Mitra, Bala Ged missionary",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9cfbb4dd-56a2-4a94-9b15-b3ef8b2f1d0b.jpg?1783942140"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Stonework Puma
+{
+    "name": "Stonework Puma",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Cat Ally",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "207",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"We suffer uneasy ground, unstable alliances, and unpredictable magic. Something you can truly trust is worth more than a chest of gold.\"\n—Nikou, Joraga bard",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/05460615-4c24-487f-841a-ca14106e5688.jpg?1783942125"
+    },
+    "colorIdentityOverride": []
+}
+
 // Vampire Nighthawk
 {
     "name": "Vampire Nighthawk",
@@ -1057,6 +1135,26 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Vastwood Gorger
+{
+    "name": "Vastwood Gorger",
+    "manaCost": "{5}{G}",
+    "typeLine": "Creature — Wurm",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"I've known true ferocity and power. Those brazen 'planar-walkers' have no idea what wild really means.\"\n—Chadir the Navigator",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc5daf96-ceae-4c9a-95cd-f6d706e9b1fa.jpg?1783942129"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -60,6 +60,26 @@
     ]
 }
 
+// Cliffhaven Sell-Sword
+{
+    "name": "Cliffhaven Sell-Sword",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kor Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Jason Rainville",
+        "flavorText": "\"I swing a sword. It's a simple life. A lot of adventurers just see me as some cheap muscle, but if my steel lets them return home with their lives and limbs intact, then I've done my job.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f334767-4353-4379-a934-fa67075db439.jpg?1783929421"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Crawling Barrens
 {
     "name": "Crawling Barrens",
@@ -350,6 +370,26 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Murasa Brute
+{
+    "name": "Murasa Brute",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Troll Warrior",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Caio Monteiro",
+        "flavorText": "Some adventuring parties are made up of old friends, their common bonds bolstering them in the face of peril. Other parties simply hire the biggest, meanest muscle they can find.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efe1c5b2-4356-41ae-ab7e-ad9fc835a911.jpg?1783929336"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 


### PR DESCRIPTION
Every card in the Scryfall Oracle corpus with **no rules text on any face** that we had not implemented yet — 240 of them, plus the 83 `Printing(...)` rows and 6 set scaffolds their canonical placement requires.

Vanilla is the one class where "can the SDK express this?" is answered by the card frame alone, so all 240 are plain `card(...)` blocks with a `metadata { }` and no script.

## Where the number comes from

The Oracle bulk holds 34,882 assayable cards. 354 are vanilla; 104 already had a `CardDefinition`; 5 of the remaining 250 are not cards at all (Unfinity stickers, `Red Mana`, `Storm Counter`, two FJ25 memorabilia). That leaves 245, of which 5 are deliberately excluded — see below.

## Placement

Canonical placement follows `scripts/check-card-printing.py`'s own rule rather than a hand-picked set: the `CardDefinition` goes in the earliest printing whose `set_type` is scaffoldable, and **every other scaffolded set that printed the card gets a `Printing(...)` row**. That second half is why 240 cards produce 323 files.

| | |
|---|---|
| Canonical `CardDefinition`s | 240 across 70 sets |
| `Printing(...)` reprint rows | 83 across 20 sets |
| Sets touched | 76 |
| New `MtgSet` scaffolds | 6 |

The heads are LEG 19, PTK 11, P02 11, THS 8, XLN 7, M10 7, SOM 7, then SOI / KLD / M14 at 6. The tail is 49 sets contributing one to four cards each. Sets receiving only reprint rows: M13 (7), ORI (5), JMP (4), PZ2 (3), J22 (2), PC2 (1).

### The six new sets

None of the cards below has an alternate printing in a set we already carry, so without a scaffold there is nowhere for the canonical to live and `check-card-printing` reports drift.

| Set | | Cards |
|---|---|---|
| `BOK` | Betrayers of Kamigawa (2005) — CHK and SOK were already here | Frost Ogre, Gnarled Mass |
| `OANA` | Arena New Player Experience Cards (2018) | Shrine Keeper, Treetop Warden |
| `ANB` | Arena Beginner Set (2020) | Shorecomber Crab |
| `TLE` | Avatar: The Last Airbender Eternal (2025) — companion to TLA | Capital Guard, Kyoshi Warrior Guard, Warship Scout |
| `TRC` | Star Trek Commander (2026) | Defense Force Aggressor, Starfleet Crew, Warship Flight Crew |
| `MSC` | Marvel Super Heroes Commander (2026) | Black Widow, Happy Hogan |

All six are `incomplete = true` and `sealedSupported = false` — canonical homes, not draftable environments. `MtgSetCatalog` discovers them off the classpath, so there is no list to append to.

One judgement call worth flagging: **Shorecomber Crab**'s canonical is `ANB` (2020), not `J25` / Foundations Jumpstart (2024). `check-card-printing` picks the earliest scaffoldable `set_type` and does *not* exclude digital-only sets, so ANB wins; scaffolding J25 instead would have failed the gate.

## Not included

Five vanilla cards are deliberately out:

- **`UNH` Little Girl** — `{HW}` for a ½/½. The SDK models neither half-mana nor fractional power/toughness, so it cannot be expressed at all.
- **`UST` Curious / Delighted / Despondent / Enraged Killbot** — silver-bordered Unstable cards. Mechanically plain 2/1 artifact creatures for `{2}`, but the repo carries no Un-set and this PR is not the place to start one.

## The AI test fix

The third commit touches a file outside `mtg-sets`, so it deserves calling out.

`TestCards.all` is the *whole* corpus — `MtgSetCatalog.all.flatMap { it.cards + it.basicLands }` plus the test-only cards — and `CombatAdvisorTest.setup()` registered it **after** each test's own definitions. `CardRegistry.register` is last-write-wins by name, so the corpus silently replaced any hand-built creature sharing a printed card's name.

That was latent until this PR implemented **Pillarfield Ox** and **Nessian Courser**. The suite builds them locally as a 4/4 and a 2/3 to pin gang-block arithmetic; the printed cards are a 2/4 and a 3/3. So "double-blocks 6/6 with 3/3 and 4/4 to kill it" stopped being able to kill it, and the advisor correctly declined to block — the AI was right and the test's premise was gone.

Swapping the two registrations fixes the class rather than the two names: a test that hand-builds a creature to pin its stats now always wins over whatever the corpus happens to contain, so implementing a card can no longer reach into an unrelated AI test's board. I verified the failure was mine and not pre-existing by shelving all 329 new files and re-running the full `:ai:test` green, then restoring them and reproducing the two failures.

## Verification

- `just build` — **green**
- `just test-ai` — green (was 2 failures before the ordering fix)
- `just check-card-printing` for all **240** cards — 240 pass, 0 drift
- `just rebless-cards` — golden diff is **purely additive**: 227 entries added to 64 existing set goldens, 13 in the 6 new ones, **zero existing entries changed or removed**
- Sampled `image_uris.normal` against Scryfall — HTTP 200

## Deviations from the `add-card` skill

- **No scenario tests.** Step 5 asks for one only when Step 4 added SDK vocabulary. These compose nothing; `CardDefinitionSnapshotTest` and `CardLintTest` are the coverage.
- **Three commits, not one per card.** 240 mechanically identical cards, and the snapshot golden is a single artifact that cannot be split per card without leaving every intermediate commit red. The split that keeps every commit green is scaffolds / cards / test fix.
- **Batch size.** The skill suggests ~5 cards per PR; this is 240. They are one idea evaluated 240 times rather than 240 ideas, which is the case the guidance is protecting against inverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
