### PR TITLE
Assay: the counters band

### DIFF
--- a/docs/plans/oracle-assay.md
+++ b/docs/plans/oracle-assay.md
@@ -190,9 +190,10 @@ is the next work:
 4. `Targets.kt` ✅ "target creature" over a filter. Still to come: "any target", "up to two target…"
 5. `Steps.kt` ✅ draw / destroy / exile / tap / untap / return to hand, one verb over one target;
    ✅ the counted verbs — life gain and loss, scry, surveil, damage (to any target, to a player, to a
-   filtered permanent) and the pump spell with its `until end of turn`.
-   Still to come: sacrifice, mill, discard, counter, counters, tokens, and the *sequence* —
-   two effect sentences in one card, which the differential currently buckets as "lines do not fold"
+   filtered permanent) and the pump spell with its `until end of turn`; ✅ the *sequence*; ✅ **the
+   counter sentences** — "Put a +1/+1 counter on target creature." and the same clause aimed at the
+   source and at the target an earlier clause chose, in both grammatical numbers.
+   Still to come: sacrifice, mill, discard, counter (the verb), removing and moving counters, tokens
 6. `Triggers.kt` ✅ enters / dies / leaves / attacks / blocks / becomes blocked / deals combat damage;
    ✅ the step triggers ("at the beginning of your upkeep", each-player's spelling as an `alternate`).
    Still to come: the other party's triggers ("whenever a creature you control dies"), the spell-cast
@@ -213,8 +214,9 @@ is the next work:
    cost, with the clause after the colon slotting `Steps.step` whole. Still to come: the rest of the
    cost vocabulary (sacrifice, pay life, discard, remove counters), `ActivationRestriction`, and
    "Activate only as a sorcery".
-9. `Replacements.kt` ✅ "~ enters tapped." and the shock-land form. Still to come: the check-land
-   `unlessCondition`, which is the condition family's first customer.
+9. `Replacements.kt` ✅ "~ enters tapped.", the shock-land form, and ✅ "~ enters with two +1/+1
+   counters on it." Still to come: the check-land `unlessCondition` and the kicker entries, which
+   are the same missing piece — a `condition` the rule refuses to drop rather than print without.
 10. `Statics.kt` ✅ the aura band — `Enchant <filter>` (in `Targets`, since the SDK models it as a
     `TargetRequirement` and not as a keyword), "Enchanted creature gets +N/+N.", "Enchanted creature
     has <keyword>.", and the joined "gets +N/+N **and has** <keyword>." which denotes two abilities
@@ -254,6 +256,16 @@ is the next work:
    capitalized, which is exactly the re-spelling that stops `Steps` being slottable. The rule is
    Wizards': of 14,042 `": "` occurrences in the corpus, 32 are followed by a lowercase letter, and
    all 32 are prose enumerations on the "hero's journey" cards rather than ability costs.
+
+**The counters band is the first one chosen by ranking the backlog rather than by picking a set, and
+it settles how to read the ranking.** The token table's top row is a trigger *subject*; the step
+triggers already proved that over-promises, because a line dies on its first unknown token and a
+trigger's real blocker is usually after the comma. The measure that decides work is therefore **cards
+whose line dies at the verb** — everything before it already read — and by that measure counters were
+the largest family in the implemented population: 1,025 cards carry a counter line the grammar could
+not read, and 656 decline on nothing else. A verb is also multiplicative, since `Triggers`, `Activated` and the modal rules all
+slot `Steps.step` whole. Prefix versus verb now has a worked example on each side; read them
+together before picking the next band.
 
 **Acceptance:** POR, LEA and a modern set (DFT or FDN) each report fineness; the per-set whole-render
 rate is directly comparable to `:mtgish-tooling`'s `gN` figure in the coverage dashboard.

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -20,8 +20,12 @@ and those are the two sentences on it. The **aura band** followed: `Enchant <fil
 attached-permanent statics, which opened `staticAbilities` — the largest `CardScript` slot the
 differential could not see into, and the one every later static family lands in.
 
-The most recent is the **Legions band**, and it is the second set read end to end and the first
-*hard* one: `just assay-gate --set LGN` reads **145 of Legions' 145 cards**. Legions is every-card-a-
+The most recent work is the **counters band**, and it is the first one picked by *ranking the
+backlog* rather than by picking a set: `just assay-report --implemented` says 656 cards with a
+hand-written golden decline on nothing but a counter sentence, which is the largest sole-blocked
+family in that population. See [the counters band](#the-counters-band) below.
+
+Before that came the **Legions band**, the second set read end to end and the first *hard* one: `just assay-gate --set LGN` reads **145 of Legions' 145 cards**. Legions is every-card-a-
 creature, so it is a set made almost entirely of the things Portal had none of — morph payoffs,
 tribal lords, granted abilities, amplify, counted variables — and reading all of it took nine new
 families rather than nine new rules. See [the Legions band](#the-legions-band) below.
@@ -127,15 +131,16 @@ non-zero on. Declines are not failures.
 Cards assayed                    34882
 Ability lines                    66793  (38943 unique)
 
-Round-trips byte-exact           22464   336.3‰ (33.6%)
-Alternate spelling normalized    1018
-Declined                         43311
+Round-trips byte-exact           22940   343.4‰ (34.3%)
+Alternate spelling normalized    1114
+Declined                         42739
 Ambiguous — distinct readings    0
 Print mismatch                   0
 Normalization not invertible     0
 Full inverse not reproduced      0
+Redundant readings (same model)  0
 
-Cards fully covered              6157 / 34882   176.5‰ (17.7%)
+Cards fully covered              6335 / 34882   181.6‰ (18.2%)
 Vanilla + keyword-only cards     1444 / 1712   843.5‰ (84.3%)   <- Phase 1 target
 Portal (set POR)                 200 / 200     1000.0‰ (100%)   <- the Portal band's target
 Legions (set LGN)                145 / 145     1000.0‰ (100%)   <- the Legions band's target
@@ -223,6 +228,82 @@ Whole-corpus coverage went from 4,287 cards to 6,157 in the same change, and the
 compared population from 1,636 to 2,387 — which is again the argument for picking a set as the target
 rather than picking the number.
 
+## The counters band
+
+Four sentences — "Put a +1/+1 counter on target creature.", the same clause aimed at the source
+("…on ~.") and at the target an earlier clause chose ("…on it."), and the entry replacement
+"~ enters with two +1/+1 counters on it." Whole-corpus coverage went 6,157 → **6,335 cards**, the
+differential's compared population 2,387 → **2,431**, and its confirmed count 2,383 → **2,425**.
+
+**It is the first band chosen by ranking the backlog rather than by picking a set, and the ranking is
+the part worth reading.** The token table's top row was `you` at 595 implemented cards — a trigger
+*subject*, which the step triggers already proved over-promises: 410 cards declined on "At the
+beginning of…" and adding every prefix moved whole-card coverage by 23, because a line dies on its
+first unknown token and a trigger's real blocker is usually after the comma. So the ranking that
+decides work is **cards whose line dies at the verb**, where everything before it already read, and
+by that measure counters are the largest family in the corpus: **1,025 implemented cards carry a
+counter line the grammar could not read, and 656 of them decline on nothing else**. The verb also multiplies rather than adds —
+`Triggers`, `Activated` and the modal rules all slot `Steps.step` whole, so one clause vocabulary
+arrives in every context already wired. That is the opposite trade from a prefix, and the two
+worked examples now sit either side of it.
+
+**Two leaves, and both of them own a spelling no rule above them can see.** `Primitives.counterKind`
+reads the noun and is gated on `CounterType.fromName` — the SDK's own answer to "is this a counter",
+the same function `StatePredicate.HasCounter` parses with — because the model field is a bare
+`String` and an ungated leaf would read *any* word as a kind and round-trip a counter Magic does not
+have. That is `creatureSubtype`'s argument, and the "Elves" → `Elve` failure it exists to prevent.
+
+The second leaf is the **indefinite article**, and it is inside the leaf for `statModifiers`' reason:
+English picks "a" or "an" from the sound of the next word, so two rules — one per article — would
+leave printing undetermined by the model, which is invariant 2 rather than a preference. It can be
+one leaf because the corpus states the rule without an exception: across all 34,882 Oracle texts
+**no counter kind is ever spelled both ways** — 223 kinds take "a", 38 take "an", disjoint. The
+letter rule predicts all but three ("an hour", "an hourglass", "a unity"), only `hourglass` is a kind
+the SDK names, and `token` re-reads what it writes on every call, so a wrong article could not
+survive a corpus run.
+
+**A two-word kind needed a lookahead, and the reason is a kernel property rather than a grammar
+one.** "first strike" and "double strike" are counter kinds, and a leaf reads exactly *one* regex
+match — `token` does not retry a shorter one when the gate rejects — so a greedy second word swallows
+the template's own "counter" and declines every single-word kind. The noun's pattern therefore spells
+out what it cannot be. Worth knowing before writing any leaf that can span a space.
+
+**The band's real risk was the anaphor, and the machinery for it already existed.** "Put a +1/+1
+counter on it" means the source in "Whenever ~ attacks, put a +1/+1 counter on it" and the *target*
+in "Tap target creature an opponent controls and put a stun counter on it" — both readings round-trip
+byte-perfectly, so nothing but the split could tell them apart. `SelfSteps.putCountersOnSelf` and
+`Continuations.putCountersOnThatPermanent` are reachable from disjoint positions, exactly as
+`SelfSteps.anaphoric` and `Continuations` have been since the differential caught "Untap target
+creature. It gets +2/+4" meaning the wrong creature. This is the second sentence to need both, which
+is the evidence that split generalized rather than patched one card.
+
+**What the gate found: 44 newly-compared cards, 42 of them confirmed, and 2 divergences that are one
+finding.** Landing on top of the divergence sweep is what makes that legible — against a baseline of
+4 the band's own contribution is readable directly, where against 122 it would have been noise.
+
+- **A card says "another" where its text says "an" — 8 cards.** Donatello, Way with Machines and
+  Mm'menon, Uthros Exile both print "Whenever **an** artifact you control enters" and are authored
+  with `binding = OTHER`, which excludes the source. The corpus maps the two spellings correctly
+  almost everywhere — 33 cards print "an" and bind `ANY`, 40 print "another" and bind `OTHER` — so
+  these are the exceptions rather than a convention, and a grep finds six more: Rimefire Torque,
+  Airbender Ascension, Path of Discovery, Gossip's Talent, Death Match and Mana Echoes.
+  **It is unobservable on all eight today**, and saying so is the honest half: every one of them is
+  an enchantment or artifact triggering on a creature entering, so the source can never *be* the
+  entering permanent and the binding never gets to matter. It is latent rather than harmless — an
+  effect that makes Donatello an artifact as it enters is all it takes — and it is **not folded**,
+  because folding would stop the gate noticing the first card where the binding is observable.
+
+That is the whole of it: both new divergences are that one finding, and nothing else the band
+brought into the population disagreed. A third — Invigorating Boon, the "you may on a triggered
+ability" spelling — was divergent when the band was written against the pre-sweep baseline and is
+not any more, because the sweep fixed that family while this was in flight.
+
+**No new bug in a hand-written card**, and that is worth recording beside the aura band's same
+result. Every bug this gate has found — Meteor Golem, Voltaic Construct, Dwarven Miner, Recollect
+and Eternal Witness, and the 22 the sweep turned up — was a clause lost *inside a filter on a longer
+sentence*. A counter sentence is short and has one filter, which is the same reason the auras added
+none: there is very little in it to drop.
+
 ## What Phase 1 already found
 
 The report is two documents at once, and the second one is about `mtg-sdk`:
@@ -267,20 +348,22 @@ named population bucket instead and the denominator stays visible.
 
 ```
   Hand-written cards                 9123
-    compared                         2387
-    not yet covered by the grammar   6104
-    script slot not modelled yet      79
-    lines do not fold into one card   49
+    compared                         2431
+    not yet covered by the grammar   6056
+    script slot not modelled yet      82
+    lines do not fold into one card   50
     multi-face (out of scope)        301
     Oracle text differs from golden  203
     golden would not decode            0
 
-  Confirmed — models agree           2383   998.3‰ (99.8%)
-  DIVERGENT — read every one            4
+  Confirmed — models agree           2425   997.5‰ (99.8%)
+  DIVERGENT — read every one            6
 ```
 
-That 122 → 4 is the **sweep**: every divergence the gate had accumulated was read, classified as
-parser bug / card bug / fold, and acted on. What it found, by kind:
+Four of those six are what the **sweep** left standing, and the other two are the counters band's,
+classified in its own section above. The sweep took the count from 122 to 4: every divergence the
+gate had accumulated was read, classified as parser bug / card bug / fold, and acted on. What it
+found, by kind:
 
 - **A bug in the gate itself, and a flaky one.** `AbilityId.generate()` is a global counter and
   `encodeDefaults` is false, so kotlinx re-evaluates the default to decide whether to emit an `id` —

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Continuations.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Continuations.kt
@@ -109,6 +109,38 @@ object Continuations {
         }
     }
 
+    /**
+     * "…and put a stun counter on it." — the counter verb over the target an earlier clause chose.
+     *
+     * [SelfSteps.putCountersOnSelf] is the identical English about the *source*, and this is the
+     * second sentence to need both readings after "it gets +2/+4". The split costs a rule and buys
+     * the guarantee: "When ~ enters, tap target creature an opponent controls and put a stun counter
+     * on it" stuns the creature it tapped, not the permanent that tapped it, and both readings
+     * round-trip byte-perfectly so nothing else in the module could tell them apart.
+     */
+    private val putCountersOnThatPermanent: List<Phrase<CardScript>> = run {
+        fun scriptFor(kind: String, count: Int) =
+            CardScript(spellEffect = Effects.AddCounters(kind, count, Targets.bound()))
+        fun rule(template: String, name: String, quantity: Phrase<*>?) =
+            phrase(template, name = name) {
+                slot("kind", if (quantity == null) Primitives.singularCounterKind else Primitives.counterKind)
+                if (quantity != null) slot("n", quantity)
+                build { scriptFor(it.value("kind"), if (quantity == null) 1 else it.int("n")) }
+                match { script ->
+                    val (kind, count) =
+                        Steps.countersAdded(script.spellEffect, Targets.bound()) ?: return@match null
+                    if (quantity == null && count != 1) return@match null
+                    if (quantity != null && !(count >= 2 && Cardinals.spellable(count))) return@match null
+                    if (script != scriptFor(kind, count)) return@match null
+                    bind("kind" to kind, "n" to count)
+                }
+            }
+        listOf(
+            rule("put {kind} counter on it", "put a counter on the target", null),
+            rule("put {n} {kind} counters on it", "put counters on the target", Cardinals.word),
+        )
+    }
+
     /** "Its owner gains 4 life." — Path of Peace, referring to the creature the first clause destroyed. */
     private val ownerGainsLife: Phrase<CardScript> = run {
         fun scriptFor(amount: Int) = CardScript(spellEffect = OwnerGainsLifeEffect(amount))
@@ -197,7 +229,7 @@ object Continuations {
         itGets,
         ownerGainsLife,
         drawForEachInHand,
-    )
+    ) + putCountersOnThatPermanent
 
     val clause: Phrase<CardScript> = oneOf("a clause referring to the target", all)
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Primitives.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Primitives.kt
@@ -10,9 +10,12 @@ import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.assay.syntax.separated
 import com.wingedsheep.assay.syntax.token
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.ProtectionScope
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * The leaf rules every other rule is built from. Slots are themselves phrases, recursively, so
@@ -71,6 +74,104 @@ object Primitives {
         sibling < 0 -> "-0"
         else -> "+0"
     }
+
+    /**
+     * A **kind** of counter, as the noun before the word "counter" — "+1/+1", "stun", "first strike".
+     *
+     * ### Gated on the SDK's own list, for [creatureSubtype]'s reason
+     *
+     * The model field is a bare `String`, so an ungated leaf would read *any* lowercase word as a
+     * counter kind and round-trip it perfectly — "put a growing counter on it" naming a counter Magic
+     * does not have, byte-exact in both directions. [CounterType.fromName] is the SDK's own answer to
+     * "is this a counter", the same function `StatePredicate.HasCounter` parses with, so a word it
+     * rejects makes this leaf decline rather than invent a kind. That is the difference between
+     * recovering information and inventing it, and it is why "Elves" → `Elve` could happen here too.
+     *
+     * ### The second word, and why it needs a lookahead
+     *
+     * "first strike" and "double strike" are two-word kinds, and a leaf reads exactly one regex match
+     * — [com.wingedsheep.assay.syntax.token] does not retry a shorter one when the gate rejects. So a
+     * greedy second word would swallow the template's own "counter" on every single-word kind and
+     * decline the lot. The lookahead spells out what the noun cannot be, which costs one clause and
+     * keeps both quantities of every kind readable.
+     */
+    val counterKind: Phrase<String> = token(
+        name = "a counter kind",
+        pattern = Regex("""[+-][0-9]+/[+-][0-9]+|[a-z]+(?: (?!counters?\b)[a-z]+)?"""),
+        read = { it.takeIf(::isCounterKind) },
+        write = { it.takeIf(::isCounterKind) },
+    )
+
+    private fun isCounterKind(name: String) = CounterType.fromName(name) != null
+
+    /**
+     * One counter of a kind, **article included** — "a +1/+1", "an aim", "an hourglass".
+     *
+     * ### Why the article is inside the leaf rather than a literal in the template
+     *
+     * English picks "a" or "an" from the sound of the following word, which no separate slot can see.
+     * Two rules — one spelling "a", one spelling "an" — would leave printing undetermined by the
+     * model, and that is invariant 2 rather than a style preference: `oneOf` would pick the first
+     * that could express the value and the other would be unreachable. One leaf can see both halves,
+     * which is exactly [statModifiers]' argument about the sign of a zero.
+     *
+     * ### The rule is Wizards', and the corpus states it without an exception
+     *
+     * Across all 34,882 Oracle texts **no counter kind is ever spelled both ways**: 223 kinds take
+     * "a", 38 take "an", and the two sets are disjoint. So the article is a total function of the
+     * kind and this leaf can be its inverse. The letter rule predicts all but three of them —
+     * "an hour", "an hourglass" (silent h) and "a unity" (the /juː/ onset) — and only `hourglass` is
+     * a kind the SDK names, so [SILENT_H] is one entry rather than a list that will grow. A kind
+     * whose article this got wrong could not round-trip: `token` re-reads what it writes on every
+     * call, and [read] rejects an article that disagrees with [article].
+     */
+    val singularCounterKind: Phrase<String> = token(
+        name = "a counter kind",
+        pattern = Regex("""an? (?:[+-][0-9]+/[+-][0-9]+|[a-z]+(?: (?!counters?\b)[a-z]+)?)"""),
+        read = { text ->
+            val kind = text.substringAfter(' ')
+            kind.takeIf { isCounterKind(it) && text.substringBefore(' ') == article(it) }
+        },
+        write = { kind -> kind.takeIf(::isCounterKind)?.let { "${article(it)} $it" } },
+    )
+
+    /** Silent-h kinds, which take "an" against the letter rule. Only `hourglass` is an SDK counter. */
+    private val SILENT_H = setOf("hour", "hourglass")
+
+    private fun article(kind: String): String =
+        if (kind in SILENT_H || kind.first() in "aeiou") "an" else "a"
+
+    /**
+     * The same kind as [CounterTypeFilter], which is how `EntersWithCounters` spells it.
+     *
+     * ### One concept, two SDK types — and a `Named` spelling the grammar must never emit
+     *
+     * An effect says which counter it means with a `String`; a replacement effect says it with a
+     * [CounterTypeFilter], whose `Named` case takes that same string. So `PlusOnePlusOne` and
+     * `Named("+1/+1")` are two spellings of one value, and registering both would be genuine
+     * ambiguity with nothing for the printer to choose between. This maps to the dedicated case
+     * wherever the SDK has published one and to `Named` only where it has not — and [counterKindOf],
+     * its inverse, **refuses** a `Named` carrying a name that has a dedicated case, so a card written
+     * the minority way reports as a divergence rather than quietly agreeing.
+     */
+    fun counterFilter(kind: String): CounterTypeFilter =
+        DEDICATED_COUNTER_FILTERS[kind] ?: CounterTypeFilter.Named(kind)
+
+    /** [counterFilter]'s inverse; null where the value is a spelling this grammar does not emit. */
+    fun counterKindOf(filter: CounterTypeFilter): String? = when (filter) {
+        is CounterTypeFilter.Named -> filter.name.takeIf { it !in DEDICATED_COUNTER_FILTERS }
+        else -> DEDICATED_COUNTER_FILTERS.entries.firstOrNull { it.value == filter }?.key
+    }
+
+    private val DEDICATED_COUNTER_FILTERS: Map<String, CounterTypeFilter> = mapOf(
+        Counters.PLUS_ONE_PLUS_ONE to CounterTypeFilter.PlusOnePlusOne,
+        Counters.MINUS_ONE_MINUS_ONE to CounterTypeFilter.MinusOneMinusOne,
+        Counters.PLUS_ONE_PLUS_ZERO to CounterTypeFilter.PlusOnePlusZero,
+        Counters.PLUS_ZERO_PLUS_ONE to CounterTypeFilter.PlusZeroPlusOne,
+        Counters.MINUS_ONE_MINUS_ZERO to CounterTypeFilter.MinusOneMinusZero,
+        Counters.MINUS_ZERO_MINUS_ONE to CounterTypeFilter.MinusZeroMinusOne,
+        Counters.LOYALTY to CounterTypeFilter.Loyalty,
+    )
 
     /**
      * A run of mana symbols — `{2}{U}`, `{W/P}`, `{X}`. Symbols are lexed as tokens and never as

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Replacements.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Replacements.kt
@@ -9,7 +9,9 @@ import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.sdk.scripting.ChoiceType
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.ReplacementEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * "This land enters tapped." — the self-replacements a permanent applies to its own entry.
@@ -80,11 +82,62 @@ object Replacements {
     private fun entersWithChoice(noun: String, choice: ChoiceType): Phrase<ReplacementEffect> =
         constant("as ${Normalizer.SELF} enters, choose $noun.", EntersWithChoice(choice))
 
+    /**
+     * "~ enters with a +1/+1 counter on it.", "~ enters with three -1/-1 counters on it."
+     *
+     * ### Why `selfOnly` is spelled by the rule and not by a slot
+     *
+     * `EntersWithCounters` models both "this permanent enters with counters" and Hardened Scales'
+     * "creatures you control enter with an extra counter" — the second is what its `appliesTo`
+     * default describes, so the *self* reading is the one the flag has to state. The sentence says
+     * "~ enters", naming the source and nothing else, so `selfOnly = true` is what this English
+     * means; a value with `otherOnly`, a `condition` or a non-default `appliesTo` is a different
+     * sentence and the reconstruct-and-compare refuses to print it. That last one matters here:
+     * the kicker cards ("If ~ was kicked, it enters with two +1/+1 counters on it") carry a
+     * `condition` and decline rather than losing the clause that makes them worth playing.
+     *
+     * ### The counter kind is a [CounterTypeFilter] here and a `String` on every effect
+     *
+     * Two SDK types for one concept, and `CounterTypeFilter.Named` can hold the same string the
+     * dedicated cases do — so the grammar emits exactly one of the two spellings and reports the
+     * other. [Primitives.counterFilter] and its inverse own that choice; the note is there.
+     */
+    private val entersWithCounters: List<Phrase<ReplacementEffect>> = run {
+        fun effectFor(kind: String, count: Int): ReplacementEffect = EntersWithCounters(
+            counterType = Primitives.counterFilter(kind),
+            count = count,
+            selfOnly = true,
+        )
+        fun rule(template: String, name: String, quantity: Phrase<*>?) =
+            phrase(template, name = name) {
+                slot("self", Primitives.self)
+                slot("kind", if (quantity == null) Primitives.singularCounterKind else Primitives.counterKind)
+                if (quantity != null) slot("n", quantity)
+                build { effectFor(it.value("kind"), if (quantity == null) 1 else it.int("n")) }
+                match { effect ->
+                    val enters = effect as? EntersWithCounters ?: return@match null
+                    val kind = Primitives.counterKindOf(enters.counterType) ?: return@match null
+                    if (quantity == null && enters.count != 1) return@match null
+                    if (quantity != null && !(enters.count >= 2 && Cardinals.spellable(enters.count))) {
+                        return@match null
+                    }
+                    if (enters != effectFor(kind, enters.count)) return@match null
+                    bind("self" to Unit, "kind" to kind, "n" to enters.count)
+                }
+            }
+        listOf(
+            rule("{self} enters with {kind} counter on it.", "enters with a counter", null),
+            rule("{self} enters with {n} {kind} counters on it.", "enters with counters", Cardinals.word),
+        )
+    }
+
     val replacement: Phrase<ReplacementEffect> = oneOf(
         "a replacement effect",
-        entersTapped,
-        shockLand,
-        entersWithChoice("a color", ChoiceType.COLOR),
-        entersWithChoice("a creature type", ChoiceType.CREATURE_TYPE),
+        listOf(
+            entersTapped,
+            shockLand,
+            entersWithChoice("a color", ChoiceType.COLOR),
+            entersWithChoice("a creature type", ChoiceType.CREATURE_TYPE),
+        ) + entersWithCounters,
     )
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/SelfSteps.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/SelfSteps.kt
@@ -48,6 +48,45 @@ object SelfSteps {
      * the pronoun come back as a [com.wingedsheep.assay.gate.LineVerdict.VARIANT], which says the
      * reading was right and only the spelling moved.
      */
+    /**
+     * "Put a +1/+1 counter on ~.", "Put two +1/+1 counters on it." — the counter verb aimed at the
+     * source, and the single commonest effect shape in the whole hand-written corpus: 363 of the
+     * 951 `AddCounters` a golden carries are exactly this one.
+     *
+     * The subject is [Primitives.self], so both spellings read and the name is what prints, the same
+     * treatment [selfGets] gets. Being in [anaphoric] is what makes the pronoun safe: [Steps] drops
+     * this whole list from every position after the first in a sequence, so once a clause has
+     * introduced a target, "on it" is [Continuations]' to read and means that target. Registering the
+     * pronoun in both places would be two readings of one text — the bug the differential caught on
+     * "Untap target creature. It gets +2/+4", in a sentence where it would be just as invisible.
+     *
+     * Singular and plural are two rules over disjoint quantities for [Steps]' reason; everything
+     * about why is written there, on the targeted twin of this pair.
+     */
+    private val putCountersOnSelf: List<Phrase<CardScript>> = run {
+        fun scriptFor(kind: String, count: Int) =
+            CardScript(spellEffect = Effects.AddCounters(kind, count, EffectTarget.Self))
+        fun rule(template: String, name: String, quantity: Phrase<*>?) =
+            phrase(template, name = name) {
+                slot("kind", if (quantity == null) Primitives.singularCounterKind else Primitives.counterKind)
+                if (quantity != null) slot("n", quantity)
+                slot("self", Primitives.self)
+                build { scriptFor(it.value("kind"), if (quantity == null) 1 else it.int("n")) }
+                match { script ->
+                    val (kind, count) =
+                        Steps.countersAdded(script.spellEffect, EffectTarget.Self) ?: return@match null
+                    if (quantity == null && count != 1) return@match null
+                    if (quantity != null && !(count >= 2 && Cardinals.spellable(count))) return@match null
+                    if (script != scriptFor(kind, count)) return@match null
+                    bind("kind" to kind, "n" to count, "self" to Unit)
+                }
+            }
+        listOf(
+            rule("put {kind} counter on {self}", "put a counter on the source", null),
+            rule("put {n} {kind} counters on {self}", "put counters on the source", Cardinals.word),
+        )
+    }
+
     private val selfGets: Phrase<CardScript> = run {
         fun scriptFor(modifiers: Pair<Int, Int>) = CardScript(
             spellEffect = Effects.ModifyStats(modifiers.first, modifiers.second, EffectTarget.Self)
@@ -329,7 +368,7 @@ object SelfSteps {
             "sacrifice it unless you sacrifice {filter}",
             "sacrifice the source unless you sacrifice",
         ) { Costs.pay.Sacrifice(it) },
-    )
+    ) + putCountersOnSelf
 
     /** Everything in this file that does not turn on the pronoun. Empty for now; the family is "it". */
     val clauses: List<Phrase<CardScript>> = emptyList()

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Steps.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Steps.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.sdk.dsl.Targets as SdkTargets
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
@@ -638,6 +639,53 @@ object Steps {
                 bind("filter" to filter, "mod" to modifiers)
             }
         }
+    }
+
+    /**
+     * "Put a +1/+1 counter on target creature.", "Put two -1/-1 counters on target Sliver you
+     * control." — the counter verb over a noun phrase this clause chooses.
+     *
+     * ### Two rules for one verb, because English has two quantities
+     *
+     * The singular carries no number at all — its quantity *is* the article, which
+     * [Primitives.singularCounterKind] owns — and the plural takes [Cardinals.word], which starts at
+     * two. Disjoint domains, so one printed form per model and nothing for the printer to choose:
+     * the same split [drawOne] and [drawMany] are, for the same reason, and the reason neither may
+     * borrow the other's leaf.
+     *
+     * The count is a **word** here and a numeral in [damageToTargetPermanent] two rules up. That is
+     * not an inconsistency to tidy: Oracle spells a quantity of counters as a word ("put two +1/+1
+     * counters") and a quantity of damage or life as a numeral ("deals 2 damage"), and the two
+     * conventions live in the same sentence often enough that a rule using the wrong one would fail
+     * to read the cards it was written for.
+     */
+    private val putCountersOnTargetPermanent: List<Phrase<CardScript>> = run {
+        fun scriptFor(kind: String, count: Int, filter: GameObjectFilter) = CardScript(
+            spellEffect = Effects.AddCounters(kind, count, Targets.bound()),
+            targetRequirements = listOf(Targets.permanent(filter)),
+        )
+        fun rule(template: String, name: String, quantity: Phrase<*>?) =
+            phrase(template, name = name) {
+                slot("kind", if (quantity == null) Primitives.singularCounterKind else Primitives.counterKind)
+                if (quantity != null) slot("n", quantity)
+                slot("filter", Filters.filter)
+                build {
+                    scriptFor(it.value("kind"), if (quantity == null) 1 else it.int("n"), it.value("filter"))
+                }
+                match { script ->
+                    val (kind, count) = countersAdded(script.spellEffect, Targets.bound()) ?: return@match null
+                    if (quantity == null && count != 1) return@match null
+                    if (quantity != null && !(count >= 2 && Cardinals.spellable(count))) return@match null
+                    val requirement = script.targetRequirements.singleOrNull() ?: return@match null
+                    val filter = Targets.permanentFilter(requirement) ?: return@match null
+                    if (script != scriptFor(kind, count, filter)) return@match null
+                    bind("kind" to kind, "n" to count, "filter" to filter)
+                }
+            }
+        listOf(
+            rule("put {kind} counter on target {filter}", "put a counter on a target", null),
+            rule("put {n} {kind} counters on target {filter}", "put counters on a target", Cardinals.word),
+        )
     }
 
     /** "Target creature gains flying until end of turn." — the pump rule's keyword sibling. */
@@ -1440,6 +1488,7 @@ object Steps {
             pumpTargetPermanent +
             grantToTargetPermanent +
             pumpAndGrantTarget +
+            putCountersOnTargetPermanent +
             permanentSteps +
             groupSteps +
             drawForEach +
@@ -1762,6 +1811,21 @@ object Steps {
     internal fun lifeLost(effect: Effect): Int? = (effect as? LoseLifeEffect)?.amount?.fixed()
 
     internal fun damageDealt(effect: Effect): Int? = (effect as? DealDamageEffect)?.amount?.fixed()
+
+    /**
+     * The kind and the count an `AddCounters` effect carries, aimed at [target].
+     *
+     * The target is checked *here* rather than by the caller because it is what tells the three
+     * counter sentences apart — the source's own ("put a +1/+1 counter on ~"), the spell's chosen
+     * one ("…on target creature") and the one an earlier clause chose ("…on it"). All three build
+     * the same effect with a different [EffectTarget], so a reader that ignored it would let each
+     * rule print the others' sentence.
+     */
+    internal fun countersAdded(effect: Effect?, target: EffectTarget): Pair<String, Int>? {
+        val add = effect as? AddCountersEffect ?: return null
+        if (add.target != target) return null
+        return add.counterType to add.count
+    }
 
     /** The two fixed bonuses a `ModifyStats` effect carries, or null for a dynamic one. */
     internal fun fixedModifiers(effect: Effect?): Pair<Int, Int>? {

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/CountersTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/CountersTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.assay.syntax.parseLine
+import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The counter sentences — "Put a +1/+1 counter on target creature.", "…on ~.", "…on it.", and
+ * "~ enters with two +1/+1 counters on it."
+ *
+ * The interesting assertions here are the ones about what *refuses* to read or print: the three
+ * sentences differ only in who the counter lands on, and all three round-trip byte-perfectly under
+ * the wrong reading, which is the class only this kind of test and the differential can see.
+ */
+class CountersTest : StringSpec({
+
+    fun fragment(line: String): CardFragment =
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Accepted<CardFragment>>().value
+
+    fun roundTrips(line: String) {
+        Grammar.abilityLine.printLine(fragment(line)) shouldBe line
+    }
+
+    fun declines(line: String) {
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+
+    "the singular sentence carries its quantity in the article" {
+        fragment("Put a +1/+1 counter on target creature.").script.spellEffect shouldBe
+            AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, Targets.bound())
+        roundTrips("Put a +1/+1 counter on target creature.")
+    }
+
+    "the plural sentence spells its count as a word" {
+        fragment("Put two -1/-1 counters on target creature you control.").script.spellEffect shouldBe
+            AddCountersEffect(Counters.MINUS_ONE_MINUS_ONE, 2, Targets.bound())
+        roundTrips("Put two -1/-1 counters on target creature you control.")
+        roundTrips("Put three +1/+1 counters on target Sliver creature.")
+    }
+
+    // The commonest effect shape in the whole hand-written corpus: 363 of the 951 AddCounters a
+    // golden carries are this one.
+    "a counter on the source names the source and not a target" {
+        fragment("Put a +1/+1 counter on ~.").script shouldBe
+            CardScript(spellEffect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self))
+        roundTrips("Put a +1/+1 counter on ~.")
+        roundTrips("Put two +1/+1 counters on ~.")
+    }
+
+    // The two anaphors. "It" is the source in a first clause and the target once a clause has chosen
+    // one, and both readings round-trip byte-perfectly — which is exactly why they are two
+    // vocabularies reachable from disjoint positions rather than one rule.
+    "\"on it\" is the source in a first clause and the chosen target in a later one" {
+        fragment("Put a +1/+1 counter on it.").script.spellEffect shouldBe
+            AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+
+        // The counter lands on the creature the first clause untapped, never on the source.
+        val sequence = fragment("Untap target creature. Put a +1/+1 counter on it.")
+        val steps = (sequence.script.spellEffect as CompositeEffect).effects
+        steps.last() shouldBe AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, Targets.bound())
+        (steps.last() == AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)) shouldBe false
+        roundTrips("Untap target creature. Put a +1/+1 counter on it.")
+    }
+
+    "the entry replacement reads both quantities" {
+        fragment("~ enters with a +1/+1 counter on it.").script.replacementEffects shouldBe
+            listOf(EntersWithCounters(CounterTypeFilter.PlusOnePlusOne, 1, selfOnly = true))
+        roundTrips("~ enters with a +1/+1 counter on it.")
+        roundTrips("~ enters with three -1/-1 counters on it.")
+    }
+
+    // Gnarlid Colony and the other kicker creatures. The condition is the clause that makes the card
+    // worth playing, and a rule that printed the value without it would be byte-perfect and wrong.
+    "an entry replacement carrying a condition refuses to print rather than dropping it" {
+        val kicked = CardFragment(
+            script = CardScript(
+                replacementEffects = listOf(
+                    EntersWithCounters(CounterTypeFilter.PlusOnePlusOne, 2, selfOnly = true, condition = WasKicked)
+                )
+            )
+        )
+        Grammar.abilityLine.printLine(kicked) shouldBe null
+    }
+
+    // Hardened Scales' shape: the same type with selfOnly false says something about *other*
+    // permanents, and this sentence names the source.
+    "an entry replacement that is not about the source refuses to print" {
+        val others = CardFragment(
+            script = CardScript(
+                replacementEffects = listOf(EntersWithCounters(CounterTypeFilter.PlusOnePlusOne, 1))
+            )
+        )
+        Grammar.abilityLine.printLine(others) shouldBe null
+    }
+
+    // The leaf is gated on the SDK's own list for creatureSubtype's reason: an ungated one would
+    // read any lowercase word as a counter kind and round-trip a counter Magic does not have.
+    "a word the SDK does not name as a counter is not a counter kind" {
+        CounterType.fromName("growing") shouldBe null
+        declines("Put a growing counter on target creature.")
+    }
+
+    "the two-word kinds read despite the leaf taking a single regex match" {
+        fragment("Put a first strike counter on target creature.").script.spellEffect shouldBe
+            AddCountersEffect(Counters.FIRST_STRIKE, 1, Targets.bound())
+        roundTrips("Put a first strike counter on target creature.")
+    }
+
+    // No counter kind in all 34,882 Oracle texts is ever spelled both ways, so the article is a
+    // total function of the kind and the leaf can be its inverse. "an hourglass" is the silent-h
+    // case the letter rule alone would get wrong.
+    "the indefinite article follows the kind, silent h included" {
+        roundTrips("Put an aim counter on target creature.")
+        roundTrips("Put an hourglass counter on target creature.")
+        roundTrips("Put a stun counter on target creature.")
+        declines("Put an stun counter on target creature.")
+        declines("Put a aim counter on target creature.")
+    }
+
+    // CounterTypeFilter.Named can hold the same string the dedicated cases do, so the two are one
+    // value written twice. The grammar emits one and refuses to print the other, which is what keeps
+    // a card written the minority way reporting as a divergence instead of quietly agreeing.
+    "the Named spelling of a kind that has a dedicated case never prints" {
+        Primitives.counterFilter(Counters.PLUS_ONE_PLUS_ONE) shouldBe CounterTypeFilter.PlusOnePlusOne
+        Primitives.counterKindOf(CounterTypeFilter.Named(Counters.PLUS_ONE_PLUS_ONE)) shouldBe null
+        Primitives.counterKindOf(CounterTypeFilter.Named(Counters.STUN)) shouldBe Counters.STUN
+
+        val named = CardFragment(
+            script = CardScript(
+                replacementEffects = listOf(
+                    EntersWithCounters(CounterTypeFilter.Named(Counters.PLUS_ONE_PLUS_ONE), 1, selfOnly = true)
+                )
+            )
+        )
+        Grammar.abilityLine.printLine(named) shouldBe null
+    }
+})


### PR DESCRIPTION
The first band chosen by **ranking the backlog** rather than by picking a set — and the ranking is
the part worth reading.

`assay-report --implemented`'s top row by dead token is `you` at 595 cards: a trigger *subject*. The
step triggers already proved that over-promises — 410 cards declined on "At the beginning of…" and
adding every prefix moved whole-card coverage by **23**, because a line dies on its first unknown
token and a trigger's real blocker is usually after the comma. So the measure that decides work is
**cards whose line dies at the verb**, where everything before it already read. By that measure
counters were the largest family in the implemented population: **1,025 cards carry a counter line
the grammar could not read, and 656 of them decline on nothing else.** A verb is also multiplicative
— `Triggers`, `Activated` and the modal rules all slot `Steps.step` whole — where a prefix is merely
additive. Prefix versus verb now has a worked example on each side.

## What's in it

Four sentences:

- `Put a +1/+1 counter on target creature.` (`Steps`)
- the same clause aimed at the source, `…on ~.` (`SelfSteps`)
- and at the target an earlier clause chose, `…on it.` (`Continuations`)
- `~ enters with two +1/+1 counters on it.` (`Replacements`)

each in both grammatical numbers, over any counter kind the SDK names.

## Numbers

Rebased onto `main` after the divergence sweep, so these are measured against
37a7815a58 rather than against the pre-sweep baseline:

| | main | this branch |
|---|---|---|
| Cards fully covered (whole corpus) | 6,157 | **6,335** |
| Round-trips byte-exact | 22,464 | **22,940** |
| Differential: compared | 2,387 | **2,431** |
| Differential: confirmed | 2,383 | **2,425** |
| Differential: divergent | 4 | **6** |

44 newly-compared cards, **42 of them confirmed**, and the 2 divergences are one finding.

`MISMATCH`, `AMBIGUOUS`, non-invertible normalizations and redundant readings are **all still 0**.
POR still reads 200/200 and LGN 145/145. `:oracle-assay:test` green, including 11 new tests in
`CountersTest`.

## Two leaves, each owning a spelling no rule above it can see

**`counterKind` is gated on `CounterType.fromName`** — the SDK's own answer to "is this a counter",
the same function `StatePredicate.HasCounter` parses with. The model field is a bare `String`, so an
ungated leaf would read any lowercase word as a kind and round-trip a counter Magic does not have.
That is `creatureSubtype`'s argument and the "Elves" → `Elve` failure it exists to prevent.

**The indefinite article is inside the leaf**, for `statModifiers`' reason: English picks "a" or "an"
from the sound of the next word, so two rules — one per article — would leave printing undetermined
by the model, which is invariant 2 rather than a preference. It can be one leaf because the corpus
states the rule without an exception: across all 34,882 Oracle texts **no counter kind is ever
spelled both ways** — 223 kinds take "a", 38 take "an", disjoint. The letter rule predicts all but
three ("an hour", "an hourglass", "a unity"); only `hourglass` is a kind the SDK names.

A two-word kind ("first strike") needed a **lookahead** rather than a greedy second word, and the
reason is a kernel property: a leaf reads exactly one regex match and `token` does not retry a
shorter one when the gate rejects, so greed swallows the template's own "counter" and declines every
single-word kind. Worth knowing before writing any leaf that can span a space.

## The anaphor needed no new machinery

"Put a +1/+1 counter on it" means the source in "Whenever ~ attacks, …" and the *target* in "Tap
target creature an opponent controls and put a stun counter on it". Both readings round-trip
byte-perfectly, so nothing but the split could tell them apart. `SelfSteps` and `Continuations` are
already reachable from disjoint positions — this is the **second** sentence to need that split, which
is the evidence it generalized rather than patched one card.

## What the gate found — both divergences are one finding

**Eight cards say "another" where their text says "an."** Donatello, Way with Machines and
Mm'menon, Uthros Exile both print "Whenever **an** artifact you control enters" and are authored
with `binding = OTHER`, which excludes the source. The corpus maps the two spellings correctly
almost everywhere — 33 cards print "an" and bind `ANY`, 40 print "another" and bind `OTHER` — and a
grep finds six more: Rimefire Torque, Airbender Ascension, Path of Discovery, Gossip's Talent,
Death Match, Mana Echoes.

**It is unobservable on all eight today**, and saying so is the honest half: every one is an
enchantment or artifact triggering on a creature entering, so the source can never *be* the entering
permanent. Latent rather than harmless — an effect that makes Donatello an artifact as it enters is
all it takes — and **not folded**, because folding would stop the gate noticing the first card where
the binding is observable. No card fixes here; that wants its own change with the scenario test, same
as Flamewave Invoker.

**No new bug in a hand-written card**, which is the aura band's result and for the same reason: every
bug this gate has found — Meteor Golem, Voltaic Construct, Dwarven Miner, Recollect, Eternal Witness,
and the 22 the sweep turned up — was a clause lost *inside a filter on a longer sentence*, and a
counter sentence has little to drop.

## Landing on the sweep is what makes those two legible

This was written against the pre-sweep baseline, where it read as +3 divergences against 122. Rebased
onto the sweep it reads as +2 against 4, which is the number that can actually be reasoned about —
and the third divergence, Invigorating Boon, is simply gone: it was the "you may on a triggered
ability" spelling (`optional` versus a wrapping `MayEffect`), and the sweep fixed that family while
this was in flight.

## Verification

```
just assay-gate            # exit 0; MISMATCH/AMBIGUOUS/non-invertible/redundant all 0
just assay-gate --set POR  # 200 / 200
just assay-gate --set LGN  # 145 / 145
just assay-differential    # 2431 compared, 2425 confirmed, 6 divergent (all classified)
:oracle-assay:test         # green
```

Docs updated in the same change: `oracle-assay/README.md` (the band, the numbers, the findings, and
the differential population block) and `docs/plans/oracle-assay.md` (Phase 2's checklist, plus the
prefix-versus-verb ranking lesson). No `mtg-sdk` change, so `docs/card-sdk-language-reference.md` is
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)