### PR TITLE
Assay: the Portal band — 200/200, and two card bugs the differential found

### DIFF
--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/5dn/cards/EternalWitness.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/5dn/cards/EternalWitness.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetObject
 
@@ -30,7 +31,10 @@ val EternalWitness = card("Eternal Witness") {
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
         optional = true
-        val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD)),
+        )
         effect = Effects.Move(t, Zone.HAND)
     }
     metadata {

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Recollect.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/Recollect.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetObject
 
@@ -24,7 +25,10 @@ val Recollect = card("Recollect") {
     typeLine = "Sorcery"
     oracleText = "Return target card from your graveyard to your hand."
     spell {
-        val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD)),
+        )
         effect = Effects.Move(t, Zone.HAND)
     }
     metadata {

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EternalWitnessScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EternalWitnessScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Eternal Witness (5DN #86) — {1}{G}{G} 2/1 Human Shaman, "When this creature enters, you may return
+ * target card from **your** graveyard to your hand."
+ *
+ * The same bug Recollect shipped with, in a trigger: the definition filtered on
+ * `TargetFilter.CardInGraveyard`, which is *any* graveyard, so the witness could recur out of an
+ * opponent's. Found by the Argentum Assay differential gate.
+ *
+ * The third test is the half that fails without the fix — with only the opponent's graveyard
+ * populated the trigger has no legal target at all, so it never goes on the stack (CR 603.3d) and
+ * the game does not stop to ask.
+ */
+class EternalWitnessScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 30))
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /**
+     * The witness has to be **cast**: putting a permanent straight onto the battlefield emits no
+     * zone-change event, so no enters trigger fires and there is nothing to target.
+     */
+    fun castWitness(d: GameTestDriver) {
+        val card = d.putCardInHand(d.player1, "Eternal Witness")
+        d.giveMana(d.player1, Color.GREEN, 3)
+        d.castSpell(d.player1, card).isSuccess shouldBe true
+        d.bothPass() // resolve the creature; its enters trigger goes on the stack and wants a target
+    }
+
+    test("the enters trigger returns a card from your own graveyard") {
+        val d = driver()
+        val mine = d.putCardInGraveyard(d.player1, "Grizzly Bears")
+
+        castWitness(d)
+        d.findPermanent(d.player1, "Eternal Witness") shouldNotBe null
+
+        val decision = d.pendingDecision.shouldNotBeNull() as ChooseTargetsDecision
+        decision.legalTargets.getValue(0) shouldContain mine
+
+        d.submitTargetSelection(d.player1, listOf(mine))
+        while (d.stackSize > 0) d.bothPass()
+
+        d.getGraveyardCardNames(d.player1) shouldNotContain "Grizzly Bears"
+        d.getHand(d.player1) shouldContain mine
+    }
+
+    test("a card in an opponent's graveyard is not a legal target") {
+        val d = driver()
+        val mine = d.putCardInGraveyard(d.player1, "Grizzly Bears")
+        val theirs = d.putCardInGraveyard(d.player2, "Centaur Courser")
+
+        castWitness(d)
+
+        val decision = d.pendingDecision.shouldNotBeNull() as ChooseTargetsDecision
+        val legal = decision.legalTargets.getValue(0)
+
+        legal shouldContain mine
+        legal shouldNotContain theirs
+    }
+
+    // The regression. With the unowned filter, an opponent's graveyard alone was enough to give the
+    // trigger a target, and the game stopped to ask for one.
+    test("the trigger has no target when only an opponent's graveyard has cards") {
+        val d = driver()
+        d.putCardInGraveyard(d.player2, "Centaur Courser")
+        d.getGraveyardCardNames(d.player1).size shouldBe 0
+
+        castWitness(d)
+        d.findPermanent(d.player1, "Eternal Witness") shouldNotBe null
+
+        d.isPaused shouldBe false
+    }
+})

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RecollectScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/RecollectScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Recollect (RAV #178) — {2}{G} Sorcery, "Return target card from **your** graveyard to your hand."
+ *
+ * The possessive is the point. The card shipped filtering on `TargetFilter.CardInGraveyard`, which
+ * is *any* graveyard, so Recollect could reach into an opponent's. A generated render that dropped
+ * the word. Found by the Argentum Assay differential gate, which read the printed sentence and
+ * diffed its reading against the committed definition; Elven Cache and Déjà Vu, the other two cards
+ * printing this sentence, both scope it to the caster's own graveyard.
+ *
+ * Both halves are asserted, because only the second would have failed before the fix: a card in your
+ * own graveyard comes back, and one in an opponent's is not a legal target at all (CR 115.4 — an
+ * illegal target can't be chosen), so the cast declaring it is rejected outright.
+ */
+class RecollectScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 30))
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /**
+     * Recollect in hand, the mana its cost wants, and the graveyard card it is aimed at.
+     *
+     * A card in a graveyard is not a permanent, so the target is declared as [ChosenTarget.Card] —
+     * the cast-time variant that carries the zone and the owner the requirement is checked against.
+     */
+    fun castRecollect(d: GameTestDriver, owner: EntityId, card: EntityId) = run {
+        val recollect = d.putCardInHand(d.player1, "Recollect")
+        d.giveMana(d.player1, Color.GREEN, 3)
+        d.castSpellWithTargets(
+            d.player1,
+            recollect,
+            listOf(ChosenTarget.Card(cardId = card, ownerId = owner, zone = Zone.GRAVEYARD)),
+        )
+    }
+
+    test("it returns a card from your own graveyard to your hand") {
+        val d = driver()
+        val mine = d.putCardInGraveyard(d.player1, "Grizzly Bears")
+
+        castRecollect(d, d.player1, mine).isSuccess shouldBe true
+        while (d.stackSize > 0) d.bothPass()
+
+        d.getGraveyardCardNames(d.player1) shouldNotContain "Grizzly Bears"
+        d.getHand(d.player1) shouldContain mine
+    }
+
+    // The regression the gate found. `CardInGraveyard` is unowned, so an opponent's graveyard was
+    // just as legal a source as your own and this cast used to succeed.
+    test("a card in an opponent's graveyard is not a legal target") {
+        val d = driver()
+        d.putCardInGraveyard(d.player1, "Grizzly Bears")
+        val theirs = d.putCardInGraveyard(d.player2, "Centaur Courser")
+
+        castRecollect(d, d.player2, theirs).isSuccess shouldBe false
+        d.getGraveyardCardNames(d.player2) shouldContain "Centaur Courser"
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/5DN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/5DN.json
@@ -707,7 +707,7 @@
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
-                        "baseFilter": {},
+                        "baseFilter": "own:you",
                         "zone": "Graveyard"
                     },
                     "id": "target"

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -2947,7 +2947,7 @@
             {
                 "type": "TargetObject",
                 "filter": {
-                    "baseFilter": {},
+                    "baseFilter": "own:you",
                     "zone": "Graveyard"
                 },
                 "id": "target"

--- a/oracle-assay/AGENTS.md
+++ b/oracle-assay/AGENTS.md
@@ -109,6 +109,14 @@ more. Never write a set-scoped rule. If a new set forces a new *file*, that is t
 which existing family the mechanic is a member of — the expected cost of a set is rows in existing
 lists, and the exceptions should be nameable.
 
+A set is, however, a good *target*: reading all of one proves the grammar has no systematic hole in
+that era rather than no hole in one family, which is a stronger statement than any percentage. The
+Portal band is the worked example — 200 of 200 cards, and the work was four pieces of machinery
+(clause sequences, the layered noun-phrase cascade in two numbers, the two anaphors, the three
+restriction vocabularies) plus rows. Nine cards in it needed a rule that unlocks only them; each says
+in its KDoc why the alternative was not a smaller rule but a wrong one, which is the bar the "a rule
+that unlocks one card needs a stated reason" line sets.
+
 ## Fail-closed matching — the rule that catches the dangerous bug class
 
 **A `match` half reconstructs what `build` would have produced and compares the whole model.** Not a
@@ -126,6 +134,13 @@ The same discipline covers values the text does not determine — target slot na
 Mint one fixed constant (`Targets.SLOT`, `Triggers.ID`); the differential normalizes both sides by
 position. A rule that tried to reproduce a generated id would be reading a counter, not a card.
 
+**Two anaphors, two vocabularies.** Oracle's "it" means the source in a first clause ("Whenever this
+creature attacks, **it** gets +2/+0") and the target in a later one ("Untap target creature. **It**
+gets +2/+4"); "that creature" always means the target. `SelfSteps.anaphoric` and `Continuations` are
+reachable from disjoint positions for exactly that reason — registering either surface form in both
+places is two readings of one text. The differential found this by *running*: the wrong reading
+round-tripped byte-perfectly and meant a different creature.
+
 ## Printed-shape information belongs to normalization
 
 Line grouping, the `;` separator, reminder text, and which noun a card uses for itself are properties
@@ -141,10 +156,13 @@ about where the information lives.
 **Case is the same kind of information, and lives one step further out.** `syntax/SentenceCase.kt`
 sits at the text boundary rather than in a normalization pass, because it moves nothing — it only
 lowercases a letter Oracle templating guarantees is uppercase. It does that at *every* sentence start
-in a line: the first word, and the clause after each ability cost's `": "`. Templates are therefore
-written mid-sentence throughout, and that is what lets `Activated` slot `Steps.step` unchanged rather
-than restating every verb capitalized. If you find yourself wanting a capital inside a template, the
-answer is almost certainly another sentence start this file should know about.
+in a line: the first word, the clause after each ability cost's `": "`, and the clause after each
+full stop. Templates are therefore written mid-sentence throughout, and that is what lets `Activated`
+slot `Steps.step` unchanged, and what lets one line hold several clauses, rather than either needing
+a capitalized second copy of the effect vocabulary. If you find yourself wanting a capital inside a
+template, the answer is almost certainly another sentence start this file should know about — the
+full stop was added exactly that way, and the shock lands' `"If you don't, …"` had to be rewritten
+mid-sentence in the same change.
 
 ## Ambiguity is a factoring signal
 

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -16,9 +16,23 @@ triggers ("When ~ enters, …", "At the beginning of your upkeep, …"), which i
 started comparing whole *abilities* rather than keyword lists, and where it found its first bug in a
 hand-written card. The **land band** followed — mana abilities and "~ enters tapped." — the first
 family where whole-card coverage moved with line coverage, because a land is a one-to-three-line card
-and those are the two sentences on it. The **aura band** is the most recent: `Enchant <filter>` and
-the attached-permanent statics, which opened `staticAbilities` — the largest `CardScript` slot the
+and those are the two sentences on it. The **aura band** followed: `Enchant <filter>` and the
+attached-permanent statics, which opened `staticAbilities` — the largest `CardScript` slot the
 differential could not see into, and the one every later static family lands in.
+
+The most recent is the **Portal band**, and it is the first one measured against a whole *set* rather
+than against a rule family: `just assay-gate --set POR` now reads **200 of Portal's 200 cards** end
+to end. Getting there was not two hundred rules — it was the machinery a set needs before any of its
+cards can be read whole. **A line is a sequence of clauses**, so a card printing two sentences reuses
+the effect vocabulary twice instead of restating it capitalized; **a noun phrase is a layered cascade
+in two grammatical numbers**, so "black creatures you control" and "creatures with power 2 or
+greater" are compositions rather than rules; **two anaphors** ("that creature", "it") are separate
+vocabularies because they point at different objects; and **three restriction vocabularies** —
+casting, activation, additional costs — reach the `CardScript` slots that say when a card may be
+played rather than what it does. Nearly everything else was rows in those lists. Whole-corpus
+coverage went from 3,004 cards to 4,287 in the same change, which is the argument for picking a set
+as the target rather than picking the number.
+
 Nothing here changes `:mtgish-tooling`, which stays authoritative until a per-set cutover replaces it
 (Phase 5). Assay is **not a runtime card loader** and never will be.
 
@@ -60,11 +74,14 @@ its own population. The Set *column* still shows the representative printing, an
 syntax/     Phrase kernel — templates, slots, both directions, memoization, the parse cap
 normalize/  Scryfall text -> canonical ability lines, every pass with its inverse; reminder glosses
 corpus/     the Scryfall Oracle bulk: download, cache, stream; per-set membership for `--set`
-grammar/    the rules, by topic — Primitives, Keywords, Cardinals, Filters, Targets, Steps, Triggers,
-            Mana, Costs, Activated, Replacements, Statics
-            Steps covers draw, destroy/exile/tap/untap/bounce, life, scry/surveil, damage, pump and
-            adding mana; Activated is the cost-colon-effect sentence, which slots Steps whole;
-            Statics is the continuous-ability slot, opened on the aura payoff lines
+grammar/    the rules, by topic — Primitives, Keywords, Cardinals, Conditions, Filters, Targets,
+            Steps, Continuations, Triggers, Mana, Costs, Activated, Replacements, Statics,
+            Restrictions, and the effect-topic files Library, Hand, Combat, Graveyard, Stack,
+            SelfSteps
+            Steps is the clause vocabulary and the sentence/sequence machinery every other file
+            slots into; Activated is the cost-colon-effect sentence; Statics is the continuous-
+            ability slot; Restrictions is the three "when may this happen" vocabularies;
+            Continuations and SelfSteps are the two anaphors ("that creature" / "it")
 gate/       the touchstone, the fineness report, the differential
 explore/    the browser UI — a loopback HTTP server over the live grammar and both gates
 cli/        assay parse | explain | gate | report | differential | explore | corpus
@@ -105,16 +122,17 @@ non-zero on. Declines are not failures.
 Cards assayed                    34882
 Ability lines                    66793  (39059 unique)
 
-Round-trips byte-exact           17977   269.1‰ (26.9%)
-Alternate spelling normalized    30
-Declined                         48786
+Round-trips byte-exact           19746   295.6‰ (29.6%)
+Alternate spelling normalized    318
+Declined                         46729
 Ambiguous — distinct readings    0
 Print mismatch                   0
 Normalization not invertible     0
 Full inverse not reproduced      0
 
-Cards fully covered              3004 / 34882   86.1‰ (8.6%)
+Cards fully covered              4287 / 34882   122.9‰ (12.3%)
 Vanilla + keyword-only cards     1440 / 1712   841.1‰ (84.1%)   <- Phase 1 target
+Portal (set POR)                 200 / 200     1000.0‰ (100%)   <- the Portal band's target
 Reminder-text glosses            2870 matched · 114 differed · 956 unglossed
 ```
 
@@ -124,6 +142,13 @@ The machinery holds: **zero** ambiguities, print mismatches, or non-invertible n
 across 66,793 ability lines. The 84.1% on Phase 1's own target class is not the round trip
 faltering — every remaining line in that class declines because the SDK has no vocabulary for the
 keyword, which `just assay-report --scope` lists in rank order.
+
+**A whole set at 1000‰ is worth more than the percentage it moved.** A rule family's coverage number
+says how much of one shape the grammar reads; a *set* is an arbitrary cross-section of Magic, so
+reading all of one means the grammar has no systematic hole in that era rather than no hole in that
+family. Portal is a deliberately simple set, which is what makes it the right first one — and the
+318 alternate spellings above are mostly its doing, because a card printing "A and B" or "A, then B"
+now reads correctly and prints back as the full-stop form.
 
 ## What Phase 1 already found
 
@@ -168,17 +193,17 @@ partially-read card would count a keyword Assay never saw as agreement, so every
 named population bucket instead and the denominator stays visible.
 
 ```
-  Hand-written cards                 8874
-    compared                         930
-    not yet covered by the grammar   7342
-    script slot not modelled yet      39
-    lines do not fold into one card   20
+  Hand-written cards                 9114
+    compared                         1636
+    not yet covered by the grammar   6830
+    script slot not modelled yet      65
+    lines do not fold into one card   40
     multi-face (out of scope)        301
     Oracle text differs from golden  242
     golden would not decode            0
 
-  Confirmed — models agree           924   993.5‰ (99.4%)
-  DIVERGENT — read every one           6
+  Confirmed — models agree           1606   981.7‰ (98.2%)
+  DIVERGENT — read every one           30
 ```
 
 The divergence count is not meant to stay at zero — it rises every time the grammar reaches a new
@@ -189,6 +214,12 @@ the population all agreed, and a by-hand sweep of every golden printing one of t
 found no disagreement either. That is a fact about the cards rather than about the gate — an aura in
 this band is two lines with nothing to drop, where the bugs the gate has found were all a clause
 lost *inside* a filter on a longer sentence.
+
+The **Portal band** took the compared population from 930 cards to 1,636 and the divergence count
+from 6 to 30, which is the ratio the gate is supposed to have: six new cards read for every one that
+disagrees. All thirty are classified below and they fall into six families, four of which are the
+already-open "two SDK spellings of one thing" findings. Two are new bugs in hand-written cards, and
+one was a bug in the parser that only this gate could have caught.
 
 Five separate things have to hold before a card is compared, and each has its own bucket. Every one
 of them was added after the gate was caught claiming a check nobody had performed:
@@ -208,6 +239,45 @@ each one has to say why it is not a difference.
 
 ### What the gate has found
 
+- **Two more bugs of the Meteor Golem class, from the Portal band.** **Recollect** prints "Return
+  target card from **your** graveyard to your hand" and filters on `TargetFilter.CardInGraveyard`,
+  which is *any* graveyard — so it can be pointed at an opponent's. **Eternal Witness** is the same
+  card text inside an enters trigger and has the same filter. Elven Cache and Déjà Vu, the other two
+  cards printing that sentence, both scope it with `ownedByYou()`, which is what makes these two a
+  bug rather than a spelling. Both are generated renders that dropped a word, and both carry the
+  clause they do not implement in their own `oracleText`. Fixed, each with the scenario test that
+  asserts the *negative* — a card in an opponent's graveyard is not a legal target — which is the
+  half that fails without the fix.
+
+  A grep for the same filter found a third of the class the gate could not have: **Revive** prints
+  "Return target **green** card from **your** graveyard to your hand" and filters on the unowned,
+  uncoloured `CardInGraveyard`, so it ignores both words. It is not fixed here because the grammar
+  declines its line — no rule reads a colour on a card noun — so the differential never compared it,
+  and a fix wants the rule first so the gate can confirm it.
+- **A parser bug of the reversible-but-wrong class — found, and fixed.** "Untap target creature. It
+  gets +2/+4 until end of turn." read "it" as the *source* rather than as the target the first clause
+  chose, because the same four words mean the source in "Whenever this creature attacks, it gets
+  +2/+0". The line round-tripped byte-perfectly the whole time and meant a different creature, which
+  is exactly what the touchstone structurally cannot see. The fix is the split between
+  `SelfSteps.anaphoric` and `Continuations`: an anaphor resolves to the most recently mentioned
+  object, so once a clause has introduced a target the pronoun is that target, and the two
+  vocabularies are reachable from disjoint positions so no text has both readings. It affected
+  Inspirit and Gerrard's Command.
+- **"Deals N damage to each creature and each player" has two SDK spellings, and eight cards use the
+  minority one.** `DealDamage(n, PlayerRef(Player.Each))` and
+  `ForEachPlayerEffect(Player.Each, [DealDamage(n, Controller)])` are equivalent for a fixed amount —
+  the second rebinds a controller the sentence does not need. Earthquake and Hurricane write the
+  first and are confirmed; Fire Tempest, Howling Gale, Volcanic Spray, Magma Giant, Devastate,
+  Hammerfist Giant, Rain of Embers and Steam Blast write the second and diverge. The grammar emits
+  one, per the rule that two SDK spellings get one rule and a finding. Nothing is broken; it is one
+  `Effects` helper away from the corpus having a single spelling.
+- **A nested plain `CompositeEffect` is the same sequence as its flattening — folded, narrowly.**
+  Cruel Tutor nests `Patterns.Library.searchLibrary` inside its outer composite and Bitter Revelation
+  splices the same recipe's steps into a flat one, for the same printed sentence; Angelic Blessing's
+  "gets +2/+2 and gains flying" is a two-element composite alone and three flat elements once a
+  "Scry 1." follows it. A composite with `stopOnError` false and no description override is an
+  ordered run and nothing more, so the two are one value written two ways. The fold splices only that
+  shape and never reorders, so `[a, [c, b]]` still disagrees with `[a, b, c]`.
 - **A bug in a hand-written card — the outcome this whole thing is for.** Meteor Golem's printed text
   is "destroy target nonland permanent **an opponent controls**"; its definition filtered on
   `TargetFilter.NonlandPermanent`, so the golem could be pointed at its own controller's board and

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Differential.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Differential.kt
@@ -279,7 +279,7 @@ class Differential(private val touchstone: Touchstone = Touchstone()) {
         val tree = CardSerialization.json.parseToJsonElement(json)
         return CardSerialization.json.encodeToString(
             JsonElement.serializer(),
-            canonicalizeAbilities(normalizeSlots(tree)),
+            Folds.flattenComposites(canonicalizeAbilities(normalizeSlots(tree))),
         )
     }
 
@@ -454,6 +454,51 @@ internal object Folds {
         if (parameterized.isEmpty()) return abilities
         return abilities.filterNot { it is KeywordAbility.Simple && it.keyword in parameterized }.toSet()
     }
+
+    /**
+     * **A plain `CompositeEffect` nested inside another is the same sequence as its flattening.**
+     *
+     * `CompositeEffect` is an ordered run of effects and nothing else: with `stopOnError` false and
+     * no `descriptionOverride`, the executor runs its members in order, so `[a, [b, c]]` and
+     * `[a, b, c]` are the same value written two ways. The corpus writes it both ways for one
+     * sentence — Cruel Tutor nests `Patterns.Library.searchLibrary` inside its outer composite while
+     * Bitter Revelation splices the same recipe's steps into a flat one, and Angelic Blessing's
+     * "gets +2/+2 and gains flying" is a two-element composite on its own and three flat elements
+     * when a "Scry 1." follows it.
+     *
+     * The fold is narrow on purpose. A composite carrying `stopOnError`, a `descriptionOverride` or
+     * description amounts says something about how its members run or read, so it is left alone and
+     * a difference in one still diverges. Ordering is untouched: `[a, [c, b]]` flattens to
+     * `[a, c, b]` and still disagrees with `[a, b, c]`, which is the difference worth catching.
+     */
+    fun flattenComposites(element: JsonElement): JsonElement = when (element) {
+        is JsonObject -> {
+            val walked = JsonObject(element.mapValues { flattenComposites(it.value) })
+            if (isPlainComposite(walked)) {
+                JsonObject(walked + ("effects" to JsonArray(spliceMembers(walked))))
+            } else {
+                walked
+            }
+        }
+
+        is JsonArray -> JsonArray(element.map(::flattenComposites))
+        else -> element
+    }
+
+    /** A composite with nothing said about how it runs or reads — the only shape safe to splice. */
+    private fun isPlainComposite(element: JsonObject): Boolean =
+        (element["type"] as? JsonPrimitive)?.content == "Composite" &&
+            element["effects"] is JsonArray &&
+            element.keys.none { it == "stopOnError" || it == "descriptionOverride" || it == "descriptionAmounts" }
+
+    private fun spliceMembers(composite: JsonObject): List<JsonElement> =
+        (composite.getValue("effects") as JsonArray).flatMap { member ->
+            if (member is JsonObject && isPlainComposite(member)) {
+                (member.getValue("effects") as JsonArray).toList()
+            } else {
+                listOf(member)
+            }
+        }
 }
 
 /** Why a hand-written card was or was not compared. The denominator is never hidden. */

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Activated.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Activated.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
@@ -70,7 +71,11 @@ object Activated {
      * rather than printing a sentence that quietly drops it. Only the id is exempt, because the id
      * is not in the text.
      */
-    private fun abilityFor(cost: AbilityCost, script: CardScript): ActivatedAbility? {
+    private fun abilityFor(
+        cost: AbilityCost,
+        script: CardScript,
+        restrictions: List<ActivationRestriction> = emptyList(),
+    ): ActivatedAbility? {
         val effect = script.spellEffect ?: return null
         val targets = script.targetRequirements
         if (script != CardScript(spellEffect = effect, targetRequirements = targets)) return null
@@ -82,6 +87,7 @@ object Activated {
             targetRequirements = targets,
             timing = if (manaAbility) TimingRule.ManaAbility else TimingRule.InstantSpeed,
             isManaAbility = manaAbility,
+            restrictions = restrictions,
         )
     }
 
@@ -139,5 +145,38 @@ object Activated {
             }
         }
 
-    val abilities: Phrase<List<ActivatedAbility>> = oneOf("an activated ability", single, choice)
+    /**
+     * "{cost}: {effect} Activate only during your turn, before attackers are declared." — the same
+     * ability with the sentence that says when it may be activated.
+     *
+     * A second rule rather than an optional slot, because an optional literal would leave printing
+     * underdetermined between the two forms for an ability whose restriction list is empty. The two
+     * take disjoint models — this one refuses an empty list — so the model decides which prints, the
+     * property every alternation in this grammar is written to have.
+     */
+    private val restricted: Phrase<List<ActivatedAbility>> =
+        phrase("{cost}: {effect} {restrictions}", name = "an activated ability with a restriction") {
+            slot("cost", Costs.cost)
+            slot("effect", Steps.step)
+            slot("restrictions", Restrictions.activationSentence)
+            build { bindings ->
+                val restrictions = bindings.value<List<ActivationRestriction>>("restrictions")
+                if (restrictions.isEmpty()) return@build null
+                abilityFor(bindings.value("cost"), bindings.value("effect"), restrictions)?.let { listOf(it) }
+            }
+            match { abilities ->
+                val ability = abilities.singleOrNull() ?: return@match null
+                if (ability.restrictions.isEmpty()) return@match null
+                val script = CardScript(
+                    spellEffect = ability.effect,
+                    targetRequirements = ability.targetRequirements,
+                )
+                if (abilityFor(ability.cost, script, ability.restrictions)?.copy(id = ability.id) != ability) {
+                    return@match null
+                }
+                bind("cost" to ability.cost, "effect" to script, "restrictions" to ability.restrictions)
+            }
+        }
+
+    val abilities: Phrase<List<ActivatedAbility>> = oneOf("an activated ability", single, restricted, choice)
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/CardFragment.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/CardFragment.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.assay.grammar
 
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
@@ -22,6 +23,17 @@ import com.wingedsheep.sdk.scripting.KeywordAbility
 data class CardFragment(
     val keywordAbilities: List<KeywordAbility> = emptyList(),
     val script: CardScript = CardScript.EMPTY,
+    /**
+     * `CardDefinition.flags` — the third behavioural slot, and the only one that is not a keyword or
+     * part of the script.
+     *
+     * It exists because "This creature can't be blocked." is `AbilityFlag.CANT_BE_BLOCKED` rather
+     * than a `StaticAbility`, so a line can reach a field neither of the other two slots covers.
+     * That the SDK has two places to say a combat restriction — a flag for the unconditional form
+     * and a static for every filtered one — is a finding rather than something this type should
+     * paper over, and holding both is what lets the differential see it.
+     */
+    val flags: Set<AbilityFlag> = emptySet(),
 ) {
 
     /**
@@ -48,9 +60,14 @@ data class CardFragment(
         if (script.auraTarget != null && other.script.auraTarget != null) return null
         return CardFragment(
             keywordAbilities = keywordAbilities + other.keywordAbilities,
+            flags = flags + other.flags,
             script = CardScript(
                 spellEffect = script.spellEffect ?: other.script.spellEffect,
                 targetRequirements = script.targetRequirements + other.script.targetRequirements,
+                // A spell states its casting restrictions and its additional costs on lines of their
+                // own, so both accumulate across lines exactly as the ability lists do.
+                castRestrictions = script.castRestrictions + other.script.castRestrictions,
+                additionalCosts = script.additionalCosts + other.script.additionalCosts,
                 // Triggered abilities are a list on purpose: one card, several trigger lines, in
                 // printed order. Unlike the spell effect there is nothing to collide over. The same
                 // holds for activated abilities — and a *single* line can contribute several of
@@ -65,7 +82,7 @@ data class CardFragment(
         )
     }
 
-    val isEmpty: Boolean get() = keywordAbilities.isEmpty() && script == CardScript.EMPTY
+    val isEmpty: Boolean get() = keywordAbilities.isEmpty() && flags.isEmpty() && script == CardScript.EMPTY
 
     companion object {
         val EMPTY = CardFragment()
@@ -82,6 +99,6 @@ data class CardFragment(
          */
         const val MODELLED_SLOTS_NOTE =
             "spellEffect, targetRequirements, triggeredAbilities, activatedAbilities, " +
-                "staticAbilities, replacementEffects, auraTarget"
+                "staticAbilities, replacementEffects, auraTarget, castRestrictions, additionalCosts"
     }
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Combat.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Combat.kt
@@ -1,0 +1,250 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.GrantCantBeBlockedExceptByColorEffect
+import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
+import com.wingedsheep.sdk.scripting.effects.ReflectCombatDamageEffect
+import com.wingedsheep.sdk.scripting.effects.SkipCombatPhasesEffect
+import com.wingedsheep.sdk.scripting.effects.SkipUntapEffect
+import com.wingedsheep.sdk.scripting.effects.TauntEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Clauses that change how a combat goes — the spell-side siblings of the combat statics in
+ * [Statics].
+ *
+ * A static says what a permanent *is* for as long as it is on the battlefield; these say what
+ * happens for a turn, which the SDK models as ordinary resolution-time effects. Both vocabularies
+ * name the same combat concepts and neither can be spelled in terms of the other, so they sit in
+ * separate files by which slot they reach rather than by what they talk about.
+ */
+object Combat {
+
+    /**
+     * "During target player's next turn, creatures that player controls attack you if able." —
+     * Taunt.
+     *
+     * The whole sentence is one SDK effect, and the "that player" in the second clause is the same
+     * player the first clause targeted — a link the model carries as a single `target` field rather
+     * than as two references, which is why this is one rule and not a [Continuations] pair.
+     */
+    private val taunt: Phrase<CardScript> = run {
+        val script = CardScript(
+            spellEffect = TauntEffect(Targets.bound()),
+            targetRequirements = listOf(Targets.player()),
+        )
+        phrase(
+            "during target player's next turn, creatures that player controls attack you if able",
+            name = "taunt",
+        ) {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * "Black creatures you control can't be blocked this turn except by black creatures." — Dread
+     * Charge.
+     *
+     * Two colours in one sentence and two fields in the model: the group that gains the evasion, and
+     * the colour that is still allowed to block it. The second is a bare `Color` rather than a
+     * filter because that is the shape the SDK gives it, so the "creatures" after it is a literal
+     * here rather than a slot — writing it as one would let the rule print a filter the effect
+     * cannot hold.
+     */
+    private val cantBeBlockedExceptByColor: Phrase<CardScript> = run {
+        fun scriptFor(filter: GameObjectFilter, colour: com.wingedsheep.sdk.core.Color) = CardScript(
+            spellEffect = GrantCantBeBlockedExceptByColorEffect(
+                filter = GroupFilter(filter),
+                canOnlyBeBlockedByColor = colour,
+            )
+        )
+        phrase(
+            "{filter} can't be blocked this turn except by {color} creatures",
+            name = "a group can't be blocked except by a colour",
+        ) {
+            slot("filter", Filters.plural)
+            slot("color", Primitives.color)
+            build { scriptFor(it.value("filter"), it.value("color")) }
+            match { script ->
+                val effect = script.spellEffect as? GrantCantBeBlockedExceptByColorEffect ?: return@match null
+                val filter = effect.filter.baseFilter
+                if (script != scriptFor(filter, effect.canOnlyBeBlockedByColor)) return@match null
+                bind("filter" to filter, "color" to effect.canOnlyBeBlockedByColor)
+            }
+        }
+    }
+
+    /**
+     * "Return one or two target attacking creatures to their owner's hand." — Command of
+     * Unsummoning.
+     *
+     * The one rule in the grammar whose effect refers to its target **positionally**, and it has to:
+     * `ForEachTargetEffect` rebinds `ContextTarget(0)` to the current target on each iteration, so a
+     * named [EffectTarget.BoundVariable] would name the *whole* declaration rather than the member
+     * being processed and would mean a different card. The differential normalizes named and
+     * positional references to a slot's position, so this reads the same as every other rule there;
+     * only the model differs, and it differs because the iteration requires it.
+     *
+     * The count pair is spelled by the template rather than by two number slots. "One or two" is a
+     * `minCount`/`count` pair in the model and there is exactly one member of the shape so far, so
+     * it is written inline — factor it when the second ("up to three target …") appears.
+     */
+    private val returnOneOrTwoTargets: Phrase<CardScript> = run {
+        fun scriptFor(filter: GameObjectFilter) = CardScript(
+            spellEffect = ForEachTargetEffect(listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND))),
+            targetRequirements = listOf(
+                TargetCreature(count = 2, minCount = 1, filter = TargetFilter(filter), id = Targets.SLOT)
+            ),
+        )
+        phrase(
+            "return one or two target {filter} to their owner's hand",
+            name = "return one or two targets to hand",
+        ) {
+            slot("filter", Filters.plural)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val requirement = script.targetRequirements.singleOrNull() ?: return@match null
+                val filter = (requirement as? com.wingedsheep.sdk.scripting.targets.TargetObject)
+                    ?.filter?.baseFilter ?: return@match null
+                if (script != scriptFor(filter)) return@match null
+                bind("filter" to filter)
+            }
+        }
+    }
+
+    /**
+     * "All creatures able to block target creature this turn do so." — the lure.
+     *
+     * `MustBeBlockedEffect`'s `allCreatures` default is exactly this sentence; the narrower form
+     * ("target creature blocks this turn if able") is a different sentence and refuses to print
+     * here, which the reconstruct-and-compare enforces.
+     */
+    private val mustBeBlocked: Phrase<CardScript> = run {
+        fun scriptFor(filter: GameObjectFilter) = CardScript(
+            spellEffect = MustBeBlockedEffect(Targets.bound()),
+            targetRequirements = listOf(Targets.permanent(filter)),
+        )
+        phrase("all creatures able to block target {filter} this turn do so", name = "lure") {
+            slot("filter", Filters.filter)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val requirement = script.targetRequirements.singleOrNull() ?: return@match null
+                val filter = Targets.permanentFilter(requirement) ?: return@match null
+                if (script != scriptFor(filter)) return@match null
+                bind("filter" to filter)
+            }
+        }
+    }
+
+    /**
+     * The turn-shaping effects a player is the object of — skipping a combat, skipping an untap.
+     *
+     * Each is one effect with one target and no variable, so each is a constant rule paired with the
+     * requirement its sentence declares. Note that the *filter* in Exhaustion's printed noun phrase
+     * ("Creatures and lands target opponent controls") is not a slot: `SkipUntapEffect` carries
+     * `affectsCreatures` and `affectsLands` as booleans rather than a filter, so the phrase is a
+     * literal here and a card naming any other combination declines.
+     */
+    private fun playerEffect(
+        template: String,
+        name: String,
+        requirement: com.wingedsheep.sdk.scripting.targets.TargetRequirement,
+        effect: (com.wingedsheep.sdk.scripting.targets.EffectTarget) -> Effect,
+    ): Phrase<CardScript> {
+        val script = CardScript(
+            spellEffect = effect(Targets.bound()),
+            targetRequirements = listOf(requirement),
+        )
+        return phrase(template, name = name) {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /** The whole-turn combat effects with no target at all — Deep Wood and Harsh Justice. */
+    private fun turnEffect(template: String, name: String, effect: Effect): Phrase<CardScript> {
+        val script = CardScript(spellEffect = effect)
+        return phrase(template, name = name) {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * "~ deals 4 damage divided as you choose among one, two, or three target creatures." — Forked
+     * Lightning.
+     *
+     * The target-count range appears in the *effect* as well as on the requirement — `minTargets`
+     * and `maxTargets` on `DividedDamageEffect`, `minCount` and `count` on the requirement — so the
+     * two numbers the phrase spells land in four model fields. They are written as one range in the
+     * template rather than as two slots because Oracle enumerates the run ("one, two, or three")
+     * rather than stating bounds, and an enumeration is a printed form rather than a number.
+     */
+    private val dividedDamage: Phrase<CardScript> = run {
+        fun scriptFor(total: Int, filter: GameObjectFilter) = CardScript(
+            spellEffect = DividedDamageEffect(totalDamage = total, minTargets = 1, maxTargets = 3),
+            targetRequirements = listOf(
+                TargetCreature(count = 3, minCount = 1, filter = TargetFilter(filter), id = Targets.SLOT)
+            ),
+        )
+        phrase(
+            "{self} deals {n} damage divided as you choose among one, two, or three target {filter}",
+            name = "divided damage among up to three targets",
+        ) {
+            slot("self", Primitives.self)
+            slot("n", Primitives.cardinal)
+            slot("filter", Filters.plural)
+            build { scriptFor(it.int("n"), it.value("filter")) }
+            match { script ->
+                val effect = script.spellEffect as? DividedDamageEffect ?: return@match null
+                val requirement = script.targetRequirements.singleOrNull()
+                    as? com.wingedsheep.sdk.scripting.targets.TargetObject ?: return@match null
+                val filter = requirement.filter.baseFilter
+                if (script != scriptFor(effect.totalDamage, filter)) return@match null
+                bind("self" to Unit, "n" to effect.totalDamage, "filter" to filter)
+            }
+        }
+    }
+
+    val clauses: List<Phrase<CardScript>> = listOf(
+        taunt,
+        cantBeBlockedExceptByColor,
+        returnOneOrTwoTargets,
+        mustBeBlocked,
+        dividedDamage,
+        playerEffect(
+            "target player skips all combat phases of their next turn",
+            "skip combat phases",
+            Targets.player(),
+        ) { SkipCombatPhasesEffect(it) },
+        playerEffect(
+            "creatures and lands target opponent controls don't untap during their next untap step",
+            "skip untap",
+            Targets.opponent(),
+        ) { SkipUntapEffect(it) },
+        turnEffect(
+            "prevent all damage that would be dealt to you this turn by attacking creatures",
+            "prevent damage from attackers",
+            Effects.PreventDamageFromAttackingCreatures(),
+        ),
+        turnEffect(
+            "this turn, whenever an attacking creature deals combat damage to you, it deals that " +
+                "much damage to its controller",
+            "reflect combat damage",
+            ReflectCombatDamageEffect(),
+        ),
+    )
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Conditions.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Conditions.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.constant
+import com.wingedsheep.assay.syntax.oneOf
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+import com.wingedsheep.sdk.dsl.Conditions as SdkConditions
+
+/**
+ * The state tests a card's text names — the "if …" half of a conditional clause and the "only if …"
+ * half of a cast restriction.
+ *
+ * The family opens with one member, which is what a condition family looks like the first time a
+ * card needs one. Every rule builds through the SDK's `Conditions` facade rather than assembling a
+ * `Compare` by hand: those facades are the curated surface, and a condition assembled here would be
+ * a second spelling of one the SDK already names — the ambiguity this module refuses everywhere
+ * else.
+ *
+ * That is also the honest reason the list is short. A condition in Oracle text is an ordinary
+ * English clause with a vocabulary as large as the game's, and the SDK names only the ones cards
+ * have needed; a rule per named condition is the shape that keeps the two in step, and a printed
+ * condition the SDK cannot name declines and is counted.
+ */
+object Conditions {
+
+    val all: List<Phrase<Condition>> = listOf(
+        constant("an opponent controls more lands than you", SdkConditions.OpponentControlsMoreLands),
+        // `YouWereAttackedThisStep` has no facade entry — it is a `data object` cards reference
+        // directly, the same situation `Replacements` and the combat statics are in. Reported as the
+        // small SDK finding it is rather than routed around.
+        constant("you've been attacked this step", YouWereAttackedThisStep),
+    )
+
+    val condition: Phrase<Condition> = oneOf("a condition", all)
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Continuations.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Continuations.kt
@@ -1,0 +1,203 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.normalize.Normalizer
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.oneOf
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.OwnerGainsLifeEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Clauses that refer **back** — "Untap that creature.", "~ deals 2 damage to that creature."
+ *
+ * A sentence like these cannot start a line: "that creature" is an anaphor, and the thing it names
+ * was introduced by an earlier sentence's `target` requirement. So these rules produce an effect
+ * bound to [Targets.SLOT] while declaring **no** requirement of their own, and they are reachable
+ * only from a later position in [Steps.sequence]. Registering them as ordinary clauses would let a
+ * card's whole text be a dangling reference, which is a reading no printed card supports.
+ *
+ * ### Why "that creature" and not "it"
+ *
+ * Oracle uses two anaphors and they point at different things. "It" is the *source* — "When this
+ * creature dies, put **it** on top of its owner's library" — which is [EffectTarget.Self] and lives
+ * in [SelfSteps] as an ordinary clause, because a source needs no earlier sentence to introduce it.
+ * "That creature" is the *target* the spell already chose. Keeping them in separate vocabularies is
+ * what stops a sequence reading one as the other.
+ */
+object Continuations {
+
+    /**
+     * The shape: a verb over the slot an earlier sentence declared, and nothing else in the script.
+     *
+     * `match` reconstructs and compares like every other rule here, so a script that also carries a
+     * requirement — the very thing this clause must not have — refuses to print.
+     */
+    private fun referringStep(
+        template: String,
+        name: String,
+        effect: () -> Effect,
+    ): Phrase<CardScript> {
+        val script = CardScript(spellEffect = effect())
+        return phrase(template, name = name) {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    private val untapThatCreature: Phrase<CardScript> =
+        referringStep("untap that creature", "untap that creature") { Effects.Untap(Targets.bound()) }
+
+    private val tapThatCreature: Phrase<CardScript> =
+        referringStep("tap that creature", "tap that creature") { Effects.Tap(Targets.bound()) }
+
+    /**
+     * "~ deals 2 damage to that creature." — the counted verb over the anaphor.
+     *
+     * Its own rule rather than a row in [referringStep] because it carries a number, which changes
+     * both halves of the inversion; the same reason [Steps] keeps its counted verbs apart from its
+     * uncounted ones.
+     */
+    private val damageToThatCreature: Phrase<CardScript> = run {
+        fun scriptFor(amount: Int) = CardScript(spellEffect = Effects.DealDamage(amount, Targets.bound()))
+        phrase(
+            "${Normalizer.SELF} deals {n} damage to that creature",
+            name = "deals damage to that creature",
+        ) {
+            slot("n", Primitives.cardinal)
+            build { scriptFor(it.int("n")) }
+            match { script ->
+                val amount = Steps.damageDealt(script.spellEffect ?: return@match null) ?: return@match null
+                if (script != scriptFor(amount)) return@match null
+                bind("n" to amount)
+            }
+        }
+    }
+
+    /**
+     * "It gets +2/+4 until end of turn." — Inspirit, after "Untap target creature."
+     *
+     * The same surface form [SelfSteps.anaphoric] reads as the *source*, and the reason the two
+     * vocabularies exist: once a clause has introduced a target, "it" is that target. This rule is
+     * reachable only from a later position in a sequence and [SelfSteps]' is reachable only from the
+     * first, so no text has both readings.
+     *
+     * That split was found by the differential rather than by reading: the line round-tripped
+     * perfectly while meaning the wrong creature, which the touchstone structurally cannot see.
+     */
+    private val itGets: Phrase<CardScript> = run {
+        fun scriptFor(modifiers: Pair<Int, Int>) = CardScript(
+            spellEffect = Effects.ModifyStats(modifiers.first, modifiers.second, Targets.bound())
+        )
+        phrase("it gets {mod} until end of turn", name = "the target gets") {
+            slot("mod", Primitives.statModifiers)
+            build { scriptFor(it.value("mod")) }
+            match { script ->
+                val modifiers = Steps.fixedModifiers(script.spellEffect) ?: return@match null
+                if (script != scriptFor(modifiers)) return@match null
+                bind("mod" to modifiers)
+            }
+        }
+    }
+
+    /** "Its owner gains 4 life." — Path of Peace, referring to the creature the first clause destroyed. */
+    private val ownerGainsLife: Phrase<CardScript> = run {
+        fun scriptFor(amount: Int) = CardScript(spellEffect = OwnerGainsLifeEffect(amount))
+        phrase("its owner gains {n} life", name = "its owner gains life") {
+            slot("n", Primitives.cardinal)
+            build { scriptFor(it.int("n")) }
+            match { script ->
+                val amount = (script.spellEffect as? OwnerGainsLifeEffect)?.amount ?: return@match null
+                if (script != scriptFor(amount)) return@match null
+                bind("n" to amount)
+            }
+        }
+    }
+
+    /**
+     * "You draw a card for each Mountain and red card in it." — Baleful Stare, after the sentence
+     * that revealed a hand.
+     *
+     * The "it" is the revealed hand, which the model names as a zone rather than as a slot: the
+     * count is `DynamicAmount.Count(TargetOpponent, HAND, …)`, so the anaphor is carried by the
+     * player and the zone together and nothing here reads the target. That is why it is a
+     * continuation and not an ordinary clause — the sentence only means something after the reveal.
+     *
+     * The two-quality filter is an `or` of a land subtype and a colour, which is the printed
+     * "**Mountain** and **red** card" read as a disjunction; Oracle's "and" here joins two ways for
+     * a card to qualify rather than two requirements, and the model says so.
+     */
+    private val drawForEachInHand: Phrase<CardScript> = run {
+        fun scriptFor(land: GameObjectFilter, colour: Color) = CardScript(
+            spellEffect = Effects.DrawCards(
+                DynamicAmount.Count(
+                    Player.TargetOpponent,
+                    Zone.HAND,
+                    land or GameObjectFilter.Any.withColor(colour),
+                )
+            )
+        )
+        phrase(
+            "you draw a card for each {land} and {color} card in it",
+            name = "draw for each matching card in the revealed hand",
+        ) {
+            slot("land", Filters.filter)
+            slot("color", Primitives.color)
+            build { scriptFor(it.value("land"), it.value("color")) }
+            match { script ->
+                val count = (script.spellEffect as? DrawCardsEffect)?.count as? DynamicAmount.Count
+                    ?: return@match null
+                val (land, colour) = splitQualities(count.filter) ?: return@match null
+                if (script != scriptFor(land, colour)) return@match null
+                bind("land" to land, "color" to colour)
+            }
+        }
+    }
+
+    /**
+     * The two halves of the `or` above, or null when the filter is anything else.
+     *
+     * `GameObjectFilter.or` folds two filters into a single `CardPredicate.Or` rather than into the
+     * `anyOf` list, so the two qualities have to be read back out of that predicate — and only the
+     * *subtype* and the *colour* are read, with the whole filter reconstructed and compared
+     * afterwards. That is what keeps the rule fail-closed over a shape whose two halves are not
+     * symmetric: the land side is an `And` of a type and a subtype, the colour side one predicate.
+     */
+    private fun splitQualities(filter: GameObjectFilter): Pair<GameObjectFilter, Color>? {
+        val alternatives = (filter.cardPredicates.singleOrNull() as? CardPredicate.Or)
+            ?.predicates?.takeIf { it.size == 2 } ?: return null
+        val subtype = subtypeIn(alternatives[0]) ?: return null
+        val colour = (alternatives[1] as? CardPredicate.HasColor)?.color ?: return null
+        val land = GameObjectFilter.Land.withSubtype(subtype)
+        return (land to colour).takeIf { filter == land or GameObjectFilter.Any.withColor(colour) }
+    }
+
+    /** The single subtype a predicate names, looking one level into a conjunction. */
+    private fun subtypeIn(predicate: CardPredicate): com.wingedsheep.sdk.core.Subtype? = when (predicate) {
+        is CardPredicate.HasSubtype -> predicate.subtype
+        is CardPredicate.And -> predicate.predicates.filterIsInstance<CardPredicate.HasSubtype>()
+            .singleOrNull()?.subtype
+
+        else -> null
+    }
+
+    val all: List<Phrase<CardScript>> = listOf(
+        untapThatCreature,
+        tapThatCreature,
+        damageToThatCreature,
+        itGets,
+        ownerGainsLife,
+        drawForEachInHand,
+    )
+
+    val clause: Phrase<CardScript> = oneOf("a clause referring to the target", all)
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Filters.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Filters.kt
@@ -5,20 +5,41 @@ import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.constant
 import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
 
 /**
- * The noun phrase a spell acts on — "creature", "artifact or enchantment", "creature you control".
+ * The noun phrase a spell acts on — "creature", "artifact or enchantment", "black creatures you
+ * control", "creatures with power 2 or greater".
  *
  * The target of these rules is `mtg-sdk`'s [GameObjectFilter], which is a *bag of predicates*, and
  * that shape decides how the grammar has to be written. A predicate bag has no canonical spelling:
  * `Creature.youControl()` could in principle be printed by a rule for the type and a rule for the
  * controller in either order, and two rules that can each print part of one value are how a
  * bidirectional grammar goes underdetermined. So the rules here are **layered, not composed**: one
- * alternation spells the whole type phrase, and exactly one optional suffix spells the controller.
- * Each layer strips precisely the field it owns and delegates the rest, which keeps one printed form
- * per model without needing a normal form for the bag itself.
+ * alternation spells the whole type phrase, and each layer around it owns exactly one field, strips
+ * precisely that field, and delegates the rest inwards. Each layer also carries the layer below as a
+ * pass-through alternative, which is what lets "black creatures you control" exist without a rule
+ * that knows about both colour and control.
+ *
+ * ### The layers, innermost first
+ *
+ * | Layer | Owns | Surface |
+ * |---|---|---|
+ * | [typeNoun] | the whole predicate set of a named type | "creature", "nonbasic land", "Mountain" |
+ * | [coloured] | the last [CardPredicate] when it is a colour one | "white creature", "nonblack creature" |
+ * | [qualified] | the last [CardPredicate] when it is a keyword or power one | "creature with flying" |
+ * | [controlledBy] | `controllerPredicate` | "creature you control" |
+ *
+ * The fluent builders these rules go through (`withColor`, `withKeyword`, `powerAtLeast`, …) all
+ * **append** to `cardPredicates`, so the list is a stack and the outermost layer owns its top. That
+ * is what makes "strip precisely the field I own" well-defined for a list-valued slot, and it is the
+ * same order English uses: "white creature with flying" is built colour-then-keyword and printed
+ * colour-then-keyword.
  *
  * ### Why the type list is enumerated
  *
@@ -27,46 +48,215 @@ import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
  * words, so deriving the surface from the predicates would need a theory of Magic's templating that
  * the SDK does not carry. Enumerating the printed forms keeps every rule provably invertible, and a
  * form nobody wrote down declines rather than being approximated — which is the point.
+ *
+ * ### Number is an axis, not a second vocabulary
+ *
+ * "Destroy target **creature**" and "Destroy all white **creatures**" name the same filters through
+ * the same layers; only the type noun inflects. So the whole cascade is a function of grammatical
+ * number and is instantiated twice — [filter] for the singular and [plural] for the plural — rather
+ * than written twice. Everything outside the type noun ("you control", "with flying", "nonblack") is
+ * number-invariant in Oracle-ese and is shared verbatim between the two.
+ *
+ * The plural of a *compound* type phrase is deliberately absent rather than derived: "artifact or
+ * enchantment" pluralizes as "artifacts **and** enchantments", so the conjunction changes with the
+ * number and nothing in the singular says so. Those rows carry no plural and decline in group
+ * position, which names the gap instead of inventing a spelling.
  */
 object Filters {
 
     /**
-     * The type phrase, without a controller clause.
+     * A type phrase and its plural, where English has one for it.
      *
-     * Ordered by nothing in particular: parsing tries every branch and the whole-span filter
-     * resolves it, so "creature" and "creature or land" cannot both consume the same text.
+     * Kept as a data row rather than as two lists so the two numbers of one type cannot drift apart,
+     * and so a new type is one line in one place.
      */
-    private val typePhrase: Phrase<GameObjectFilter> = oneOf(
-        "a permanent type",
-        constant("creature", GameObjectFilter.Creature),
-        constant("artifact", GameObjectFilter.Artifact),
-        constant("enchantment", GameObjectFilter.Enchantment),
-        constant("land", GameObjectFilter.Land),
-        constant("planeswalker", GameObjectFilter.Planeswalker),
-        constant("permanent", GameObjectFilter.Permanent),
-        constant("nonland permanent", GameObjectFilter.NonlandPermanent),
-        constant("noncreature permanent", GameObjectFilter.NoncreaturePermanent),
-        constant("nonbasic land", GameObjectFilter.NonbasicLand),
-        constant("artifact creature", GameObjectFilter.ArtifactCreature),
-        constant("creature or planeswalker", GameObjectFilter.CreatureOrPlaneswalker),
-        constant("creature or enchantment", GameObjectFilter.CreatureOrEnchantment),
-        constant("creature or land", GameObjectFilter.CreatureOrLand),
-        constant("artifact or enchantment", GameObjectFilter.ArtifactOrEnchantment),
-        constant("artifact or land", GameObjectFilter.ArtifactOrLand),
-        constant("attacking creature", GameObjectFilter.Creature.attacking()),
-        constant("blocking creature", GameObjectFilter.Creature.blocking()),
-        constant("tapped creature", GameObjectFilter.Creature.tapped()),
-        constant("untapped creature", GameObjectFilter.Creature.untapped()),
+    private data class TypeNoun(
+        val singular: String,
+        val plural: String?,
+        val filter: GameObjectFilter,
     )
+
+    private val TYPES: List<TypeNoun> = listOf(
+        TypeNoun("creature", "creatures", GameObjectFilter.Creature),
+        TypeNoun("artifact", "artifacts", GameObjectFilter.Artifact),
+        TypeNoun("enchantment", "enchantments", GameObjectFilter.Enchantment),
+        TypeNoun("land", "lands", GameObjectFilter.Land),
+        TypeNoun("planeswalker", "planeswalkers", GameObjectFilter.Planeswalker),
+        TypeNoun("permanent", "permanents", GameObjectFilter.Permanent),
+        TypeNoun("nonland permanent", "nonland permanents", GameObjectFilter.NonlandPermanent),
+        TypeNoun("noncreature permanent", "noncreature permanents", GameObjectFilter.NoncreaturePermanent),
+        TypeNoun("basic land", "basic lands", GameObjectFilter.BasicLand),
+        // The two card types that are never permanents. They appear in the same slot as the rest —
+        // "target **sorcery** card in your graveyard", "search your library for an **instant**
+        // card" — which is why they are rows here rather than a vocabulary of their own.
+        TypeNoun("instant", "instants", GameObjectFilter.Instant),
+        TypeNoun("sorcery", "sorceries", GameObjectFilter.Sorcery),
+        TypeNoun("nonbasic land", "nonbasic lands", GameObjectFilter.NonbasicLand),
+        TypeNoun("artifact creature", "artifact creatures", GameObjectFilter.ArtifactCreature),
+        TypeNoun("creature or planeswalker", null, GameObjectFilter.CreatureOrPlaneswalker),
+        TypeNoun("creature or enchantment", null, GameObjectFilter.CreatureOrEnchantment),
+        // The plural swaps the conjunction: "creature or land" becomes "creatures **and** lands",
+        // which is why a plural is a column in this table rather than a suffix rule.
+        TypeNoun("creature or land", "creatures and lands", GameObjectFilter.CreatureOrLand),
+        TypeNoun("artifact or enchantment", null, GameObjectFilter.ArtifactOrEnchantment),
+        TypeNoun("artifact or land", null, GameObjectFilter.ArtifactOrLand),
+        TypeNoun("attacking creature", "attacking creatures", GameObjectFilter.Creature.attacking()),
+        TypeNoun("blocking creature", "blocking creatures", GameObjectFilter.Creature.blocking()),
+        TypeNoun("tapped creature", "tapped creatures", GameObjectFilter.Creature.tapped()),
+        TypeNoun("untapped creature", "untapped creatures", GameObjectFilter.Creature.untapped()),
+    )
+
+    /**
+     * The basic land types, which stand in a type noun's slot with no "land" after them — "for each
+     * **Mountain** target opponent controls".
+     *
+     * Generated from the SDK's own list rather than enumerated, because the CR defines the five as a
+     * closed set and the SDK publishes it; and built as `Land.withSubtype(…)` because that is the
+     * shape every hand-written card uses for them, the basic land types being land types.
+     *
+     * Only the *basic* land types are here. A capitalized word is a subtype of some kind, but which
+     * card type it implies is not recoverable from the word — "Goblin" is a creature, "Equipment" an
+     * artifact, "Gate" a land — and the SDK publishes no list to rank against for the latter two.
+     * Guessing would be the reversible-but-wrong class again, so the rest decline.
+     */
+    private val BASIC_LAND_TYPES: List<TypeNoun> = Subtype.ALL_BASIC_LAND_TYPES.map { type ->
+        // "Plains" is its own plural — the one invariant among the five, and the same trap
+        // `Primitives.pluralSubtype` exists for. Appending an "s" would spell a type that is not one.
+        TypeNoun(type, if (type.endsWith("s")) type else "${type}s", GameObjectFilter.Land.withSubtype(Subtype(type)))
+    }
+
+    private fun typeNoun(plural: Boolean): Phrase<GameObjectFilter> = oneOf(
+        if (plural) "a permanent type (plural)" else "a permanent type",
+        (TYPES + BASIC_LAND_TYPES).mapNotNull { noun ->
+            (if (plural) noun.plural else noun.singular)?.let { constant(it, noun.filter) }
+        },
+    )
+
+    // ---------------------------------------------------------------------------------------
+    // The layers
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Strip the top of the predicate stack when it is the kind this layer owns.
+     *
+     * The pair is (the predicate, the filter without it) — the two halves a layer's `match` needs,
+     * and the only place a layer is allowed to reach into `cardPredicates`.
+     */
+    private inline fun <reified P : CardPredicate> GameObjectFilter.stripTop(): Pair<P, GameObjectFilter>? {
+        val top = cardPredicates.lastOrNull() as? P ?: return null
+        return top to copy(cardPredicates = cardPredicates.dropLast(1))
+    }
+
+    /** "white creature" — one colour, as an adjective in front of the type noun. */
+    private fun colour(inner: Phrase<GameObjectFilter>, name: String): Phrase<GameObjectFilter> =
+        phrase("{color} {type}", name = name) {
+            slot("color", Primitives.color)
+            slot("type", inner)
+            build { it.value<GameObjectFilter>("type").withColor(it.value("color")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.HasColor>()
+                    ?.let { (predicate, rest) -> bind("color" to predicate.color, "type" to rest) }
+            }
+        }
+
+    /** "nonblack creature" — the negated colour, which Oracle writes as one word. */
+    private fun notColour(inner: Phrase<GameObjectFilter>, name: String): Phrase<GameObjectFilter> =
+        phrase("non{color} {type}", name = name) {
+            slot("color", Primitives.color)
+            slot("type", inner)
+            build { it.value<GameObjectFilter>("type").notColor(it.value("color")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.NotColor>()
+                    ?.let { (predicate, rest) -> bind("color" to predicate.color, "type" to rest) }
+            }
+        }
+
+    /**
+     * "black and/or red creatures" — the disjunctive colour, which is one `Or` predicate rather
+     * than two.
+     *
+     * "and/or" is the only join spelled here. "black or red creature" is a different printed form
+     * for the same value and would be genuine ambiguity, so it declines; which of the two a card
+     * prints is a templating choice the model has nowhere to keep.
+     */
+    private fun anyColour(inner: Phrase<GameObjectFilter>, name: String): Phrase<GameObjectFilter> =
+        phrase("{first} and/or {second} {type}", name = name) {
+            slot("first", Primitives.color)
+            slot("second", Primitives.color)
+            slot("type", inner)
+            build {
+                it.value<GameObjectFilter>("type")
+                    .withAnyColor(it.value("first"), it.value("second"))
+            }
+            match { filter ->
+                val (predicate, rest) = filter.stripTop<CardPredicate.Or>() ?: return@match null
+                val colours = predicate.predicates.map { (it as? CardPredicate.HasColor)?.color ?: return@match null }
+                if (colours.size != 2) return@match null
+                bind("first" to colours[0], "second" to colours[1], "type" to rest)
+            }
+        }
+
+    /** "creatures with flying" — a keyword the members must have. */
+    private fun withKeyword(inner: Phrase<GameObjectFilter>, name: String): Phrase<GameObjectFilter> =
+        phrase("{type} with {kw}", name = name) {
+            slot("type", inner)
+            slot("kw", Keywords.keyword)
+            build { it.value<GameObjectFilter>("type").withKeyword(it.value<Keyword>("kw")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.HasKeyword>()
+                    ?.let { (predicate, rest) -> bind("type" to rest, "kw" to predicate.keyword) }
+            }
+        }
+
+    /** "creatures without flying" — the keyword layer's negation. */
+    private fun withoutKeyword(inner: Phrase<GameObjectFilter>, name: String): Phrase<GameObjectFilter> =
+        phrase("{type} without {kw}", name = name) {
+            slot("type", inner)
+            slot("kw", Keywords.keyword)
+            build { it.value<GameObjectFilter>("type").withoutKeyword(it.value<Keyword>("kw")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.NotKeyword>()
+                    ?.let { (predicate, rest) -> bind("type" to rest, "kw" to predicate.keyword) }
+            }
+        }
+
+    /** "creatures with power 2 or greater". */
+    private fun withPowerAtLeast(inner: Phrase<GameObjectFilter>, name: String): Phrase<GameObjectFilter> =
+        phrase("{type} with power {n} or greater", name = name) {
+            slot("type", inner)
+            slot("n", Primitives.cardinal)
+            build { it.value<GameObjectFilter>("type").powerAtLeast(it.int("n")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.PowerAtLeast>()
+                    ?.let { (predicate, rest) -> bind("type" to rest, "n" to predicate.min) }
+            }
+        }
+
+    /** "creatures with power 2 or less". */
+    private fun withPowerAtMost(inner: Phrase<GameObjectFilter>, name: String): Phrase<GameObjectFilter> =
+        phrase("{type} with power {n} or less", name = name) {
+            slot("type", inner)
+            slot("n", Primitives.cardinal)
+            build { it.value<GameObjectFilter>("type").powerAtMost(it.int("n")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.PowerAtMost>()
+                    ?.let { (predicate, rest) -> bind("type" to rest, "n" to predicate.max) }
+            }
+        }
 
     /**
      * The controller clause, which is a suffix in English and a single field in the model — so it is
      * one rule per printed form, each stripping [GameObjectFilter.controllerPredicate] and handing
-     * the rest back to [typePhrase].
+     * the rest back inwards.
      */
-    private fun controlledBy(surface: String, predicate: ControllerPredicate): Phrase<GameObjectFilter> =
-        phrase("{type} $surface", name = "a permanent $surface") {
-            slot("type", typePhrase)
+    private fun controlledBy(
+        inner: Phrase<GameObjectFilter>,
+        surface: String,
+        predicate: ControllerPredicate,
+        name: String,
+    ): Phrase<GameObjectFilter> =
+        phrase("{type} $surface", name = name) {
+            slot("type", inner)
             build { it.value<GameObjectFilter>("type").copy(controllerPredicate = predicate) }
             match { filter ->
                 if (filter.controllerPredicate != predicate) {
@@ -78,16 +268,77 @@ object Filters {
         }
 
     /**
-     * A whole noun phrase: a type, optionally with a controller clause.
+     * The whole cascade, for one grammatical number.
      *
-     * A filter carrying no controller predicate can only be printed by [typePhrase], and one that
-     * carries a predicate only by the matching suffix rule, so printing is determined by the model
-     * and the alternation order is irrelevant — the property every `oneOf` in this grammar wants.
+     * Each level carries the level below as its first alternative, so a filter that uses none of a
+     * layer's vocabulary is printed by the layer that owns what it *does* use. Printing stays
+     * determined by the model rather than by alternation order, because every rule's `match` tests
+     * the exact field it owns and the type nouns are exact values.
      */
-    val filter: Phrase<GameObjectFilter> = oneOf(
-        "a permanent",
-        typePhrase,
-        controlledBy("you control", ControllerPredicate.ControlledByYou),
-        controlledBy("an opponent controls", ControllerPredicate.ControlledByOpponent),
+    private fun nounPhrase(plural: Boolean): Phrase<GameObjectFilter> {
+        val suffix = if (plural) " (plural)" else ""
+        val types = typeNoun(plural)
+        val coloured = oneOf(
+            "a coloured permanent$suffix",
+            types,
+            colour(types, "a coloured permanent$suffix"),
+            notColour(types, "a permanent of another colour$suffix"),
+            anyColour(types, "a permanent of either colour$suffix"),
+        )
+        val qualified = oneOf(
+            "a qualified permanent$suffix",
+            coloured,
+            withKeyword(coloured, "a permanent with a keyword$suffix"),
+            withoutKeyword(coloured, "a permanent without a keyword$suffix"),
+            withPowerAtLeast(coloured, "a permanent with power at least$suffix"),
+            withPowerAtMost(coloured, "a permanent with power at most$suffix"),
+        )
+        return oneOf(
+            "a permanent$suffix",
+            qualified,
+            controlledBy(qualified, "you control", ControllerPredicate.ControlledByYou, "a permanent you control$suffix"),
+            controlledBy(
+                qualified,
+                "an opponent controls",
+                ControllerPredicate.ControlledByOpponent,
+                "a permanent an opponent controls$suffix",
+            ),
+        )
+    }
+
+    /** A whole noun phrase in the singular — "creature", "nonblack attacking creature". */
+    val filter: Phrase<GameObjectFilter> = nounPhrase(plural = false)
+
+    /** …and in the plural — "creatures you control", "creatures with power 2 or greater". */
+    val plural: Phrase<GameObjectFilter> = nounPhrase(plural = true)
+
+    /**
+     * "a Forest", "an Island", "a creature" — a singular noun phrase with its indefinite article.
+     *
+     * The article is not in the model and never will be: English derives it from the *spelling* of
+     * the word that follows, which the filter's printed form supplies. So both halves of both rules
+     * derive it from the same function over [filter]'s own output, and the rule whose article
+     * disagrees refuses in **both** directions — "an Forest" fails to parse for exactly the reason
+     * it fails to print. That is what keeps one printed form per model with two alternatives in the
+     * alternation, and it is why this is a pair of rules rather than a leaf: the noun inside is a
+     * whole layered phrase, which a [com.wingedsheep.assay.syntax.token] cannot slot.
+     */
+    val indefinite: Phrase<GameObjectFilter> = oneOf(
+        "a permanent with its article",
+        article("a"),
+        article("an"),
     )
+
+    private fun article(article: String): Phrase<GameObjectFilter> =
+        phrase("$article {type}", name = "\"$article\" plus a permanent") {
+            slot("type", filter)
+            build { it.value<GameObjectFilter>("type").takeIf { f -> articleFor(f) == article } }
+            match { f -> if (articleFor(f) == article) bind("type" to f) else null }
+        }
+
+    /** The article [filter] would print [f] with, or null when it cannot print it at all. */
+    private fun articleFor(f: GameObjectFilter): String? {
+        val head = filter.unparse(f)?.firstOrNull()?.lowercaseChar() ?: return null
+        return if (head in listOf('a', 'e', 'i', 'o', 'u')) "an" else "a"
+    }
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Grammar.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Grammar.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.assay.grammar
 
+import com.wingedsheep.assay.normalize.Normalizer
 import com.wingedsheep.assay.syntax.Bindings
 import com.wingedsheep.assay.syntax.Phrase
 import com.wingedsheep.assay.syntax.alternate
@@ -7,6 +8,7 @@ import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.assay.syntax.separated
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
@@ -237,9 +239,58 @@ object Grammar {
         match { if (it.isEmpty) Bindings.EMPTY else null }
     }
 
+    /**
+     * "Cast this spell only during the declare attackers step and only if you've been attacked this
+     * step." — a line that constrains rather than does.
+     *
+     * The first line kind whose fragment carries no effect at all, which is why it is a line rather
+     * than a clause: nothing in [Steps] could hold it, and a `CardScript` keeps it in a slot of its
+     * own.
+     */
+    private val castRestrictionLine: Phrase<CardFragment> =
+        phrase("{restrictions}", name = "a casting restriction line") {
+            slot("restrictions", Restrictions.castLine)
+            build { CardFragment.of(CardScript(castRestrictions = it.value("restrictions"))) }
+            match { fragment ->
+                val restrictions = fragment.script.castRestrictions.takeIf { it.isNotEmpty() }
+                    ?: return@match null
+                if (fragment != CardFragment.of(CardScript(castRestrictions = restrictions))) return@match null
+                bind("restrictions" to restrictions)
+            }
+        }
+
+    /** "As an additional cost to cast this spell, sacrifice a creature." — the same shape, one slot over. */
+    private val additionalCostLine: Phrase<CardFragment> =
+        phrase("{costs}", name = "an additional cost line") {
+            slot("costs", Restrictions.additionalCostLine)
+            build { CardFragment.of(CardScript(additionalCosts = it.value("costs"))) }
+            match { fragment ->
+                val costs = fragment.script.additionalCosts.takeIf { it.isNotEmpty() } ?: return@match null
+                if (fragment != CardFragment.of(CardScript(additionalCosts = costs))) return@match null
+                bind("costs" to costs)
+            }
+        }
+
+    /**
+     * "~ can't be blocked." — the one line whose whole content is a `CardDefinition` flag.
+     *
+     * A flag rather than a static because that is how the SDK spells the *unconditional* form; every
+     * filtered one ("can't be blocked by black creatures") is a `StaticAbility` in [Statics]. Two
+     * places to say one kind of thing is a finding the differential can now see, which is the reason
+     * [CardFragment] grew a slot for it rather than the grammar picking whichever it preferred.
+     */
+    private val flagLine: Phrase<CardFragment> =
+        phrase("${Normalizer.SELF} can't be blocked.", name = "a flag line") {
+            build { CardFragment(flags = setOf(AbilityFlag.CANT_BE_BLOCKED)) }
+            match { if (it == CardFragment(flags = setOf(AbilityFlag.CANT_BE_BLOCKED))) Bindings.EMPTY else null }
+        }
+
     val abilityLine: Phrase<CardFragment> = oneOf(
         "an ability line",
         emptyLine,
+        castRestrictionLine,
+        additionalCostLine,
+        flagLine,
         keywordLine,
         semicolonKeywordLine,
         spellLine,

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Graveyard.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Graveyard.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+
+/**
+ * Clauses that reach into a graveyard — "Return target creature card from your graveyard to your
+ * hand."
+ *
+ * The first rules whose target is **not on the battlefield**, which is the whole reason they are a
+ * file: [Targets.permanent] mints a battlefield `TargetObject` and its inverse refuses anything
+ * else, deliberately, so that "destroy target creature" cannot print a script pointing at a
+ * graveyard. A graveyard target is the same `TargetObject` with a `zone` and an owner predicate, and
+ * both are printed by the noun phrase — "**your** graveyard" is the owner and "from your graveyard"
+ * is the zone.
+ *
+ * The noun ends in "card" rather than naming a permanent, which is Oracle's own distinction: an
+ * object in a graveyard is a *card*, not a permanent, so the printed form is "{filter} card" and the
+ * bare type nouns [Filters] spells are the modifier in front of it.
+ */
+object Graveyard {
+
+    /** "target creature card from your graveyard" — the requirement half. */
+    private fun inYourGraveyard(filter: GameObjectFilter): TargetRequirement =
+        TargetObject(filter = TargetFilter(filter.ownedByYou(), zone = Zone.GRAVEYARD), id = Targets.SLOT)
+
+    /** The inverse: the filter a your-graveyard requirement restricts to, or null for anything else. */
+    private fun graveyardFilter(requirement: TargetRequirement): GameObjectFilter? {
+        val base = (requirement as? TargetObject)?.filter?.baseFilter ?: return null
+        val unowned = base.copy(controllerPredicate = null)
+        return unowned.takeIf { requirement == inYourGraveyard(it) }
+    }
+
+    /**
+     * The shape: a verb, one card targeted in your graveyard, and nothing else.
+     *
+     * Two members — to your hand and onto the battlefield — differing only in the destination, which
+     * is a different English sentence rather than a different word, so each spells its own template.
+     */
+    private fun graveyardStep(
+        template: String,
+        name: String,
+        effect: (com.wingedsheep.sdk.scripting.targets.EffectTarget) -> com.wingedsheep.sdk.scripting.effects.Effect,
+    ): Phrase<CardScript> {
+        fun scriptFor(filter: GameObjectFilter) = CardScript(
+            spellEffect = effect(Targets.bound()),
+            targetRequirements = listOf(inYourGraveyard(filter)),
+        )
+        return phrase(template, name = name) {
+            slot("filter", Filters.filter)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val requirement = script.targetRequirements.singleOrNull() ?: return@match null
+                val filter = graveyardFilter(requirement) ?: return@match null
+                if (script != scriptFor(filter)) return@match null
+                bind("filter" to filter)
+            }
+        }
+    }
+
+    /**
+     * "Return target card from your graveyard to your hand." — Elven Cache.
+     *
+     * `GameObjectFilter.Any` is what "card" with no modifier means, and [Filters] has no noun for it
+     * on purpose: "card" is not a permanent type, and a row for it would let "destroy target card"
+     * parse. So the unqualified form is its own rule rather than a filter the general one slots.
+     */
+    private val returnAnyCardToHand: Phrase<CardScript> = run {
+        val script = CardScript(
+            spellEffect = Effects.Move(Targets.bound(), Zone.HAND),
+            targetRequirements = listOf(inYourGraveyard(GameObjectFilter.Any)),
+        )
+        phrase("return target card from your graveyard to your hand", name = "return any card from your graveyard") {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    val clauses: List<Phrase<CardScript>> = listOf(
+        graveyardStep(
+            "return target {filter} card from your graveyard to your hand",
+            "return a card from your graveyard to your hand",
+        ) { Effects.Move(it, Zone.HAND) },
+        graveyardStep(
+            "return target {filter} card from your graveyard to the battlefield",
+            "return a card from your graveyard to the battlefield",
+        ) { Effects.Move(it, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD) },
+        returnAnyCardToHand,
+    )
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Hand.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Hand.kt
@@ -1,0 +1,227 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.DrawUpToEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.ForEachEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LookAtTargetHandEffect
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Clauses about hands — looking at one, making a player discard from one, drawing into one.
+ *
+ * Like [Library], most of these denote a `Patterns` recipe rather than a single effect, and the
+ * rules build through the published facade and match by reconstructing it. The exception is looking
+ * at a hand, which really is one effect.
+ */
+object Hand {
+
+    /** "Look at target opponent's hand." — Sorcerous Sight. */
+    private val lookAtOpponentHand: Phrase<CardScript> = run {
+        val script = CardScript(
+            spellEffect = LookAtTargetHandEffect(Targets.bound()),
+            targetRequirements = listOf(Targets.opponent()),
+        )
+        phrase("look at target opponent's hand", name = "look at target opponent's hand") {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /** "Target opponent discards a card at random." — Mind Knives. */
+    private val opponentDiscardsAtRandom: Phrase<CardScript> = run {
+        val script = CardScript(
+            spellEffect = Patterns.Hand.discardRandom(1, Targets.bound()),
+            targetRequirements = listOf(Targets.opponent()),
+        )
+        phrase("target opponent discards a card at random", name = "target opponent discards at random") {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /** "Each opponent discards a card." — Noxious Toad's death trigger. */
+    private val eachOpponentDiscards: Phrase<CardScript> = run {
+        val script = CardScript(spellEffect = Patterns.Hand.eachOpponentDiscards(1))
+        phrase("each opponent discards a card", name = "each opponent discards a card") {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * "Each player may draw up to two cards. For each card less than two a player draws this way,
+     * that player gains 2 life." — Temporary Truce.
+     *
+     * Two printed sentences and one rule, for [Library.lookAtOpponentTopAndBury]'s reason: the model
+     * is a single `ForEachPlayer` iteration whose two inner steps are *linked by a pipeline slot*
+     * ("cardsNotDrawn"), so the second sentence has no meaning without the first and the split
+     * [Steps.sequence] performs would produce a half that denotes nothing.
+     *
+     * The card's limit appears twice in the text and once in the model, so the rule takes two slots
+     * and refuses to build when they disagree — the honest reading of a sentence that states one
+     * number in two places, and the only one that stays invertible.
+     */
+    private val eachPlayerMayDraw: Phrase<CardScript> = run {
+        fun scriptFor(maximum: Int, life: Int) =
+            CardScript(spellEffect = Patterns.Hand.eachPlayerMayDraw(maxCards = maximum, lifePerCardNotDrawn = life))
+        phrase(
+            "each player may draw up to {max} cards. for each card less than {limit} a player " +
+                "draws this way, that player gains {life} life",
+            name = "each player may draw up to N cards",
+        ) {
+            slot("max", Cardinals.word)
+            slot("limit", Cardinals.word)
+            slot("life", Primitives.cardinal)
+            build { bindings ->
+                val maximum = bindings.int("max")
+                if (maximum != bindings.int("limit")) return@build null
+                scriptFor(maximum, bindings.int("life"))
+            }
+            match { script ->
+                val body = (script.spellEffect as? ForEachEffect)?.body as? CompositeEffect ?: return@match null
+                val maximum = (body.effects.firstOrNull() as? DrawUpToEffect)?.maxCards ?: return@match null
+                val gain = (body.effects.getOrNull(1) as? GainLifeEffect)?.amount as? DynamicAmount.Multiply
+                    ?: return@match null
+                if (!Cardinals.spellable(maximum)) return@match null
+                if (script != scriptFor(maximum, gain.multiplier)) return@match null
+                bind("max" to maximum, "limit" to maximum, "life" to gain.multiplier)
+            }
+        }
+    }
+
+    /** "Look at target player's hand." — Ingenious Thief; the same effect over the wider target. */
+    private val lookAtPlayerHand: Phrase<CardScript> = run {
+        val script = CardScript(
+            spellEffect = LookAtTargetHandEffect(Targets.bound()),
+            targetRequirements = listOf(Targets.player()),
+        )
+        phrase("look at target player's hand", name = "look at target player's hand") {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * The discards — "discard a card.", "Target player discards two cards.", "Have target opponent
+     * discard a card."
+     *
+     * One recipe (`Patterns.Hand.discardCards`) with two variables, the count and who discards, and
+     * English spells the second as the sentence's *subject* rather than as a word in a fixed
+     * position — "target player discards" against "have target opponent discard". So the shape is a
+     * template per subject, each carrying its own requirement, and the singular and plural counts
+     * are two rows for the reason [Steps] gives: the article and the noun both change.
+     */
+    private fun discard(
+        template: String,
+        name: String,
+        count: Int?,
+        target: com.wingedsheep.sdk.scripting.targets.EffectTarget,
+        requirements: List<com.wingedsheep.sdk.scripting.targets.TargetRequirement>,
+    ): Phrase<CardScript> {
+        fun scriptFor(cards: Int) = CardScript(
+            spellEffect = Patterns.Hand.discardCards(cards, target),
+            targetRequirements = requirements,
+        )
+        return phrase(template, name = name) {
+            if (count == null) slot("n", Cardinals.word)
+            build { bindings -> scriptFor(count ?: bindings.int("n")) }
+            match { script ->
+                val cards = count ?: discardedCount(script) ?: return@match null
+                if (count == null && !Cardinals.spellable(cards)) return@match null
+                if (script != scriptFor(cards)) return@match null
+                bind("n" to cards)
+            }
+        }
+    }
+
+    /** How many cards a `discardCards` pipeline discards, read off its select step. */
+    private fun discardedCount(script: CardScript): Int? {
+        val select = (script.spellEffect as? CompositeEffect)?.effects
+            ?.filterIsInstance<SelectFromCollectionEffect>()?.firstOrNull() ?: return null
+        val mode = select.selection as? SelectionMode.ChooseExactly ?: return null
+        return (mode.count as? DynamicAmount.Fixed)?.amount
+    }
+
+    /**
+     * The whole-table hand effects — "Each player draws X cards.", "Each player discards any number
+     * of cards, then draws that many cards.", the wheel.
+     *
+     * Each is one published recipe and one printed sentence with no variable in it, so each is a
+     * constant rule: the reconstruction *is* the comparison, and a card whose pipeline differs in
+     * any field declines rather than printing a sentence it does not mean.
+     */
+    private fun tableWide(template: String, name: String, effect: Effect): Phrase<CardScript> {
+        val script = CardScript(spellEffect = effect)
+        return phrase(template, name = name) {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /** "Target opponent reveals their hand." — Baleful Stare's first sentence. */
+    private val opponentRevealsHand: Phrase<CardScript> = run {
+        val script = CardScript(
+            spellEffect = RevealHandEffect(Targets.bound()),
+            targetRequirements = listOf(Targets.opponent()),
+        )
+        phrase("target opponent reveals their hand", name = "target opponent reveals their hand") {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    val clauses: List<Phrase<CardScript>> = listOf(
+        lookAtOpponentHand,
+        opponentRevealsHand,
+        lookAtPlayerHand,
+        opponentDiscardsAtRandom,
+        eachOpponentDiscards,
+        eachPlayerMayDraw,
+        discard(
+            "discard a card", "discard a card",
+            count = 1, target = EffectTarget.Controller, requirements = emptyList(),
+        ),
+        discard(
+            "discard {n} cards", "discard cards",
+            count = null, target = EffectTarget.Controller, requirements = emptyList(),
+        ),
+        discard(
+            "target player discards a card", "target player discards a card",
+            count = 1, target = Targets.bound(), requirements = listOf(Targets.player()),
+        ),
+        discard(
+            "target player discards {n} cards", "target player discards cards",
+            count = null, target = Targets.bound(), requirements = listOf(Targets.player()),
+        ),
+        discard(
+            "have target opponent discard a card", "have target opponent discard a card",
+            count = 1, target = Targets.bound(), requirements = listOf(Targets.opponent()),
+        ),
+        tableWide(
+            "each player draws X cards", "each player draws X cards",
+            Patterns.Hand.eachPlayerDrawsX(includeController = true, includeOpponents = true),
+        ),
+        tableWide(
+            "each player discards any number of cards, then draws that many cards",
+            "each player discards and redraws",
+            Patterns.Hand.eachPlayerDiscardsDraws(),
+        ),
+        tableWide(
+            "each player shuffles the cards from their hand into their library, then draws that many cards",
+            "the wheel",
+            Patterns.Hand.wheelEffect(Player.Each),
+        ),
+    )
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Library.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Library.kt
@@ -1,0 +1,333 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.alternate
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Clauses about a library — looking at the top of one, searching one, shuffling one.
+ *
+ * These are the first rules whose model is a **`Patterns` composition** rather than a single
+ * effect: "Search your library for a card, then shuffle and put that card on top." is four pipeline
+ * steps with string slot keys, and the SDK publishes the recipe as `Patterns.Library.searchLibrary`.
+ * The rules therefore `build` through that facade and `match` by reconstructing it and comparing —
+ * exactly the discipline the atomic rules follow, and the reason a card whose pipeline differs by a
+ * single field declines instead of printing this sentence.
+ *
+ * That is also why the printed sentence and the model are so far apart here. The clause is one
+ * English sentence and the value is a `CompositeEffect` of four steps, so nothing about the shape of
+ * the model suggests where the sentence's boundaries are; only the recipe does. [Steps.sequence]
+ * never decomposes one of these, because its own split is over the *outer* composite and none of
+ * these inner steps has a clause rule of its own.
+ */
+object Library {
+
+    /**
+     * "Look at the top three cards of your library, then put them back in any order." — Omen.
+     *
+     * The count is [Cardinals.word] rather than a numeral: Oracle spells a quantity of *cards* as a
+     * word, the convention [Steps] takes both leaves for.
+     */
+    private val lookAtTopAndReorder: Phrase<CardScript> = run {
+        fun scriptFor(count: Int) = CardScript(spellEffect = Patterns.Library.lookAtTopAndReorder(count))
+        phrase(
+            "look at the top {n} cards of your library, then put them back in any order",
+            name = "look at the top cards and reorder",
+        ) {
+            slot("n", Cardinals.word)
+            build { scriptFor(it.int("n")) }
+            match { script ->
+                val count = topOfLibraryCount(script) ?: return@match null
+                if (!Cardinals.spellable(count) || script != scriptFor(count)) return@match null
+                bind("n" to count)
+            }
+        }
+    }
+
+    /** The number of cards a `lookAtTopAndReorder` pipeline gathers, or null for any other value. */
+    private fun topOfLibraryCount(script: CardScript): Int? {
+        val gather = (script.spellEffect as? CompositeEffect)
+            ?.effects?.firstOrNull() as? GatherCardsEffect ?: return null
+        val source = gather.source as? CardSource.TopOfLibrary ?: return null
+        return (source.count as? DynamicAmount.Fixed)?.amount
+    }
+
+    /**
+     * "Search your library for a card, then shuffle and put that card on top." — Cruel Tutor.
+     *
+     * The destination is spelled by the template rather than by a slot, because each destination is
+     * a different English sentence ("put it into your hand", "onto the battlefield") rather than a
+     * different word in this one — the same argument [Steps.pumpTargetPermanent] makes about
+     * durations. `filter` is `Any`, which is what "a card" means; a filtered search is a different
+     * noun phrase and a rule this one does not claim.
+     */
+    private val searchForACardToTop: Phrase<CardScript> = run {
+        val script = CardScript(
+            spellEffect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any,
+                destination = SearchDestination.TOP_OF_LIBRARY,
+            )
+        )
+        phrase(
+            "search your library for a card, then shuffle and put that card on top",
+            name = "search your library and put a card on top",
+        ) {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * "You may shuffle." — the optional shuffle Omen ends on.
+     *
+     * `MayEffect` is the SDK's spelling of a player-chosen action inside a spell's effect. Note the
+     * deliberate asymmetry with [Triggers]: on a *triggered ability* the same English lowers to the
+     * ability's `optional` flag instead, because that is the field the hand-written cards set and
+     * the one the trigger's own sentence introduces. Two SDK spellings of "you may", each canonical
+     * in the sentence context that owns it, and [Triggers.abilityFor] is the lowering between them.
+     */
+    private val mayShuffle: Phrase<CardScript> = run {
+        val script = CardScript(spellEffect = MayEffect(ShuffleLibraryEffect()))
+        phrase("you may shuffle", name = "you may shuffle") {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * "Look at the top five cards of target opponent's library. Put one of those cards into that
+     * player's graveyard and the rest on top of their library in any order." — Cruel Fate.
+     *
+     * **Two printed sentences, one rule**, and the only rule in the grammar shaped that way. The
+     * model is a four-step gather / select / move / move pipeline whose steps do not line up with
+     * the sentence boundary at all — the second sentence is three of the four steps, and the first
+     * step is what makes the second sentence's "those cards" mean anything. [Steps.sequence] splits
+     * a line where the *model* is a composite of clause-sized effects; here it is not, so splitting
+     * the text would produce two halves neither of which denotes anything.
+     *
+     * It unlocks one card, which the module's own rule says needs a stated reason: the reason is
+     * that the alternative is not a smaller rule but a wrong one. The prompt labels are part of the
+     * recipe rather than of the text, so they are reproduced from the card and compared by the
+     * equality below like every other field.
+     */
+    private val lookAtOpponentTopAndBury: Phrase<CardScript> = run {
+        fun scriptFor(count: Int) = CardScript(
+            spellEffect = CompositeEffect(
+                listOf(
+                    GatherCardsEffect(
+                        CardSource.TopOfLibrary(DynamicAmount.Fixed(count), Player.TargetOpponent),
+                        storeAs = "looked",
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "looked",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        storeSelected = "toGraveyard",
+                        storeRemainder = "toTop",
+                        selectedLabel = "Put in graveyard",
+                        remainderLabel = "Put on top",
+                    ),
+                    MoveCollectionEffect(
+                        from = "toGraveyard",
+                        destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.TargetOpponent),
+                    ),
+                    MoveCollectionEffect(
+                        from = "toTop",
+                        destination = CardDestination.ToZone(Zone.LIBRARY, Player.TargetOpponent, ZonePlacement.Top),
+                        order = CardOrder.ControllerChooses,
+                    ),
+                )
+            ),
+            targetRequirements = listOf(Targets.opponent()),
+        )
+        phrase(
+            "look at the top {n} cards of target opponent's library. put one of those cards into " +
+                "that player's graveyard and the rest on top of their library in any order",
+            name = "look at an opponent's top cards and bury one",
+        ) {
+            slot("n", Cardinals.word)
+            build { scriptFor(it.int("n")) }
+            match { script ->
+                val count = topOfLibraryCount(script) ?: return@match null
+                if (!Cardinals.spellable(count) || script != scriptFor(count)) return@match null
+                bind("n" to count)
+            }
+        }
+    }
+
+    /**
+     * "Search your library for a Forest card, put that card onto the battlefield, then shuffle." —
+     * the filtered searches, which are one recipe with one slot.
+     *
+     * `Patterns.Library.searchLibrary`'s other parameters are spelled by the *template* rather than
+     * by slots, for the reason [Steps.pumpTargetPermanent] spells its duration: each destination and
+     * each reveal is a different English sentence, not a different word in one. So the family is a
+     * row per sentence over one shared shape, and the noun phrase goes through [Filters.indefinite]
+     * so the article agrees with whatever type the card names.
+     *
+     * "…put **that card** onto the battlefield" and "…put **it** onto the battlefield" are two
+     * printed forms of one recipe — Nature's Lore prints the first, Natural Order the second — so
+     * one is canonical and the other parses without printing, and a card using the pronoun comes
+     * back as a variant.
+     */
+    private fun search(
+        template: String,
+        name: String,
+        canonicalForm: Boolean = true,
+        destination: SearchDestination,
+        reveal: Boolean = false,
+    ): Phrase<CardScript> {
+        fun scriptFor(filter: GameObjectFilter) = CardScript(
+            spellEffect = Patterns.Library.searchLibrary(
+                filter = filter,
+                destination = destination,
+                reveal = reveal,
+            )
+        )
+        val rule = phrase<CardScript>(template, name = name) {
+            slot("filter", Filters.indefinite)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val filter = searchedFilter(script) ?: return@match null
+                if (script != scriptFor(filter)) return@match null
+                bind("filter" to filter)
+            }
+            canonical = canonicalForm
+        }
+        return if (canonicalForm) rule else alternate(rule)
+    }
+
+    /** The filter a `searchLibrary` pipeline looks for, read off its gather step. */
+    private fun searchedFilter(script: CardScript): GameObjectFilter? {
+        val gather = (script.spellEffect as? CompositeEffect)?.effects?.firstOrNull() as? GatherCardsEffect
+            ?: return null
+        return (gather.source as? CardSource.FromZone)?.filter
+    }
+
+    /**
+     * "If an opponent controls more lands than you, search your library for up to three Plains
+     * cards, reveal them, put them into your hand, then shuffle." — Gift of Estates.
+     *
+     * The counted search, which is a different sentence from the singular one in every clause after
+     * the noun: "up to three … cards, reveal **them**, put **them** into your hand". The condition in
+     * front of it is [Steps]' conditional wrapper, so this rule is only the search half.
+     */
+    private val searchUpToNToHand: Phrase<CardScript> = run {
+        fun scriptFor(count: Int, filter: GameObjectFilter) = CardScript(
+            spellEffect = Patterns.Library.searchLibrary(
+                filter = filter,
+                count = count,
+                destination = SearchDestination.HAND,
+                reveal = true,
+            )
+        )
+        phrase(
+            "search your library for up to {n} {filter} cards, reveal them, put them into your hand, then shuffle",
+            name = "search your library for several cards",
+        ) {
+            slot("n", Cardinals.word)
+            slot("filter", Filters.plural)
+            build { scriptFor(it.int("n"), it.value("filter")) }
+            match { script ->
+                val filter = searchedFilter(script) ?: return@match null
+                val count = searchedCount(script) ?: return@match null
+                if (!Cardinals.spellable(count) || script != scriptFor(count, filter)) return@match null
+                bind("n" to count, "filter" to filter)
+            }
+        }
+    }
+
+    /** How many cards a `searchLibrary` pipeline selects, read off its select step. */
+    private fun searchedCount(script: CardScript): Int? {
+        val select = (script.spellEffect as? CompositeEffect)?.effects
+            ?.filterIsInstance<SelectFromCollectionEffect>()?.firstOrNull() ?: return null
+        val mode = select.selection as? SelectionMode.ChooseUpTo ?: return null
+        return (mode.count as? DynamicAmount.Fixed)?.amount
+    }
+
+    /**
+     * "Look at the top seven cards of your library. Put two of them into your hand and the rest into
+     * your graveyard." — Ancestral Memories.
+     *
+     * Two printed sentences and one recipe, for [lookAtOpponentTopAndBury]'s reason: the second
+     * sentence is the *disposition* of the cards the first gathered, which the model carries as two
+     * destinations on one pipeline rather than as a second effect.
+     */
+    private val lookAtTopAndKeep: Phrase<CardScript> = run {
+        fun scriptFor(count: Int, keep: Int) =
+            CardScript(spellEffect = Patterns.Library.lookAtTopAndKeep(count = count, keepCount = keep))
+        phrase(
+            "look at the top {n} cards of your library. put {k} of them into your hand and the rest " +
+                "into your graveyard",
+            name = "look at the top cards and keep some",
+        ) {
+            slot("n", Cardinals.word)
+            slot("k", Cardinals.word)
+            build { scriptFor(it.int("n"), it.int("k")) }
+            match { script ->
+                val count = topOfLibraryCount(script) ?: return@match null
+                val keep = keptCount(script) ?: return@match null
+                if (!Cardinals.spellable(count) || !Cardinals.spellable(keep)) return@match null
+                if (script != scriptFor(count, keep)) return@match null
+                bind("n" to count, "k" to keep)
+            }
+        }
+    }
+
+    /** How many of the looked-at cards a `lookAtTopAndKeep` pipeline keeps. */
+    private fun keptCount(script: CardScript): Int? {
+        val select = (script.spellEffect as? CompositeEffect)?.effects
+            ?.filterIsInstance<SelectFromCollectionEffect>()?.firstOrNull() ?: return null
+        val mode = select.selection as? SelectionMode.ChooseExactly ?: return null
+        return (mode.count as? DynamicAmount.Fixed)?.amount
+    }
+
+    val clauses: List<Phrase<CardScript>> = listOf(
+        lookAtTopAndReorder,
+        lookAtTopAndKeep,
+        searchForACardToTop,
+        searchUpToNToHand,
+        mayShuffle,
+        lookAtOpponentTopAndBury,
+        search(
+            "search your library for {filter} card, put that card onto the battlefield, then shuffle",
+            "search your library for a card to the battlefield",
+            destination = SearchDestination.BATTLEFIELD,
+        ),
+        search(
+            "search your library for {filter} card, put it onto the battlefield, then shuffle",
+            "search your library for a card to the battlefield (pronoun)",
+            canonicalForm = false,
+            destination = SearchDestination.BATTLEFIELD,
+        ),
+        search(
+            "search your library for {filter} card, reveal it, then shuffle and put that card on top",
+            "search your library for a card, revealed, to the top",
+            destination = SearchDestination.TOP_OF_LIBRARY,
+            reveal = true,
+        ),
+        search(
+            "search your library for {filter} card, put it into your hand, then shuffle",
+            "search your library for a card to your hand",
+            destination = SearchDestination.HAND,
+        ),
+    )
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Mana.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Mana.kt
@@ -60,8 +60,14 @@ object Mana {
         write = ::writeProduction,
     )
 
-    /** "Add {G}." — the whole sentence, which is a spell effect in its own right (Dark Ritual). */
-    val added: Phrase<CardScript> = phrase("add {mana}.", name = "add mana") {
+    /**
+     * "add {G}" — the clause, which is a spell effect in its own right (Dark Ritual).
+     *
+     * Periodless like every other clause in [Steps]: the full stop belongs to the sentence, not to
+     * the verb phrase, which is what lets the same rule be a whole spell and the clause after an
+     * activated ability's colon.
+     */
+    val addClause: Phrase<CardScript> = phrase("add {mana}", name = "add mana") {
         slot("mana", production)
         build { CardScript(spellEffect = it.value("mana")) }
         match { script ->

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Primitives.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Primitives.kt
@@ -1,6 +1,8 @@
 package com.wingedsheep.assay.grammar
 
+import com.wingedsheep.assay.normalize.Normalizer
 import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.alternate
 import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.constant
 import com.wingedsheep.assay.syntax.oneOf
@@ -85,6 +87,28 @@ object Primitives {
     val color: Phrase<Color> = oneOf(
         "a color",
         Color.entries.map { constant(it.displayName.lowercase(), it) },
+    )
+
+    /**
+     * The subject of a sentence when that subject is the card itself — "**~** deals 2 damage…",
+     * "**it** deals 2 damage…".
+     *
+     * Oracle uses the pronoun once a clause earlier in the same ability has already named the
+     * source: Fire Imp prints "When this creature enters, **it** deals 2 damage to target creature."
+     * Both spellings denote the same thing and the model has no room for which one was printed, so
+     * the name is canonical and the pronoun is an [com.wingedsheep.assay.syntax.alternate]. That is
+     * the same treatment [com.wingedsheep.assay.normalize.Normalizer] gives "this creature" versus
+     * the card's own name, one level further in: normalization abstracts both to `~`, and this rule
+     * abstracts the pronoun that stands for `~`.
+     *
+     * The value is [Unit] because a subject that is always the source carries no information; what
+     * the rule buys is that every sentence in the grammar spelling `~` reads the pronoun too,
+     * without a second copy of the rule.
+     */
+    val self: Phrase<Unit> = oneOf(
+        "this permanent",
+        constant(Normalizer.SELF, Unit),
+        alternate(constant("it", Unit)),
     )
 
     /**

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Replacements.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Replacements.kt
@@ -48,9 +48,13 @@ object Replacements {
      * The same type with one field set, which is why it is a row beside the plain rule rather than
      * a family of its own. The digit is [Primitives.cardinal] because Oracle spells a quantity of
      * life as a numeral, the convention [Steps] takes both leaves for.
+     *
+     * The template spells its second sentence mid-sentence ("if you don't") for the reason every
+     * template here is written mid-sentence: a full stop is a sentence start, and
+     * [com.wingedsheep.assay.syntax.SentenceCase] owns the capital at every one of them.
      */
     private val shockLand: Phrase<ReplacementEffect> = phrase(
-        "as ${Normalizer.SELF} enters, you may pay {n} life. If you don't, it enters tapped.",
+        "as ${Normalizer.SELF} enters, you may pay {n} life. if you don't, it enters tapped.",
         name = "enters tapped unless you pay life",
     ) {
         slot("n", Primitives.cardinal)

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Restrictions.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Restrictions.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.constant
+import com.wingedsheep.assay.syntax.oneOf
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.assay.syntax.separated
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.CastRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+
+/**
+ * When a spell may be cast and when an ability may be activated — the two restriction vocabularies,
+ * plus the additional cost a spell's own line declares.
+ *
+ * All three are content a card states in a *sentence of its own* rather than as part of an effect,
+ * and each lands in a different slot: `CardScript.castRestrictions`, `CardScript.additionalCosts`,
+ * and `ActivatedAbility.restrictions`. They share a file because they share a shape — a printed
+ * clause that constrains rather than does — and because the first two are the only lines in the
+ * grammar that produce no effect at all.
+ *
+ * ### Restrictions are a run, not a rule per combination
+ *
+ * "Cast this spell only during the declare attackers step **and** only if you've been attacked this
+ * step." is two restrictions joined by "and", and the model is a list of two. So the rule is a run
+ * over a one-restriction vocabulary rather than a rule per printed combination, which is what keeps
+ * a third restriction one row instead of doubling the table.
+ */
+object Restrictions {
+
+    // ---------------------------------------------------------------------------------------
+    // Casting
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * One cast restriction.
+     *
+     * The step forms are enumerated rather than slotted over a step vocabulary because Oracle names
+     * a step with an article and a noun phrase ("the declare attackers step") whose spelling is not
+     * derivable from the SDK's `Step` constant, and a rule that guessed it would be reading an enum
+     * name rather than a card.
+     */
+    private val one: Phrase<CastRestriction> = oneOf(
+        "a casting restriction",
+        constant(
+            "only during the declare attackers step",
+            CastRestriction.OnlyDuringStep(Step.DECLARE_ATTACKERS),
+        ),
+        constant(
+            "only during the declare blockers step",
+            CastRestriction.OnlyDuringStep(Step.DECLARE_BLOCKERS),
+        ),
+        phrase("only if {cond}", name = "only if a condition holds") {
+            slot("cond", Conditions.condition)
+            build { CastRestriction.OnlyIfCondition(it.value("cond")) }
+            match { (it as? CastRestriction.OnlyIfCondition)?.let { r -> bind("cond" to r.condition) } }
+        },
+    )
+
+    /** "Cast this spell only during …, and only if …" — the whole line. */
+    val castLine: Phrase<List<CastRestriction>> =
+        phrase("cast this spell {restrictions}.", name = "a casting restriction line") {
+            slot("restrictions", separated("casting restrictions", one, " and "))
+            build { it.value("restrictions") }
+            match { restrictions -> restrictions.takeIf { it.isNotEmpty() }?.let { bind("restrictions" to it) } }
+        }
+
+    // ---------------------------------------------------------------------------------------
+    // Additional costs
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * "As an additional cost to cast this spell, sacrifice a creature." — the line that adds to what
+     * a spell costs rather than to what it does.
+     *
+     * The noun phrase goes through [Filters.indefinite], so "a creature" and "a green creature" are
+     * the same rule; the cost is reconstructed from the filter for the comparison, the same
+     * fail-closed shape [SelfSteps.sacrificeUnless] uses on the pay-cost side.
+     */
+    val additionalCostLine: Phrase<List<AdditionalCost>> = run {
+        fun costFor(filter: GameObjectFilter) = listOf(Costs.additional.SacrificePermanent(filter))
+        phrase(
+            "as an additional cost to cast this spell, sacrifice {filter}.",
+            name = "an additional cost line",
+        ) {
+            slot("filter", Filters.indefinite)
+            build { costFor(it.value("filter")) }
+            match { costs ->
+                val atom = (costs.singleOrNull() as? AdditionalCost.Atom)?.atom as? CostAtom.Sacrifice
+                    ?: return@match null
+                if (costs != costFor(atom.filter)) return@match null
+                bind("filter" to atom.filter)
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Activation
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * One activation restriction, and the run of them an ability's last sentence spells.
+     *
+     * "Activate only during your turn, before attackers are declared." joins its two with a comma
+     * rather than with "and", which is a printed-shape difference from the casting line and the
+     * reason each has its own separator rather than a shared one.
+     */
+    private val oneActivation: Phrase<ActivationRestriction> = oneOf(
+        "an activation restriction",
+        constant("during your turn", ActivationRestriction.OnlyDuringYourTurn),
+        constant("before attackers are declared", ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS)),
+        constant("before blockers are declared", ActivationRestriction.BeforeStep(Step.DECLARE_BLOCKERS)),
+        constant("once each turn", ActivationRestriction.OncePerTurn),
+    )
+
+    /** "Activate only during your turn, before attackers are declared." — the trailing sentence. */
+    val activationSentence: Phrase<List<ActivationRestriction>> =
+        phrase("activate only {restrictions}.", name = "an activation restriction sentence") {
+            slot("restrictions", separated("activation restrictions", oneActivation, ", "))
+            build { it.value("restrictions") }
+            match { restrictions -> restrictions.takeIf { it.isNotEmpty() }?.let { bind("restrictions" to it) } }
+        }
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/SelfSteps.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/SelfSteps.kt
@@ -1,0 +1,193 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Clauses about the **source** — "it gets +2/+0 until end of turn.", "put it on top of its owner's
+ * library.", "sacrifice it unless you discard a land card."
+ *
+ * Oracle's "it" here is the permanent whose ability this is, which is [EffectTarget.Self] and needs
+ * no earlier sentence to introduce it — so unlike [Continuations] these are ordinary clauses that
+ * can stand alone. The two anaphors are kept in separate vocabularies precisely because they point
+ * at different things: "that creature" is the target the spell already chose, "it" is the source.
+ *
+ * Almost every card that prints one of these prints it inside a triggered ability ("When this
+ * creature dies, put it on top of its owner's library"), and none of these rules knows that:
+ * [Triggers] slots [Steps.step] whole, so the clause is the same clause wherever it lands.
+ */
+object SelfSteps {
+
+    /** "It gets +2/+0 until end of turn." — Charging Bandits' attack trigger. */
+    private val itGets: Phrase<CardScript> = run {
+        fun scriptFor(modifiers: Pair<Int, Int>) = CardScript(
+            spellEffect = Effects.ModifyStats(modifiers.first, modifiers.second, EffectTarget.Self)
+        )
+        phrase("it gets {mod} until end of turn", name = "the source gets") {
+            slot("mod", Primitives.statModifiers)
+            build { scriptFor(it.value("mod")) }
+            match { script ->
+                val modifiers = Steps.fixedModifiers(script.spellEffect) ?: return@match null
+                if (script != scriptFor(modifiers)) return@match null
+                bind("mod" to modifiers)
+            }
+        }
+    }
+
+    /** "Put it on top of its owner's library." — Undying Beast's death trigger. */
+    private val putOnTop: Phrase<CardScript> = run {
+        val script = CardScript(spellEffect = Effects.PutOnTopOfLibrary(EffectTarget.Self))
+        phrase("put it on top of its owner's library", name = "put the source on top of its library") {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * "Sacrifice it unless you discard a land card." — the Portal drawback, and one shape with two
+     * costs.
+     *
+     * `PayOrSufferEffect` is the SDK's name for the whole sentence: a cost the controller may pay
+     * and the thing that happens if they do not. The two members differ only in the [PayCost], which
+     * is why the rule is a function of the cost's surface and both halves of the cost — the printed
+     * noun phrase goes through [Filters.indefinite] so the article comes out right, and the cost is
+     * reconstructed from the filter for the comparison.
+     */
+    private fun sacrificeUnless(
+        template: String,
+        name: String,
+        cost: (GameObjectFilter) -> PayCost,
+    ): Phrase<CardScript> {
+        fun scriptFor(filter: GameObjectFilter) = CardScript(
+            spellEffect = PayOrSufferEffect(cost = cost(filter), suffer = SacrificeSelfEffect)
+        )
+        return phrase(template, name = name) {
+            slot("filter", Filters.indefinite)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val effect = script.spellEffect as? PayOrSufferEffect ?: return@match null
+                val filter = paidFilter(effect.cost) ?: return@match null
+                if (script != scriptFor(filter)) return@match null
+                bind("filter" to filter)
+            }
+        }
+    }
+
+    /** The filter a one-atom pay cost names, or null when the cost is anything more complicated. */
+    private fun paidFilter(cost: PayCost): GameObjectFilter? {
+        val atom = (cost as? PayCost.Atom)?.atom ?: return null
+        return when (atom) {
+            is CostAtom.Discard -> atom.filter
+            is CostAtom.Sacrifice -> atom.filter
+            else -> null
+        }
+    }
+
+    /** The moves whose object is the source and whose destination the template names. */
+    private fun moveSelf(template: String, name: String, effect: Effect): Phrase<CardScript> {
+        val script = CardScript(spellEffect = effect)
+        return phrase(template, name = name) {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * "Sacrifice it unless you sacrifice three Forests." — the counted cost, Primeval Force's.
+     *
+     * A row of the [sacrificeUnless] shape would need the count in the cost *and* a plural noun in
+     * the text, which changes both slots; the singular rules keep the noun singular and this one
+     * carries the number, which is the same singular/plural split every counting rule here makes.
+     */
+    private val sacrificeUnlessCounted: Phrase<CardScript> = run {
+        fun scriptFor(count: Int, filter: GameObjectFilter) = CardScript(
+            spellEffect = PayOrSufferEffect(
+                cost = Costs.pay.Sacrifice(filter, count = count),
+                suffer = SacrificeSelfEffect,
+            )
+        )
+        phrase(
+            "sacrifice it unless you sacrifice {n} {filter}",
+            name = "sacrifice the source unless you sacrifice several",
+        ) {
+            slot("n", Cardinals.word)
+            slot("filter", Filters.plural)
+            build { scriptFor(it.int("n"), it.value("filter")) }
+            match { script ->
+                val effect = script.spellEffect as? PayOrSufferEffect ?: return@match null
+                val atom = (effect.cost as? PayCost.Atom)?.atom as? CostAtom.Sacrifice ?: return@match null
+                if (!Cardinals.spellable(atom.count)) return@match null
+                if (script != scriptFor(atom.count, atom.filter)) return@match null
+                bind("n" to atom.count, "filter" to atom.filter)
+            }
+        }
+    }
+
+    /** "Sacrifice it unless you discard a card at random." — Pillaging Horde. */
+    private val sacrificeUnlessRandomDiscard: Phrase<CardScript> = run {
+        val script = CardScript(
+            spellEffect = PayOrSufferEffect(
+                cost = Costs.pay.Discard(random = true),
+                suffer = SacrificeSelfEffect,
+            )
+        )
+        phrase(
+            "sacrifice it unless you discard a card at random",
+            name = "sacrifice the source unless you discard at random",
+        ) {
+            build { script }
+            match { if (it == script) bind() else null }
+        }
+    }
+
+    /**
+     * The clauses whose "it" is the **source**.
+     *
+     * Kept apart from the rest because English resolves an anaphor to the most recently mentioned
+     * object: in "Whenever this creature attacks, it gets +2/+0" the only mention is the source, but
+     * in "Untap target creature. It gets +2/+4 until end of turn." it is the target the first clause
+     * introduced. So these rules are clauses in their own right and are *not* offered in a later
+     * position of a sequence — [Continuations] owns "it" there. Registering them in both places
+     * would be two readings of one text, which is ambiguity rather than a choice.
+     */
+    val anaphoric: List<Phrase<CardScript>> = listOf(
+        itGets,
+        putOnTop,
+        sacrificeUnlessCounted,
+        sacrificeUnlessRandomDiscard,
+        moveSelf(
+            "shuffle it into its owner's library",
+            "shuffle the source into its library",
+            Effects.Move(EffectTarget.Self, Zone.LIBRARY, ZonePlacement.Shuffled),
+        ),
+        moveSelf(
+            "return it to its owner's hand",
+            "return the source to its owner's hand",
+            Effects.Move(EffectTarget.Self, Zone.HAND),
+        ),
+        sacrificeUnless(
+            "sacrifice it unless you discard {filter} card",
+            "sacrifice the source unless you discard",
+        ) { Costs.pay.Discard(filter = it) },
+        sacrificeUnless(
+            "sacrifice it unless you sacrifice {filter}",
+            "sacrifice the source unless you sacrifice",
+        ) { Costs.pay.Sacrifice(it) },
+    )
+
+    /** Everything in this file that does not turn on the pronoun. Empty for now; the family is "it". */
+    val clauses: List<Phrase<CardScript>> = emptyList()
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Stack.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Stack.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.constant
+import com.wingedsheep.assay.syntax.oneOf
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Clauses about the stack — countering a spell.
+ *
+ * The one clause family whose target is a *spell* rather than a permanent, a player or a card, which
+ * is why it is its own file rather than a row in [Steps]: `TargetSpell` is a `TargetObject` scoped to
+ * `Zone.STACK`, and [Targets.permanent]'s inverse refuses anything that is not on the battlefield —
+ * deliberately, so that "destroy target creature" cannot print a script aimed at the stack.
+ *
+ * ### The spell type phrase is enumerated
+ *
+ * "Target creature or sorcery spell" is `GameObjectFilter.CreatureOrSorcery` — an ordered `Or` — and
+ * "target creature spell" is one predicate, which is the same shape problem [Filters] states for its
+ * own type list: English does not distinguish them except by the words. So the spell nouns are rows
+ * here rather than [Filters.filter] slotted whole, and a form nobody wrote down declines. They are
+ * *not* [Filters] rows because the noun ends in "spell" and the zone is part of the requirement
+ * rather than of the filter — a permanent noun in this position would build a battlefield target.
+ */
+object Stack {
+
+    private val spellFilter: Phrase<TargetFilter> = oneOf(
+        "a spell on the stack",
+        constant("spell", TargetFilter.SpellOnStack),
+        constant("creature or sorcery spell", TargetFilter.CreatureOrSorcerySpellOnStack),
+        constant("creature spell", TargetFilter(com.wingedsheep.sdk.scripting.GameObjectFilter.Creature, zone = Zone.STACK)),
+        constant("instant spell", TargetFilter.InstantSpellOnStack),
+    )
+
+    /** "Counter target creature or sorcery spell." — Mystic Denial. */
+    private val counter: Phrase<CardScript> = run {
+        fun scriptFor(filter: TargetFilter) = CardScript(
+            spellEffect = CounterEffect(),
+            targetRequirements = listOf(TargetSpell(filter = filter, id = Targets.SLOT)),
+        )
+        phrase("counter target {filter}", name = "counter a spell") {
+            slot("filter", spellFilter)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val requirement = script.targetRequirements.singleOrNull()
+                    as? com.wingedsheep.sdk.scripting.targets.TargetObject ?: return@match null
+                if (script != scriptFor(requirement.filter)) return@match null
+                bind("filter" to requirement.filter)
+            }
+        }
+    }
+
+    val clauses: List<Phrase<CardScript>> = listOf(counter)
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Statics.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Statics.kt
@@ -1,13 +1,25 @@
 package com.wingedsheep.assay.grammar
 
+import com.wingedsheep.assay.normalize.Normalizer
+import com.wingedsheep.assay.syntax.Bindings
 import com.wingedsheep.assay.syntax.Phrase
 import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
 import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.StaticAbility
+import com.wingedsheep.sdk.scripting.conditions.Condition
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 
 /**
  * Continuous abilities a permanent has just by being on the battlefield — `staticAbilities`, the
@@ -100,7 +112,137 @@ object Statics {
             }
         }
 
-    val all: List<Phrase<StaticAbility>> = listOf(attachedPump, attachedKeyword)
+    // ---------------------------------------------------------------------------------------
+    // Combat restrictions — the statics a creature has about its own attacking and blocking
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * "~ can't block.", "~ can't be blocked by black and/or red creatures.", "~ can block only
+     * creatures with flying." — the evasion and restriction family, which is the second static
+     * family and the one that made [Statics] a file about the slot rather than about auras.
+     *
+     * All three are the same shape: a `StaticAbility` whose `filter` is the source itself (the
+     * `GroupFilter.source()` default every one of them declares) and whose only other content is a
+     * blocker filter, if it takes one. The shape is written as a function over that blocker filter
+     * for the reason the module states — three members is a family, and the fourth ("can't be
+     * blocked except by …") is a row rather than a rule.
+     *
+     * The blocker filter is [Filters.plural] whole, so "creatures with flying", "black and/or red
+     * creatures" and "creatures with power 2 or greater" are rows in a filter list rather than three
+     * rules here. Plural because that is the number English uses after "blocked by": a restriction
+     * names a *class* of blocker, never one.
+     *
+     * `match` reconstructs and compares, so a copy of one of these carrying a real `GroupFilter` —
+     * "Creatures you control can't be blocked by …" is the same SDK type — refuses to print as a
+     * sentence about this creature.
+     */
+    private fun blockerRestriction(
+        template: String,
+        name: String,
+        ability: (GameObjectFilter) -> StaticAbility,
+    ): Phrase<StaticAbility> = phrase(template, name = name) {
+        slot("blockers", Filters.plural)
+        build { ability(it.value("blockers")) }
+        match { value ->
+            val blockers = when (value) {
+                is CantBeBlockedBy -> value.blockerFilter
+                is CanOnlyBlockCreaturesWith -> value.blockerFilter
+                else -> return@match null
+            }
+            if (value != ability(blockers)) return@match null
+            bind("blockers" to blockers)
+        }
+    }
+
+    private val cantBlock: Phrase<StaticAbility> =
+        phrase("${Normalizer.SELF} can't block.", name = "can't block") {
+            build { CantBlock() }
+            match { if (it == CantBlock()) Bindings.EMPTY else null }
+        }
+
+    /**
+     * "~ can't attack unless defending player controls an Island." — Deep-Sea Serpent, and the
+     * island-walk-in-reverse family the older sets are full of.
+     *
+     * The condition is `Conditions.DefendingPlayerControlsLandType`, which is the SDK's own name for
+     * exactly this sentence; the grammar reads the land type out of the `Exists` it lowers to rather
+     * than modelling the condition itself, so the rule stays a sentence and not a second condition
+     * vocabulary. The noun goes through [Filters.indefinite], which owns the article — English
+     * derives it from the type's spelling and the model has nowhere to keep it.
+     */
+    private val cantAttackUnlessLandType: Phrase<StaticAbility> =
+        phrase(
+            "${Normalizer.SELF} can't attack unless defending player controls {land}.",
+            name = "can't attack unless defending player controls a land type",
+        ) {
+            slot("land", Filters.indefinite)
+            build { bindings ->
+                landTypeOf(bindings.value("land"))
+                    ?.let { CantAttackUnless(Conditions.DefendingPlayerControlsLandType(it)) }
+            }
+            match { value ->
+                val restriction = value as? CantAttackUnless ?: return@match null
+                val type = defendingPlayerLandType(restriction.condition) ?: return@match null
+                if (value != CantAttackUnless(Conditions.DefendingPlayerControlsLandType(type))) return@match null
+                bind("land" to GameObjectFilter.Land.withSubtype(type))
+            }
+        }
+
+    /** The single subtype a filter names, or null when it names none or more than one. */
+    private fun landTypeOf(filter: GameObjectFilter): String? =
+        filter.cardPredicates.filterIsInstance<CardPredicate.HasSubtype>().singleOrNull()?.subtype?.value
+
+    /** The land type a `DefendingPlayerControlsLandType` condition names, or null for any other. */
+    private fun defendingPlayerLandType(condition: Condition): String? {
+        val exists = condition as? Exists ?: return null
+        val subtype = landTypeOf(exists.filter) ?: return null
+        return subtype.takeIf { condition == Conditions.DefendingPlayerControlsLandType(it) }
+    }
+
+    /**
+     * "~ can't be blocked by more than one creature." — Charging Rhino, Stalking Tiger.
+     *
+     * The number is spelled as a *word with its noun* ("one creature", "two creatures") rather than
+     * as a numeral, which is why the count is [Cardinals.word]-shaped and the singular is its own
+     * template: "more than one creature" and "more than two creatures" differ in both.
+     */
+    private fun cantBeBlockedByMoreThan(template: String, name: String, count: Int?): Phrase<StaticAbility> =
+        phrase(template, name = name) {
+            if (count == null) slot("n", Cardinals.word)
+            build { bindings -> CantBeBlockedByMoreThan(maxBlockers = count ?: bindings.int("n")) }
+            match { value ->
+                val blockers = (value as? CantBeBlockedByMoreThan)?.maxBlockers ?: return@match null
+                if (count != null && blockers != count) return@match null
+                if (count == null && (blockers < 2 || !Cardinals.spellable(blockers))) return@match null
+                if (value != CantBeBlockedByMoreThan(maxBlockers = blockers)) return@match null
+                bind("n" to blockers)
+            }
+        }
+
+    val all: List<Phrase<StaticAbility>> = listOf(
+        attachedPump,
+        attachedKeyword,
+        cantBlock,
+        cantAttackUnlessLandType,
+        cantBeBlockedByMoreThan(
+            "${Normalizer.SELF} can't be blocked by more than one creature.",
+            "can't be blocked by more than one creature",
+            count = 1,
+        ),
+        cantBeBlockedByMoreThan(
+            "${Normalizer.SELF} can't be blocked by more than {n} creatures.",
+            "can't be blocked by more than several creatures",
+            count = null,
+        ),
+        blockerRestriction(
+            "${Normalizer.SELF} can't be blocked by {blockers}.",
+            "can't be blocked by",
+        ) { CantBeBlockedBy(blockerFilter = it) },
+        blockerRestriction(
+            "${Normalizer.SELF} can block only {blockers}.",
+            "can block only",
+        ) { CanOnlyBlockCreaturesWith(blockerFilter = it) },
+    )
 
     val static: Phrase<StaticAbility> = oneOf("a static ability", all)
 

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Steps.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Steps.kt
@@ -2,36 +2,64 @@ package com.wingedsheep.assay.grammar
 
 import com.wingedsheep.assay.normalize.Normalizer
 import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.alternate
 import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.assay.syntax.separated
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.dsl.DynamicAmounts
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.effects.Effect
-import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
 import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.effects.PlayAdditionalLandsEffect
 import com.wingedsheep.sdk.scripting.effects.ScryEffect
 import com.wingedsheep.sdk.scripting.effects.SurveilEffect
+import com.wingedsheep.sdk.scripting.effects.TakeExtraTurnEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
- * The steps a spell performs — the start of the pipeline family, and the first rules that produce
- * something other than a keyword.
+ * The steps a spell performs — the pipeline family, and the rules that produce a `CardScript`
+ * rather than a keyword.
  *
- * Each rule targets `mtg-sdk` through its companion facade ([Effects]) rather than a raw
+ * Each rule targets `mtg-sdk` through its companion facade ([Effects], `Patterns`) rather than a raw
  * constructor, matching the discipline `FacadeBoundaryTest` enforces for cards. A rule's `match`
  * half necessarily destructures the concrete effect class, since that is the only way to read a
  * model back; the asymmetry is inherent to a bidirectional rule and is why `build` going through the
  * facade matters — it is the half that would otherwise drift from how cards are written.
  *
- * Templates are written in their **mid-sentence** form ("draw a card.") because
- * [com.wingedsheep.assay.syntax.SentenceCase] decapitalizes a line before the grammar sees it — the
- * same reason the keyword rules spell themselves "flying" rather than "Flying".
+ * ## A clause, a sentence, and a line
+ *
+ * The unit the rules below are written in is the **clause** — the verb phrase with no full stop on
+ * it. A [sentence] is a clause plus its stop, and a [step] is either one sentence or a [sequence] of
+ * them. That three-way split is what lets a card printing two sentences on one line
+ * ("Target creature gets +1/+3 until end of turn. Untap that creature.") reuse the ordinary effect
+ * vocabulary twice instead of needing a second, capitalized copy of every verb: a full stop is a
+ * sentence start, which [com.wingedsheep.assay.syntax.SentenceCase] owns, so every template here is
+ * written mid-sentence exactly as the keyword rules spell themselves "flying" rather than "Flying".
+ *
+ * Everything outside this file slots [step], so a trigger, an activated ability and a spell line all
+ * gained sequences at once and none of them had to be told.
  *
  * ## Singular and plural are separate rules
  *
@@ -47,12 +75,12 @@ object Steps {
     // Draw
     // ---------------------------------------------------------------------------------------
 
-    private val drawOne: Phrase<CardScript> = phrase("draw a card.", name = "draw a card") {
+    private val drawOne: Phrase<CardScript> = phrase("draw a card", name = "draw a card") {
         build { CardScript(spellEffect = Effects.DrawCards(1)) }
         match { script -> if (drawnByController(script) == 1) bind() else null }
     }
 
-    private val drawMany: Phrase<CardScript> = phrase("draw {n} cards.", name = "draw cards") {
+    private val drawMany: Phrase<CardScript> = phrase("draw {n} cards", name = "draw cards") {
         slot("n", Cardinals.word)
         build { CardScript(spellEffect = Effects.DrawCards(it.int("n"))) }
         match { script ->
@@ -65,13 +93,13 @@ object Steps {
     }
 
     private val targetPlayerDrawsOne: Phrase<CardScript> =
-        phrase("target player draws a card.", name = "target player draws a card") {
+        phrase("target player draws a card", name = "target player draws a card") {
             build { targetPlayerDraws(1) }
             match { script -> if (drawnByTarget(script) == 1) bind() else null }
         }
 
     private val targetPlayerDrawsMany: Phrase<CardScript> =
-        phrase("target player draws {n} cards.", name = "target player draws cards") {
+        phrase("target player draws {n} cards", name = "target player draws cards") {
             slot("n", Cardinals.word)
             build { targetPlayerDraws(it.int("n")) }
             match { script ->
@@ -117,7 +145,7 @@ object Steps {
     }
 
     // ---------------------------------------------------------------------------------------
-    // Counted verbs — "scry 2.", "you gain 3 life.", "target player gains 3 life."
+    // Counted verbs — "scry 2", "you gain 3 life", "target player gains 3 life"
     // ---------------------------------------------------------------------------------------
 
     /**
@@ -142,22 +170,43 @@ object Steps {
         count: (Effect) -> Int?,
     ): Phrase<CardScript> = phrase(template, name = name) {
         slot("n", Primitives.cardinal)
+        if (template.contains("{self}")) slot("self", Primitives.self)
         build { script(it.int("n")) }
         match { model ->
             val amount = count(model.spellEffect ?: return@match null) ?: return@match null
             if (model != script(amount)) return@match null
-            bind("n" to amount)
+            bind("n" to amount, "self" to Unit)
         }
+    }
+
+    /**
+     * The same shape over a [DynamicAmount] the text names in words rather than in digits — "deals
+     * **X** damage", "gains life equal to the number of Mountains you control".
+     *
+     * Kept apart from [countedStep] rather than generalized over the amount, because the *printed
+     * form* of the amount is not a slot at all in these: "X" is a literal, and "equal to the number
+     * of …" is a whole clause. What varies is which amount the template denotes, so the amount is a
+     * parameter of the rule and not of the sentence.
+     */
+    private fun amountStep(
+        template: String,
+        name: String,
+        amount: DynamicAmount,
+        script: (DynamicAmount) -> CardScript,
+    ): Phrase<CardScript> = phrase(template, name = name) {
+        if (template.contains("{self}")) slot("self", Primitives.self)
+        build { script(amount) }
+        match { if (it == script(amount)) bind("self" to Unit) else null }
     }
 
     private val countedSteps: List<Phrase<CardScript>> = listOf(
         countedStep(
-            "you gain {n} life.", "you gain life",
+            "you gain {n} life", "you gain life",
             script = { CardScript(spellEffect = Effects.GainLife(it)) },
             count = ::lifeGained,
         ),
         countedStep(
-            "target player gains {n} life.", "target player gains life",
+            "target player gains {n} life", "target player gains life",
             script = {
                 CardScript(
                     spellEffect = Effects.GainLife(it, Targets.bound()),
@@ -167,12 +216,12 @@ object Steps {
             count = ::lifeGained,
         ),
         countedStep(
-            "you lose {n} life.", "you lose life",
+            "you lose {n} life", "you lose life",
             script = { CardScript(spellEffect = Effects.LoseLife(it, EffectTarget.Controller)) },
             count = ::lifeLost,
         ),
         countedStep(
-            "target player loses {n} life.", "target player loses life",
+            "target player loses {n} life", "target player loses life",
             script = {
                 CardScript(
                     spellEffect = Effects.LoseLife(it, Targets.bound()),
@@ -182,17 +231,17 @@ object Steps {
             count = ::lifeLost,
         ),
         countedStep(
-            "scry {n}.", "scry",
+            "scry {n}", "scry",
             script = { CardScript(spellEffect = Effects.Scry(it)) },
             count = { (it as? ScryEffect)?.count },
         ),
         countedStep(
-            "surveil {n}.", "surveil",
+            "surveil {n}", "surveil",
             script = { CardScript(spellEffect = Effects.Surveil(it)) },
             count = { (it as? SurveilEffect)?.count },
         ),
         countedStep(
-            "${Normalizer.SELF} deals {n} damage to any target.", "deals damage to any target",
+            "{self} deals {n} damage to any target", "deals damage to any target",
             script = {
                 CardScript(
                     spellEffect = Effects.DealDamage(it, Targets.bound()),
@@ -202,7 +251,7 @@ object Steps {
             count = ::damageDealt,
         ),
         countedStep(
-            "${Normalizer.SELF} deals {n} damage to target player.", "deals damage to target player",
+            "{self} deals {n} damage to target player", "deals damage to target player",
             script = {
                 CardScript(
                     spellEffect = Effects.DealDamage(it, Targets.bound()),
@@ -211,6 +260,100 @@ object Steps {
             },
             count = ::damageDealt,
         ),
+        // "Target opponent or planeswalker" is the modern redirection wording, and it is a
+        // requirement type of its own rather than a filter — so it is a row beside "target player"
+        // rather than a case inside it.
+        countedStep(
+            "{self} deals {n} damage to target opponent or planeswalker",
+            "deals damage to target opponent or planeswalker",
+            script = {
+                CardScript(
+                    spellEffect = Effects.DealDamage(it, Targets.bound()),
+                    targetRequirements = listOf(Targets.opponentOrPlaneswalker()),
+                )
+            },
+            count = ::damageDealt,
+        ),
+        countedStep(
+            "{self} deals {n} damage to target player or planeswalker",
+            "deals damage to target player or planeswalker",
+            script = {
+                CardScript(
+                    spellEffect = Effects.DealDamage(it, Targets.bound()),
+                    targetRequirements = listOf(Targets.playerOrPlaneswalker()),
+                )
+            },
+            count = ::damageDealt,
+        ),
+    )
+
+    /**
+     * The one-off clauses: a whole printed sentence that denotes one published effect, with at most
+     * one number in it.
+     *
+     * Each unlocks a single card today, which the module's own rule says needs a stated reason. The
+     * reason is the same for all four: the *model* is one effect type with one field, so there is no
+     * smaller rule to write — the sentence is the unit, and a shape parameterized over four
+     * unrelated effect types would be a factory with one member each.
+     */
+    private val turnSteps: List<Phrase<CardScript>> = listOf(
+        // "You may play up to three additional lands this turn." — Summer Bloom. The count is a
+        // word rather than a numeral, so it takes Cardinals rather than [countedStep]'s digit leaf.
+        run {
+            fun scriptFor(count: Int) = CardScript(spellEffect = PlayAdditionalLandsEffect(count))
+            phrase("you may play up to {n} additional lands this turn", name = "play additional lands") {
+                slot("n", Cardinals.word)
+                build { scriptFor(it.int("n")) }
+                match { script ->
+                    val count = (script.spellEffect as? PlayAdditionalLandsEffect)?.count ?: return@match null
+                    if (!Cardinals.spellable(count) || script != scriptFor(count)) return@match null
+                    bind("n" to count)
+                }
+            }
+        },
+        // "Take an extra turn after this one. At the beginning of that turn's end step, you lose the
+        // game." — Last Chance. Two printed sentences and one model: `loseAtEndStep` is a field on
+        // the extra turn rather than a second effect, so there is nothing for [sequenceClause] to
+        // split and the rule spans both sentences.
+        run {
+            val script = CardScript(spellEffect = TakeExtraTurnEffect(loseAtEndStep = true))
+            phrase(
+                "take an extra turn after this one. at the beginning of that turn's end step, you lose the game",
+                name = "take an extra turn and lose",
+            ) {
+                build { script }
+                match { if (it == script) bind() else null }
+            }
+        },
+        // "You lose half your life, rounded up." — Cruel Bargain's second sentence.
+        run {
+            val script = CardScript(
+                spellEffect = Effects.LoseLife(
+                    DynamicAmount.Divide(DynamicAmount.LifeTotal(Player.You), DynamicAmount.Fixed(2), roundUp = true),
+                    EffectTarget.Controller,
+                )
+            )
+            phrase("you lose half your life, rounded up", name = "lose half your life") {
+                build { script }
+                match { if (it == script) bind() else null }
+            }
+        },
+        // "If target opponent has more cards in hand than you, draw cards equal to the difference." —
+        // Balance of Power. The "if" is inside the amount (`IfPositive` around a subtraction) rather
+        // than around the effect, so this is one clause and not [conditionalClause]'s shape.
+        run {
+            val script = CardScript(
+                spellEffect = Effects.DrawCards(DynamicAmounts.handSizeDifferenceFromTargetOpponent()),
+                targetRequirements = listOf(Targets.opponent()),
+            )
+            phrase(
+                "if target opponent has more cards in hand than you, draw cards equal to the difference",
+                name = "draw the hand-size difference",
+            ) {
+                build { script }
+                match { if (it == script) bind() else null }
+            }
+        },
     )
 
     // ---------------------------------------------------------------------------------------
@@ -220,11 +363,6 @@ object Steps {
     /**
      * "~ deals 2 damage to target creature." — the same verb as above over a noun phrase rather than
      * over the fixed "any target" / "target player" forms, so it carries two slots instead of one.
-     *
-     * Kept as its own rule rather than folded into [countedStep]: a shape parameterized over *both*
-     * the count and the filter would have to thread the filter through the same `script`/`count`
-     * pair, and there is exactly one member of it so far. Written inline until the second appears,
-     * per the module's own rule about when to factor.
      */
     private val damageToTargetPermanent: Phrase<CardScript> = run {
         fun scriptFor(amount: Int, filter: GameObjectFilter) = CardScript(
@@ -232,9 +370,10 @@ object Steps {
             targetRequirements = listOf(Targets.permanent(filter)),
         )
         phrase(
-            "${Normalizer.SELF} deals {n} damage to target {filter}.",
+            "{self} deals {n} damage to target {filter}",
             name = "deals damage to target permanent",
         ) {
+            slot("self", Primitives.self)
             slot("n", Primitives.cardinal)
             slot("filter", Filters.filter)
             build { scriptFor(it.int("n"), it.value("filter")) }
@@ -243,7 +382,7 @@ object Steps {
                 val requirement = script.targetRequirements.singleOrNull() ?: return@match null
                 val filter = Targets.permanentFilter(requirement) ?: return@match null
                 if (script != scriptFor(amount, filter)) return@match null
-                bind("n" to amount, "filter" to filter)
+                bind("self" to Unit, "n" to amount, "filter" to filter)
             }
         }
     }
@@ -262,50 +401,777 @@ object Steps {
             spellEffect = Effects.ModifyStats(modifiers.first, modifiers.second, Targets.bound()),
             targetRequirements = listOf(Targets.permanent(filter)),
         )
-        phrase("target {filter} gets {mod} until end of turn.", name = "pump target") {
+        phrase("target {filter} gets {mod} until end of turn", name = "pump target") {
             slot("filter", Filters.filter)
             slot("mod", Primitives.statModifiers)
             build { scriptFor(it.value("mod"), it.value("filter")) }
             match { script ->
-                val effect = script.spellEffect as? ModifyStatsEffect ?: return@match null
-                val power = (effect.powerModifier as? DynamicAmount.Fixed)?.amount ?: return@match null
-                val toughness = (effect.toughnessModifier as? DynamicAmount.Fixed)?.amount ?: return@match null
+                val modifiers = fixedModifiers(script.spellEffect) ?: return@match null
                 val requirement = script.targetRequirements.singleOrNull() ?: return@match null
                 val filter = Targets.permanentFilter(requirement) ?: return@match null
-                val modifiers = power to toughness
                 if (script != scriptFor(modifiers, filter)) return@match null
                 bind("filter" to filter, "mod" to modifiers)
             }
         }
     }
 
+    /** "Target creature gains flying until end of turn." — the pump rule's keyword sibling. */
+    private val grantToTargetPermanent: Phrase<CardScript> = run {
+        fun scriptFor(keyword: Keyword, filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.GrantKeyword(keyword, Targets.bound()),
+            targetRequirements = listOf(Targets.permanent(filter)),
+        )
+        phrase("target {filter} gains {kw} until end of turn", name = "grant a keyword to a target") {
+            slot("filter", Filters.filter)
+            slot("kw", Keywords.keyword)
+            build { scriptFor(it.value("kw"), it.value("filter")) }
+            match { script ->
+                val keyword = grantedKeyword(script.spellEffect) ?: return@match null
+                val requirement = script.targetRequirements.singleOrNull() ?: return@match null
+                val filter = Targets.permanentFilter(requirement) ?: return@match null
+                if (script != scriptFor(keyword, filter)) return@match null
+                bind("filter" to filter, "kw" to keyword)
+            }
+        }
+    }
+
+    /**
+     * "Target creature gets +3/+3 and gains flying until end of turn." — Angelic Blessing.
+     *
+     * One sentence, one target, **two** effects, which is why it is a rule of its own rather than a
+     * [sequence]: the second clause has no subject of its own in the text, and the model shares one
+     * requirement between the two effects. [Statics.pumpAndKeyword] is the same shape on the static
+     * side, and the answer is the same — the model is already right, and what a compound SDK type
+     * would buy is nothing.
+     */
+    private val pumpAndGrantTarget: Phrase<CardScript> = run {
+        fun scriptFor(modifiers: Pair<Int, Int>, keyword: Keyword, filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.Composite(
+                listOf(
+                    Effects.ModifyStats(modifiers.first, modifiers.second, Targets.bound()),
+                    Effects.GrantKeyword(keyword, Targets.bound()),
+                )
+            ),
+            targetRequirements = listOf(Targets.permanent(filter)),
+        )
+        phrase(
+            "target {filter} gets {mod} and gains {kw} until end of turn",
+            name = "pump and grant a keyword to a target",
+        ) {
+            slot("filter", Filters.filter)
+            slot("mod", Primitives.statModifiers)
+            slot("kw", Keywords.keyword)
+            build { scriptFor(it.value("mod"), it.value("kw"), it.value("filter")) }
+            match { script ->
+                val effects = (script.spellEffect as? CompositeEffect)?.effects ?: return@match null
+                val modifiers = fixedModifiers(effects.firstOrNull()) ?: return@match null
+                val keyword = grantedKeyword(effects.getOrNull(1)) ?: return@match null
+                val requirement = script.targetRequirements.singleOrNull() ?: return@match null
+                val filter = Targets.permanentFilter(requirement) ?: return@match null
+                if (script != scriptFor(modifiers, keyword, filter)) return@match null
+                bind("filter" to filter, "mod" to modifiers, "kw" to keyword)
+            }
+        }
+    }
+
+    /**
+     * "Destroy two target lands.", "Tap up to three target creatures without flying." — a verb over
+     * *several* targets, which the SDK spells as one requirement with a count and a
+     * `ForEachTargetEffect` over `ContextTarget(0)`.
+     *
+     * Positional rather than named for [Combat.returnOneOrTwoTargets]'s reason: the iteration
+     * rebinds slot 0 per target, so a named reference would name the whole declaration.
+     *
+     * "Up to three" and "three" differ in one field — `optional` on the requirement — and in one
+     * word, so they are two rows of this shape rather than one rule with an optional literal.
+     */
+    private fun multiTargetStep(
+        template: String,
+        name: String,
+        optional: Boolean,
+        member: (EffectTarget) -> Effect,
+    ): Phrase<CardScript> {
+        fun scriptFor(count: Int, filter: GameObjectFilter) = CardScript(
+            spellEffect = ForEachTargetEffect(listOf(member(EffectTarget.ContextTarget(0)))),
+            targetRequirements = listOf(
+                TargetCreature(
+                    count = count,
+                    optional = optional,
+                    filter = TargetFilter(filter),
+                    id = Targets.SLOT,
+                )
+            ),
+        )
+        return phrase(template, name = name) {
+            slot("n", Cardinals.word)
+            slot("filter", Filters.plural)
+            build { scriptFor(it.int("n"), it.value("filter")) }
+            match { script ->
+                val requirement = script.targetRequirements.singleOrNull() as? TargetObject ?: return@match null
+                val filter = requirement.filter.baseFilter
+                if (!Cardinals.spellable(requirement.count)) return@match null
+                if (script != scriptFor(requirement.count, filter)) return@match null
+                bind("n" to requirement.count, "filter" to filter)
+            }
+        }
+    }
+
     private val permanentSteps: List<Phrase<CardScript>> = listOf(
-        targetedPermanentStep("destroy target {filter}.", "destroy target") { Effects.Destroy(it) },
-        targetedPermanentStep("exile target {filter}.", "exile target") { Effects.Exile(it) },
-        targetedPermanentStep("tap target {filter}.", "tap target") { Effects.Tap(it) },
-        targetedPermanentStep("untap target {filter}.", "untap target") { Effects.Untap(it) },
+        targetedPermanentStep("destroy target {filter}", "destroy target") { Effects.Destroy(it) },
+        targetedPermanentStep("exile target {filter}", "exile target") { Effects.Exile(it) },
+        targetedPermanentStep("tap target {filter}", "tap target") { Effects.Tap(it) },
+        targetedPermanentStep("untap target {filter}", "untap target") { Effects.Untap(it) },
         targetedPermanentStep(
-            "return target {filter} to its owner's hand.",
+            "return target {filter} to its owner's hand",
             "return target to hand",
         ) { Effects.ReturnToHand(it) },
+        targetedPermanentStep(
+            "put target {filter} on top of its owner's library",
+            "put target on top of its library",
+        ) { Effects.PutOnTopOfLibrary(it) },
+        multiTargetStep("destroy {n} target {filter}", "destroy several targets", optional = false) {
+            Effects.Destroy(it)
+        },
+        multiTargetStep("tap up to {n} target {filter}", "tap up to several targets", optional = true) {
+            Effects.Tap(it)
+        },
+    )
+
+    // ---------------------------------------------------------------------------------------
+    // Whole groups — "Creatures you control get +1/+1", "Destroy all white creatures"
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * The mass effects, which the SDK spells as one iteration over a `GroupFilter` with the
+     * per-member effect written against [EffectTarget.Self].
+     *
+     * One shape, four surfaces, because English gives the same model four templates and the
+     * difference between them is the *noun phrase*, not the verb: a bare plural subject ("Creatures
+     * you control get …"), "all" plus a plural ("Destroy all white creatures"), and "each" plus a
+     * singular ("deals 1 damage to each attacking creature"). Which one a card prints is a fact
+     * about the sentence's shape rather than about the group, so the templates are enumerated and
+     * the group filter is [Filters.plural] or [Filters.filter] slotted whole.
+     *
+     * `GroupFilter(filter)` and nothing else: `excludeSelf`, `excludeTarget`, a non-battlefield
+     * scope and `noRegenerate` all say things these sentences do not, and the reconstruct-and-
+     * compare refuses to print a value carrying any of them.
+     */
+    private fun groupStep(
+        template: String,
+        name: String,
+        plural: Boolean,
+        member: (EffectTarget) -> Effect,
+    ): Phrase<CardScript> {
+        fun scriptFor(filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.ForEachInGroup(GroupFilter(filter), member(EffectTarget.Self)),
+        )
+        return phrase(template, name = name) {
+            slot("filter", if (plural) Filters.plural else Filters.filter)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val filter = iteratedGroup(script.spellEffect) ?: return@match null
+                if (script != scriptFor(filter)) return@match null
+                bind("filter" to filter)
+            }
+        }
+    }
+
+    /**
+     * The mass effects whose per-member effect also carries a number or a keyword.
+     *
+     * Written as its own shape rather than as a parameter on [groupStep] because the extra slot
+     * changes both halves of the inversion: `member` has to be reconstructed from a value read back
+     * out of the iterated effect, which [groupStep]'s fixed `member` never needs.
+     */
+    private fun <V> parameterizedGroupStep(
+        template: String,
+        name: String,
+        parameter: Phrase<V>,
+        plural: Boolean,
+        member: (V, EffectTarget) -> Effect,
+        read: (Effect) -> V?,
+    ): Phrase<CardScript> {
+        fun scriptFor(value: V, filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.ForEachInGroup(GroupFilter(filter), member(value, EffectTarget.Self)),
+        )
+        return phrase(template, name = name) {
+            if (template.contains("{self}")) slot("self", Primitives.self)
+            slot("filter", if (plural) Filters.plural else Filters.filter)
+            slot("v", parameter)
+            build { scriptFor(it.value("v"), it.value("filter")) }
+            match { script ->
+                val filter = iteratedGroup(script.spellEffect) ?: return@match null
+                val value = read(iteratedBody(script.spellEffect) ?: return@match null) ?: return@match null
+                if (script != scriptFor(value, filter)) return@match null
+                bind("self" to Unit, "filter" to filter, "v" to value)
+            }
+        }
+    }
+
+    /**
+     * The same shape over a group that **excludes the source** — "tap all *other* creatures."
+     *
+     * `excludeSelf` is a field on the `GroupFilter` rather than on the base filter, which is exactly
+     * why it is a separate rule and not a [Filters] layer: "other" is a fact about the iteration's
+     * relationship to the ability's source, not about what a permanent is.
+     */
+    private fun otherGroupStep(
+        template: String,
+        name: String,
+        member: (EffectTarget) -> Effect,
+    ): Phrase<CardScript> {
+        fun scriptFor(filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.ForEachInGroup(
+                GroupFilter(filter, excludeSelf = true),
+                member(EffectTarget.Self),
+            ),
+        )
+        return phrase(template, name = name) {
+            slot("filter", Filters.plural)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val filter = iteratedGroup(script.spellEffect) ?: return@match null
+                if (script != scriptFor(filter)) return@match null
+                bind("filter" to filter)
+            }
+        }
+    }
+
+    /**
+     * "Destroy all creatures. They can't be regenerated." — Wrath of God.
+     *
+     * Two printed sentences and one model: `noRegenerate` is a field on the *same* iteration, not a
+     * second effect, so [sequence] has nothing to split. The rule therefore spans both sentences,
+     * which is what makes the plain "Destroy all creatures." rule above safe — a sweep that forbids
+     * regeneration refuses to print as one that does not.
+     */
+    private val destroyAllNoRegenerate: Phrase<CardScript> = run {
+        fun scriptFor(filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.ForEachInGroup(
+                GroupFilter(filter),
+                Effects.Destroy(EffectTarget.Self),
+                noRegenerate = true,
+            ),
+        )
+        phrase("destroy all {filter}. they can't be regenerated", name = "destroy all without regeneration") {
+            slot("filter", Filters.plural)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val filter = iteratedGroup(script.spellEffect) ?: return@match null
+                if (script != scriptFor(filter)) return@match null
+                bind("filter" to filter)
+            }
+        }
+    }
+
+    private val groupSteps: List<Phrase<CardScript>> = listOf(
+        groupStep("destroy all {filter}", "destroy all", plural = true) { Effects.Destroy(it) },
+        groupStep("exile all {filter}", "exile all", plural = true) { Effects.Exile(it) },
+        groupStep("tap all {filter}", "tap all", plural = true) { Effects.Tap(it) },
+        groupStep("untap all {filter}", "untap all", plural = true) { Effects.Untap(it) },
+        otherGroupStep("tap all other {filter}", "tap all other") { Effects.Tap(it) },
+        otherGroupStep("untap all other {filter}", "untap all other") { Effects.Untap(it) },
+        destroyAllNoRegenerate,
+        parameterizedGroupStep(
+            "{filter} get {v} until end of turn", "a group gets",
+            parameter = Primitives.statModifiers, plural = true,
+            member = { (power, toughness), target -> Effects.ModifyStats(power, toughness, target) },
+            read = ::fixedModifiers,
+        ),
+        parameterizedGroupStep(
+            "{filter} gain {v} until end of turn", "a group gains a keyword",
+            parameter = Keywords.keyword, plural = true,
+            member = { keyword, target -> Effects.GrantKeyword(keyword, target) },
+            read = ::grantedKeyword,
+        ),
+        parameterizedGroupStep(
+            "{self} deals {v} damage to each {filter}", "deals damage to each",
+            parameter = Primitives.cardinal, plural = false,
+            member = { amount, target -> Effects.DealDamage(amount, target) },
+            read = ::damageDealt,
+        ),
+    )
+
+    // ---------------------------------------------------------------------------------------
+    // Damage whose amount is not a numeral
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * "~ deals X damage to any target." — the X spells.
+     *
+     * `DynamicAmount.XValue` is a *constant* in the model and a literal in the text, so these go
+     * through [amountStep] rather than [countedStep]: there is no number to read back, only a
+     * reconstruction to compare against.
+     */
+    private val xDamageSteps: List<Phrase<CardScript>> = listOf(
+        amountStep("{self} deals X damage to any target", "deals X damage to any target", DynamicAmount.XValue) {
+            CardScript(
+                spellEffect = Effects.DealDamage(it, Targets.bound()),
+                targetRequirements = listOf(Targets.any()),
+            )
+        },
+        amountStep(
+            "{self} deals X damage to target player or planeswalker",
+            "deals X damage to target player or planeswalker",
+            DynamicAmount.XValue,
+        ) {
+            CardScript(
+                spellEffect = Effects.DealDamage(it, Targets.bound()),
+                targetRequirements = listOf(Targets.playerOrPlaneswalker()),
+            )
+        },
+        amountStep(
+            "{self} deals damage to target opponent or planeswalker equal to the sacrificed creature's power",
+            "deals damage equal to the sacrificed creature's power",
+            DynamicAmounts.sacrificedPower(),
+        ) {
+            CardScript(
+                spellEffect = Effects.DealDamage(it, Targets.bound()),
+                targetRequirements = listOf(Targets.opponentOrPlaneswalker()),
+            )
+        },
     )
 
     /**
-     * Every step rule, as one alternation. Grows with the family.
+     * "~ deals damage to target creature equal to the number of Mountains you control." — Spitting
+     * Earth, and Fire Dragon's enters trigger with the same clause.
      *
-     * [Mana.added] is a member declared elsewhere: producing mana is a spell effect in its own
-     * right (Dark Ritual) *and* the effect clause of nearly every activated ability, so its two
-     * halves — the sentence and the choice form that denotes several abilities — are kept together
-     * in [Mana] rather than split across two files by which slot each one reaches.
+     * Two filters in one sentence: the thing damaged and the thing counted. The count is the same
+     * `AggregateBattlefield` [gainLifeForEach] builds, which is why "you control" is a literal here
+     * — the player is the aggregate's field and the clause spells exactly one of them.
      */
-    val all: List<Phrase<CardScript>> =
-        listOf(drawOne, drawMany, targetPlayerDrawsOne, targetPlayerDrawsMany) +
-            countedSteps + damageToTargetPermanent + pumpTargetPermanent + permanentSteps + Mana.added
+    private val damageEqualToCount: Phrase<CardScript> = run {
+        fun scriptFor(counted: GameObjectFilter, filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.DealDamage(
+                DynamicAmount.AggregateBattlefield(Player.You, counted),
+                Targets.bound(),
+            ),
+            targetRequirements = listOf(Targets.permanent(filter)),
+        )
+        phrase(
+            "{self} deals damage to target {filter} equal to the number of {counted} you control",
+            name = "deals damage equal to a battlefield count",
+        ) {
+            slot("self", Primitives.self)
+            slot("filter", Filters.filter)
+            slot("counted", Filters.plural)
+            build { scriptFor(it.value("counted"), it.value("filter")) }
+            match { script ->
+                val amount = (script.spellEffect as? DealDamageEffect)?.amount
+                    as? DynamicAmount.AggregateBattlefield ?: return@match null
+                val requirement = script.targetRequirements.singleOrNull() ?: return@match null
+                val filter = Targets.permanentFilter(requirement) ?: return@match null
+                if (script != scriptFor(amount.filter, filter)) return@match null
+                bind("self" to Unit, "filter" to filter, "counted" to amount.filter)
+            }
+        }
+    }
 
-    val step: Phrase<CardScript> = oneOf("a spell effect", all)
+    /**
+     * "~ deals 1 damage to each creature and each player." — the symmetric sweeps.
+     *
+     * One printed sentence, two effects: the board half is the ordinary [groupStep] iteration and
+     * the player half is a single damage effect aimed at `Player.Each`. It is one rule rather than a
+     * [sequence] because the sentence is one sentence; a card printing the two halves separately
+     * denotes the identical model and comes back as a variant.
+     *
+     * **The player half has two SDK spellings and this emits one.** `DealDamage(n, PlayerRef(Each))`
+     * and `ForEachPlayerEffect(Each, [DealDamage(n, Controller)])` are equivalent for a fixed amount;
+     * the first is what the grammar prints, because per-player controller rebinding is machinery this
+     * sentence does not need. Cards written the other way decline and are a reported inconsistency,
+     * not an approximation.
+     */
+    private fun damageToEachAndEachPlayer(
+        template: String,
+        name: String,
+        amount: Phrase<Int>?,
+        fixed: DynamicAmount?,
+    ): Phrase<CardScript> {
+        fun scriptFor(value: DynamicAmount, filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.Composite(
+                listOf(
+                    Effects.ForEachInGroup(GroupFilter(filter), Effects.DealDamage(value, EffectTarget.Self)),
+                    Effects.DealDamage(value, EffectTarget.PlayerRef(Player.Each)),
+                )
+            )
+        )
+        return phrase(template, name = name) {
+            slot("self", Primitives.self)
+            slot("filter", Filters.filter)
+            if (amount != null) slot("n", amount)
+            build { bindings ->
+                val value = fixed ?: DynamicAmount.Fixed(bindings.int("n"))
+                scriptFor(value, bindings.value("filter"))
+            }
+            match { script ->
+                val effects = (script.spellEffect as? CompositeEffect)?.effects ?: return@match null
+                val filter = iteratedGroup(effects.firstOrNull()) ?: return@match null
+                val value = (effects.getOrNull(1) as? DealDamageEffect)?.amount ?: return@match null
+                if (fixed != null && value != fixed) return@match null
+                val number = if (fixed != null) null else value.fixed() ?: return@match null
+                if (script != scriptFor(value, filter)) return@match null
+                bind("self" to Unit, "filter" to filter, "n" to number)
+            }
+        }
+    }
 
     // ---------------------------------------------------------------------------------------
-    // Model helpers — the `match` side, kept out of the rules so the two draw pairs read alike
+    // Counting the battlefield — "You gain 2 life for each Mountain target opponent controls."
+    // ---------------------------------------------------------------------------------------
+
+    /** "Draw a card for each tapped creature target opponent controls." — Theft of Dreams. */
+    private val drawForEach: Phrase<CardScript> = run {
+        fun scriptFor(counted: GameObjectFilter) = CardScript(
+            spellEffect = Effects.DrawCards(DynamicAmount.AggregateBattlefield(Player.TargetOpponent, counted)),
+            targetRequirements = listOf(Targets.opponent()),
+        )
+        phrase("draw a card for each {filter} target opponent controls", name = "draw for each") {
+            slot("filter", Filters.filter)
+            build { scriptFor(it.value("filter")) }
+            match { script ->
+                val amount = (script.spellEffect as? DrawCardsEffect)?.count
+                    as? DynamicAmount.AggregateBattlefield ?: return@match null
+                if (script != scriptFor(amount.filter)) return@match null
+                bind("filter" to amount.filter)
+            }
+        }
+    }
+
+    /**
+     * "You gain N life for each …" — the first rules whose amount is a [DynamicAmount] rather than
+     * a numeral.
+     *
+     * Two shapes over disjoint counts, for exactly the reason the draw rules are two: the SDK writes
+     * "1 life for each X" as the bare count and "2 life for each X" as `Multiply(count, 2)`, so one
+     * is not a special case of the other in the model either. Refusing 1 in the multiplying rule is
+     * what keeps one printed form per model.
+     *
+     * The *whose battlefield* half is a `Player` inside the aggregate and, when it is a targeted
+     * one, a `TargetRequirement` beside it — two places for one printed clause, which is why the
+     * surface and both halves are passed together rather than derived.
+     */
+    private fun gainLifeForEach(
+        surface: String,
+        player: Player,
+        requirements: List<TargetRequirement>,
+    ): List<Phrase<CardScript>> {
+        fun scriptFor(amount: DynamicAmount) = CardScript(
+            spellEffect = Effects.GainLife(amount),
+            targetRequirements = requirements,
+        )
+
+        fun count(filter: GameObjectFilter): DynamicAmount = DynamicAmount.AggregateBattlefield(player, filter)
+
+        /** The aggregate this surface spells, or null when the value counts someone else's board. */
+        fun aggregate(amount: DynamicAmount?): DynamicAmount.AggregateBattlefield? =
+            (amount as? DynamicAmount.AggregateBattlefield)
+                ?.takeIf { it == count(it.filter) }
+
+        val one = phrase("you gain 1 life for each {filter} $surface", name = "gain one life for each") {
+            slot("filter", Filters.filter)
+            build { scriptFor(count(it.value("filter"))) }
+            match { script ->
+                val total = aggregate((script.spellEffect as? GainLifeEffect)?.amount) ?: return@match null
+                if (script != scriptFor(total)) return@match null
+                bind("filter" to total.filter)
+            }
+        }
+        val many = phrase("you gain {n} life for each {filter} $surface", name = "gain life for each") {
+            slot("n", Primitives.cardinal)
+            slot("filter", Filters.filter)
+            build { bindings ->
+                val multiplier = bindings.int("n")
+                if (multiplier < 2) return@build null
+                scriptFor(DynamicAmount.Multiply(count(bindings.value("filter")), multiplier))
+            }
+            match { script ->
+                val product = (script.spellEffect as? GainLifeEffect)?.amount as? DynamicAmount.Multiply
+                    ?: return@match null
+                val total = aggregate(product.amount) ?: return@match null
+                if (product.multiplier < 2) return@match null
+                if (script != scriptFor(product)) return@match null
+                bind("n" to product.multiplier, "filter" to total.filter)
+            }
+        }
+        return listOf(one, many)
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The sentence, the sequence, and the line
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Every clause rule, as one alternation.
+     *
+     * [Mana.addClause] is a member declared elsewhere: producing mana is a spell effect in its own
+     * right (Dark Ritual) *and* the effect clause of nearly every activated ability, so its two
+     * halves — the sentence and the choice form that denotes several abilities — are kept together
+     * in [Mana] rather than split across two files by which slot each one reaches. [Library],
+     * [Hand], [SelfSteps] and [Combat] are the same: one file per topic, all of them rows here.
+     */
+    /**
+     * "You gain 3 life for each creature attacking you." — Blessed Reversal.
+     *
+     * Not a surface of [gainLifeForEach], because "attacking you" is *two* fields in the model — the
+     * opponents' battlefield and the attacking state — for one printed phrase, and a rule that
+     * slotted the noun would have to put half of the phrase in the slot and half in the surface.
+     * Spelled once, with the noun fixed.
+     */
+    private val gainLifePerAttacker: Phrase<CardScript> = run {
+        fun scriptFor(multiplier: Int) = CardScript(
+            spellEffect = Effects.GainLife(
+                DynamicAmount.Multiply(
+                    DynamicAmount.AggregateBattlefield(
+                        Player.EachOpponent,
+                        GameObjectFilter.Creature.attacking(),
+                    ),
+                    multiplier,
+                )
+            )
+        )
+        phrase("you gain {n} life for each creature attacking you", name = "gain life per attacker") {
+            slot("n", Primitives.cardinal)
+            build { bindings -> bindings.int("n").takeIf { it >= 2 }?.let(::scriptFor) }
+            match { script ->
+                val product = (script.spellEffect as? GainLifeEffect)?.amount as? DynamicAmount.Multiply
+                    ?: return@match null
+                if (product.multiplier < 2 || script != scriptFor(product.multiplier)) return@match null
+                bind("n" to product.multiplier)
+            }
+        }
+    }
+
+    private val atomicClauses: List<Phrase<CardScript>> =
+        listOf(drawOne, drawMany, targetPlayerDrawsOne, targetPlayerDrawsMany) +
+            countedSteps +
+            xDamageSteps +
+            damageToTargetPermanent +
+            damageEqualToCount +
+            damageToEachAndEachPlayer(
+                "{self} deals {n} damage to each {filter} and each player",
+                "deals damage to each permanent and each player",
+                amount = Primitives.cardinal,
+                fixed = null,
+            ) +
+            damageToEachAndEachPlayer(
+                "{self} deals X damage to each {filter} and each player",
+                "deals X damage to each permanent and each player",
+                amount = null,
+                fixed = DynamicAmount.XValue,
+            ) +
+            pumpTargetPermanent +
+            grantToTargetPermanent +
+            pumpAndGrantTarget +
+            permanentSteps +
+            groupSteps +
+            drawForEach +
+            gainLifePerAttacker +
+            gainLifeForEach("on the battlefield", Player.Each, emptyList()) +
+            gainLifeForEach("target opponent controls", Player.TargetOpponent, listOf(Targets.opponent())) +
+            turnSteps +
+            Stack.clauses +
+            Mana.addClause +
+            Library.clauses +
+            Hand.clauses +
+            Combat.clauses +
+            Graveyard.clauses +
+            SelfSteps.clauses +
+            SelfSteps.anaphoric
+
+    /**
+     * One clause, plus the joined form of two.
+     *
+     * "~ deals 4 damage to any target and you gain 4 life." and "~ deals 4 damage to any target. You
+     * gain 4 life." denote the identical `CompositeEffect`: the model has no room for the
+     * conjunction, so exactly one of the two is canonical and the other parses without printing.
+     * The sequence wins because it is what the corpus overwhelmingly prints and because it composes
+     * to any length; a card printing the join comes back as a
+     * [com.wingedsheep.assay.gate.LineVerdict.VARIANT], which says the reading was right and only
+     * the spelling moved.
+     */
+    /**
+     * The atoms alone, for the rules that wrap or join clauses without being one.
+     *
+     * Declared before everything built from it — object initializers run in declaration order, and a
+     * `val` reaching a later one reads a null out of a half-initialized object.
+     */
+    private val atom: Phrase<CardScript> = oneOf("a spell effect", atomicClauses)
+
+    /**
+     * "You may draw a card." — the controller chooses whether the clause happens.
+     *
+     * Wrapping rather than a vocabulary of its own, so every clause the grammar can read is
+     * optional-able for free. Note that a *triggered* ability spells the same English with its own
+     * `optional` flag instead; [Triggers] lowers this wrapper into that field, which is what keeps
+     * one printed form for the two SDK spellings.
+     */
+    private val mayClause: Phrase<CardScript> = phrase("you may {inner}", name = "you may") {
+        slot("inner", atom)
+        build { bindings -> wrap(bindings.value("inner")) { MayEffect(it) } }
+        match { script ->
+            val gated = script.spellEffect as? GatedEffect ?: return@match null
+            if (gated.gate !is Gate.MayDecide) return@match null
+            val inner = CardScript(spellEffect = gated.then, targetRequirements = script.targetRequirements)
+            if (wrap(inner) { MayEffect(it) } != script) return@match null
+            bind("inner" to inner)
+        }
+    }
+
+    /**
+     * "If an opponent controls more lands than you, search your library for …" — Gift of Estates.
+     *
+     * The SDK lowers a spell's `condition` into a `ConditionalEffect` wrapping the whole effect, so
+     * this is a wrapper for the same reason [mayClause] is one, and the condition is the slot. The
+     * condition vocabulary is [Conditions]; it has two members, which is what a condition family
+     * looks like the first time cards need one.
+     */
+    private val conditionalClause: Phrase<CardScript> =
+        phrase("if {cond}, {inner}", name = "a conditional clause") {
+            slot("cond", Conditions.condition)
+            slot("inner", atom)
+            build { bindings ->
+                val condition = bindings.value<Condition>("cond")
+                wrap(bindings.value("inner")) { ConditionalEffect(condition, it) }
+            }
+            match { script ->
+                val gated = script.spellEffect as? GatedEffect ?: return@match null
+                val gate = gated.gate as? Gate.WhenCondition ?: return@match null
+                val inner = CardScript(spellEffect = gated.then, targetRequirements = script.targetRequirements)
+                if (wrap(inner) { ConditionalEffect(gate.condition, it) } != script) return@match null
+                bind("cond" to gate.condition, "inner" to inner)
+            }
+        }
+
+    /** Re-wrap a clause's effect, keeping the targets it declared. Shared by the two wrappers. */
+    private fun wrap(inner: CardScript, wrapper: (Effect) -> Effect): CardScript? {
+        val effect = inner.spellEffect ?: return null
+        if (inner != CardScript(spellEffect = effect, targetRequirements = inner.targetRequirements)) return null
+        return CardScript(spellEffect = wrapper(effect), targetRequirements = inner.targetRequirements)
+    }
+
+    /** One self-contained clause: an atom, or an atom under a wrapper. */
+    private val simpleClause: Phrase<CardScript> =
+        oneOf("a spell effect", atomicClauses + mayClause + conditionalClause)
+
+    /**
+     * A clause that can only be a *later* one: it refers back to something an earlier clause
+     * introduced, so it declares nothing of its own.
+     */
+    private val laterClause: Phrase<CardScript> = oneOf(
+        "a spell effect",
+        // Everything except the source-anaphora: once a clause has introduced a target, "it" means
+        // that target, and [Continuations] owns the pronoun from here on. See [SelfSteps.anaphoric].
+        (atomicClauses - SelfSteps.anaphoric.toSet()) + mayClause + conditionalClause + Continuations.all,
+    )
+
+    /**
+     * What joins one clause to the next inside a line — a full stop, "and", or ", then".
+     *
+     * All three denote the same thing, because a `CompositeEffect` has no room for the conjunction:
+     * the model says *these effects, in this order* and nothing about the word between them. So the
+     * full stop is canonical and the other two are [alternate]s, and a card printing a join comes
+     * back as a [com.wingedsheep.assay.gate.LineVerdict.VARIANT] — the reading was right, only the
+     * spelling moved, which is worth strictly more than the decline it replaces.
+     *
+     * The separator belongs to the *tail* rather than to the run, which is what lets one line mix
+     * them: "Scry 2, then draw two cards. You lose 2 life." is three clauses joined two different
+     * ways, and it folds to the same flat composite the all-full-stops spelling does. A run with one
+     * separator could not read that line at all, and a join rule that was itself a clause would have
+     * folded it into a *nested* composite — a model no card carries and nothing could print.
+     */
+    private fun tail(separator: String, canonicalJoin: Boolean): Phrase<CardScript> {
+        val rule = phrase<CardScript>("$separator{clause}", name = "a later clause") {
+            slot("clause", laterClause)
+            build { it.value("clause") }
+            match { bind("clause" to it) }
+            canonical = canonicalJoin
+        }
+        return if (canonicalJoin) rule else alternate(rule)
+    }
+
+    private val tails: Phrase<CardScript> = oneOf(
+        "a later clause",
+        tail(". ", canonicalJoin = true),
+        tail(", then ", canonicalJoin = false),
+        tail(" and ", canonicalJoin = false),
+    )
+
+    /**
+     * "Target creature gets +1/+3 until end of turn. Untap that creature." — two or more clauses on
+     * one printed line, which the SDK models as one `CompositeEffect`.
+     *
+     * **A target is declared at its first mention.** English introduces a referent before it refers
+     * back to one, so the whole line's `targetRequirements` belong to the first clause and every
+     * later one is either self-contained or a [Continuations] clause reading the slot the first
+     * declared. That makes the split deterministic rather than a search, and a model whose target
+     * belongs anywhere else simply fails to print — the fail-closed answer, since the alternative
+     * would be a rule guessing which clause a requirement was for.
+     *
+     * The run's separator is the empty string because each tail carries its own; see [tail].
+     */
+    private val sequenceClause: Phrase<CardScript> = phrase("{first}{rest}", name = "several clauses") {
+        slot("first", simpleClause)
+        slot("rest", separated("later clauses", tails, separator = "", min = 1))
+        build { merge(listOf(it.value<CardScript>("first")) + it.value<List<CardScript>>("rest")) }
+        match { script ->
+            val composite = script.spellEffect as? CompositeEffect ?: return@match null
+            if (composite.effects.size < 2) return@match null
+            if (composite != CompositeEffect(composite.effects)) return@match null
+            val parts = composite.effects.mapIndexed { index, effect ->
+                CardScript(
+                    spellEffect = effect,
+                    targetRequirements = if (index == 0) script.targetRequirements else emptyList(),
+                )
+            }
+            if (merge(parts) != script) return@match null
+            bind("first" to parts.first(), "rest" to parts.drop(1))
+        }
+    }
+
+    /** Everything one clause position can hold. */
+    private val clause: Phrase<CardScript> = oneOf("a spell effect", simpleClause, sequenceClause)
+
+    /** One clause and the stop that ends it — what a whole effect line is. */
+    private val sentence: Phrase<CardScript> = phrase("{clause}.", name = "a sentence") {
+        slot("clause", clause)
+        build { it.value("clause") }
+        match { bind("clause" to it) }
+    }
+
+    /**
+     * Fold clause scripts into the one script the line denotes, or null when they cannot be one.
+     *
+     * A clause may contribute a spell effect and the targets it declared and nothing else; anything
+     * more is content this fold would silently drop, so it refuses instead.
+     *
+     * ### Two clauses that each declare a target refuse to fold
+     *
+     * [Targets.SLOT] is a single fixed name, which is enough while every rule takes at most one
+     * target — and stops being enough exactly here. "Destroy target land. ~ deals 13 damage to
+     * target creature." would fold into a script with *two* requirements both called `target` and
+     * two effects both reading that name, which is not the card: it is a model in which the second
+     * slot has no way to be referred to. Refusing is the fail-closed answer, and the gap it names is
+     * a slot-name **generator** in [Targets] rather than anything about this fold. Until that
+     * exists, those lines decline and are counted.
+     */
+    private fun merge(parts: List<CardScript>): CardScript? {
+        if (parts.count { it.targetRequirements.isNotEmpty() } > 1) return null
+        val effects = parts.map { part ->
+            val effect = part.spellEffect ?: return null
+            if (part != CardScript(spellEffect = effect, targetRequirements = part.targetRequirements)) return null
+            effect
+        }
+        return CardScript(
+            spellEffect = if (effects.size == 1) effects.single() else Effects.Composite(effects),
+            targetRequirements = parts.flatMap { it.targetRequirements },
+        )
+    }
+
+    /** What a spell's whole effect text denotes: one sentence, or several. */
+    val step: Phrase<CardScript> = sentence
+
+    // ---------------------------------------------------------------------------------------
+    // Model helpers — the `match` side, kept out of the rules so like rules read alike
     // ---------------------------------------------------------------------------------------
 
     private fun targetPlayerDraws(count: Int) = CardScript(
@@ -323,27 +1189,49 @@ object Steps {
             ?.takeIf { script.targetRequirements == listOf(Targets.player()) }
 
     /**
-     * Reads the fixed count off a script whose only content is a draw.
-     *
-     * The `spellEffect`-and-nothing-else check is deliberate and load-bearing: a rule that printed a
-     * script it had only partly inspected would drop whatever else was in it and still round-trip,
-     * which is precisely the reversible-but-wrong class. Refusing anything unrecognised keeps a
-     * decline the only outcome for text this rule does not fully account for.
-     */
-    /**
      * The fixed amounts the counted verbs read back.
      *
      * Each recovers only the *number*; nothing here checks the target or the rest of the script,
      * because [countedStep]'s equality against its own `script(n)` already does, exhaustively. A
      * dynamic amount ("equal to the number of…") has no numeral to print, so it declines here.
      */
-    private fun lifeGained(effect: Effect): Int? = (effect as? GainLifeEffect)?.amount?.fixed()
+    internal fun lifeGained(effect: Effect): Int? = (effect as? GainLifeEffect)?.amount?.fixed()
 
-    private fun lifeLost(effect: Effect): Int? = (effect as? LoseLifeEffect)?.amount?.fixed()
+    internal fun lifeLost(effect: Effect): Int? = (effect as? LoseLifeEffect)?.amount?.fixed()
 
-    private fun damageDealt(effect: Effect): Int? = (effect as? DealDamageEffect)?.amount?.fixed()
+    internal fun damageDealt(effect: Effect): Int? = (effect as? DealDamageEffect)?.amount?.fixed()
 
-    private fun DynamicAmount.fixed(): Int? = (this as? DynamicAmount.Fixed)?.amount
+    /** The two fixed bonuses a `ModifyStats` effect carries, or null for a dynamic one. */
+    internal fun fixedModifiers(effect: Effect?): Pair<Int, Int>? {
+        val stats = effect as? ModifyStatsEffect ?: return null
+        val power = stats.powerModifier.fixed() ?: return null
+        val toughness = stats.toughnessModifier.fixed() ?: return null
+        return power to toughness
+    }
+
+    /**
+     * The [Keyword] a grant effect names, or null when it names a synthesized marker instead.
+     *
+     * `GrantKeywordEffect` holds a `String`, which is wider than the enum: the SDK also uses the
+     * field for markers like `PROTECTION_FROM_BLACK` that no constant names. Reading it back has to
+     * find the constant rather than assume one.
+     */
+    internal fun grantedKeyword(effect: Effect?): Keyword? {
+        val grant = effect as? com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect ?: return null
+        return Keyword.entries.firstOrNull { it.name == grant.keyword }
+    }
+
+    /** The group a mass effect iterates, or null when the effect is not a plain battlefield sweep. */
+    private fun iteratedGroup(effect: Effect?): GameObjectFilter? {
+        val forEach = effect as? com.wingedsheep.sdk.scripting.effects.ForEachEffect ?: return null
+        val space = forEach.space as? com.wingedsheep.sdk.scripting.effects.IterationSpace.Group ?: return null
+        return space.filter.baseFilter
+    }
+
+    private fun iteratedBody(effect: Effect?): Effect? =
+        (effect as? com.wingedsheep.sdk.scripting.effects.ForEachEffect)?.body
+
+    internal fun DynamicAmount.fixed(): Int? = (this as? DynamicAmount.Fixed)?.amount
 
     private fun drawCount(script: CardScript, requireTarget: Boolean): Int? {
         val effect = script.spellEffect as? DrawCardsEffect ?: return null

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Targets.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Targets.kt
@@ -8,8 +8,11 @@ import com.wingedsheep.sdk.scripting.targets.AnyTarget
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.targets.TargetOpponentOrPlaneswalker
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.targets.TargetPlayerOrPlaneswalker
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 
 /**
@@ -51,6 +54,15 @@ object Targets {
      * it. Worth an `id` parameter on the facade; noted rather than changed here.
      */
     fun player(): TargetRequirement = TargetPlayer(id = SLOT)
+
+    /** "target opponent" — the requirement half, constructed directly for the reason [player] is. */
+    fun opponent(): TargetRequirement = TargetOpponent(id = SLOT)
+
+    /** "target opponent or planeswalker" — the modern damage-redirection wording (CR 115.7b). */
+    fun opponentOrPlaneswalker(): TargetRequirement = TargetOpponentOrPlaneswalker(id = SLOT)
+
+    /** …and its any-player sibling, which older burn spells print instead. */
+    fun playerOrPlaneswalker(): TargetRequirement = TargetPlayerOrPlaneswalker(id = SLOT)
 
     /**
      * "any target" — the burn-spell requirement, covering any creature, player or planeswalker.

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Triggers.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Triggers.kt
@@ -8,6 +8,9 @@ import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.dsl.Triggers as SdkTriggers
@@ -62,31 +65,51 @@ object Triggers {
      * is not in the text.
      */
     private fun triggerRule(surface: String, spec: TriggerSpec): Phrase<TriggeredAbility> {
-        fun abilityFor(script: CardScript): TriggeredAbility? {
-            val effect = script.spellEffect ?: return null
-            if (script.targetRequirements.size > 1) return null
-            return TriggeredAbility(
-                id = ID,
-                trigger = spec.event,
-                binding = spec.binding,
-                effect = effect,
-                targetRequirement = script.targetRequirements.singleOrNull(),
-            )
-        }
-
         return phrase("$surface, {effect}", name = surface) {
             slot("effect", Steps.step)
-            build { abilityFor(it.value("effect")) }
+            build { abilityFor(spec, it.value("effect")) }
             match { ability ->
-                val script = CardScript(
-                    spellEffect = ability.effect,
-                    targetRequirements = listOfNotNull(ability.targetRequirement),
-                )
-                if (abilityFor(script)?.copy(id = ability.id) != ability) return@match null
+                val script = scriptFor(ability)
+                if (abilityFor(spec, script)?.copy(id = ability.id) != ability) return@match null
                 bind("effect" to script)
             }
         }
     }
+
+    /**
+     * Build the ability a trigger's effect clause denotes — **including the lowering of "you may".**
+     *
+     * A triggered ability spells the controller's choice with its own `optional` flag, which is what
+     * every hand-written card sets; a spell spells the identical English as a `MayEffect` around the
+     * effect, because a spell has no such flag. Both are real SDK spellings of one sentence, so
+     * reading "you may …" here has to *lower* one into the other rather than register a second rule:
+     * a rule per spelling would be two readings of one text, which is the ambiguity the design says
+     * never to resolve by picking one.
+     *
+     * The lowering runs in both directions — [scriptFor] wraps `optional` back into a `MayEffect`
+     * before the comparison — so the round trip is over the same value in both halves.
+     */
+    private fun abilityFor(spec: TriggerSpec, script: CardScript): TriggeredAbility? {
+        val effect = script.spellEffect ?: return null
+        if (script.targetRequirements.size > 1) return null
+        val gated = effect as? GatedEffect
+        val optional = gated != null && gated.gate is Gate.MayDecide &&
+            gated == MayEffect(gated.then)
+        return TriggeredAbility(
+            id = ID,
+            trigger = spec.event,
+            binding = spec.binding,
+            effect = if (optional) (effect as GatedEffect).then else effect,
+            targetRequirement = script.targetRequirements.singleOrNull(),
+            optional = optional,
+        )
+    }
+
+    /** The inverse of the lowering: the clause script an ability's effect and target denote. */
+    private fun scriptFor(ability: TriggeredAbility): CardScript = CardScript(
+        spellEffect = if (ability.optional) MayEffect(ability.effect) else ability.effect,
+        targetRequirements = listOfNotNull(ability.targetRequirement),
+    )
 
     /**
      * The trigger events with an unambiguous one-clause surface form.

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/syntax/SentenceCase.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/syntax/SentenceCase.kt
@@ -20,28 +20,32 @@ package com.wingedsheep.assay.syntax
  * ## A line has more than one sentence start
  *
  * `"{T}: Add {C}."` capitalizes "Add", and `"{2}, {T}: Draw a card."` capitalizes "Draw", because
- * an activated ability's effect clause begins a sentence after the cost colon. That is the same
- * templating rule the line start obeys, applied at every place Oracle applies it, so it belongs
- * here rather than in a grammar combinator — the alternative is every activated-ability rule
- * spelling its effect clause capitalized, which is exactly the re-spelling that would stop
+ * an activated ability's effect clause begins a sentence after the cost colon. A full stop starts
+ * one for the same reason: "Target creature gets +1/+3 until end of turn. Untap that creature." is
+ * two sentences on one printed line. That is the same templating rule the line start obeys, applied
+ * at every place Oracle applies it, so it belongs here rather than in a grammar combinator — the
+ * alternative is every activated-ability and every second-clause rule spelling its verbs
+ * capitalized, which is exactly the re-spelling that would stop
  * [com.wingedsheep.assay.grammar.Steps] being slottable into a new sentence context.
  *
  * The rule is Wizards' and the corpus states it: of 14,042 `": "` occurrences in Oracle text, 32
  * are followed by a lowercase letter, and all 32 are prose enumerations on the "hero's journey"
- * cards ("• Setting: a land") rather than ability costs. Those lines decline, which is what
- * [decapitalize] returning null means, and they declined before this too.
+ * cards ("• Setting: a land") rather than ability costs. Of every `". "` in the corpus, 15 are
+ * followed by a lowercase letter and every one is an Un-set joke card or an abbreviation
+ * ("B.F.M.", "S.N.E.A.K.", "Ph.D."). Those lines decline, which is what [decapitalize] returning
+ * null means, and they declined before this too.
  */
 object SentenceCase {
 
     /**
-     * Where Oracle starts a sentence inside one ability line: the line itself, and each clause
-     * after an ability cost's `": "`.
+     * Where Oracle starts a sentence inside one ability line: the line itself, each clause after an
+     * ability cost's `": "`, and each sentence after a full stop.
      *
      * Positions rather than a rewrite, because both directions need the same list and a
      * one-character-for-one-character substitution keeps every index stable between them.
      */
     private fun sentenceStarts(line: String): List<Int> =
-        (listOf(0) + COST_COLON.findAll(line).map { it.range.last + 1 }).filter { it < line.length }
+        (listOf(0) + SENTENCE_BREAK.findAll(line).map { it.range.last + 1 }).filter { it < line.length }
 
     /** Line as the grammar sees it, or null when a leading character makes the inverse a guess. */
     fun decapitalize(line: String): String? {
@@ -64,7 +68,16 @@ object SentenceCase {
         return String(chars)
     }
 
-    private val COST_COLON = Regex(": ")
+    /**
+     * The two places Oracle starts a new sentence *inside* one ability line: after an ability
+     * cost's `": "`, and after a full stop.
+     *
+     * The full stop is what lets a line spelling two sentences — "Target creature gets +1/+3 until
+     * end of turn. Untap that creature." — slot the ordinary effect vocabulary twice instead of
+     * needing a capitalized copy of every verb. It is the same argument the cost colon carries, and
+     * it is why this file exists rather than a `capitalized(...)` combinator in the grammar.
+     */
+    private val SENTENCE_BREAK = Regex("""(?:: |\. )""")
 }
 
 /** Parse a whole sentence-cased ability line. */

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/gate/DifferentialTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/gate/DifferentialTest.kt
@@ -120,8 +120,9 @@ class DifferentialTest : StringSpec({
     // compared: the keywords it did not see would look like agreement, and the gate would be
     // reporting confidence it has not earned.
     "a card the grammar cannot read whole is excluded, not silently confirmed" {
-        val card = oracleCard("Doom Blade", "Destroy target nonblack creature.")
-        val result = differential.compare(implemented(definition("Doom Blade", "Destroy target nonblack creature.")), index(card))
+        val text = "Whenever a creature you control dies, put a +1/+1 counter on target creature."
+        val card = oracleCard("Unread Card", text)
+        val result = differential.compare(implemented(definition("Unread Card", text)), index(card))
 
         result.population shouldBe Population.NOT_COVERED
         result.verdict shouldBe null

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/FiltersTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/FiltersTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.parseText
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The noun-phrase cascade: type nouns, the colour and quality layers around them, the controller
+ * suffix, and the two grammatical numbers the whole thing is instantiated in.
+ *
+ * The properties worth holding are that each layer owns exactly one field, that the layers compose
+ * in the order English writes them, and that printing is decided by the model rather than by the
+ * alternation's order — which is what the round trips below check one layer at a time.
+ */
+class FiltersTest : StringSpec({
+
+    fun read(phrase: com.wingedsheep.assay.syntax.Phrase<GameObjectFilter>, text: String): GameObjectFilter =
+        phrase.parseText(text).shouldBeInstanceOf<ParseOutcome.Accepted<GameObjectFilter>>().value
+
+    fun roundTrips(phrase: com.wingedsheep.assay.syntax.Phrase<GameObjectFilter>, text: String) {
+        phrase.unparse(read(phrase, text)) shouldBe text
+    }
+
+    "a bare type noun is the whole filter" {
+        read(Filters.filter, "creature") shouldBe GameObjectFilter.Creature
+        roundTrips(Filters.filter, "creature")
+        roundTrips(Filters.filter, "nonbasic land")
+        roundTrips(Filters.filter, "artifact or enchantment")
+    }
+
+    // The colour layer owns the top of the predicate stack and delegates the rest inward, which is
+    // what lets it sit in front of a type phrase that already carries a state predicate.
+    "the colour layer wraps any type noun" {
+        read(Filters.filter, "white creature") shouldBe GameObjectFilter.Creature.withColor(Color.WHITE)
+        read(Filters.filter, "nonblack attacking creature") shouldBe
+            GameObjectFilter.Creature.notColor(Color.BLACK).attacking()
+        read(Filters.plural, "black and/or red creatures") shouldBe
+            GameObjectFilter.Creature.withAnyColor(Color.BLACK, Color.RED)
+
+        roundTrips(Filters.filter, "white creature")
+        roundTrips(Filters.filter, "nonblack attacking creature")
+        roundTrips(Filters.plural, "black and/or red creatures")
+    }
+
+    "the quality suffix owns the keyword and power predicates" {
+        read(Filters.plural, "creatures with flying") shouldBe
+            GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+        read(Filters.plural, "creatures without flying") shouldBe
+            GameObjectFilter.Creature.withoutKeyword(Keyword.FLYING)
+        read(Filters.plural, "creatures with power 2 or greater") shouldBe
+            GameObjectFilter.Creature.powerAtLeast(2)
+
+        roundTrips(Filters.plural, "creatures with flying")
+        roundTrips(Filters.plural, "creatures without flying")
+        roundTrips(Filters.plural, "creatures with power 2 or greater")
+    }
+
+    // Colour then quality then controller, which is both the printed order and the order the SDK's
+    // fluent builders append in — the reason "strip the top of the stack" is well defined.
+    "the layers compose in the order English writes them" {
+        read(Filters.plural, "black creatures you control") shouldBe
+            GameObjectFilter.Creature.withColor(Color.BLACK).youControl()
+        roundTrips(Filters.plural, "black creatures you control")
+        roundTrips(Filters.filter, "creature an opponent controls")
+    }
+
+    // Number is an axis rather than a second vocabulary, so every layer exists in both.
+    "the plural cascade is the same cascade" {
+        read(Filters.plural, "creatures") shouldBe GameObjectFilter.Creature
+        roundTrips(Filters.plural, "creatures")
+        roundTrips(Filters.plural, "artifact creatures")
+        // The conjunction changes with the number, which is why the plural is a column in the table
+        // rather than a rule derived from the singular.
+        read(Filters.plural, "creatures and lands") shouldBe GameObjectFilter.CreatureOrLand
+        roundTrips(Filters.plural, "creatures and lands")
+    }
+
+    // "Plains" is its own plural — the same trap Primitives.pluralSubtype exists for.
+    "a basic land type is a type noun, and Plains is invariant" {
+        read(Filters.filter, "Mountain") shouldBe GameObjectFilter.Land.withSubtype(Subtype("Mountain"))
+        roundTrips(Filters.filter, "Mountain")
+        roundTrips(Filters.plural, "Mountains")
+        roundTrips(Filters.plural, "Plains")
+    }
+
+    // The article is a function of the noun's spelling, so both halves of both rules derive it and
+    // the disagreeing one refuses in both directions.
+    "the indefinite article agrees with the noun in both directions" {
+        roundTrips(Filters.indefinite, "a creature")
+        roundTrips(Filters.indefinite, "an artifact")
+        roundTrips(Filters.indefinite, "an Island")
+        roundTrips(Filters.indefinite, "a Forest")
+
+        Filters.indefinite.parseText("an Forest").shouldBeInstanceOf<ParseOutcome.Declined>()
+        Filters.indefinite.parseText("a artifact").shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+
+    // A form nobody wrote down declines rather than being approximated — the point of enumerating
+    // the type list at all.
+    "a phrase the list does not spell declines" {
+        Filters.filter.parseText("legendary creature").shouldBeInstanceOf<ParseOutcome.Declined>()
+        Filters.plural.parseText("artifact or enchantments").shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+})

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/RestrictionsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/RestrictionsTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.assay.syntax.parseLine
+import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.CastRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.YouWereAttackedThisStep
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The lines and clauses that constrain rather than do — Portal's combat tricks and its
+ * before-attackers activated abilities, and the additional cost a spell states on a line of its own.
+ *
+ * These are the first fragments carrying no effect at all, which is why they are lines rather than
+ * clauses: nothing in [Steps] could hold them.
+ */
+class RestrictionsTest : StringSpec({
+
+    fun fragment(line: String): CardFragment =
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Accepted<CardFragment>>().value
+
+    fun roundTrips(line: String) {
+        Grammar.abilityLine.printLine(fragment(line)) shouldBe line
+    }
+
+    // Two restrictions joined by "and", and the model is a list of two — which is why the rule is a
+    // run rather than a rule per printed combination.
+    "a casting restriction line is a run over one vocabulary" {
+        fragment(
+            "Cast this spell only during the declare attackers step and only if you've been attacked this step."
+        ) shouldBe CardFragment(
+            script = CardScript(
+                castRestrictions = listOf(
+                    CastRestriction.OnlyDuringStep(Step.DECLARE_ATTACKERS),
+                    CastRestriction.OnlyIfCondition(YouWereAttackedThisStep),
+                )
+            )
+        )
+        roundTrips(
+            "Cast this spell only during the declare attackers step and only if you've been attacked this step."
+        )
+        roundTrips("Cast this spell only during the declare attackers step.")
+    }
+
+    "an additional cost is a line of its own" {
+        fragment("As an additional cost to cast this spell, sacrifice a creature.") shouldBe CardFragment(
+            script = CardScript(
+                additionalCosts = listOf(Costs.additional.SacrificePermanent(GameObjectFilter.Creature))
+            )
+        )
+        roundTrips("As an additional cost to cast this spell, sacrifice a creature.")
+        roundTrips("As an additional cost to cast this spell, sacrifice a green creature.")
+    }
+
+    // The activation restriction is a *sentence* after the ability's own, joined by a comma rather
+    // than by "and" — a printed-shape difference from the casting line, so each has its separator.
+    "an activated ability carries its restrictions in a trailing sentence" {
+        val line = "{T}: Destroy target tapped creature. Activate only during your turn, " +
+            "before attackers are declared."
+        val ability = fragment(line).script.activatedAbilities.single()
+        ability.restrictions shouldBe listOf(
+            ActivationRestriction.OnlyDuringYourTurn,
+            ActivationRestriction.BeforeStep(Step.DECLARE_ATTACKERS),
+        )
+        roundTrips(line)
+    }
+
+    // The unrestricted rule and the restricted one take disjoint models, so the model decides which
+    // prints rather than the alternation's order.
+    "an unrestricted ability still prints without the sentence" {
+        roundTrips("{T}: Destroy target tapped creature.")
+    }
+
+    // A condition the SDK cannot name declines rather than being approximated by the nearest one.
+    "a restriction the vocabulary does not name declines" {
+        Grammar.abilityLine
+            .parseLine("Cast this spell only if you control a Forest.")
+            .shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+})

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/SequencesTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/SequencesTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.assay.syntax.parseLine
+import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * A line with more than one clause in it: the full stop, the two joins, the anaphors that make a
+ * later clause mean anything, and the one fold the whole thing rests on — that a target is declared
+ * at its first mention.
+ */
+class SequencesTest : StringSpec({
+
+    fun fragment(line: String): CardFragment =
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Accepted<CardFragment>>().value
+
+    fun roundTrips(line: String) {
+        Grammar.abilityLine.printLine(fragment(line)) shouldBe line
+    }
+
+    "two sentences on one line are one composite" {
+        fragment("Draw a card. You gain 2 life.") shouldBe CardFragment(
+            script = CardScript(
+                spellEffect = Effects.Composite(listOf(Effects.DrawCards(1), Effects.GainLife(2)))
+            )
+        )
+        roundTrips("Draw a card. You gain 2 life.")
+        roundTrips("Scry 2. Draw a card. You gain 2 life.")
+    }
+
+    // The requirement belongs to the clause that introduces the referent, and the later clause reads
+    // the slot without declaring one.
+    "a target is declared at its first mention and referred to afterwards" {
+        fragment("Target creature gets +1/+3 until end of turn. Untap that creature.") shouldBe CardFragment(
+            script = CardScript(
+                spellEffect = Effects.Composite(
+                    listOf(
+                        Effects.ModifyStats(1, 3, Targets.bound()),
+                        Effects.Untap(Targets.bound()),
+                    )
+                ),
+                targetRequirements = listOf(Targets.permanent(GameObjectFilter.Creature)),
+            )
+        )
+        roundTrips("Target creature gets +1/+3 until end of turn. Untap that creature.")
+    }
+
+    // The bug the differential found: the same four words mean the source in one position and the
+    // target in the other, and reading the wrong one round-trips perfectly.
+    "\"it\" is the source in a first clause and the target in a later one" {
+        fragment("It gets +2/+0 until end of turn.") shouldBe CardFragment(
+            script = CardScript(spellEffect = Effects.ModifyStats(2, 0, EffectTarget.Self))
+        )
+        fragment("Untap target creature. It gets +2/+4 until end of turn.") shouldBe CardFragment(
+            script = CardScript(
+                spellEffect = Effects.Composite(
+                    listOf(
+                        Effects.Untap(Targets.bound()),
+                        Effects.ModifyStats(2, 4, Targets.bound()),
+                    )
+                ),
+                targetRequirements = listOf(Targets.permanent(GameObjectFilter.Creature)),
+            )
+        )
+        roundTrips("It gets +2/+0 until end of turn.")
+        roundTrips("Untap target creature. It gets +2/+4 until end of turn.")
+    }
+
+    // The joins denote the same composite the full stop does, so they parse and never print: the
+    // model has no room for the conjunction and something has to be canonical.
+    "the joins are alternate spellings of the full stop" {
+        fragment("Draw a card and you gain 2 life.") shouldBe fragment("Draw a card. You gain 2 life.")
+        fragment("Scry 2, then draw a card.") shouldBe fragment("Scry 2. Draw a card.")
+
+        Grammar.abilityLine.printLine(fragment("Draw a card and you gain 2 life.")) shouldBe
+            "Draw a card. You gain 2 life."
+        Grammar.abilityLine.printLine(fragment("Scry 2, then draw a card.")) shouldBe
+            "Scry 2. Draw a card."
+    }
+
+    // Mixing the separators has to fold to the same flat composite; a run with one separator could
+    // not read the line, and a join rule that was itself a clause would have nested it.
+    "one line can mix the joins" {
+        fragment("Scry 2, then draw two cards. You lose 2 life.") shouldBe
+            fragment("Scry 2. Draw two cards. You lose 2 life.")
+    }
+
+    // Fail-closed: one slot name means two declared targets cannot both be referred to, so a line
+    // that would need two declines rather than producing a model whose second slot is unreachable.
+    "two clauses that each declare a target decline" {
+        Grammar.abilityLine
+            .parseLine("Destroy target land. Draw a card. Target player draws a card.")
+            .shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+
+    // A continuation cannot start a line: the thing it names has not been introduced.
+    "a dangling anaphor is not a line" {
+        Grammar.abilityLine.parseLine("Untap that creature.").shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+
+    // The wrappers are clauses, so a trigger and an activated ability get sequences for free.
+    "a sequence is the same clause wherever it lands" {
+        roundTrips("When ~ enters, draw a card. You gain 2 life.")
+        roundTrips("{T}: Draw a card. You gain 2 life.")
+        roundTrips("You may draw a card.")
+    }
+})

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/StaticsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/StaticsTest.kt
@@ -3,8 +3,10 @@ package com.wingedsheep.assay.grammar
 import com.wingedsheep.assay.syntax.ParseOutcome
 import com.wingedsheep.assay.syntax.parseLine
 import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.CantBlock
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
 import com.wingedsheep.sdk.scripting.ModifyStats
@@ -115,6 +117,27 @@ class StaticsTest : StringSpec({
             .shouldBeInstanceOf<ParseOutcome.Declined>()
     }
 
+    // The second static family: what a creature may and may not do in combat. The blocker filter is
+    // the whole of Filters slotted in, so the three sentences below are one shape and a filter list.
+    "the combat restrictions are the source's own statics" {
+        fragment("~ can't block.") shouldBe
+            CardFragment(script = CardScript(staticAbilities = listOf(CantBlock())))
+        roundTrips("~ can't block.")
+        roundTrips("~ can't be blocked by creatures with power 2 or greater.")
+        roundTrips("~ can't be blocked by black and/or red creatures.")
+        roundTrips("~ can block only creatures with flying.")
+        roundTrips("~ can't be blocked by more than one creature.")
+        roundTrips("~ can't attack unless defending player controls an Island.")
+    }
+
+    // "Can't be blocked" with no filter at all is an `AbilityFlag` rather than a static — two SDK
+    // places for one kind of thing, which is why the fragment holds both and the differential can
+    // see the difference.
+    "the unfiltered form is a flag, not a static" {
+        fragment("~ can't be blocked.") shouldBe CardFragment(flags = setOf(AbilityFlag.CANT_BE_BLOCKED))
+        roundTrips("~ can't be blocked.")
+    }
+
     // Every rule in the family can print what it parses — the meta-test each family gets, because a
     // `match` half that quietly matches nothing compiles, parses, and surfaces as a print mismatch
     // far from its cause.
@@ -123,6 +146,11 @@ class StaticsTest : StringSpec({
             "Enchanted creature gets +1/+2.",
             "Enchanted creature has flying.",
             "Enchanted creature gets +2/+2 and has flying.",
+            "~ can't block.",
+            "~ can't be blocked by creatures with power 2 or greater.",
+            "~ can block only creatures with flying.",
+            "~ can't be blocked by more than one creature.",
+            "~ can't attack unless defending player controls an Island.",
         )
         lines.forEach { line -> Grammar.abilityLine.printLine(fragment(line)) shouldBe line }
     }

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/StepsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/StepsTest.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
@@ -216,5 +217,45 @@ class StepsTest : StringSpec({
         )
 
         Grammar.abilityLine.printLine(other) shouldBe null
+    }
+
+    // The mass effects: one iteration over a GroupFilter with the per-member effect written against
+    // EffectTarget.Self. Four printed shapes for one model, which is why the templates are
+    // enumerated and the group filter is Filters slotted whole.
+    "a group effect is one iteration over a filter" {
+        fragment("Creatures you control get +1/+1 until end of turn.") shouldBe CardFragment(
+            script = CardScript(
+                spellEffect = Effects.ForEachInGroup(
+                    com.wingedsheep.sdk.scripting.filters.unified.GroupFilter(
+                        GameObjectFilter.Creature.youControl()
+                    ),
+                    Effects.ModifyStats(1, 1, com.wingedsheep.sdk.scripting.targets.EffectTarget.Self),
+                )
+            )
+        )
+        roundTrips("Creatures you control get +1/+1 until end of turn.")
+        roundTrips("White creatures get +2/+0 until end of turn.")
+        roundTrips("Creatures you control gain reach until end of turn.")
+        roundTrips("Destroy all white creatures.")
+        roundTrips("Untap all creatures you control.")
+        roundTrips("Tap all other creatures.")
+        roundTrips("~ deals 1 damage to each attacking creature.")
+    }
+
+    // `noRegenerate` is a field on the same iteration rather than a second effect, so the rule spans
+    // both printed sentences and the plain sweep refuses to print a value carrying it.
+    "a sweep that forbids regeneration is its own sentence pair" {
+        roundTrips("Destroy all creatures. They can't be regenerated.")
+        fragment("Destroy all creatures. They can't be regenerated.") shouldNotBe
+            fragment("Destroy all creatures.")
+    }
+
+    // Both leaves in one file: a quantity of cards is a word, a quantity of life or damage a numeral.
+    "the counted verbs keep the two number conventions apart" {
+        roundTrips("You gain 3 life.")
+        roundTrips("You gain 1 life for each Forest on the battlefield.")
+        roundTrips("You gain 2 life for each Mountain target opponent controls.")
+        roundTrips("~ deals X damage to any target.")
+        roundTrips("Target creature gets +3/+3 and gains flying until end of turn.")
     }
 })

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/TriggersTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/TriggersTest.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.assay.grammar
 import com.wingedsheep.assay.syntax.ParseOutcome
 import com.wingedsheep.assay.syntax.parseLine
 import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.AbilityId
@@ -100,9 +101,10 @@ class TriggersTest : StringSpec({
             "At the beginning of each upkeep, draw a card."
     }
 
-    // Fail-closed, the same rule the step matchers follow: an ability carrying anything the sentence
-    // does not spell must refuse to print rather than print a sentence that drops it.
-    "an ability with content the prefix does not spell refuses to print" {
+    // "You may …" is not unspellable content: a triggered ability's `optional` flag and a spell's
+    // `MayEffect` are two SDK spellings of one sentence, and `Triggers.abilityFor` lowers between
+    // them so the printed form is the same either way.
+    "the optional flag is the trigger's spelling of \"you may\"" {
         val optional = TriggeredAbility(
             id = AbilityId("trigger"),
             trigger = SdkTriggers.EntersBattlefield.event,
@@ -113,6 +115,25 @@ class TriggersTest : StringSpec({
 
         Grammar.abilityLine.printLine(
             CardFragment(script = CardScript(triggeredAbilities = listOf(optional)))
+        ) shouldBe "When ~ enters, you may draw a card."
+        fragment("When ~ enters, you may draw a card.") shouldBe
+            CardFragment(script = CardScript(triggeredAbilities = listOf(optional)))
+    }
+
+    // Fail-closed, the same rule the step matchers follow: an ability carrying anything the sentence
+    // does not spell must refuse to print rather than print a sentence that drops it. An
+    // intervening-if condition (CR 603.4) is the example — no trigger rule spells one.
+    "an ability with content the prefix does not spell refuses to print" {
+        val gated = TriggeredAbility(
+            id = AbilityId("trigger"),
+            trigger = SdkTriggers.EntersBattlefield.event,
+            binding = SdkTriggers.EntersBattlefield.binding,
+            effect = Effects.DrawCards(1),
+            triggerCondition = Conditions.OpponentControlsMoreLands,
+        )
+
+        Grammar.abilityLine.printLine(
+            CardFragment(script = CardScript(triggeredAbilities = listOf(gated)))
         ) shouldBe null
     }
 


### PR DESCRIPTION
`just assay-gate --set POR` reads **200 of Portal's 200 cards** end to end.

```
set POR — 200 cards printed in it
  Round-trips byte-exact   219 / 225 lines     Declined  0
  Alternate spelling         6                 Ambiguous 0 · Mismatch 0
  Cards fully covered      200 / 200   1000.0‰
```

Whole-corpus coverage went **3,004 → 4,287** cards (86.1‰ → 122.9‰) in the same change. The set is the target rather than the number: reading all of one says the grammar has no systematic hole in that era, which a rule family's percentage cannot.

## What it took

Four pieces of machinery, then rows — not two hundred rules.

- **A line is a sequence of clauses.** Templates are periodless clauses now, and `SentenceCase` learned that a full stop is a sentence start, so "Target creature gets +1/+3 until end of turn. Untap that creature." reuses the effect vocabulary twice instead of needing a capitalized second copy of every verb. Triggers, activated abilities and spell lines all gained sequences without being told, because they slot `Steps.step`. "A and B" and "A, then B" denote the same composite, so they parse and print back as the full-stop form.
- **A noun phrase is a layered cascade in two grammatical numbers.** `Filters` grew colour, quality and controller layers over a type table with singular/plural columns — each layer owning exactly one field and stripping precisely it — so "black creatures you control" and "creatures with power 2 or greater" are compositions rather than rules.
- **Two anaphors are two vocabularies.** "That creature" is the target; "it" is the source in a first clause and the target in a later one, so `SelfSteps.anaphoric` and `Continuations` are reachable from disjoint positions.
- **Three restriction vocabularies** — casting, activation, additional costs — reaching the `CardScript` slots that say *when* a card may be played rather than *what* it does. `CardFragment` grew `flags` for the one line that is an `AbilityFlag`.

Nine Portal cards needed a rule that unlocks only them (Cruel Fate, Temporary Truce, Ancestral Memories, Last Chance, …). Each carries a KDoc paragraph saying why the alternative was a *wrong* rule rather than a smaller one, which is the bar `oracle-assay/AGENTS.md` sets.

## Bugs fixed

**Two in hand-written cards, both the Meteor Golem class.** Recollect and Eternal Witness print "Return target card from **your** graveyard to your hand" and filter on `TargetFilter.CardInGraveyard` — *any* graveyard — so both could recur out of an opponent's. Elven Cache and Déjà Vu scope the same sentence with `ownedByYou()`, which is what makes these a bug rather than a spelling. Each fix ships with a scenario test asserting the **negative** — a card in an opponent's graveyard is not a legal target, so the cast declaring it is rejected — which is the half that fails without the fix.

**One in the parser, of the class only this gate can catch.** "Untap target creature. It gets +2/+4 until end of turn." read "it" as the *source* rather than the target the first clause chose. It round-tripped byte-perfectly the whole time and meant a different creature. Affected Inspirit and Gerrard's Command.

## Not fixed here

A grep for the same filter found a third card of the same class the gate could not have: **Revive** prints "Return target **green** card from **your** graveyard to your hand" and ignores both words. The grammar declines its line — no rule reads a colour on a card noun — so the differential never compared it. Recorded in the README; the fix wants the rule first, so the gate can confirm it rather than a human asserting it.

## Verification

| Gate | Result |
|---|---|
| `just assay-gate` (66,793 lines) | 0 ambiguous · 0 mismatch · 0 non-invertible normalization |
| `just assay-differential` | 1,636 cards compared (was 930), **98.3% confirmed**, 28 divergences |
| `:oracle-assay:test` | 168 tests, 0 failures (3 new files: Filters, Sequences, Restrictions) |
| `RecollectScenarioTest`, `EternalWitnessScenarioTest` | pass |
| `just rebless-cards` | two lines moved, both the cards above |

The 28 divergences are classified in `oracle-assay/README.md`. All but four are the already-open "two SDK spellings of one thing" findings; the four new ones are named there too, the largest being that "deals N damage to each creature and each player" is authored two ways across nine cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)