### PR TITLE
Stop the AI livelocking on a combat tax it cannot pay

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/AIPlayer.kt
@@ -303,7 +303,7 @@ class AIPlayer(
             val engine = PlayoutEngine(
                 cardRegistry = cardRegistry,
                 evaluator = evaluator,
-                policy = PlayoutPolicy(playoutCombat, intents, settings),
+                policy = PlayoutPolicy(playoutCombat, intents, settings, cardRegistry),
                 decisions = FastDecisionResponder(intents),
                 settings = settings,
                 winProbabilityScale = winProbabilityScale,

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatAdvisor.kt
@@ -131,7 +131,14 @@ class CombatAdvisor(
             )
         }
 
-        return DeclareAttackers(playerId, seedMap)
+        // Local search may have added attackers back on top of an already-trimmed seed, so the tax
+        // is re-priced against the plan we are about to submit. See [CombatTaxBudget].
+        return DeclareAttackers(
+            playerId,
+            CombatTaxBudget.affordableAttack(
+                state, projected, playerId, cardRegistry, seedMap, mandatory.toSet()
+            ),
+        )
     }
 
     /**
@@ -263,10 +270,15 @@ class CombatAdvisor(
         // ── Menace fix: remove illegal single-blocker assignments for menace attackers ──
         fixMenaceAssignments(state, projected, bestMap, validBlockers, assignedBlockers)
 
-        return DeclareBlockers(
-            playerId,
-            legalizeBlockerPlan(state, playerId, bestMap, mandatoryBlockerIds)
+        // ── Block tax: a plan we cannot pay for is a plan we would only decline (see
+        // [CombatTaxBudget]) ──
+        val affordable = CombatTaxBudget.affordableBlock(
+            state, projected, playerId, cardRegistry,
+            legalizeBlockerPlan(state, playerId, bestMap, mandatoryBlockerIds),
+            mandatoryBlockerIds,
         )
+
+        return DeclareBlockers(playerId, affordable)
     }
 
     /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatSeed.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatSeed.kt
@@ -67,7 +67,13 @@ object CombatSeed {
 
         // ── Lethal check: alpha-strike if damage gets through even with optimal blocking ──
         if (CombatMath.isLethalAttack(state, projected, validAttackers, opponentCreatures, opponentLife)) {
-            return AttackSeed(validAttackers.associateWith { opponentId }, opponentId, lethal = true)
+            val alphaStrike = validAttackers.associateWith { opponentId }
+            val affordable = CombatTaxBudget.affordableAttack(
+                state, projected, playerId, cardRegistry, alphaStrike, mandatory.toSet()
+            )
+            // A trimmed alpha strike is not the attack the lethal check approved, so it goes back to
+            // being an ordinary plan for the caller's local search to improve on.
+            return AttackSeed(affordable, opponentId, lethal = affordable.size == alphaStrike.size)
         }
 
         // ── Heuristic seed: no-downside and clearly profitable attackers ──
@@ -180,7 +186,15 @@ object CombatSeed {
             }
         }
 
-        return AttackSeed(seedMap, opponentId, lethal = false)
+        // A plan whose attack tax we cannot pay is one we would be asked to pay for and could only
+        // decline, ending up back at this same choice — see [CombatTaxBudget].
+        return AttackSeed(
+            CombatTaxBudget.affordableAttack(
+                state, projected, playerId, cardRegistry, seedMap, mandatory.toSet()
+            ),
+            opponentId,
+            lethal = false,
+        )
     }
 
     /**

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatTaxBudget.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/CombatTaxBudget.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.mechanics.combat.CombatTaxes
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.mechanics.mana.ManaPool
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Trims a combat declaration down to what the player can actually pay the tax for — Ghostly Prison,
+ * Windborn Muse, Baird, Archangel of Tithes, Whipgrass Entangler.
+ *
+ * **Why this exists.** A tax is part of the cost of declaring (CR 508.1a / 509.1a), and the engine
+ * asks for it *after* the declaration, as a `SelectManaSourcesDecision` the declaring player may
+ * decline. Declining is a clean no-op: no attackers, and the step is still waiting for a
+ * declaration. So an AI that proposes an attack it cannot pay for, is asked to pay, and declines,
+ * lands back in exactly the position it just chose from — and chooses the same attack again, for
+ * ever. That livelock is what this fixes: price the plan before proposing it, and propose one that
+ * can be paid for.
+ *
+ * The tax is monotone in the declared set ([CombatTaxes]), so a plan is made affordable by dropping
+ * creatures one at a time — cheapest first, so the creatures that survive the trim are the ones
+ * worth taxing. Mandatory attackers/blockers are never dropped: leaving one out is its own illegal
+ * declaration, and which of the two illegalities the engine complains about is its call, not ours.
+ */
+object CombatTaxBudget {
+
+    /**
+     * [attackers] (creature → defender), reduced until its attack tax is payable.
+     *
+     * Returns the plan unchanged when there is no tax (the overwhelming majority of combats — one
+     * cheap scan of the defender's permanents and no solver run), or when nothing can be dropped.
+     */
+    fun affordableAttack(
+        state: GameState,
+        projected: ProjectedState,
+        playerId: EntityId,
+        cardRegistry: CardRegistry?,
+        attackers: Map<EntityId, EntityId>,
+        mandatory: Set<EntityId> = emptySet(),
+    ): Map<EntityId, EntityId> {
+        if (cardRegistry == null || attackers.isEmpty()) return attackers
+        val solver = ManaSolver(cardRegistry)
+        val payable = { plan: Map<EntityId, EntityId> ->
+            payable(state, playerId, solver, CombatTaxes.attackTax(state, cardRegistry, plan, projected))
+        }
+        if (payable(attackers)) return attackers
+
+        var plan = attackers
+        for (attackerId in cheapestFirst(state, projected, attackers.keys - mandatory)) {
+            plan = plan - attackerId
+            if (plan.isEmpty()) return emptyMap()
+            if (payable(plan)) return plan
+        }
+        return plan
+    }
+
+    /**
+     * [blockers] (blocker → the attackers it blocks), reduced until its block tax is payable.
+     *
+     * Blocks are dropped cheapest-blocker-first for the same reason attacks are: with only part of
+     * the tax payable, the blocks worth keeping are the ones made by the creatures worth paying for.
+     */
+    fun affordableBlock(
+        state: GameState,
+        projected: ProjectedState,
+        playerId: EntityId,
+        cardRegistry: CardRegistry?,
+        blockers: Map<EntityId, List<EntityId>>,
+        mandatory: Set<EntityId> = emptySet(),
+    ): Map<EntityId, List<EntityId>> {
+        if (cardRegistry == null) return blockers
+        val declared = blockers.filterValues { it.isNotEmpty() }
+        if (declared.isEmpty()) return blockers
+        val solver = ManaSolver(cardRegistry)
+        val payable = { plan: Map<EntityId, List<EntityId>> ->
+            payable(state, playerId, solver, CombatTaxes.blockTax(state, cardRegistry, plan.keys, projected))
+        }
+        if (payable(declared)) return blockers
+
+        var plan = declared
+        for (blockerId in cheapestFirst(state, projected, declared.keys - mandatory)) {
+            plan = plan - blockerId
+            if (plan.isEmpty()) return emptyMap()
+            if (payable(plan)) return plan
+        }
+        return plan
+    }
+
+    /**
+     * Whether [playerId] can cover a [tax] of generic mana right now.
+     *
+     * Deliberately the *narrower* question than [ManaSolver.canPay]: floating mana first, then the
+     * auto-tap solver for what is left, which is exactly what
+     * `CombatTaxContinuationResumer.payTax` will do when the prompt comes back. `canPay` would also
+     * count Treasures and Springleaf-Drum-style sources, and combat-tax payment refuses both — so
+     * trusting it here would leave the AI declaring an attack whose prompt it can only decline,
+     * which is the livelock this class exists to prevent.
+     */
+    private fun payable(state: GameState, playerId: EntityId, solver: ManaSolver, tax: Int): Boolean {
+        if (tax <= 0) return true
+        val pool = state.getEntity(playerId)?.get<ManaPoolComponent>()?.let {
+            ManaPool(it.white, it.blue, it.black, it.red, it.green, it.colorless, it.restrictedMana)
+        } ?: ManaPool()
+        val remaining = pool.payPartial(CombatTaxes.genericCost(tax)).remainingCost
+        return remaining.isEmpty() || solver.solve(state, playerId, remaining) != null
+    }
+
+    private fun cheapestFirst(
+        state: GameState,
+        projected: ProjectedState,
+        creatures: Set<EntityId>,
+    ): List<EntityId> = creatures.sortedBy { CombatMath.creatureValue(state, projected, it) }
+}

--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/rollout/PlayoutPolicy.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/rollout/PlayoutPolicy.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.core.GameAction
 import com.wingedsheep.engine.core.PassPriority
 import com.wingedsheep.engine.legalactions.LegalAction
 import com.wingedsheep.engine.legalactions.MeaningfulActionFilter
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.model.EntityId
@@ -51,6 +52,13 @@ class PlayoutPolicy(
     private val combatAdvisor: CombatAdvisor,
     private val intents: IntentCatalog = IntentCatalog.NONE,
     private val settings: RolloutSettings = RolloutSettings.DEFAULT,
+    /**
+     * Only the seed's attack-tax pricing needs it (see [com.wingedsheep.ai.engine.CombatTaxBudget]).
+     * Null means a playout may imagine an attack its player cannot pay for and then spend the rest
+     * of its action budget re-declaring it — `maxActionsPerPlayout` ends it, but the sample is
+     * wasted, so production wires the registry through.
+     */
+    private val cardRegistry: CardRegistry? = null,
 ) {
     /** Combat inside a playout gets the seed and nothing else — see [DecisionBudget] tiers. */
     private val noSearch =
@@ -78,7 +86,7 @@ class PlayoutPolicy(
         // Combat declaration is never optional — the enumerator offers exactly one of these and the
         // engine will not move on until it is answered.
         legalActions.firstOrNull { it.actionType == "DeclareAttackers" }?.let { action ->
-            val seed = CombatSeed.attackers(state, state.projectedState, action, playerId)
+            val seed = CombatSeed.attackers(state, state.projectedState, action, playerId, cardRegistry)
             return DeclareAttackers(playerId, seed.attackers) to rng
         }
         legalActions.firstOrNull { it.actionType == "DeclareBlockers" }?.let { action ->

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/CombatTaxAiTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/CombatTaxAiTest.kt
@@ -1,0 +1,194 @@
+package com.wingedsheep.ai.engine
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dom.cards.BairdStewardOfArgive
+import com.wingedsheep.mtg.sets.definitions.ori.cards.ArchangelOfTithes
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * The AI and combat taxes — Baird, Steward of Argive ("creatures can't attack you unless their
+ * controller pays {1} for each of those creatures") and Archangel of Tithes' blocking half.
+ *
+ * The engine asks for the tax *after* the declaration, as a decision the declarer may decline, and
+ * declining puts the game back at the declaration step with nothing changed. So an AI that declares
+ * a combat it cannot pay for is handed back the position it just chose from — and, being
+ * deterministic, chooses the same declaration again. Reported as "engine AI goes in an infinite loop
+ * selecting mana sources"; the fix is [CombatTaxBudget], which prices the tax before proposing.
+ */
+class CombatTaxAiTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(BairdStewardOfArgive, ArchangelOfTithes, PredefinedTokens.Treasure))
+        initMirrorMatch(Deck.of("Plains" to 20, "Forest" to 20))
+    }
+
+    /**
+     * Two attackers for [attacker], Baird for their opponent.
+     *
+     * Unblockable ones, so that whether the AI attacks turns on the tax and nothing else: a
+     * blockable creature facing Baird's own 2/4 body is a plan the advisor can reject on its merits.
+     */
+    fun GameTestDriver.taxedBoard(attacker: EntityId, defender: EntityId): List<EntityId> {
+        val a1 = putCreatureOnBattlefield(attacker, "Phantom Warrior")
+        val a2 = putCreatureOnBattlefield(attacker, "Phantom Warrior")
+        removeSummoningSickness(a1)
+        removeSummoningSickness(a2)
+        putCreatureOnBattlefield(defender, "Baird, Steward of Argive")
+        return listOf(a1, a2)
+    }
+
+    fun GameTestDriver.attackAction(playerId: EntityId) =
+        LegalActionEnumerator.create(cardRegistry).enumerate(state, playerId)
+            .single { it.actionType == "DeclareAttackers" }
+
+    test("declares no attackers when it cannot pay the attack tax") {
+        val driver = driver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.taxedBoard(p1, p2)
+        // No untapped lands: the {2} Baird asks for two attackers is unpayable.
+        val turn = driver.state.turnNumber
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.state.turnNumber shouldBe turn
+
+        val ai = AIPlayer.create(driver.cardRegistry, p1)
+        val chosen = ai.chooseFrom(driver.state, listOf(driver.attackAction(p1))).action as DeclareAttackers
+
+        chosen.attackers.keys.shouldBeEmpty()
+        driver.submit(chosen).isSuccess shouldBe true
+        driver.state.pendingDecision shouldBe null
+    }
+
+    test("still attacks when it can pay the attack tax") {
+        val driver = driver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.taxedBoard(p1, p2)
+        repeat(2) { driver.putLandOnBattlefield(p1, "Forest") }
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        val ai = AIPlayer.create(driver.cardRegistry, p1)
+        val chosen = ai.chooseFrom(driver.state, listOf(driver.attackAction(p1))).action as DeclareAttackers
+
+        chosen.attackers.size shouldBe 2
+        // The engine pauses for the {2}; the AI's own responder pays it and combat proceeds.
+        val paused = driver.submit(chosen)
+        paused.error shouldBe null
+        val decision = driver.state.pendingDecision
+        decision shouldNotBe null
+        driver.submitDecision(p1, ai.respondToDecision(driver.state, decision!!)).isSuccess shouldBe true
+        driver.state.pendingDecision shouldBe null
+        driver.getUntappedLands(p1).shouldBeEmpty()
+    }
+
+    test("trims the attack down to the attackers it can pay for") {
+        val driver = driver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.taxedBoard(p1, p2)
+        // Three unblockable attackers, one Forest: {3} to send them all, and {1} in the bank.
+        val third = driver.putCreatureOnBattlefield(p1, "Phantom Warrior")
+        driver.removeSummoningSickness(third)
+        driver.putLandOnBattlefield(p1, "Forest")
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        val ai = AIPlayer.create(driver.cardRegistry, p1)
+        val chosen = ai.chooseFrom(driver.state, listOf(driver.attackAction(p1))).action as DeclareAttackers
+
+        chosen.attackers.size shouldBe 1
+        driver.submit(chosen).error shouldBe null
+    }
+
+    test("a Treasure does not count as attack-tax mana") {
+        // `ManaSolver.canPay` counts Treasures, but combat-tax payment refuses sacrifice sources —
+        // the prompt for a Treasure-only tax comes back with an empty auto-pay suggestion and
+        // nothing to do but decline. So the AI must read this board as unpayable, not as payable.
+        val driver = driver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.taxedBoard(p1, p2)
+        driver.putPermanentOnBattlefield(p1, "Treasure")
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        val ai = AIPlayer.create(driver.cardRegistry, p1)
+        val chosen = ai.chooseFrom(driver.state, listOf(driver.attackAction(p1))).action as DeclareAttackers
+
+        chosen.attackers.keys.shouldBeEmpty()
+        driver.submit(chosen).isSuccess shouldBe true
+        driver.state.pendingDecision shouldBe null
+    }
+
+    test("an AI turn against an unpayable tax reaches the end step") {
+        val driver = driver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.taxedBoard(p1, p2)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        val processor = ActionProcessor(driver.cardRegistry)
+        val ai1 = AIPlayer.create(driver.cardRegistry, p1)
+        val ai2 = AIPlayer.create(driver.cardRegistry, p2)
+
+        // Before the fix this never left DECLARE_ATTACKERS: declare both warriors, get asked for the
+        // tax, decline, repeat. `windows` is the livelock detector — the step advances in a handful.
+        var state = driver.state
+        var windows = 0
+        while (!state.gameOver && state.step == Step.DECLARE_ATTACKERS && windows < 40) {
+            state = when (state.priorityPlayerId) {
+                p1 -> ai1.playPriorityWindow(state, processor)
+                else -> ai2.playPriorityWindow(state, processor)
+            }
+            windows++
+        }
+
+        state.step shouldNotBe Step.DECLARE_ATTACKERS
+        windows shouldBeLessThanOrEqual 10
+    }
+
+    test("declares no blockers when it cannot pay the block tax") {
+        val driver = driver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Archangel of Tithes taxes every blocker {1} while it attacks; the Courser is what the AI
+        // would otherwise want to block, since its own 5/5 eats it for free.
+        val archangel = driver.putCreatureOnBattlefield(p1, "Archangel of Tithes")
+        val courser = driver.putCreatureOnBattlefield(p1, "Centaur Courser")
+        driver.removeSummoningSickness(archangel)
+        driver.removeSummoningSickness(courser)
+        val blocker = driver.putCreatureOnBattlefield(p2, "Force of Nature")
+        driver.removeSummoningSickness(blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(archangel, courser), p2).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        val ai = AIPlayer.create(driver.cardRegistry, p2)
+        val blockAction = LegalActionEnumerator.create(driver.cardRegistry).enumerate(driver.state, p2)
+            .single { it.actionType == "DeclareBlockers" }
+        val chosen = ai.chooseFrom(driver.state, listOf(blockAction)).action as DeclareBlockers
+
+        chosen.blockers.filterValues { it.isNotEmpty() }.keys.shouldBeEmpty()
+        driver.submit(chosen).isSuccess shouldBe true
+        driver.state.pendingDecision shouldBe null
+    }
+})

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DainLordOfTheIronHills.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DainLordOfTheIronHills.kt
@@ -20,8 +20,8 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * for each of those creatures.
  *
  * A Ghostly Prison that only switches on with the enduring story. The gate rides [AttackTax.condition]
- * rather than a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] wrapper: `AttackPhaseManager.
- * calculateTotalAttackTax` scans `cardDef.staticAbilities` **raw** and only recognizes a bare
+ * rather than a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] wrapper: `CombatTaxes.
+ * attackTax` scans `cardDef.staticAbilities` **raw** and only recognizes a bare
  * [AttackTax], so a wrapped one would silently tax nothing. The field exists for exactly this shape
  * (Archangel of Tithes gates on being untapped); it is evaluated with Dáin's controller as "you", which
  * is the player being attacked.

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DainLordOfTheIronHillsScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DainLordOfTheIronHillsScenarioTest.kt
@@ -17,7 +17,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  *
  * A Ghostly Prison behind the storied gate. The gate rides `AttackTax.condition` rather than a
  * `ConditionalStaticAbility` wrapper, and that is exactly what these tests pin:
- * `AttackPhaseManager.calculateTotalAttackTax` scans `cardDef.staticAbilities` **raw**, matching only
+ * `CombatTaxes.attackTax` scans `cardDef.staticAbilities` **raw**, matching only
  * a bare `AttackTax`, so a wrapped ability would tax nothing at all and the "off" case below would
  * pass for the wrong reason. Asserting both directions is what separates "gate works" from "gate
  * never fires".

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -2,7 +2,6 @@ package com.wingedsheep.engine.mechanics.combat
 
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
-import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.mana.ManaPool
 import com.wingedsheep.engine.mechanics.mana.ManaSolver
 import com.wingedsheep.engine.registry.CardRegistry
@@ -23,10 +22,8 @@ import com.wingedsheep.engine.mechanics.combat.rules.AttackCheckContext
 import com.wingedsheep.engine.mechanics.combat.rules.AttackDefenderRule
 import com.wingedsheep.engine.mechanics.combat.rules.AttackRestrictionRule
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.ManaSymbol
 import com.wingedsheep.sdk.model.EntityId
-import com.wingedsheep.sdk.scripting.AttackTax
 import com.wingedsheep.sdk.scripting.AttackerCountLimit
 import com.wingedsheep.sdk.scripting.CantAttackUnlessCoAttacker
 import com.wingedsheep.sdk.scripting.MustAttack
@@ -51,7 +48,6 @@ internal class AttackPhaseManager(
     private val manaAbilitySideEffectExecutor: com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor,
 ) {
 
-    private val dynamicAmountEvaluator = com.wingedsheep.engine.handlers.DynamicAmountEvaluator()
     private val predicateEvaluator = PredicateEvaluator()
     private val conditionEvaluator = com.wingedsheep.engine.handlers.ConditionEvaluator()
 
@@ -154,7 +150,7 @@ internal class AttackPhaseManager(
         // Calculate (but don't pay) the attack tax. If non-zero, pause for the attacking
         // player to confirm before we tap any of their mana — otherwise auto-tapping the
         // pool would steal sources they were saving for instants/post-combat plays.
-        val totalTax = calculateTotalAttackTax(state, attackingPlayer, attackers, projected)
+        val totalTax = calculateTotalAttackTax(state, attackers, projected)
         if (totalTax > 0) {
             return pauseForAttackTaxConfirmation(state, attackingPlayer, attackers, totalTax, bands)
         }
@@ -736,78 +732,12 @@ internal class AttackPhaseManager(
     /**
      * Compute the total generic-mana attack tax owed for [attackers] without paying it.
      * Used by [declareAttackers] to decide whether to pause for player confirmation
-     * before tapping any mana.
+     * before tapping any mana. Shared with the AI via [CombatTaxes], which prices a
+     * proposed attack before proposing it.
      */
     internal fun calculateTotalAttackTax(
         state: GameState,
-        attackingPlayer: EntityId,
         attackers: Map<EntityId, EntityId>,
         projected: ProjectedState
-    ): Int {
-        if (attackers.isEmpty()) return 0
-        val attackersPerDefender = mutableMapOf<EntityId, Int>()
-        for ((_, defenderId) in attackers) {
-            val defenderPlayerId = if (state.turnOrder.contains(defenderId)) {
-                defenderId
-            } else {
-                projected.getController(defenderId)
-            }
-            if (defenderPlayerId != null) {
-                attackersPerDefender[defenderPlayerId] = (attackersPerDefender[defenderPlayerId] ?: 0) + 1
-            }
-        }
-
-        var totalGenericTax = 0
-        for ((defenderId, attackerCount) in attackersPerDefender) {
-            val defenderPermanents = projected.getBattlefieldControlledBy(defenderId)
-            for (entityId in defenderPermanents) {
-                val container = state.getEntity(entityId) ?: continue
-                val cardComponent = container.get<CardComponent>() ?: continue
-                val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
-                for (ability in cardDef.staticAbilities) {
-                    if (ability is AttackTax) {
-                        val ctx = com.wingedsheep.engine.handlers.EffectContext(
-                            sourceId = entityId,
-                            controllerId = defenderId,
-                        )
-                        // Gate on the source's state (e.g. Archangel of Tithes — only while untapped).
-                        val condition = ability.condition
-                        if (condition != null && !conditionEvaluator.evaluate(state, condition, ctx)) {
-                            continue
-                        }
-                        val taxPerAttacker = maxOf(0, dynamicAmountEvaluator.evaluate(state, ability.amountPerAttacker, ctx, projected))
-                        totalGenericTax += taxPerAttacker * attackerCount
-                    }
-                }
-            }
-        }
-
-        totalGenericTax += calculatePerCreatureTax(state, attackers.keys, projected)
-        return totalGenericTax
-    }
-
-    /**
-     * Calculate per-creature tax from AttackBlockTaxPerCreatureType floating effects.
-     */
-    private fun calculatePerCreatureTax(
-        state: GameState,
-        creatureIds: Set<EntityId>,
-        projected: ProjectedState
-    ): Int {
-        var totalTax = 0
-        for (creatureId in creatureIds) {
-            for (floatingEffect in state.floatingEffects) {
-                val mod = floatingEffect.effect.modification
-                if (mod !is SerializableModification.AttackBlockTaxPerCreatureType) continue
-                if (creatureId !in floatingEffect.effect.affectedEntities) continue
-
-                val creatureTypeCount = state.getBattlefield().count { entityId ->
-                    projected.isCreature(entityId) && projected.hasSubtype(entityId, mod.creatureType)
-                }
-                val costPerCreature = ManaCost.parse(mod.manaCostPer).cmc
-                totalTax += costPerCreature * creatureTypeCount
-            }
-        }
-        return totalTax
-    }
+    ): Int = CombatTaxes.attackTax(state, cardRegistry, attackers, projected)
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -27,7 +27,6 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
-import com.wingedsheep.sdk.scripting.BlockTax
 import com.wingedsheep.sdk.scripting.BlockerCountLimit
 import com.wingedsheep.sdk.scripting.CanBlockAnyNumber
 import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
@@ -60,7 +59,6 @@ internal class BlockPhaseManager(
     private val manaAbilitySideEffectExecutor: com.wingedsheep.engine.mechanics.mana.ManaAbilitySideEffectExecutor,
 ) {
     private val conditionEvaluator = ConditionEvaluator()
-    private val dynamicAmountEvaluator = DynamicAmountEvaluator()
     private val predicateEvaluator = PredicateEvaluator()
 
     /**
@@ -136,8 +134,7 @@ internal class BlockPhaseManager(
         // player to confirm — same reasoning as attack taxes: don't tap their mana
         // without consent.
         val projected = state.projectedState
-        val totalBlockTax = calculatePerCreatureTax(state, blockers.keys, projected) +
-            calculateBlockTax(state, blockers.keys, projected)
+        val totalBlockTax = CombatTaxes.blockTax(state, cardRegistry, blockers.keys, projected)
         if (totalBlockTax > 0) {
             return pauseForBlockTaxConfirmation(state, blockingPlayer, blockers, totalBlockTax)
         }
@@ -1166,67 +1163,5 @@ internal class BlockPhaseManager(
             state.withPendingDecision(decision).pushContinuation(continuation),
             decision,
         )
-    }
-
-    /**
-     * Calculate per-creature tax from AttackBlockTaxPerCreatureType floating effects.
-     */
-    private fun calculatePerCreatureTax(
-        state: GameState,
-        creatureIds: Set<EntityId>,
-        projected: ProjectedState
-    ): Int {
-        var totalTax = 0
-        for (creatureId in creatureIds) {
-            for (floatingEffect in state.floatingEffects) {
-                val mod = floatingEffect.effect.modification
-                if (mod !is SerializableModification.AttackBlockTaxPerCreatureType) continue
-                if (creatureId !in floatingEffect.effect.affectedEntities) continue
-
-                val creatureTypeCount = state.getBattlefield().count { entityId ->
-                    projected.isCreature(entityId) && projected.hasSubtype(entityId, mod.creatureType)
-                }
-                val costPerCreature = ManaCost.parse(mod.manaCostPer).cmc
-                totalTax += costPerCreature * creatureTypeCount
-            }
-        }
-        return totalTax
-    }
-
-    /**
-     * Calculate the generic-mana block tax from [BlockTax] static abilities (Archangel of Tithes —
-     * "creatures can't block unless their controller pays {1} for each of those creatures").
-     *
-     * Unlike [AttackTax], this is a global restriction: every permanent on the battlefield with a
-     * [BlockTax] ability (whose optional condition holds, e.g. "as long as this creature is
-     * attacking") taxes each declared blocker by its per-blocker amount. Multiple sources stack.
-     */
-    private fun calculateBlockTax(
-        state: GameState,
-        blockerIds: Set<EntityId>,
-        projected: ProjectedState
-    ): Int {
-        if (blockerIds.isEmpty()) return 0
-        var totalTax = 0
-        for (entityId in state.getBattlefield()) {
-            val container = state.getEntity(entityId) ?: continue
-            val cardComponent = container.get<CardComponent>() ?: continue
-            val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
-            for (ability in cardDef.staticAbilities) {
-                if (ability !is BlockTax) continue
-                val controllerId = projected.getController(entityId) ?: continue
-                val ctx = EffectContext(
-                    sourceId = entityId,
-                    controllerId = controllerId,
-                )
-                val condition = ability.condition
-                if (condition != null && !conditionEvaluator.evaluate(state, condition, ctx)) {
-                    continue
-                }
-                val taxPerBlocker = maxOf(0, dynamicAmountEvaluator.evaluate(state, ability.amountPerBlocker, ctx, projected))
-                totalTax += taxPerBlocker * blockerIds.size
-            }
-        }
-        return totalTax
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatTaxes.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatTaxes.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.engine.mechanics.combat
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.ManaSymbol
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AttackTax
+import com.wingedsheep.sdk.scripting.BlockTax
+
+/**
+ * What a proposed attack or block costs in generic mana before it may be declared — Ghostly Prison,
+ * Windborn Muse, Baird, Archangel of Tithes, Whipgrass Entangler.
+ *
+ * The tax is part of the *cost* of the declaration (CR 508.1a / 509.1a), so it is not only
+ * [AttackPhaseManager]'s and [BlockPhaseManager]'s business: anyone deciding whether a declaration
+ * is worth proposing — most importantly the AI, which otherwise proposes attacks it cannot pay for
+ * and then has nothing to do with the payment prompt but decline it — has to be able to price one
+ * first. Hence a public object rather than a private method on each phase manager (which is also
+ * where the per-creature half of it used to live twice, verbatim).
+ *
+ * The tax is monotone in the declared set: dropping a creature never raises it. That is what lets a
+ * caller trim an unaffordable declaration one creature at a time until it can pay.
+ */
+object CombatTaxes {
+
+    private val dynamicAmountEvaluator = DynamicAmountEvaluator()
+    private val conditionEvaluator = ConditionEvaluator()
+
+    /** [total] generic mana, the shape every combat tax is paid in. */
+    fun genericCost(total: Int): ManaCost = ManaCost(List(total) { ManaSymbol.generic(1) })
+
+    /**
+     * The generic-mana tax owed for declaring [attackers] (creature → defender), without paying it.
+     *
+     * [AttackTax] is a per-defender restriction: only permanents controlled by the player being
+     * attacked (or protecting the attacked planeswalker/battle) tax, and only for the attackers
+     * aimed at them.
+     */
+    fun attackTax(
+        state: GameState,
+        cardRegistry: CardRegistry,
+        attackers: Map<EntityId, EntityId>,
+        projected: ProjectedState,
+    ): Int {
+        if (attackers.isEmpty()) return 0
+        val attackersPerDefender = mutableMapOf<EntityId, Int>()
+        for ((_, defenderId) in attackers) {
+            val defenderPlayerId = if (state.turnOrder.contains(defenderId)) {
+                defenderId
+            } else {
+                projected.getController(defenderId)
+            }
+            if (defenderPlayerId != null) {
+                attackersPerDefender[defenderPlayerId] = (attackersPerDefender[defenderPlayerId] ?: 0) + 1
+            }
+        }
+
+        var totalGenericTax = 0
+        for ((defenderId, attackerCount) in attackersPerDefender) {
+            val defenderPermanents = projected.getBattlefieldControlledBy(defenderId)
+            for (entityId in defenderPermanents) {
+                val container = state.getEntity(entityId) ?: continue
+                val cardComponent = container.get<CardComponent>() ?: continue
+                val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
+                for (ability in cardDef.staticAbilities) {
+                    if (ability !is AttackTax) continue
+                    val ctx = EffectContext(sourceId = entityId, controllerId = defenderId)
+                    // Gate on the source's state (e.g. Archangel of Tithes — only while untapped).
+                    val condition = ability.condition
+                    if (condition != null && !conditionEvaluator.evaluate(state, condition, ctx)) {
+                        continue
+                    }
+                    val taxPerAttacker =
+                        maxOf(0, dynamicAmountEvaluator.evaluate(state, ability.amountPerAttacker, ctx, projected))
+                    totalGenericTax += taxPerAttacker * attackerCount
+                }
+            }
+        }
+
+        return totalGenericTax + perCreatureTax(state, attackers.keys, projected)
+    }
+
+    /**
+     * The generic-mana tax owed for declaring [blockerIds] as blockers, without paying it.
+     *
+     * Unlike [AttackTax], [BlockTax] is a global restriction: every permanent on the battlefield
+     * with one (whose optional condition holds, e.g. "as long as this creature is attacking") taxes
+     * each declared blocker by its per-blocker amount. Multiple sources stack.
+     */
+    fun blockTax(
+        state: GameState,
+        cardRegistry: CardRegistry,
+        blockerIds: Set<EntityId>,
+        projected: ProjectedState,
+    ): Int {
+        if (blockerIds.isEmpty()) return 0
+        var totalTax = 0
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val cardComponent = container.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
+            for (ability in cardDef.staticAbilities) {
+                if (ability !is BlockTax) continue
+                val controllerId = projected.getController(entityId) ?: continue
+                val ctx = EffectContext(sourceId = entityId, controllerId = controllerId)
+                val condition = ability.condition
+                if (condition != null && !conditionEvaluator.evaluate(state, condition, ctx)) {
+                    continue
+                }
+                val taxPerBlocker =
+                    maxOf(0, dynamicAmountEvaluator.evaluate(state, ability.amountPerBlocker, ctx, projected))
+                totalTax += taxPerBlocker * blockerIds.size
+            }
+        }
+        return totalTax + perCreatureTax(state, blockerIds, projected)
+    }
+
+    /**
+     * Per-creature tax from `AttackBlockTaxPerCreatureType` floating effects (Whipgrass Entangler —
+     * "creatures can't attack or block unless their controller pays {1} for each creature of the
+     * chosen type"). Taxes attackers and blockers identically, hence one implementation.
+     */
+    private fun perCreatureTax(
+        state: GameState,
+        creatureIds: Set<EntityId>,
+        projected: ProjectedState,
+    ): Int {
+        var totalTax = 0
+        for (creatureId in creatureIds) {
+            for (floatingEffect in state.floatingEffects) {
+                val mod = floatingEffect.effect.modification
+                if (mod !is SerializableModification.AttackBlockTaxPerCreatureType) continue
+                if (creatureId !in floatingEffect.effect.affectedEntities) continue
+
+                val creatureTypeCount = state.getBattlefield().count { entityId ->
+                    projected.isCreature(entityId) && projected.hasSubtype(entityId, mod.creatureType)
+                }
+                val costPerCreature = ManaCost.parse(mod.manaCostPer).cmc
+                totalTax += costPerCreature * creatureTypeCount
+            }
+        }
+        return totalTax
+    }
+}


### PR DESCRIPTION
## The bug

Reported as *"engine AI goes in an infinite loop selecting mana sources."* It is a livelock at
declare-attackers, not a mana bug.

From the attached state: the AI declared seven attackers into Dáin, Lord of the Iron Hills
(`{1}` per attacker → `{7}`). Every one of its lands was tapped, so the engine's
`SelectManaSourcesDecision` arrived with an **empty** `autoPaySuggestion` and `canDecline = true`.
`DecisionResponder` declines that — and declining an attack tax is a *clean no-op*: no attackers
stamped, and the step is still waiting for a declaration. The AI is handed back exactly the
position it just chose from, deterministically chooses the same seven-attacker plan, and the cycle
repeats for ever.

The same shape exists on the blocking side (Archangel of Tithes' block tax).

## The fix

Price the tax **before** proposing the declaration. New `CombatTaxBudget` (`:ai`) trims an attack
or block one creature at a time — cheapest first, never a mandatory one — until the tax is
payable, so the AI proposes a combat it can actually complete.

Its payability oracle deliberately mirrors `CombatTaxContinuationResumer.payTax` (floating mana
first, then the auto-tap solver) rather than `ManaSolver.canPay`: `canPay` counts Treasures and
Springleaf-Drum-style sources, and combat-tax payment refuses both, so trusting it would leave the
AI declaring an attack whose prompt it could still only decline.

Wired in at three points: `CombatSeed` (so rollout playouts stop wasting their action budget the
same way), `CombatAdvisor`'s post-local-search attack plan, and its blocker plan.

Supporting refactor: the tax computation moves out of `AttackPhaseManager` / `BlockPhaseManager`
into a public `CombatTaxes`. The AI has to be able to price a declaration it is deciding whether
to make, and the per-creature half of the calculation was duplicated verbatim across the two phase
managers anyway (net −100 lines there).

## Tests

New `CombatTaxAiTest` (`:ai`), six cases — each verified to fail with the fix disabled:

- declares **no** attackers when the tax is unpayable
- still attacks, and pays, when it can afford the tax
- trims three attackers to the one Forest's worth it can pay for
- a Treasure does **not** count as attack-tax mana (why the oracle is narrower than `canPay`)
- an AI-vs-AI turn against an unpayable tax leaves DECLARE_ATTACKERS instead of spinning
- declares no blockers when the block tax is unpayable

## Verification

`just test-ai`, `just test-rules` (engine + all card scenarios), `just build` — all green.

## Known adjacent gap (not touched)

If a creature is *required* to attack (goad, Taunt) and the tax is unpayable, CR 508.1a says it
isn't able to attack and the requirement should not apply — the engine still enforces the
requirement, so that position has no legal declaration for a human either. The trim never drops a
mandatory attacker, so this PR neither fixes nor worsens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)