### PR TITLE
Offer X on an Adventure face's own mana cost

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -244,7 +244,10 @@ carries the other side for the hover preview's flip toggle.
   the primary face from exile — *cast* the creature, or *play* the land for a **land // spell** Adventure
   (`Land — Town // Sorcery — Adventure`, e.g. Ishgard, the Holy See // Faith & Grief). The generic may-play
   permission covers both; from hand a land-primary Adventure offers *play the land* (PlayLandEnumerator) **and**
-  *cast the Adventure spell* (`CastSpell.faceIndex = 0`).
+  *cast the Adventure spell* (`CastSpell.faceIndex = 0`). An `{X}` in the *face's* own mana cost is supported —
+  the face's cast action carries `hasXCost`/`maxAffordableX`, so the client opens its X picker and
+  `DynamicAmount.XValue` in the face's `spell { }` reads the declared X (An Unexpected Party // At the Door,
+  `{X}{2}{W}` "Create X 2/2 red Dwarf creature tokens").
 - `OMEN` — primary face is a permanent (creature), `cardFaces[0]` is an instant/sorcery Omen (Tarkir: Dragonstorm).
   Casts exactly like an Adventure (creature face, or Omen via `CastSpell.faceIndex = 0`), but resolving the Omen
   **shuffles the card into its owner's library** instead of exiling it — no cast-from-exile linkage. DSL:

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AnUnexpectedPartyScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AnUnexpectedPartyScenarioTest.kt
@@ -1,0 +1,161 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.hob.cards.AnUnexpectedParty
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * An Unexpected Party // At the Door (HOB #29) — {2}{W}{W} Enchantment with an
+ * `{X}{2}{W} Sorcery — Adventure` face ("Create X 2/2 red Dwarf creature tokens").
+ *
+ * The Adventure's {X} lives in the *face's* mana cost, not the card's top-level one. The
+ * enumerated cast action therefore has to carry `hasXCost` / `maxAffordableX` off the face's
+ * effective cost — without them the client never opens the X picker, the face casts at X = 0, and
+ * "create X tokens" creates nothing (the reported bug).
+ */
+class AnUnexpectedPartyScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AnUnexpectedParty)
+        return driver
+    }
+
+    fun startAtMain(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return player
+    }
+
+    test("the Adventure face is offered with an X picker, and the ceiling is what the board can pay") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        driver.putCardInHand(player, "An Unexpected Party")
+        repeat(6) { driver.putPermanentOnBattlefield(player, "Plains") }
+
+        val adventure = driver.legalActions(player)
+            .single { (it.action as? CastSpell)?.faceIndex == 0 }
+
+        adventure.hasXCost shouldBe true
+        // Six Plains, {X}{2}{W} — three mana is spoken for by the fixed part, so X tops out at 3.
+        adventure.maxAffordableX shouldBe 3
+        adventure.manaCostString shouldBe "{X}{2}{W}"
+    }
+
+    test("the enchantment face carries no X picker") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        driver.putCardInHand(player, "An Unexpected Party")
+        repeat(6) { driver.putPermanentOnBattlefield(player, "Plains") }
+
+        val enchantment = driver.legalActions(player)
+            .single { (it.action as? CastSpell)?.faceIndex == null && it.description.contains("An Unexpected Party") }
+
+        enchantment.hasXCost shouldBe false
+        enchantment.maxAffordableX shouldBe null
+    }
+
+    test("casting At the Door for X = 3 creates three 2/2 red Dwarves and exiles the card") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val party = driver.putCardInHand(player, "An Unexpected Party")
+        driver.giveMana(player, Color.WHITE, 6) // {X=3}{2}{W}
+
+        driver.submit(
+            CastSpell(playerId = player, cardId = party, faceIndex = 0, xValue = 3)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        val dwarves = dwarfTokens(driver, player)
+        dwarves.size shouldBe 3
+        dwarves.forEach { token ->
+            projector.getProjectedPower(driver.state, token) shouldBe 2
+            projector.getProjectedToughness(driver.state, token) shouldBe 2
+            driver.state.getEntity(token)!!.get<CardComponent>()!!.colors shouldBe setOf(Color.RED)
+        }
+
+        // CR 715.3d — the Adventure exiles itself, castable as the enchantment later.
+        driver.getExile(player) shouldContain party
+        driver.state.mayPlayPermissions.any { party in it.cardIds && it.controllerId == player } shouldBe true
+    }
+
+    test("X is read from the cast, not hardcoded: X = 1 creates one Dwarf") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val party = driver.putCardInHand(player, "An Unexpected Party")
+        driver.giveMana(player, Color.WHITE, 4) // {X=1}{2}{W}
+
+        driver.submit(
+            CastSpell(playerId = player, cardId = party, faceIndex = 0, xValue = 1)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        dwarfTokens(driver, player).size shouldBe 1
+    }
+
+    test("the enchantment's chosen type gets +2/+2 — Dwarves the Adventure made included") {
+        val driver = createDriver()
+        val player = startAtMain(driver)
+
+        val party = driver.putCardInHand(player, "An Unexpected Party")
+        driver.giveMana(player, Color.WHITE, 5) // {X=2}{2}{W}
+        driver.submit(
+            CastSpell(playerId = player, cardId = party, faceIndex = 0, xValue = 2)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        val dwarves = dwarfTokens(driver, player)
+        dwarves.size shouldBe 2
+
+        // The enchantment face, with "Dwarf" already chosen (the EntersWithChoice resumer's own
+        // path is covered by the shared choose-a-type tests; this isolates the lord).
+        val enchantment = driver.putPermanentOnBattlefield(player, "An Unexpected Party")
+        driver.replaceState(
+            driver.state.updateEntity(enchantment) { c ->
+                c.with(
+                    CastChoicesComponent(
+                        chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Dwarf"))
+                    )
+                )
+            }
+        )
+
+        dwarves.forEach { token ->
+            projector.getProjectedPower(driver.state, token) shouldBe 4
+            projector.getProjectedToughness(driver.state, token) shouldBe 4
+        }
+    }
+})
+
+private fun dwarfTokens(driver: GameTestDriver, player: EntityId): List<EntityId> =
+    driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD)).filter { id ->
+        val entity = driver.state.getEntity(id) ?: return@filter false
+        entity.has<TokenComponent>() &&
+            entity.get<ControllerComponent>()?.playerId == player &&
+            entity.get<CardComponent>()?.typeLine?.subtypes?.any { it.value == "Dwarf" } == true
+    }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -107,7 +107,8 @@ class CastSpellEnumerator : ActionEnumerator {
                         // The land primary is always an available alternative, so surface the
                         // spell face even when unaffordable (grayed out in the drag-to-play menu).
                         enumerateSecondaryFace(
-                            context, cardId, landCardDef, result, primaryFaceAffordable = true
+                            context, cardId, landCardDef, cardComponent, result,
+                            primaryFaceAffordable = true
                         )
                     }
                 }
@@ -165,7 +166,8 @@ class CastSpellEnumerator : ActionEnumerator {
                     state, playerId, primaryFaceCost, precomputedSources = context.availableManaSources
                 )
                 secondaryFaceAffordable = enumerateSecondaryFace(
-                    context, cardId, cardDef, result, primaryFaceAffordable = primaryFaceAffordable
+                    context, cardId, cardDef, cardComponent, result,
+                    primaryFaceAffordable = primaryFaceAffordable
                 )
                 // Don't `continue` — let the surrounding loop also enumerate the primary face.
             }
@@ -3010,10 +3012,10 @@ class CastSpellEnumerator : ActionEnumerator {
      * cast path; this method only adds the alternative-characteristics cast that uses
      * [CastSpell.faceIndex] = 0.
      *
-     * Supports mana cost, instant/sorcery timing, and per-face target requirements. Additional
-     * costs declared on the face's script are honoured for affordability but the full
-     * additional-cost UX (sacrifice picker, blight, etc.) is not yet wired for these faces —
-     * cards that need that can extend this method later.
+     * Supports mana cost (including an {X} in the face's own cost), instant/sorcery timing, and
+     * per-face target requirements. Additional costs declared on the face's script are honoured
+     * for affordability but the full additional-cost UX (sacrifice picker, blight, etc.) is not
+     * yet wired for these faces — cards that need that can extend this method later.
      *
      * @param primaryFaceAffordable Whether the card's primary (creature) face is affordable.
      *        When the secondary face is unaffordable but the primary is affordable, a grayed-out
@@ -3139,6 +3141,7 @@ class CastSpellEnumerator : ActionEnumerator {
         context: EnumerationContext,
         cardId: EntityId,
         cardDef: CardDefinition,
+        cardComponent: CardComponent,
         result: MutableList<LegalAction>,
         primaryFaceAffordable: Boolean,
     ): Boolean {
@@ -3153,8 +3156,12 @@ class CastSpellEnumerator : ActionEnumerator {
         val effectiveCost = context.costCalculator
             .calculateEffectiveCostWithAlternativeBase(state, cardDef, face.manaCost, playerId)
         val cachedSources = context.availableManaSources
+        // Same payment context `CastSpellHandler.validatePayment` builds for this cast, so
+        // conditional mana ("spend only to cast …") is judged identically on both sides and the
+        // X ceiling below can never offer more than validation will accept.
+        val spellContext = spellPaymentContextFor(cardComponent)
         val canAfford = context.manaSolver
-            .canPay(state, playerId, effectiveCost, precomputedSources = cachedSources)
+            .canPay(state, playerId, effectiveCost, precomputedSources = cachedSources, spellContext = spellContext)
         if (!canAfford) {
             // Secondary face is unaffordable. If the primary face is affordable, still surface
             // this face as a grayed-out option so the drag-to-play menu presents both and the
@@ -3181,12 +3188,29 @@ class CastSpellEnumerator : ActionEnumerator {
         }
         val manaCostString = effectiveCost.toString()
 
+        // {X} in the *face's* mana cost (An Unexpected Party // At the Door — "{X}{2}{W}, Create X
+        // 2/2 red Dwarf creature tokens"). Without these two fields the client never opens the
+        // X picker, so the face casts at X = 0 and the spell does nothing. The ceiling is the
+        // plain-mana one the primary cast path computes; convoke/delve/waterbend are not wired
+        // for secondary faces, so none of their ceiling contributions apply here.
+        val hasXCost = effectiveCost.hasX
+        val maxAffordableX: Int? = if (hasXCost) {
+            val availableSources = context.manaSolver.getAvailableManaCount(
+                state, playerId, precomputedSources = cachedSources, spellContext = spellContext
+            )
+            val fixedCost = effectiveCost.cmc // X contributes 0 to CMC
+            val xSymbolCount = effectiveCost.xCount.coerceAtLeast(1)
+            ((availableSources - fixedCost) / xSymbolCount).coerceAtLeast(0)
+        } else null
+
         if (targetReqs.isEmpty()) {
             result.add(
                 LegalAction(
                     actionType = "CastSpell",
                     description = "Cast ${face.name}",
                     action = CastSpell(playerId, cardId, faceIndex = 0),
+                    hasXCost = hasXCost,
+                    maxAffordableX = maxAffordableX,
                     manaCostString = manaCostString,
                     autoTapPreview = autoTapPreview,
                 )
@@ -3209,6 +3233,12 @@ class CastSpellEnumerator : ActionEnumerator {
                 minTargets = firstReq.effectiveMinCount,
                 targetDescription = firstReq.description,
                 targetRequirements = if (targetInfos.size > 1) targetInfos else null,
+                xConstrainsTargetManaValue = firstInfo.xConstrainsManaValue,
+                xConstrainsTargetManaValueExactly = firstInfo.xConstrainsManaValueExactly,
+                xConstrainsTargetPower = firstInfo.xConstrainsPower,
+                xConstrainsTargetCount = firstInfo.xConstrainsCount,
+                hasXCost = hasXCost,
+                maxAffordableX = maxAffordableX,
                 manaCostString = manaCostString,
                 autoTapPreview = autoTapPreview,
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/AdventureFaceEnumerationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/legalactions/AdventureFaceEnumerationTest.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.legalactions.support.setupP1
 import com.wingedsheep.mtg.sets.definitions.blc.cards.BrightcapBadger
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -79,6 +80,51 @@ class AdventureFaceEnumerationTest : FunSpec({
             typeLine = "Sorcery — Adventure"
             spell { effect = Effects.DrawCards(1) }
         }
+    }
+
+    // An {X} in the *Adventure face's* own mana cost. The face's cast action has to carry the X
+    // fields, or the client never opens the X picker and the face casts at X = 0.
+    val xCostAdventure = card("Test Thane") {
+        manaCost = "{2}{W}{W}"
+        typeLine = "Enchantment"
+        adventure("Test Muster") {
+            manaCost = "{X}{2}{W}"
+            typeLine = "Sorcery — Adventure"
+            spell {
+                effect = Effects.CreateToken(
+                    count = DynamicAmount.XValue, power = 2, toughness = 2, creatureTypes = setOf("Dwarf")
+                )
+            }
+        }
+    }
+
+    test("an {X} in the Adventure face's cost is offered as an X cost, with a board-derived ceiling") {
+        val driver = setupP1(
+            hand = listOf("Test Thane"),
+            battlefield = List(6) { "Plains" },
+            extraSetCards = listOf(xCostAdventure),
+        )
+
+        val adventure = driver.enumerateFor(driver.player1).castActionsFor("Test Thane")
+            .single { (it.action as CastSpell).faceIndex == 0 }
+
+        adventure.hasXCost shouldBe true
+        // Six lands, {X}{2}{W}: three mana is spoken for by the fixed part.
+        adventure.maxAffordableX shouldBe 3
+    }
+
+    test("the primary face of the same card keeps its own (X-free) cost") {
+        val driver = setupP1(
+            hand = listOf("Test Thane"),
+            battlefield = List(6) { "Plains" },
+            extraSetCards = listOf(xCostAdventure),
+        )
+
+        val primary = driver.enumerateFor(driver.player1).castActionsFor("Test Thane")
+            .single { (it.action as CastSpell).faceIndex == null }
+
+        primary.hasXCost shouldBe false
+        primary.maxAffordableX shouldBe null
     }
 
     test("only the creature face affordable: Adventure face surfaces as a grayed-out placeholder") {


### PR DESCRIPTION
## The bug

An Unexpected Party // At the Door (HOB #29) — the Adventure face is `{X}{2}{W}, Sorcery — Adventure`, "Create X 2/2 red Dwarf creature tokens". In the UI there was no way to choose X: the face was offered, the cast went through at X = 0, and nothing was created.

## Cause

`CastSpellEnumerator.enumerateSecondaryFace` — the path that offers the secondary spell face of an Adventure / Omen / modal DFC — never computed `hasXCost` or `maxAffordableX`, even when the face's *own* mana cost carries `{X}`. The client gates its `xSelection` pipeline phase on exactly those two fields (`pipelinePhases.ts`), so the picker never opened.

Everything downstream was already face-aware, which is why this was a UI-only symptom rather than a wrong resolution: `CastSpellHandler` reads the face's mana cost, validates the X payment against it, reads `xManaRestriction` off the face script, and `StackResolver` carries the declared X through to `DynamicAmount.XValue`.

## The fix

`rules-engine/.../CastSpellEnumerator.kt`

- Derive `hasXCost` / `maxAffordableX` from the face's effective cost and attach them to both emitted actions (targeted and untargeted), along with the `xConstrains*` target fields the primary cast path already carries. The ceiling is the plain-mana one the primary path computes; convoke/delve/waterbend aren't wired for secondary faces, so none of their contributions apply here.
- The same function now passes the spell payment context `CastSpellHandler.validatePayment` builds into `canPay` / `getAvailableManaCount`, so conditional mana ("spend this mana only to …") is judged identically on both sides and the offered ceiling can never exceed what validation accepts.

No client change was needed — the X picker, the mana-source exposure (`LegalActionEnricher.shouldExposeManaSources`), and the DTO passthrough all key off those two fields.

## Tests

- `AdventureFaceEnumerationTest` — two new cases over a synthetic `{X}{2}{W}` Adventure face: the face's action carries `hasXCost` with a board-derived ceiling (6 lands → X ≤ 3), and the primary face of the same card stays X-free.
- `AnUnexpectedPartyScenarioTest` (new, one card / one file) — the enumerated X picker and its ceiling, the X = 3 and X = 1 casts (3 and 1 Dwarves, 2/2 red, card exiled with replay permission per CR 715.3d), and the enchantment half's chosen-type lord picking up the Dwarves it made.

`just test-rules` (engine tests + every card scenario) passes.

## Docs

`docs/card-sdk-language-reference.md` — the `ADVENTURE` layout entry now records that an `{X}` in the face's own cost is supported end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)