### PR TITLE
Add five Mirrodin artifacts

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/AltarOfShadows.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/AltarOfShadows.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Altar of Shadows — Mirrodin #143 (canonical printing, only printing)
+ * {7} · Artifact
+ *
+ * At the beginning of your first main phase, add {B} for each charge counter on this artifact.
+ * {7}, {T}: Destroy target creature. Then put a charge counter on this artifact.
+ *
+ * The mana trigger is [Triggers.FirstMainPhase] — the precombat main phase, which the 2004-10-04
+ * ruling is explicit about being the *first* main phase of the turn regardless of what else moved
+ * around it. The amount is `countersOnSelf(charge)`, re-read each turn, so the altar ramps itself as
+ * its activated ability feeds it counters.
+ *
+ * "Destroy target creature. Then put a charge counter" is a plain [Effects.Composite]: the counter is
+ * not conditional on the destruction sticking, which is exactly the 2004-12-01 ruling ("You put the
+ * counter on Altar of Shadows even if the creature regenerates").
+ */
+val AltarOfShadows = card("Altar of Shadows") {
+    manaCost = "{7}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "At the beginning of your first main phase, add {B} for each charge counter on this artifact.\n" +
+        "{7}, {T}: Destroy target creature. Then put a charge counter on this artifact."
+
+    triggeredAbility {
+        trigger = Triggers.FirstMainPhase
+        effect = Effects.AddMana(
+            Color.BLACK,
+            DynamicAmounts.countersOnSelf(CounterTypeFilter.Named(Counters.CHARGE))
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}"), Costs.Tap)
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Destroy(creature),
+            Effects.AddCounters(Counters.CHARGE, 1, EffectTarget.Self)
+        )
+        description = "{7}, {T}: Destroy target creature. Then put a charge counter on this artifact."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "143"
+        artist = "Sam Wood"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/ebc3824c-11ee-4fec-9397-823783b682d9.jpg?1783944528"
+        ruling("2004-10-04", "The precombat main phase is the first main phase of the turn. All others are postcombat main phases, even if they technically occur before combat.")
+        ruling("2004-12-01", "You put the counter on Altar of Shadows even if the creature regenerates.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CrystalShard.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/CrystalShard.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Crystal Shard — Mirrodin #159 (canonical printing)
+ * {3} · Artifact
+ *
+ * {3}, {T} or {U}, {T}: Return target creature to its owner's hand unless its controller pays {1}.
+ *
+ * The blue member of the Mirrodin Shard cycle. The dual cost is modelled the same way as
+ * [GraniteShard] and [PearlShard]: one printed ability with two alternative cost sets becomes two
+ * `activatedAbility` blocks with identical effects (2004-10-04 ruling: pay one or the other, never
+ * both), competing for the shard's single `{T}`.
+ *
+ * "Unless its controller pays {1}" is an *inverted* gate — the bounce is the `otherwise` branch, so
+ * paying is what stops it. Both halves of the gate point at the targeted creature's controller
+ * rather than the shard's: `decisionMaker = TargetController` prompts them, and
+ * `PayDynamicMana(payer = ControllerOf(...))` charges them. `Gate.MayPay` skips the prompt entirely
+ * when the cost is unpayable and goes straight to the bounce, so a tapped-out opponent is never
+ * offered an impossible "yes". The `then` branch is deliberately empty — a paid {1} simply keeps the
+ * creature where it is.
+ *
+ * `colorIdentity = "U"` because the {U} alternative puts blue in the card's identity even though the
+ * card itself is colorless (CR 903.4).
+ */
+val CrystalShard = card("Crystal Shard") {
+    manaCost = "{3}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{3}, {T} or {U}, {T}: Return target creature to its owner's hand unless its controller pays {1}."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val creature = target("creature", Targets.Creature)
+        effect = bounceUnlessControllerPays(creature)
+        description = "{3}, {T}: Return target creature to its owner's hand unless its controller pays {1}."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap)
+        val creature = target("creature", Targets.Creature)
+        effect = bounceUnlessControllerPays(creature)
+        description = "{U}, {T}: Return target creature to its owner's hand unless its controller pays {1}."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Doug Chaffee"
+        flavorText = "The vedalken know it is not of this world, so they know that this world is not the only one."
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1c1d05b-92be-40d7-859f-75293a531a84.jpg?1783944524"
+        ruling("2004-10-04", "You can pay either of the two costs (but not both at the same time) to activate the ability.")
+    }
+}
+
+private fun bounceUnlessControllerPays(creature: EffectTarget) = GatedEffect(
+    gate = Gate.MayPay(
+        Effects.PayDynamicMana(
+            amount = DynamicAmount.Fixed(1),
+            payer = Player.ControllerOf("target creature")
+        )
+    ),
+    decisionMaker = EffectTarget.TargetController,
+    then = Effects.Composite(emptyList()),
+    otherwise = Effects.ReturnToHand(creature),
+    descriptionOverride = "Return target creature to its owner's hand unless its controller pays {1}."
+)

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/PearlShard.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/PearlShard.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Pearl Shard — Mirrodin #225 (canonical printing)
+ * {3} · Artifact
+ *
+ * {3}, {T} or {W}, {T}: Prevent the next 2 damage that would be dealt to any target this turn.
+ *
+ * The white member of the Mirrodin Shard cycle, and modelled exactly like [GraniteShard]: the printed
+ * "{3}, {T} or {W}, {T}" is one ability with two alternative cost sets (2004-10-04 ruling: pay one or
+ * the other, never both), which two `activatedAbility` blocks with identical effects express directly.
+ * Both include the shard's own `{T}`, so they compete for the same tap and only one can be activated
+ * per untap — the same play pattern as the single printed ability.
+ *
+ * `colorIdentity = "W"` because the {W} alternative puts white in the card's identity even though the
+ * card itself is colorless (CR 903.4).
+ */
+val PearlShard = card("Pearl Shard") {
+    manaCost = "{3}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "{3}, {T} or {W}, {T}: Prevent the next 2 damage that would be dealt to any target this turn."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        val recipient = target("any target", AnyTarget())
+        effect = Effects.PreventNextDamage(2, recipient)
+        description = "{3}, {T}: Prevent the next 2 damage that would be dealt to any target this turn."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val recipient = target("any target", AnyTarget())
+        effect = Effects.PreventNextDamage(2, recipient)
+        description = "{W}, {T}: Prevent the next 2 damage that would be dealt to any target this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Doug Chaffee"
+        flavorText = "Leonin folktales claim it was brought from beyond the sky by the first kha."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abde295d-af41-4b9c-af48-3067befe9383.jpg?1783944508"
+        ruling("2004-10-04", "You can pay either of the two costs (but not both at the same time) to activate the ability.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SwordOfKaldra.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/SwordOfKaldra.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sword of Kaldra — Mirrodin #251 (canonical printing, only printing)
+ * {4} · Legendary Artifact — Equipment
+ *
+ * Equipped creature gets +5/+5.
+ * Whenever equipped creature deals damage to a creature, exile that creature.
+ * Equip {4}
+ *
+ * The first piece of the Kaldra cycle (with [com.wingedsheep.mtg.sets.definitions.dst.cards.ShieldOfKaldra]
+ * and Helm of Kaldra in Darksteel).
+ *
+ * The trigger is [TriggerBinding.ATTACHED] over `DamageType.Any` — *any* damage, not just combat, so
+ * it fires on a Viridian Longbow ping as readily as on a block. `RecipientFilter.AnyCreature` narrows
+ * it to damage dealt to creatures, and [EffectTarget.TriggeringEntity] is the *damaged* creature: a
+ * damage trigger stamps the recipient as the triggering entity, which is what "exile that creature"
+ * refers to. The printed reminder "(Exile it only if it's still on the battlefield)" needs no wiring —
+ * a creature that already died to the damage is simply no longer there to move.
+ */
+val SwordOfKaldra = card("Sword of Kaldra") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Equipped creature gets +5/+5.\n" +
+        "Whenever equipped creature deals damage to a creature, exile that creature. " +
+        "(Exile it only if it's still on the battlefield.)\n" +
+        "Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(5, 5)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Any,
+            recipient = RecipientFilter.AnyCreature,
+            binding = TriggerBinding.ATTACHED,
+        )
+        effect = Effects.Exile(EffectTarget.TriggeringEntity)
+    }
+
+    equipAbility("{4}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "251"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a665bff-b57a-450c-9310-932b0686a03e.jpg?1783944501"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Worldslayer.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mrd/cards/Worldslayer.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.mrd.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Worldslayer — Mirrodin #276 (canonical printing; reprinted in M12)
+ * {5} · Artifact — Equipment
+ *
+ * Whenever equipped creature deals combat damage to a player, destroy all permanents other than this
+ * Equipment.
+ * Equip {5}
+ *
+ * Same trigger shape as [MaskOfMemory] — combat damage to a player, [TriggerBinding.ATTACHED] so it
+ * reads the equipped creature rather than the Equipment itself.
+ *
+ * "All permanents other than this Equipment" is a single [Effects.DestroyAll] over
+ * `GameObjectFilter.Permanent.notSourceItself()`; the source-relative exclusion is what keeps
+ * Worldslayer on the battlefield to be equipped again. Nothing else is spared — the 2011-09-22
+ * ruling ("The equipped creature is also destroyed") falls straight out of the filter rather than
+ * needing a carve-out, and lands go with everything else.
+ */
+val Worldslayer = card("Worldslayer") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Whenever equipped creature deals combat damage to a player, destroy all permanents " +
+        "other than this Equipment.\n" +
+        "Equip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            binding = TriggerBinding.ATTACHED,
+        )
+        effect = Effects.DestroyAll(GameObjectFilter.Permanent.notSourceItself())
+    }
+
+    equipAbility("{5}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "276"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3cb1b869-3e2d-4447-a12d-e790883feeee.jpg?1783944496"
+        ruling("2011-09-22", "The equipped creature is also destroyed.")
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AltarOfShadowsScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AltarOfShadowsScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.AltarOfShadows
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Altar of Shadows (MRD #143) — "At the beginning of your first main phase, add {B} for each charge
+ * counter on this artifact. {7}, {T}: Destroy target creature. Then put a charge counter on this
+ * artifact."
+ *
+ * The card ramps *itself*, so the two halves have to agree: the activated ability must actually add a
+ * counter, and the trigger's amount must re-read the counters each turn rather than snapshot a
+ * starting value. With zero counters the trigger must add nothing at all — an off-by-one that gave a
+ * free {B} would be invisible against any board with counters on it.
+ */
+class AltarOfShadowsScenarioTest : FunSpec({
+
+    val destroyAbility = AltarOfShadows.activatedAbilities.single().id
+
+    /** Player1's turn, stopped in their upkeep — before the first-main trigger would fire. */
+    fun driverAtUpkeep(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + AltarOfShadows)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.UPKEEP)
+        return d
+    }
+
+    fun driver(): GameTestDriver = driverAtUpkeep().also { it.passPriorityUntil(Step.PRECOMBAT_MAIN) }
+
+    fun GameTestDriver.chargeCounters(altar: EntityId): Int =
+        state.getEntity(altar)?.get<CountersComponent>()?.getCount(CounterType.CHARGE) ?: 0
+
+    fun GameTestDriver.blackMana(player: EntityId): Int =
+        state.getEntity(player)?.get<ManaPoolComponent>()?.black ?: 0
+
+    test("destroying a creature also puts a charge counter on the altar") {
+        val d = driver()
+        val altar = d.putPermanentOnBattlefield(d.player1, "Altar of Shadows")
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.giveColorlessMana(d.player1, 7)
+
+        d.chargeCounters(altar) shouldBe 0
+
+        d.submit(
+            ActivateAbility(d.player1, altar, destroyAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.state.getBattlefield().contains(bear) shouldBe false
+        withClue("the counter is the second half of the same resolution") {
+            d.chargeCounters(altar) shouldBe 1
+        }
+    }
+
+    test("the first-main trigger adds one {B} per charge counter") {
+        val d = driverAtUpkeep()
+        val altar = d.putPermanentOnBattlefield(d.player1, "Altar of Shadows")
+        // Two activations' worth of counters, without needing two turns to place them.
+        d.addComponent(altar, CountersComponent(mapOf(CounterType.CHARGE to 2)))
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.bothPass()
+
+        withClue("the amount is countersOnSelf, re-read at trigger time") {
+            d.blackMana(d.player1) shouldBe 2
+        }
+    }
+
+    test("with no charge counters the trigger adds nothing") {
+        val d = driverAtUpkeep()
+        d.putPermanentOnBattlefield(d.player1, "Altar of Shadows")
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.bothPass()
+
+        d.blackMana(d.player1) shouldBe 0
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrystalShardScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/CrystalShardScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.CrystalShard
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Crystal Shard (MRD #159) — "{3}, {T} or {U}, {T}: Return target creature to its owner's hand
+ * unless its controller pays {1}."
+ *
+ * The gate is *inverted*: paying is what stops the bounce, so the bounce lives in the gate's
+ * `otherwise` branch. Everything that could plausibly go wrong is a wiring question about *who* the
+ * gate talks to — the shard's controller is not the creature's controller — so these tests pin the
+ * three answers: the opponent is the one prompted, the opponent is the one charged, and a paying
+ * opponent keeps their creature. The fourth test pins the affordability short-circuit: `Gate.MayPay`
+ * must not offer an impossible "yes" to a tapped-out player.
+ */
+class CrystalShardScenarioTest : FunSpec({
+
+    val genericAbility = CrystalShard.activatedAbilities.first().id
+    val blueAbility = CrystalShard.activatedAbilities[1].id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + CrystalShard)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** The shard on the battlefield, untapped and ready (activation costs {T}, not summoning sick). */
+    fun GameTestDriver.shard(): EntityId = putPermanentOnBattlefield(player1, "Crystal Shard")
+
+    test("the creature's controller — not the shard's — is the one asked to pay") {
+        val d = driver()
+        val shard = d.shard()
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.giveColorlessMana(d.player1, 3)
+        d.giveColorlessMana(d.player2, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, shard, genericAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("'its controller pays' points at player2, who controls the bear") {
+            d.pendingDecision?.playerId shouldBe d.player2
+        }
+    }
+
+    test("paying {1} keeps the creature on the battlefield and empties that player's pool") {
+        val d = driver()
+        val shard = d.shard()
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.giveColorlessMana(d.player1, 3)
+        d.giveColorlessMana(d.player2, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, shard, genericAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.submitYesNo(d.player2, true)
+
+        withClue("the bounce is the gate's `otherwise` — a paid {1} skips it") {
+            d.state.getBattlefield().contains(bear) shouldBe true
+        }
+        d.getHand(d.player2).none { d.getCardName(it) == "Grizzly Bears" } shouldBe true
+    }
+
+    test("declining bounces the creature to its owner's hand") {
+        val d = driver()
+        val shard = d.shard()
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.giveColorlessMana(d.player1, 3)
+        d.giveColorlessMana(d.player2, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, shard, genericAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.submitYesNo(d.player2, false)
+
+        d.state.getBattlefield().contains(bear) shouldBe false
+        withClue("it goes to its *owner's* hand — player2 both owns and controls it here") {
+            d.getHand(d.player2).any { d.getCardName(it) == "Grizzly Bears" } shouldBe true
+        }
+    }
+
+    test("a controller with no mana is never prompted — the bounce just happens") {
+        val d = driver()
+        val shard = d.shard()
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.giveColorlessMana(d.player1, 3)
+        // player2 has an empty pool and no lands to tap.
+
+        d.submit(
+            ActivateAbility(d.player1, shard, genericAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        withClue("Gate.MayPay skips an unpayable cost instead of offering an impossible yes") {
+            d.pendingDecision shouldBe null
+        }
+        d.state.getBattlefield().contains(bear) shouldBe false
+    }
+
+    test("the {U} half of the printed ability does the same thing for one blue mana") {
+        val d = driver()
+        val shard = d.shard()
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        d.giveMana(d.player1, Color.BLUE, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, shard, blueAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.state.getBattlefield().contains(bear) shouldBe false
+    }
+
+    test("only one of the two costs can be paid per untap — both include the shard's {T}") {
+        val d = driver()
+        val shard = d.shard()
+        val bear = d.putCreatureOnBattlefield(d.player2, "Grizzly Bears")
+        val other = d.putCreatureOnBattlefield(d.player2, "Centaur Courser")
+        d.giveColorlessMana(d.player1, 3)
+        d.giveMana(d.player1, Color.BLUE, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, shard, genericAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+
+        withClue("the shard is now tapped, so the {U} half has no {T} left to pay") {
+            d.submit(
+                ActivateAbility(d.player1, shard, blueAbility, targets = listOf(ChosenTarget.Permanent(other)))
+            ).isSuccess shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PearlShardScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/PearlShardScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.PearlShard
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pearl Shard (MRD #225) — "{3}, {T} or {W}, {T}: Prevent the next 2 damage that would be dealt to
+ * any target this turn."
+ *
+ * "Any target" means a player as readily as a creature, and "the next 2" means a shield that absorbs
+ * partially and then runs out — a prevent-all reading would look identical against a single small
+ * hit. Both are pinned here, along with the shared `{T}` that makes the two printed cost halves
+ * mutually exclusive per untap (2004-10-04 ruling).
+ */
+class PearlShardScenarioTest : FunSpec({
+
+    val genericAbility = PearlShard.activatedAbilities.first().id
+    val whiteAbility = PearlShard.activatedAbilities[1].id
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + PearlShard)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.shard(): EntityId = putPermanentOnBattlefield(player1, "Pearl Shard")
+
+    /** Bolt [victim] for 3 from player2, handing them priority first (they are not the active player). */
+    fun GameTestDriver.boltAt(victim: EntityId) {
+        val bolt = putCardInHand(player2, "Lightning Bolt")
+        giveMana(player2, Color.RED, 1)
+        passPriority(player1)
+        castSpell(player2, bolt, targets = listOf(victim)).isSuccess shouldBe true
+        bothPass()
+    }
+
+    test("a shield on a player absorbs 2 of a 3-damage burn spell") {
+        val d = driver()
+        val shard = d.shard()
+        d.giveColorlessMana(d.player1, 3)
+
+        d.submit(
+            ActivateAbility(d.player1, shard, genericAbility, targets = listOf(ChosenTarget.Player(d.player1)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.boltAt(d.player1)
+
+        withClue("2 of the 3 prevented, so exactly 1 gets through") {
+            d.getLifeTotal(d.player1) shouldBe 19
+        }
+    }
+
+    test("a shield on a creature keeps a 2-damage hit from killing it") {
+        val d = driver()
+        val shard = d.shard()
+        val bear = d.putCreatureOnBattlefield(d.player1, "Grizzly Bears") // 2/2
+        d.giveMana(d.player1, Color.WHITE, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, shard, whiteAbility, targets = listOf(ChosenTarget.Permanent(bear)))
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        d.boltAt(bear)
+
+        withClue("3 damage minus the 2 prevented is 1 — not lethal to a 2/2") {
+            d.state.getBattlefield().contains(bear) shouldBe true
+        }
+    }
+
+    test("only one of the two costs can be paid per untap — both include the shard's {T}") {
+        val d = driver()
+        val shard = d.shard()
+        d.giveColorlessMana(d.player1, 3)
+        d.giveMana(d.player1, Color.WHITE, 1)
+
+        d.submit(
+            ActivateAbility(d.player1, shard, genericAbility, targets = listOf(ChosenTarget.Player(d.player1)))
+        ).isSuccess shouldBe true
+
+        withClue("the shard is now tapped, so the {W} half has no {T} left to pay") {
+            d.submit(
+                ActivateAbility(d.player1, shard, whiteAbility, targets = listOf(ChosenTarget.Player(d.player1)))
+            ).isSuccess shouldBe false
+        }
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SwordOfKaldraScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SwordOfKaldraScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.ViridianLongbow
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sword of Kaldra (MRD #251) — "Equipped creature gets +5/+5. Whenever equipped creature deals damage
+ * to a creature, exile that creature." Equip {4}.
+ *
+ * Two claims in the trigger are easy to get backwards, and both are pinned here.
+ *
+ * **"That creature" is the *damaged* one.** A damage trigger stamps the *recipient* as the triggering
+ * entity, so `EffectTarget.TriggeringEntity` is the creature that was hit — not the equipped creature
+ * that hit it. The exile landing on the wrong side of the damage would still "work" in a test that
+ * only counted exiles.
+ *
+ * **"Deals damage", not "deals combat damage".** A Viridian Longbow ping is the cleanest proof: it is
+ * noncombat damage, and it is only 1, so the target survives the damage itself and can be observed
+ * going to exile rather than dying to a state-based action. (The printed reminder "(Exile it only if
+ * it's still on the battlefield)" is why a lethal hit needs no wiring — there is nothing left to move.)
+ */
+class SwordOfKaldraScenarioTest : ScenarioTestBase() {
+
+    // The pinger the Longbow grants its host — the noncombat damage source used below.
+    private val longbowPinger =
+        ViridianLongbow.staticAbilities.filterIsInstance<GrantActivatedAbility>().single().ability.id
+
+    init {
+        context("Sword of Kaldra — exile whatever the equipped creature damages") {
+            test("a 1-damage ping exiles the damaged creature and leaves the equipped one alone") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Sword of Kaldra", "Grizzly Bears")
+                    .withCardAttachedTo(1, "Viridian Longbow", "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val courser = game.findPermanent("Centaur Courser")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bears,
+                        abilityId = longbowPinger,
+                        targets = listOf(ChosenTarget.Permanent(courser)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("1 damage to a 3/3 is survivable — it left the battlefield by exile, not by dying") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                    game.isInExile(2, "Centaur Courser") shouldBe true
+                    game.isInGraveyard(2, "Centaur Courser") shouldBe false
+                }
+                withClue("'that creature' is the damage's recipient, not its source") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("damage dealt to a player does not trigger it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Sword of Kaldra", "Grizzly Bears")
+                    .withCardAttachedTo(1, "Viridian Longbow", "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Centaur Courser", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bears,
+                        abilityId = longbowPinger,
+                        targets = listOf(ChosenTarget.Player(game.player2Id)),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("RecipientFilter.AnyCreature — a face ping is not a creature") {
+                    game.getLifeTotal(2) shouldBe 19
+                    game.isOnBattlefield("Centaur Courser") shouldBe true
+                    game.isInExile(2, "Centaur Courser") shouldBe false
+                }
+            }
+
+            test("equipped creature gets +5/+5") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Sword of Kaldra", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = StateProjector().project(game.state)
+
+                projected.getPower(bears) shouldBe 7
+                projected.getToughness(bears) shouldBe 7
+            }
+        }
+    }
+}

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WorldslayerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WorldslayerScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Worldslayer (MRD #276) — "Whenever equipped creature deals combat damage to a player, destroy all
+ * permanents other than this Equipment." Equip {5}.
+ *
+ * The whole card is one [com.wingedsheep.sdk.dsl.Effects.DestroyAll] over
+ * `GameObjectFilter.Permanent.notSourceItself()`, so the two things worth proving are the two halves
+ * of that filter: it really does spare Worldslayer (otherwise the card destroys itself and the
+ * board-reset-and-re-equip loop it is famous for never happens), and it really does spare *nothing
+ * else* — the 2011-09-22 ruling ("The equipped creature is also destroyed") and the lands both fall
+ * out of the same filter rather than a carve-out.
+ *
+ * The third test pins the trigger's recipient: combat damage to a *creature* is not combat damage to
+ * a player, so a blocked Worldslayer carrier leaves the board standing.
+ */
+class WorldslayerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Worldslayer — combat damage to a player wipes everything but the Equipment") {
+            test("every other permanent is destroyed, including the equipped creature and both players' lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Worldslayer", "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Centaur Courser", summoningSickness = false)
+                    .withLandsOnBattlefield(2, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareNoBlockers()
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.passPriority()
+                game.resolveStack()
+
+                withClue("`notSourceItself()` is the only exclusion — Worldslayer survives its own wipe") {
+                    game.isOnBattlefield("Worldslayer") shouldBe true
+                }
+                withClue("2011-09-22 ruling: the equipped creature is also destroyed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("'all permanents' means lands too, on both sides") {
+                    game.isOnBattlefield("Forest") shouldBe false
+                    game.isOnBattlefield("Mountain") shouldBe false
+                }
+                withClue("the opponent's board goes with it") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                }
+            }
+
+            test("combat damage to a blocking creature is not damage to a player — nothing is destroyed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Worldslayer", "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardOnBattlefield(2, "Force of Nature", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                // The 5/5 eats the 2/2; the damage the Bears deal goes to a creature, not a player.
+                game.declareBlockers(mapOf("Force of Nature" to listOf("Grizzly Bears"))).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.passPriority()
+                game.resolveStack()
+
+                withClue("RecipientFilter.AnyPlayer never matched, so no wipe") {
+                    game.isOnBattlefield("Force of Nature") shouldBe true
+                    game.isOnBattlefield("Forest") shouldBe true
+                    game.isOnBattlefield("Worldslayer") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/WorldslayerReprint.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/WorldslayerReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Worldslayer reprint in M12. Canonical CardDefinition lives in Mirrodin, its earliest set.
+ */
+val WorldslayerReprint = Printing(
+    oracleId = "31be715f-9ad3-435c-9e52-e108fe96b969",
+    name = "Worldslayer",
+    setCode = "M12",
+    collectorNumber = "222",
+    scryfallId = "db6c6b15-40f3-4556-978f-878bedb13762",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db6c6b15-40f3-4556-978f-878bedb13762.jpg?1783941046",
+    releaseDate = "2011-07-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -93,6 +93,108 @@
     "colorIdentityOverride": []
 }
 
+// Altar of Shadows
+{
+    "name": "Altar of Shadows",
+    "manaCost": "{7}",
+    "typeLine": "Artifact",
+    "oracleText": "At the beginning of your first main phase, add {B} for each charge counter on this artifact.\n{7}, {T}: Destroy target creature. Then put a charge counter on this artifact.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "PRECOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": {
+                                "type": "Named",
+                                "name": "charge"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            },
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "charge",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ],
+                "descriptionOverride": "{7}, {T}: Destroy target creature. Then put a charge counter on this artifact."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "RARE",
+        "artist": "Sam Wood",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/ebc3824c-11ee-4fec-9397-823783b682d9.jpg?1783944528",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "The precombat main phase is the first main phase of the turn. All others are postcombat main phases, even if they technically occur before combat."
+            },
+            {
+                "date": "2004-12-01",
+                "text": "You put the counter on Altar of Shadows even if the creature regenerates."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Altar's Light
 {
     "name": "Altar's Light",
@@ -1484,6 +1586,148 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Crystal Shard
+{
+    "name": "Crystal Shard",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T} or {U}, {T}: Return target creature to its owner's hand unless its controller pays {1}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayDynamicManaCost",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "payer": {
+                                "type": "ControllerOf",
+                                "targetDescription": "target creature"
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": []
+                    },
+                    "otherwise": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature"
+                        },
+                        "destination": "Hand"
+                    },
+                    "decisionMaker": "TargetController",
+                    "descriptionOverride": "Return target creature to its owner's hand unless its controller pays {1}."
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ],
+                "descriptionOverride": "{3}, {T}: Return target creature to its owner's hand unless its controller pays {1}."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayDynamicManaCost",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "payer": {
+                                "type": "ControllerOf",
+                                "targetDescription": "target creature"
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": []
+                    },
+                    "otherwise": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature"
+                        },
+                        "destination": "Hand"
+                    },
+                    "decisionMaker": "TargetController",
+                    "descriptionOverride": "Return target creature to its owner's hand unless its controller pays {1}."
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ],
+                "descriptionOverride": "{U}, {T}: Return target creature to its owner's hand unless its controller pays {1}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Doug Chaffee",
+        "flavorText": "The vedalken know it is not of this world, so they know that this world is not the only one.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1c1d05b-92be-40d7-859f-75293a531a84.jpg?1783944524",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "You can pay either of the two costs (but not both at the same time) to activate the ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -6261,6 +6505,102 @@
     ]
 }
 
+// Pearl Shard
+{
+    "name": "Pearl Shard",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{3}, {T} or {W}, {T}: Prevent the next 2 damage that would be dealt to any target this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{3}, {T}: Prevent the next 2 damage that would be dealt to any target this turn."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "PreventDamageShield",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    },
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ],
+                "descriptionOverride": "{W}, {T}: Prevent the next 2 damage that would be dealt to any target this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "UNCOMMON",
+        "artist": "Doug Chaffee",
+        "flavorText": "Leonin folktales claim it was brought from beyond the sky by the first kha.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abde295d-af41-4b9c-af48-3067befe9383.jpg?1783944508",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "You can pay either of the two costs (but not both at the same time) to activate the ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Pentavus
 {
     "name": "Pentavus",
@@ -8564,6 +8904,76 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Sword of Kaldra
+{
+    "name": "Sword of Kaldra",
+    "manaCost": "{4}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Equipped creature gets +5/+5.\nWhenever equipped creature deals damage to a creature, exile that creature. (Exile it only if it's still on the battlefield.)\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "recipient": "AnyCreature"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "TriggeringEntity",
+                    "destination": "Exile"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 5,
+                "toughnessBonus": 5
+            }
+        ]
+    },
+    "equipCost": "{4}",
+    "metadata": {
+        "collectorNumber": "251",
+        "rarity": "RARE",
+        "artist": "Donato Giancola",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a665bff-b57a-450c-9310-932b0686a03e.jpg?1783944501"
+    },
+    "colorIdentityOverride": []
 }
 
 // Sylvan Scrying
@@ -10940,6 +11350,103 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Worldslayer
+{
+    "name": "Worldslayer",
+    "manaCost": "{5}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Whenever equipped creature deals combat damage to a player, destroy all permanents other than this Equipment.\nEquip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsPermanent"
+                                    ],
+                                    "statePredicates": [
+                                        {
+                                            "type": "StateNot",
+                                            "predicate": "IsSource"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ]
+    },
+    "equipCost": "{5}",
+    "metadata": {
+        "collectorNumber": "276",
+        "rarity": "RARE",
+        "artist": "Greg Staples",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3cb1b869-3e2d-4447-a12d-e790883feeee.jpg?1783944496",
+        "rulings": [
+            {
+                "date": "2011-09-22",
+                "text": "The equipped creature is also destroyed."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Wrench Mind


### PR DESCRIPTION
Five Mirrodin artifacts, all built from existing `Effects.*` / `Triggers.*` primitives. MRD goes 222/291 → 227/291.

| Card | What it does | Built from |
|---|---|---|
| **Pearl Shard** {3} | `{3}, {T} or {W}, {T}`: prevent the next 2 damage to any target | `Effects.PreventNextDamage` + `AnyTarget`; two `activatedAbility` blocks for the dual cost |
| **Crystal Shard** {3} | `{3}, {T} or {U}, {T}`: bounce target creature unless its controller pays {1} | `GatedEffect` + `Gate.MayPay` with `decisionMaker = TargetController` and `PayDynamicMana(payer = ControllerOf(...))` |
| **Altar of Shadows** {7} | First-main {B} per charge counter; `{7}, {T}`: destroy a creature, then add a counter | `Triggers.FirstMainPhase` + `AddMana(BLACK, countersOnSelf(charge))`; `Composite(Destroy, AddCounters)` |
| **Worldslayer** {5} | Equipped creature connects → destroy all permanents but this Equipment | `Triggers.dealsDamage(Combat, AnyPlayer, ATTACHED)` + `DestroyAll(Permanent.notSourceItself())` |
| **Sword of Kaldra** {4} | +5/+5; equipped creature damages a creature → exile it | `ModifyStats(5,5)` + `dealsDamage(Any, AnyCreature, ATTACHED)` + `Exile(TriggeringEntity)` |

Pearl Shard and Crystal Shard complete the Mirrodin Shard cycle — Granite, Heartwood and Skeleton Shard were already in the corpus, so all five now share the `GraniteShard` dual-cost shape.

## Notes

**No new SDK vocabulary.** Every card composes what was already there.

**Worldslayer's M12 reprint** gets a `Printing` row; the canonical stays in Mirrodin. `just check-card-printing` is clean for all five.

**Scenario tests** — one file per card, 17 tests. They aren't strictly required (nothing new was added to the SDK), but four of these wirings are the kind that look right and resolve wrong, so each is pinned:
- Crystal Shard: the *opponent* is the one prompted and the one charged, a paying opponent keeps their creature, and a tapped-out opponent is never offered an impossible "yes".
- Worldslayer: Worldslayer survives its own wipe, the equipped creature and both players' lands do not (2011-09-22 ruling), and a *blocked* carrier triggers nothing.
- Sword of Kaldra: "that creature" is the damage's recipient, not its source — proved with a 1-damage Viridian Longbow ping so the target survives the damage and is observably exiled rather than dying.
- Altar of Shadows: the counter goes on in the same resolution, and the trigger's amount is re-read (0 counters → 0 mana).

**Cards dropped from the batch**, each because it needs new engine vocabulary rather than composition:
- *Mesmeric Orb* — `Patterns.Library.mill` maps its `EffectTarget` to a `Player`, and `EffectTarget.ControllerOfTriggeringEntity` falls through to `Player.You`. Milling "that permanent's controller" needs a `Player` variant that doesn't exist, and faking it would silently mill the wrong player.
- *Myr Prototype* — "can't attack or block unless you pay {1} for each +1/+1 counter on it" is a self-scoped tax; `AttackTax`/`BlockTax` are global, and `GrantAttackBlockTaxPerCreatureType` is keyed to a creature type.
- *Loxodon Peacekeeper* — needs "player with the *lowest* life, ties broken by choice"; `GainControlByMostLife` is most-life and no-change-on-tie.
- *Jinxed Choker* — "target opponent gains control of this artifact" inverts `GainControlEffect`, which always gives control to the ability's controller.
- Every imprint card in the missing list (Chrome Mox, Duplicant, Isochron Scepter, Mirror Golem, Mourner's Shield, Soul Foundry, Spellweaver Helix, Extraplanar Lens) — imprint has no SDK support at all.

**Unrelated observation, not touched here:** `ShieldOfKaldra.kt` (DST, generated) renders "Equipment named Sword of Kaldra, Shield of Kaldra, and Helm of Kaldra have indestructible" as `GrantKeyword(INDESTRUCTIBLE, GroupFilter(GameObjectFilter.Permanent))` — indestructible for *every permanent on the battlefield*. Left alone per the focus-on-your-own-work rule; worth its own fix.

## Verification

- `just build` — green (`CardDefinitionSnapshotTest` re-blessed; only the five new cards appear in `MRD.json`, additions only)
- `just test-scenarios 2003-2007` — green
- `just check-card-printing` — clean for all five

🤖 Generated with [Claude Code](https://claude.com/claude-code)