### PR TITLE
Collapse `TriggeredAbility.optional` into the consent gate it already built

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3945,20 +3945,37 @@ table because the prompt looks identical. Rather than mis-place the gate silentl
 throws, and `EffectOncePerTurnLoweringTest` sweeps every card in the pool for the shape so the
 failure lands at build time rather than mid-game.
 
-**`optional` = "you may [effect]"; `elseEffect` adds "If you don't, [elseEffect]."** For a
-**targeted** trigger, `optional` lets the player choose 0 targets to decline, and `elseEffect` runs
-on decline or when no legal targets exist (Entrails Feaster: "you may exile a creature card from a
-graveyard … if you don't, tap this"). A **no-target** optional trigger lowers to a
-`GatedEffect(Gate.MayDecide, then = effect, otherwise = elseEffect)` resolved by the unified gated
-executor — a resolution-time yes/no whose "no" runs `elseEffect` (or nothing when there is none,
-e.g. Song of Stupefaction's "you may mill two cards"); the wrap is skipped when `effect` already
-carries its own consent gate (a `May*`-gated `GatedEffect`), so an authored `Effects.May` never
-double-prompts. The may-action's feasibility is
-derived from `effect` (a `SacrificeEffect` needs the controller to control a matching permanent), so
-an impossible "may" skips the prompt and runs `elseEffect` directly — the no-target analogue of "no
-legal targets → else" (Yawgmoth Demon: "you may sacrifice an artifact. If you don't, tap this
-creature and it deals 2 damage to you" — with no artifact the tax just applies). Always-feasible
-bodies (gain life, draw, add a counter) always prompt.
+**`optional` = "you may [effect]" — a DSL shorthand, not a field on the model.** `build()` lowers it
+to `MayEffect(effect, otherwise = elseEffect)`, i.e. a `GatedEffect(Gate.MayDecide, …)` around the
+effect, and clears `elseEffect`. `TriggeredAbility` has **no** `optional` flag: it had one, the
+engine read it and constructed exactly this gate before the ability reached the stack, and two
+spellings of one fact meant a card could be written either way and a differential fold had to bridge
+them. Writing `MayEffect(...)` by hand is equivalent and is the only option outside the DSL
+(`TriggeredAbility.create` takes no `optional`). Setting `optional = true` on an effect that already
+owns a consent gate is rejected at build time rather than prompting twice.
+
+What that gets you, uniformly, for targeted and untargeted triggers alike:
+
+- **The yes/no is its own decision.** For a **no-target** trigger the unified gated executor asks it
+  at resolution and runs the gate's `otherwise` on "no" (or nothing when there is none, e.g. Song of
+  Stupefaction's "you may mill two cards"). For a **targeted** trigger `TriggerProcessor` asks it as
+  the ability goes on the stack and only then selects targets, so declining never costs you a target
+  choice first — and the trigger becomes eligible for batching and for a remembered auto-answer, both
+  of which key on the gate.
+- **Targets follow CR 603.3d.** A slot's minimum is the *requirement's*: "target creature" stays
+  mandatory and the ability is removed from the stack when nothing is legal. "Up to one target
+  creature" is an optional **requirement** (`TargetCreature(optional = true)`), which is a different
+  statement and now has a different spelling.
+- **`elseEffect` keeps its own meaning.** On a mandatory ability it is still the branch for target
+  selection producing nothing. A "you may … If you don't, …" ability carries that clause inside the
+  gate; the no-legal-target path reads it from there too, so Entrails Feaster ("you may exile a
+  creature card from a graveyard … if you don't, tap this") still taps with every graveyard empty.
+- **Feasibility is derived, never authored.** `TriggerProcessor` stamps it onto a no-target
+  `Gate.MayDecide` from the effect — a `SacrificeEffect` needs the controller to control a matching
+  permanent — so an impossible "may" skips the prompt and runs the else directly (Yawgmoth Demon:
+  "you may sacrifice an artifact. If you don't, tap this creature and it deals 2 damage to you" —
+  with no artifact the tax just applies). A gate that states its own `feasibility` keeps it.
+  Always-feasible bodies (gain life, draw, add a counter) always prompt.
 
 ### Zone change
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -20,6 +20,8 @@ import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.ManaExpiry
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.ownsConsentGate
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.Mode
 import com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect
@@ -1474,6 +1476,24 @@ class TriggeredAbilityBuilder {
 
     var effect: Effect? = null
     var target: TargetRequirement? = null
+
+    /**
+     * `you may …` — authoring shorthand for wrapping [effect] in a [Gate.MayDecide].
+     *
+     * **The model has no `optional` flag; [build] lowers this one.** `TriggeredAbility.optional`
+     * used to exist beside the gate and the engine read it and built the gate anyway, so the two
+     * spellings were one fact and a card could be written either way. The shorthand survives because
+     * `optional = true` beside `effect = Effects.Destroy(…)` reads better than nesting the effect,
+     * but it produces exactly one model: `MayEffect(effect, otherwise = elseEffect)`.
+     *
+     * Consequences of it being a lowering rather than a flag:
+     *
+     *  - [elseEffect] moves *inside* the gate, becoming the branch taken when the controller
+     *    declines. That is where a "you may … If you don't, …" ability's else belongs; the field
+     *    itself stays for the announcement-time decline (see [TriggeredAbility.elseEffect]).
+     *  - Setting this on an effect that already owns a consent gate is rejected here rather than
+     *    silently double-prompting.
+     */
     var optional: Boolean = false
     var elseEffect: Effect? = null
     /**
@@ -1530,7 +1550,12 @@ class TriggeredAbilityBuilder {
     }
 
     fun build(): TriggeredAbility {
-        requireNotNull(effect) { "Triggered ability must have an effect" }
+        val declared = requireNotNull(effect) { "Triggered ability must have an effect" }
+        require(!optional || !declared.ownsConsentGate()) {
+            "Triggered ability sets optional = true on an effect that already asks — the lowering " +
+                "would wrap a second 'you may' around it and prompt twice. Drop one of them. " +
+                "Effect: $declared"
+        }
         val allTargets = if (namedTargets.isNotEmpty()) {
             namedTargets.map { it.second }
         } else {
@@ -1541,11 +1566,10 @@ class TriggeredAbilityBuilder {
         return TriggeredAbility.create(
             trigger = trigger.event,
             binding = trigger.binding,
-            effect = effect!!,
-            optional = optional,
+            effect = if (optional) MayEffect(declared, otherwise = elseEffect) else declared,
             targetRequirement = primaryTarget,
             additionalTargetRequirements = additionalTargets,
-            elseEffect = elseEffect,
+            elseEffect = if (optional) null else elseEffect,
             activeZones = triggerZones,
             triggerCondition = triggerCondition,
             controlledByTriggeringEntityController = controlledByTriggeringEntityController,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/FlurryDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/FlurryDsl.kt
@@ -26,8 +26,9 @@ fun CardBuilder.flurry(init: TriggeredAbilityBuilder.() -> Unit) {
     builder.init()
     builder.trigger = Triggers.NthSpellCast(2, Player.You)
     val ability = builder.build()
+    // No "you may " prefix to add: `optional = true` has already been lowered into a consent gate,
+    // and a gated effect's own description opens with "You may …".
     val effectText = (builder.description ?: buildString {
-        if (ability.optional) append("you may ")
         ability.targetRequirement?.let { append(it.description); append(" ") }
         append(ability.effect.description.replaceFirstChar { it.lowercase() })
         ability.elseEffect?.let {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SoulbondDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/SoulbondDsl.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggeredAbility
 import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.references.Player
 
 /**
@@ -33,7 +34,7 @@ import com.wingedsheep.sdk.scripting.references.Player
  * - **Another creature you control enters.** [Triggers.OtherCreatureEnters] already carries the
  *   "another creature **you control**" half of the intervening-if, and a creature that just entered
  *   can never already be paired, so the only clause left to check is that *this* creature is
- *   unpaired — [Conditions.SourceIsUnpaired] as the `triggerCondition`. `optional = true` supplies
+ *   unpaired — [Conditions.SourceIsUnpaired] as the `triggerCondition`. A [MayEffect] supplies
  *   the "you may" as a plain yes/no, which reads better than a one-candidate selection.
  *
  * The "for as long as both remain creatures on the battlefield under your control" duration is not
@@ -80,11 +81,12 @@ fun CardBuilder.soulbond() {
         TriggeredAbility.create(
             trigger = Triggers.OtherCreatureEnters.event,
             binding = Triggers.OtherCreatureEnters.binding,
-            effect = Effects.Pipeline {
-                val partner = gather(CardSource.TriggeringEntity)
-                pairWithSource(partner)
-            },
-            optional = true,
+            effect = MayEffect(
+                Effects.Pipeline {
+                    val partner = gather(CardSource.TriggeringEntity)
+                    pairWithSource(partner)
+                }
+            ),
             triggerCondition = Conditions.SourceIsUnpaired,
             descriptionOverride = "You may pair that creature with this creature"
         )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TriggeredAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TriggeredAbility.kt
@@ -22,11 +22,28 @@ data class TriggeredAbility(
     val id: AbilityId,
     val trigger: EventPattern,
     val binding: TriggerBinding = TriggerBinding.SELF,
+    /**
+     * What the ability does.
+     *
+     * **A printed "you may" lives here, as a [com.wingedsheep.sdk.scripting.effects.Gate.MayDecide]
+     * around the effect** — there is no `optional` flag beside it. There used to be one, and it was
+     * the same fact written twice: the engine read it and *built* this gate before the ability
+     * reached the stack, so every game lowered one spelling into the other. The DSL still writes
+     * `optional = true` (see `TriggeredAbilityBuilder.optional`); that is a shorthand the builder
+     * lowers, not a second field on the model.
+     */
     val effect: Effect,
-    val optional: Boolean = false,
     val targetRequirement: TargetRequirement? = null,
     /** Additional target requirements for multi-target triggered abilities (e.g., exchange control). */
     val additionalTargetRequirements: List<TargetRequirement> = emptyList(),
+    /**
+     * The branch taken when target selection produces nothing — a declined "up to N" slot, or a
+     * mandatory slot with no legal target (CR 603.3d).
+     *
+     * Not the same position as a consent gate's `otherwise`, which is the branch taken when the
+     * controller *declines* at resolution. A "you may … If you don't, …" ability carries its else
+     * inside the gate; this field is the announcement-time one.
+     */
     val elseEffect: Effect? = null,
     /**
      * The zones this ability's trigger condition functions in (CR 113.6b — "an ability that states
@@ -112,7 +129,6 @@ data class TriggeredAbility(
                 append(", ")
                 append(triggerCondition.description)
             }
-            if (optional) append(", you may")
             append(", ")
             if (targetRequirement != null) {
                 append(targetRequirement.description)
@@ -158,7 +174,6 @@ data class TriggeredAbility(
             trigger: EventPattern,
             binding: TriggerBinding = TriggerBinding.SELF,
             effect: Effect,
-            optional: Boolean = false,
             targetRequirement: TargetRequirement? = null,
             additionalTargetRequirements: List<TargetRequirement> = emptyList(),
             elseEffect: Effect? = null,
@@ -175,7 +190,6 @@ data class TriggeredAbility(
                 trigger = trigger,
                 binding = binding,
                 effect = effect,
-                optional = optional,
                 targetRequirement = targetRequirement,
                 additionalTargetRequirements = additionalTargetRequirements,
                 elseEffect = elseEffect,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/GatedEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/GatedEffects.kt
@@ -342,6 +342,30 @@ fun OptionalCostEffect(
 )
 
 /**
+ * Gates that are the printed **"you may"** — the controller's own consent to the effect, as opposed
+ * to a state test ([Gate.WhenCondition]) or a bookkeeping cap ([Gate.OnceEachTurn]).
+ *
+ * One list, in the SDK, because three layers ask the same question about the same value: the DSL
+ * refuses to lower `optional = true` onto an effect that already asks, the engine's
+ * `effectOncePerTurn` lowering has to place its budget gate *inside* this gate, and the trigger
+ * processor decides where a "you may" is answered by whether the effect owns one.
+ */
+val Gate.isConsentGate: Boolean
+    get() = this is Gate.MayDecide || this is Gate.MayPay || this is Gate.MayPayX
+
+/**
+ * Does this effect already ask its controller for consent before doing anything?
+ *
+ * Looks through a [Gate.OnceEachTurn] because the `effectOncePerTurn` lowering sandwiches a capped
+ * optional ability as `OnceEachTurn(spend = false) → May… → OnceEachTurn() → effect`; the consent
+ * gate is still there, one level down.
+ */
+fun Effect.ownsConsentGate(): Boolean {
+    val gated = this as? GatedEffect ?: return false
+    return gated.gate.isConsentGate || (gated.gate is Gate.OnceEachTurn && gated.then.ownsConsentGate())
+}
+
+/**
  * "You may [effect]." — the player may choose to perform or skip [effect].
  *
  * Backwards-compatible facade preserved for the cards that authored against the former

--- a/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EbonDragonScenarioTest.kt
+++ b/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EbonDragonScenarioTest.kt
@@ -1,7 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
-import com.wingedsheep.engine.core.ChooseTargetsDecision
-import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Phase
@@ -10,6 +9,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.model.CardDefinition
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
  * Scenario test for Ebon Dragon (POR #91) — {5}{B}{B} Creature — Dragon, 5/4.
@@ -17,14 +17,15 @@ import io.kotest.matchers.shouldBe
  * "Flying
  *  When this creature enters, you may have target opponent discard a card."
  *
- * The card is modelled as `optional = true` on the triggered ability plus a `TargetOpponent`
- * requirement, which makes it the regression case for the fail-open bug in
- * `TriggerProcessor.processTargetedTrigger`: with a single legal opponent the processor used to
- * auto-select that opponent and put the trigger straight on the stack, skipping the
- * target-selection decision whose `minTargets = 0` is what carries the "you may" decline. The
- * opponent discarded whether or not the controller wanted them to.
+ * A "you may" plus a `TargetOpponent` requirement, which makes it the regression case for a
+ * fail-open bug in `TriggerProcessor.processTargetedTrigger`: with a single legal opponent the
+ * processor auto-selected that opponent and put the trigger straight on the stack, and back when
+ * consent rode on the target-selection decision's `minTargets = 0` that skipped the decline
+ * entirely — the opponent discarded whether or not the controller wanted them to.
  *
- * Both branches are covered — accepting discards, declining does not.
+ * The auto-select is back and is fine, because consent is now a gate on the effect and is answered
+ * before targeting is reached at all. That is what these two tests pin: the may-question is raised,
+ * and each answer does what it says.
  */
 class EbonDragonScenarioTest : ScenarioTestBase() {
 
@@ -54,14 +55,11 @@ class EbonDragonScenarioTest : ScenarioTestBase() {
                 game.castSpell(1, "Ebon Dragon").error shouldBe null
                 game.resolveStack()
 
-                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
-                    ?: error("expected a ChooseTargetsDecision for the may/target; got ${game.state.pendingDecision}")
-
-                withClue("the optional trigger must offer the decline (minTargets = 0)") {
-                    targetDecision.targetRequirements.single().minTargets shouldBe 0
+                withClue("the optional trigger must ask before doing anything") {
+                    game.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
                 }
 
-                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(game.player2Id))))
+                game.answerYesNo(true)
                 game.resolveStack()
 
                 withClue("Player 2 should have discarded their only card") {
@@ -83,10 +81,8 @@ class EbonDragonScenarioTest : ScenarioTestBase() {
                 game.castSpell(1, "Ebon Dragon").error shouldBe null
                 game.resolveStack()
 
-                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
-                    ?: error("expected a ChooseTargetsDecision for the may/target; got ${game.state.pendingDecision}")
-
-                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to emptyList())))
+                game.state.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
                 game.resolveStack()
 
                 withClue("declining must not make Player 2 discard") {

--- a/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GravediggerTest.kt
+++ b/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/GravediggerTest.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.mtg.sets.definitions.por.cards.Gravedigger
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.ownsConsentGate
 import com.wingedsheep.sdk.scripting.targets.TargetObject
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
@@ -29,7 +30,8 @@ class GravediggerTest : FunSpec({
         gravedigger.triggeredAbilities.size shouldBe 1
 
         val etbAbility = gravedigger.triggeredAbilities.first()
-        etbAbility.optional shouldBe true
+        // "you may" is a consent gate on the effect, not a flag beside it.
+        etbAbility.effect.ownsConsentGate() shouldBe true
         etbAbility.targetRequirement.shouldNotBeNull()
         etbAbility.targetRequirement.shouldBeInstanceOf<TargetObject>()
     }
@@ -67,9 +69,10 @@ class GravediggerTest : FunSpec({
         // Gravedigger should be on the battlefield
         driver.findPermanent(activePlayer, "Gravedigger") shouldNotBe null
 
-        // The ETB trigger should have fired and we should have a target selection decision
+        // The ETB trigger fires and asks the "you may" first; accepting leads to target selection.
         driver.isPaused shouldBe true
         driver.pendingDecision.shouldNotBeNull()
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
 
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision

--- a/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SerpentAssassinTest.kt
+++ b/mtg-sets/1993-1999/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SerpentAssassinTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
@@ -63,10 +64,11 @@ class SerpentAssassinTest : FunSpec({
         // Serpent Assassin should be on the battlefield
         driver.findPermanent(activePlayer, "Serpent Assassin") shouldNotBe null
 
-        // The ETB trigger should have fired and we should have a target selection decision
-        // Since the ability has a targetRequirement, the engine should pause for target selection
+        // The ETB trigger fires and asks the "you may" first; accepting it leads to target selection.
         driver.isPaused shouldBe true
         driver.pendingDecision.shouldNotBeNull()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
 
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision
@@ -171,16 +173,16 @@ class SerpentAssassinTest : FunSpec({
         // Serpent Assassin should be on the battlefield
         driver.findPermanent(activePlayer, "Serpent Assassin") shouldNotBe null
 
-        // The ability fires and we can select a target or decline
-        // "you may destroy" means the player can choose not to use the ability
+        // "you may destroy" means the player can choose not to use the ability — and the decline is
+        // the yes/no, not an empty target selection. Once accepted the target is *mandatory*
+        // (CR 603.3d: "target nonblack creature", not "up to one"), which is what minTargets says.
         driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(activePlayer, true)
+
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
-
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision
-        val minTargets = targetDecision.targetRequirements.firstOrNull()?.minTargets ?: 0
-
-        // For optional abilities, minTargets is 0 allowing the player to decline
-        minTargets shouldBe 0
+        targetDecision.targetRequirements.first().minTargets shouldBe 1
 
         // Submit the target selection (choose Grizzly Bears to use the ability)
         driver.submitTargetSelection(activePlayer, listOf(grizzlyBears))
@@ -195,7 +197,7 @@ class SerpentAssassinTest : FunSpec({
         driver.getGraveyardCardNames(opponent) shouldContain "Grizzly Bears"
     }
 
-    test("Serpent Assassin ETB trigger can be declined by selecting no targets") {
+    test("Serpent Assassin ETB trigger can be declined at the may-question") {
         val driver = createDriver()
         driver.initMirrorMatch(
             deck = Deck.of(
@@ -225,12 +227,12 @@ class SerpentAssassinTest : FunSpec({
         // Serpent Assassin should be on the battlefield
         driver.findPermanent(activePlayer, "Serpent Assassin") shouldNotBe null
 
-        // The ability fires - player chooses to decline by selecting 0 targets
+        // The ability fires and asks the "you may" before anything else is chosen — the player never
+        // has to pick a target they intend to spare.
         driver.isPaused shouldBe true
-        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
 
-        // Decline the ability by submitting empty target selection
-        val declineResult = driver.submitTargetSelection(activePlayer, emptyList())
+        val declineResult = driver.submitYesNo(activePlayer, false)
         declineResult.isSuccess shouldBe true
 
         // The game should continue without the ability on the stack

--- a/mtg-sets/2000-2002/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AphettoVultureTest.kt
+++ b/mtg-sets/2000-2002/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AphettoVultureTest.kt
@@ -72,9 +72,11 @@ class AphettoVultureTest : FunSpec({
         // Vulture should be dead
         driver.findPermanent(activePlayer, "Aphetto Vulture") shouldBe null
 
-        // Death trigger should fire - should have a target selection decision
+        // Death trigger should fire. "You may …" is a consent gate on the effect, so the yes/no
+        // comes first and target selection follows the acceptance.
         driver.isPaused shouldBe true
         driver.pendingDecision.shouldNotBeNull()
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
 
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision
@@ -111,6 +113,7 @@ class AphettoVultureTest : FunSpec({
 
         // Death trigger should fire
         driver.isPaused shouldBe true
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
 
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision
@@ -146,7 +149,8 @@ class AphettoVultureTest : FunSpec({
         // Resolve bolt
         driver.bothPass()
 
-        // Select the zombie as target
+        // Accept the "you may", then select the zombie as target
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
         driver.submitTargetSelection(activePlayer, listOf(zombieInGraveyard))
 
@@ -191,6 +195,7 @@ class AphettoVultureTest : FunSpec({
         // Vulture itself is a Zombie, so it's now in the graveyard and is a valid target.
         // The trigger should still fire because Aphetto Vulture itself is a Zombie in the graveyard.
         driver.isPaused shouldBe true
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
 
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision
@@ -235,6 +240,7 @@ class AphettoVultureTest : FunSpec({
 
         // Trigger should fire (Aphetto Vulture itself is a Zombie in our graveyard)
         driver.isPaused shouldBe true
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
 
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision

--- a/mtg-sets/2000-2002/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EntrailsFeasterTest.kt
+++ b/mtg-sets/2000-2002/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EntrailsFeasterTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
@@ -60,14 +61,15 @@ class EntrailsFeasterTest : FunSpec({
         // Advance to the controller's upkeep
         advanceToPlayerUpkeep(driver, activePlayer)
 
-        // Trigger should fire - target selection decision
+        // The trigger targets, and its "you may … If you don't, …" is answered as it *resolves*
+        // (CR 603.3d picks targets on announcement; the consent gate's own executor asks later).
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
-
-        // Choose the creature in graveyard as target
         driver.submitTargetSelection(activePlayer, listOf(creature))
 
-        // Resolve the trigger
+        // Resolve the trigger, accepting the may
         driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(activePlayer, true)
 
         // Creature should be exiled
         driver.state.getGraveyard(activePlayer).contains(creature) shouldBe false
@@ -92,18 +94,19 @@ class EntrailsFeasterTest : FunSpec({
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
         val feaster = driver.putCreatureOnBattlefield(activePlayer, "Entrails Feaster")
-        driver.putCardInGraveyard(activePlayer, "Grizzly Bears")
+        val creature = driver.putCardInGraveyard(activePlayer, "Grizzly Bears")
 
         advanceToPlayerUpkeep(driver, activePlayer)
 
-        // Trigger fires - target selection
+        // The target is mandatory ("a creature card" is modelled as a target), so it is chosen on
+        // announcement whether or not the exile happens; the decline is the may-question below.
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(activePlayer, listOf(creature))
 
-        // Decline by selecting 0 targets
-        driver.submitTargetSelection(activePlayer, emptyList())
-
-        // Resolve the else effect (tap)
+        // Decline at resolution; the gate's `otherwise` — the printed "If you don't, …" — taps.
         driver.bothPass()
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(activePlayer, false)
 
         // Feaster should be tapped
         driver.isTapped(feaster) shouldBe true
@@ -170,6 +173,7 @@ class EntrailsFeasterTest : FunSpec({
         // Exile it
         driver.submitTargetSelection(activePlayer, listOf(oppCreature))
         driver.bothPass()
+        driver.submitYesNo(activePlayer, true)
 
         // Creature should be exiled from opponent's graveyard
         driver.state.getGraveyard(opponent).contains(oppCreature) shouldBe false

--- a/mtg-sets/2000-2002/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OversoldCemeteryTest.kt
+++ b/mtg-sets/2000-2002/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/OversoldCemeteryTest.kt
@@ -62,7 +62,8 @@ class OversoldCemeteryTest : FunSpec({
         // Advance to the controller's upkeep
         advanceToPlayerUpkeep(driver, activePlayer)
 
-        // Trigger should fire - target selection decision
+        // Trigger should fire — the "you may" comes first, then target selection
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
 
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision
@@ -162,6 +163,7 @@ class OversoldCemeteryTest : FunSpec({
         advanceToPlayerUpkeep(driver, activePlayer)
 
         // Select target and resolve
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
         driver.submitTargetSelection(activePlayer, listOf(target))
         driver.bothPass()
@@ -196,6 +198,7 @@ class OversoldCemeteryTest : FunSpec({
         // Advance to upkeep
         advanceToPlayerUpkeep(driver, activePlayer)
 
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision
         val legalTargets = targetDecision.legalTargets[0] ?: emptyList()

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/BroodSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/BroodSliver.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 
 /**
@@ -32,13 +33,14 @@ val BroodSliver = card("Brood Sliver") {
             ability = TriggeredAbility.create(
                 trigger = Triggers.DealsCombatDamageToPlayer.event,
                 binding = Triggers.DealsCombatDamageToPlayer.binding,
-                effect = Effects.CreateToken(
-                    power = 1,
-                    toughness = 1,
-                    colors = emptySet(),
-                    creatureTypes = setOf("Sliver")
-                ),
-                optional = true
+                effect = MayEffect(
+                    Effects.CreateToken(
+                        power = 1,
+                        toughness = 1,
+                        colors = emptySet(),
+                        creatureTypes = setOf("Sliver")
+                    )
+                )
             ),
             filter = sliverFilter
         )

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/HunterSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/HunterSliver.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
 import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
@@ -45,8 +46,7 @@ val HunterSliver = card("Hunter Sliver") {
             ability = TriggeredAbility.create(
                 trigger = Triggers.Attacks.event,
                 binding = Triggers.Attacks.binding,
-                effect = Effects.Provoke(EffectTarget.ContextTarget(0)),
-                optional = true,
+                effect = MayEffect(Effects.Provoke(EffectTarget.ContextTarget(0))),
                 targetRequirement = Targets.CreatureOpponentControls
             ),
             filter = sliverFilter

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/SynapseSliver.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lgn/cards/SynapseSliver.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 
 /**
@@ -31,8 +32,7 @@ val SynapseSliver = card("Synapse Sliver") {
             ability = TriggeredAbility.create(
                 trigger = Triggers.DealsCombatDamageToPlayer.event,
                 binding = Triggers.DealsCombatDamageToPlayer.binding,
-                effect = Effects.DrawCards(1),
-                optional = true
+                effect = MayEffect(Effects.DrawCards(1))
             ),
             filter = sliverFilter
         )

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BladewingTheRisenTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BladewingTheRisenTest.kt
@@ -66,7 +66,8 @@ class BladewingTheRisenTest : FunSpec({
         driver.castSpell(activePlayer, bladewing)
         driver.bothPass() // resolve Bladewing
 
-        // ETB trigger fires — engine pauses for target selection (optional = true means can decline)
+        // ETB trigger fires — the "you may" is asked first, then targets
+        driver.submitYesNo(activePlayer, true)
         driver.submitTargetSelection(activePlayer, listOf(dragonInGraveyard))
 
         // Trigger on stack — resolve it
@@ -95,8 +96,8 @@ class BladewingTheRisenTest : FunSpec({
         driver.castSpell(activePlayer, bladewing)
         driver.bothPass()
 
-        // Decline the ETB trigger by submitting empty targets
-        driver.submitTargetSelection(activePlayer, emptyList())
+        // Decline the ETB trigger at its may-question
+        driver.submitYesNo(activePlayer, false)
         driver.bothPass()
 
         // Dragon should remain in graveyard

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EternalWitnessScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/EternalWitnessScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
@@ -44,6 +45,10 @@ class EternalWitnessScenarioTest : FunSpec({
         d.giveMana(d.player1, Color.GREEN, 3)
         d.castSpell(d.player1, card).isSuccess shouldBe true
         d.bothPass() // resolve the creature; its enters trigger goes on the stack and wants a target
+        // "you may return target card …" — the consent gate is answered before the target is asked
+        // for, so accept it here and leave the target decision pending for the caller. A trigger
+        // with no legal target never asks (CR 603.3d), which is what the third test relies on.
+        if (d.pendingDecision is YesNoDecision) d.submitYesNo(d.player1, true)
     }
 
     test("the enters trigger returns a card from your own graveyard") {

--- a/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WoebearerScenarioTest.kt
+++ b/mtg-sets/2003-2007/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/WoebearerScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
@@ -30,7 +31,12 @@ class WoebearerScenarioTest : ScenarioTestBase() {
         }
         passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
         resolveStack()
-        if (hasPendingDecision() && getPendingDecision() !is ChooseTargetsDecision) {
+        // Anything that is not already the trigger's own decision (its "you may", then its target)
+        // is a combat-damage assignment still owed.
+        if (hasPendingDecision() &&
+            getPendingDecision() !is ChooseTargetsDecision &&
+            getPendingDecision() !is YesNoDecision
+        ) {
             submitDefaultCombatDamage()
             resolveStack()
         }
@@ -54,6 +60,8 @@ class WoebearerScenarioTest : ScenarioTestBase() {
                     game.getLifeTotal(2) shouldBe 18
                 }
 
+                // The "you may" is answered before targeting is reached.
+                game.answerYesNo(true)
                 val decision = game.getPendingDecision()
                 withClue("The trigger should ask for a target; got $decision") {
                     decision.shouldBeInstanceOf<ChooseTargetsDecision>()
@@ -82,16 +90,13 @@ class WoebearerScenarioTest : ScenarioTestBase() {
 
                 game.connectWithWoebearer()
 
-                // A targeted "you may" carries its consent through the target decision itself:
-                // `optional = true` drops minTargets to 0, so choosing nothing *is* the decline.
+                // A "you may" is a consent gate on the effect, so the decline is its own yes/no and
+                // comes before any target is chosen — no picking a card you mean to leave behind.
                 val decision = game.getPendingDecision()
-                withClue("The trigger should ask for a target; got $decision") {
-                    decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+                withClue("The trigger should ask the may; got $decision") {
+                    decision.shouldBeInstanceOf<YesNoDecision>()
                 }
-                withClue("An optional trigger must allow selecting zero targets") {
-                    (decision as ChooseTargetsDecision).targetRequirements.single().minTargets shouldBe 0
-                }
-                game.skipTargets()
+                game.answerYesNo(false)
                 game.resolveStack()
 
                 withClue("Grizzly Bears should still be in the graveyard") {
@@ -112,6 +117,8 @@ class WoebearerScenarioTest : ScenarioTestBase() {
 
                 game.connectWithWoebearer()
 
+                // The "you may" is answered before targeting is reached.
+                game.answerYesNo(true)
                 val decision = game.getPendingDecision()
                 withClue("The trigger should ask for a target; got $decision") {
                     decision.shouldBeInstanceOf<ChooseTargetsDecision>()

--- a/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrunaTheFadingLightScenarioTest.kt
+++ b/mtg-sets/2008-2016/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/BrunaTheFadingLightScenarioTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.support.ScenarioTestBase
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContain
@@ -35,6 +36,9 @@ class BrunaTheFadingLightScenarioTest : ScenarioTestBase() {
                 }
 
                 game.resolveStack()
+                // "you may return …" — the consent gate is answered before targeting.
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(true)
                 val targetDecision = game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
                 val human = game.findCardsInGraveyard(1, "Glory Seeker").single()
                 val bear = game.findCardsInGraveyard(1, "Grizzly Bears").single()

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/GrothamaAllDevouring.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/GrothamaAllDevouring.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
 import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -54,8 +55,7 @@ val GrothamaAllDevouring = card("Grothama, All-Devouring") {
             ability = TriggeredAbility.create(
                 trigger = Triggers.Attacks.event,
                 binding = Triggers.Attacks.binding,
-                effect = Effects.Fight(EffectTarget.Self, EffectTarget.ContextTarget(0)),
-                optional = true,
+                effect = MayEffect(Effects.Fight(EffectTarget.Self, EffectTarget.ContextTarget(0))),
                 targetRequirement = grothamaTarget,
             ),
             filter = GroupFilter.AllCreatures.other(),

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GriffnautTracker.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/GriffnautTracker.kt
@@ -23,7 +23,7 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * across two opponents' graveyards. It is a *targeting* restriction, checked when targets are chosen
  * and re-checked on resolution — not a resolution-time filter.
  *
- * "Up to two" makes the whole ability optional in the targeting sense (`optional = true`): it still
+ * "Up to two" is [TargetObject.optional] on the *requirement*, not a "you may" on the ability: it still
  * goes on the stack with zero targets when every graveyard is empty, and it resolves doing nothing
  * rather than being removed for lack of targets (CR 608.2b).
  */

--- a/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AffectionateIndrikScenarioTest.kt
+++ b/mtg-sets/2024/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/AffectionateIndrikScenarioTest.kt
@@ -40,8 +40,9 @@ class AffectionateIndrikScenarioTest : FunSpec({
         val indrik = driver.putCardInHand(driver.player1, "Affectionate Indrik")
         driver.giveMana(driver.player1, Color.GREEN, 6)
         driver.castSpell(driver.player1, indrik).isSuccess shouldBe true
-        driver.bothPass() // resolve the Indrik; its enters trigger asks for a target
+        driver.bothPass() // resolve the Indrik; its enters trigger asks its "you may", then a target
 
+        driver.submitYesNo(driver.player1, true)
         val decision = driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
         // The Indrik itself is a creature you control, and so is Grizzly Bears — neither may be
         // offered. Only the opponent's Minotaur Warrior is a legal fight target.
@@ -58,6 +59,7 @@ class AffectionateIndrikScenarioTest : FunSpec({
         driver.castSpell(driver.player1, indrik).isSuccess shouldBe true
         driver.bothPass()
 
+        driver.submitYesNo(driver.player1, true)
         driver.submitTargetSelection(driver.player1, listOf(theirs))
         driver.bothPass() // resolve the triggered ability
 

--- a/mtg-sets/src/test/resources/snapshots/cards/5DN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/5DN.json
@@ -139,13 +139,16 @@
                 },
                 "binding": "OTHER",
                 "effect": {
-                    "type": "GainLife",
-                    "amount": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },
@@ -178,11 +181,14 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "TapUntap",
-                    "target": "Self",
-                    "tap": false
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                }
             }
         ],
         "activatedAbilities": [
@@ -696,14 +702,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -1063,18 +1072,21 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "ForEach",
-                    "space": "IterationSpace.Targets",
-                    "body": {
-                        "type": "MoveToZone",
-                        "target": {
-                            "type": "ContextTarget",
-                            "index": 0
-                        },
-                        "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Hand"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "count": 2,

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -3330,10 +3330,13 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "ChooseNumberForSource",
-                    "prompt": "Choose a number between 0 and 7"
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ChooseNumberForSource",
+                        "prompt": "Choose a number between 0 and 7"
+                    }
+                }
             }
         ],
         "staticAbilities": [
@@ -3848,33 +3851,36 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "ConvertCountersToTokens",
-                    "tokenFactory": {
-                        "power": 1,
-                        "toughness": 1,
-                        "colors": [],
-                        "creatureTypes": [
-                            "Tetravite"
-                        ],
-                        "keywords": [
-                            "FLYING"
-                        ],
-                        "name": "Tetravite",
-                        "artifactToken": true,
-                        "staticAbilities": [
-                            {
-                                "type": "GrantKeyword",
-                                "keyword": "CANT_BE_ENCHANTED",
-                                "filter": {
-                                    "baseFilter": "permanent",
-                                    "scope": "Self"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ConvertCountersToTokens",
+                        "tokenFactory": {
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Tetravite"
+                            ],
+                            "keywords": [
+                                "FLYING"
+                            ],
+                            "name": "Tetravite",
+                            "artifactToken": true,
+                            "staticAbilities": [
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "CANT_BE_ENCHANTED",
+                                    "filter": {
+                                        "baseFilter": "permanent",
+                                        "scope": "Self"
+                                    }
                                 }
-                            }
-                        ],
-                        "stampCreator": true
+                            ],
+                            "stampCreator": true
+                        }
                     }
-                },
-                "optional": true
+                }
             },
             {
                 "id": "ability_2",
@@ -3884,47 +3890,50 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "BattlefieldMatching",
-                                "filter": {
-                                    "statePredicates": [
-                                        "CreatedBySource"
-                                    ]
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": {
+                                        "statePredicates": [
+                                            "CreatedBySource"
+                                        ]
+                                    }
+                                },
+                                "storeAs": "tetraviteTokens"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "tetraviteTokens",
+                                "selection": "ChooseAnyNumber",
+                                "storeSelected": "exiledTokens",
+                                "prompt": "Exile any number of Tetravite tokens created with this creature"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "exiledTokens",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
                                 }
                             },
-                            "storeAs": "tetraviteTokens"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "tetraviteTokens",
-                            "selection": "ChooseAnyNumber",
-                            "storeSelected": "exiledTokens",
-                            "prompt": "Exile any number of Tetravite tokens created with this creature"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "exiledTokens",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Exile"
+                            {
+                                "type": "AddDynamicCounters",
+                                "counterType": "+1/+1",
+                                "amount": {
+                                    "type": "VariableReference",
+                                    "variableName": "exiledTokens_count"
+                                },
+                                "target": "Self"
                             }
-                        },
-                        {
-                            "type": "AddDynamicCounters",
-                            "counterType": "+1/+1",
-                            "amount": {
-                                "type": "VariableReference",
-                                "variableName": "exiledTokens_count"
-                            },
-                            "target": "Self"
-                        }
-                    ]
-                },
-                "optional": true
+                        ]
+                    }
+                }
             }
         ],
         "replacementEffects": [
@@ -4905,27 +4914,30 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "Sacrifice",
-                    "filter": "artifact"
-                },
-                "optional": true,
-                "elseEffect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "TapUntap",
-                            "target": "Self"
-                        },
-                        {
-                            "type": "DealDamage",
-                            "amount": {
-                                "type": "Fixed",
-                                "amount": 2
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Sacrifice",
+                        "filter": "artifact"
+                    },
+                    "otherwise": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "TapUntap",
+                                "target": "Self"
                             },
-                            "target": "Controller",
-                            "damageSource": "Self"
-                        }
-                    ]
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Controller",
+                                "damageSource": "Self"
+                            }
+                        ]
+                    }
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -833,20 +833,23 @@
                 },
                 "binding": "OTHER",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": "TriggeringEntity",
-                            "storeAs": "gathered0"
-                        },
-                        {
-                            "type": "PairWithSource",
-                            "from": "gathered0"
-                        }
-                    ]
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "TriggeringEntity",
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "PairWithSource",
+                                "from": "gathered0"
+                            }
+                        ]
+                    }
                 },
-                "optional": true,
                 "triggerCondition": {
                     "type": "EntityMatches",
                     "entity": "Self",
@@ -1502,20 +1505,23 @@
                 },
                 "binding": "OTHER",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": "TriggeringEntity",
-                            "storeAs": "gathered0"
-                        },
-                        {
-                            "type": "PairWithSource",
-                            "from": "gathered0"
-                        }
-                    ]
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "TriggeringEntity",
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "PairWithSource",
+                                "from": "gathered0"
+                            }
+                        ]
+                    }
                 },
-                "optional": true,
                 "triggerCondition": {
                     "type": "EntityMatches",
                     "entity": "Self",

--- a/mtg-sets/src/test/resources/snapshots/cards/BLC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLC.json
@@ -223,12 +223,15 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "AddCounters",
-                    "counterType": "quest",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "quest",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                }
             }
         ],
         "staticAbilities": [
@@ -1599,14 +1602,17 @@
                     "id": "ability_2",
                     "trigger": "AttackEvent",
                     "effect": {
-                        "type": "Fight",
-                        "target1": "Self",
-                        "target2": {
-                            "type": "ContextTarget",
-                            "index": 0
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "Fight",
+                            "target1": "Self",
+                            "target2": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
                         }
                     },
-                    "optional": true,
                     "targetRequirement": {
                         "type": "TargetObject",
                         "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/CSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CSP.json
@@ -149,41 +149,44 @@
                 "id": "ability_1",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 3
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
                                 }
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Battlefield"
-                            }
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -1153,13 +1153,16 @@
                 "id": "ability_1",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "TapUntap",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -5169,14 +5169,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "historic"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "historic"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -9648,15 +9651,18 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "historic card in your graveyard"
-                    },
-                    "destination": "Exile",
-                    "linkToSource": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "historic card in your graveyard"
+                        },
+                        "destination": "Exile",
+                        "linkToSource": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -8490,31 +8490,34 @@
                 "id": "ability_1",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "TopOfLibrary",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 2
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "isMill": true
                                 },
-                                "isMill": true
+                                "storeAs": "milled"
                             },
-                            "storeAs": "milled"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "milled",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Graveyard"
+                            {
+                                "type": "MoveCollection",
+                                "from": "milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
                             }
-                        }
-                    ]
-                },
-                "optional": true
+                        ]
+                    }
+                }
             },
             {
                 "id": "ability_2",
@@ -20477,15 +20480,18 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "card in a graveyard"
-                    },
-                    "destination": "Exile",
-                    "linkToSource": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "card in a graveyard"
+                        },
+                        "destination": "Exile",
+                        "linkToSource": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/DST.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DST.json
@@ -573,11 +573,14 @@
                 "trigger": "SpellCastEvent",
                 "binding": "ANY",
                 "effect": {
-                    "type": "TapUntap",
-                    "target": "Self",
-                    "tap": false
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                }
             }
         ],
         "activatedAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -9112,14 +9112,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target creature card from your graveyard"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card from your graveyard"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -516,14 +516,17 @@
                 "id": "ability_1",
                 "trigger": "CastThisSpellEvent",
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target Angel or Human creature card in your graveyard"
-                    },
-                    "destination": "Battlefield"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target Angel or Human creature card in your graveyard"
+                        },
+                        "destination": "Battlefield"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -2983,14 +2986,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -3287,14 +3293,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/EXO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EXO.json
@@ -17,14 +17,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -66,14 +69,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -404,14 +410,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -567,14 +576,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -5648,19 +5648,22 @@
                 "id": "ability_2",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "CreateToken",
-                    "power": 8,
-                    "toughness": 8,
-                    "colors": [
-                        "BLUE"
-                    ],
-                    "creatureTypes": [
-                        "Octopus"
-                    ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/2/6/26c478f7-b426-4055-8d06-e5782226c826.jpg?1740922203",
-                    "legendary": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 8,
+                        "toughness": 8,
+                        "colors": [
+                            "BLUE"
+                        ],
+                        "creatureTypes": [
+                            "Octopus"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/2/6/26c478f7-b426-4055-8d06-e5782226c826.jpg?1740922203",
+                        "legendary": true
+                    }
                 },
-                "optional": true,
                 "triggerCondition": {
                     "type": "Compare",
                     "left": {
@@ -8095,50 +8098,53 @@
                 },
                 "binding": "OTHER",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherUntilMatch",
-                            "filter": "creature",
-                            "storeMatch": "ignored",
-                            "storeRevealed": "revealed"
-                        },
-                        {
-                            "type": "RevealCollection",
-                            "from": "revealed"
-                        },
-                        {
-                            "type": "FilterCollection",
-                            "from": "revealed",
-                            "filter": {
-                                "type": "MatchesFilter",
-                                "filter": "creature"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherUntilMatch",
+                                "filter": "creature",
+                                "storeMatch": "ignored",
+                                "storeRevealed": "revealed"
                             },
-                            "storeMatching": "matchedToHand",
-                            "storeNonMatching": "rest"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "matchedToHand",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "RevealCollection",
+                                "from": "revealed"
                             },
-                            "revealed": true
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "rest",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Library",
-                                "placement": "Bottom"
+                            {
+                                "type": "FilterCollection",
+                                "from": "revealed",
+                                "filter": {
+                                    "type": "MatchesFilter",
+                                    "filter": "creature"
+                                },
+                                "storeMatching": "matchedToHand",
+                                "storeNonMatching": "rest"
                             },
-                            "order": "Random"
-                        }
-                    ]
-                },
-                "optional": true
+                            {
+                                "type": "MoveCollection",
+                                "from": "matchedToHand",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "rest",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Bottom"
+                                },
+                                "order": "Random"
+                            }
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/FRF.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FRF.json
@@ -145,15 +145,18 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Graveyard",
-                    "byDestruction": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/GRN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GRN.json
@@ -17,14 +17,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Fight",
-                    "target1": "Self",
-                    "target2": {
-                        "type": "BoundVariable",
-                        "name": "target creature you don't control"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Fight",
+                        "target1": "Self",
+                        "target2": {
+                            "type": "BoundVariable",
+                            "name": "target creature you don't control"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/INV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/INV.json
@@ -1185,15 +1185,18 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Graveyard",
-                    "byDestruction": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -2514,17 +2514,20 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "DealDamage",
-                    "amount": {
-                        "type": "Fixed",
-                        "amount": 4
-                    },
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -5463,15 +5466,18 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Graveyard",
-                    "byDestruction": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -5147,14 +5147,17 @@
                 "id": "ability_1",
                 "trigger": "TurnFaceUpEvent",
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "another creature"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "another creature"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -11685,13 +11688,16 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "ExileUntilLeaves",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "creature with toughness 3 or greater"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ExileUntilLeaves",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature with toughness 3 or greater"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3893,63 +3893,66 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": {
-                                    "cardPredicates": [
-                                        {
-                                            "type": "Or",
-                                            "predicates": [
-                                                "IsBasicLand",
-                                                {
-                                                    "type": "And",
-                                                    "predicates": [
-                                                        "IsLand",
-                                                        {
-                                                            "type": "HasSubtype",
-                                                            "subtype": "Cave"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            {
+                                                "type": "Or",
+                                                "predicates": [
+                                                    "IsBasicLand",
+                                                    {
+                                                        "type": "And",
+                                                        "predicates": [
+                                                            "IsLand",
+                                                            {
+                                                                "type": "HasSubtype",
+                                                                "subtype": "Cave"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        "ShuffleLibrary",
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Library",
-                                "placement": "Top"
+                            "ShuffleLibrary",
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -4730,31 +4733,34 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "TopOfLibrary",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 2
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "isMill": true
                                 },
-                                "isMill": true
+                                "storeAs": "milled"
                             },
-                            "storeAs": "milled"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "milled",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Graveyard"
+                            {
+                                "type": "MoveCollection",
+                                "from": "milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
                             }
-                        }
-                    ]
-                },
-                "optional": true
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -11731,31 +11737,34 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "TopOfLibrary",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 2
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "isMill": true
                                 },
-                                "isMill": true
+                                "storeAs": "milled"
                             },
-                            "storeAs": "milled"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "milled",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Graveyard"
+                            {
+                                "type": "MoveCollection",
+                                "from": "milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
                             }
-                        }
-                    ]
-                },
-                "optional": true
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -16476,31 +16485,34 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "TopOfLibrary",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 2
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "isMill": true
                                 },
-                                "isMill": true
+                                "storeAs": "milled"
                             },
-                            "storeAs": "milled"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "milled",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Graveyard"
+                            {
+                                "type": "MoveCollection",
+                                "from": "milled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
                             }
-                        }
-                    ]
-                },
-                "optional": true
+                        ]
+                    }
+                }
             }
         ],
         "staticAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -4410,13 +4410,16 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "DrawCards",
-                    "count": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/LGN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LGN.json
@@ -603,8 +603,11 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "Provoke",
-                "optional": true,
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Provoke"
+                },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -648,15 +651,18 @@
                         "recipient": "AnyPlayer"
                     },
                     "effect": {
-                        "type": "CreateToken",
-                        "power": 1,
-                        "toughness": 1,
-                        "colors": [],
-                        "creatureTypes": [
-                            "Sliver"
-                        ]
-                    },
-                    "optional": true
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Sliver"
+                            ]
+                        }
+                    }
                 },
                 "filter": {
                     "baseFilter": "creature Sliver"
@@ -960,17 +966,20 @@
                 "id": "ability_1",
                 "trigger": "TurnFaceUpEvent",
                 "effect": {
-                    "type": "ExchangeControl",
-                    "target1": {
-                        "type": "BoundVariable",
-                        "name": "creature you control"
-                    },
-                    "target2": {
-                        "type": "BoundVariable",
-                        "name": "creature an opponent controls"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ExchangeControl",
+                        "target1": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        },
+                        "target2": {
+                            "type": "BoundVariable",
+                            "name": "creature an opponent controls"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -1306,8 +1315,11 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "Provoke",
-                "optional": true,
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Provoke"
+                },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -1928,8 +1940,11 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "Provoke",
-                "optional": true,
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Provoke"
+                },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -2556,8 +2571,11 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "Provoke",
-                "optional": true,
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Provoke"
+                },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -3454,8 +3472,11 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "Provoke",
-                "optional": true,
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Provoke"
+                },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -3844,8 +3865,11 @@
                 "ability": {
                     "id": "ability_1",
                     "trigger": "AttackEvent",
-                    "effect": "Provoke",
-                    "optional": true,
+                    "effect": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": "Provoke"
+                    },
                     "targetRequirement": {
                         "type": "TargetObject",
                         "filter": {
@@ -4267,8 +4291,11 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "Provoke",
-                "optional": true,
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Provoke"
+                },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -4446,8 +4473,11 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "Provoke",
-                "optional": true,
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Provoke"
+                },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -4587,13 +4617,16 @@
                 "id": "ability_1",
                 "trigger": "TurnFaceUpEvent",
                 "effect": {
-                    "type": "TurnFaceDown",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "creature with a morph ability"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TurnFaceDown",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature with a morph ability"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -6587,8 +6620,11 @@
             {
                 "id": "ability_1",
                 "trigger": "AttackEvent",
-                "effect": "Provoke",
-                "optional": true,
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Provoke"
+                },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -6648,13 +6684,16 @@
                         "recipient": "AnyPlayer"
                     },
                     "effect": {
-                        "type": "DrawCards",
-                        "count": {
-                            "type": "Fixed",
-                            "amount": 1
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
                         }
-                    },
-                    "optional": true
+                    }
                 },
                 "filter": {
                     "baseFilter": "creature Sliver"
@@ -6750,13 +6789,16 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "GainLife",
-                    "amount": {
-                        "type": "Fixed",
-                        "amount": 3
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },
@@ -7704,18 +7746,21 @@
                 },
                 "binding": "OTHER",
                 "effect": {
-                    "type": "CreateToken",
-                    "power": 1,
-                    "toughness": 1,
-                    "colors": [
-                        "GREEN"
-                    ],
-                    "creatureTypes": [
-                        "Insect"
-                    ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa47df37-f246-4f80-a944-008cdf347dad.jpg?1561757793"
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "GREEN"
+                        ],
+                        "creatureTypes": [
+                            "Insect"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa47df37-f246-4f80-a944-008cdf347dad.jpg?1561757793"
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -6717,12 +6717,15 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": "Self",
-                    "destination": "Library",
-                    "positionFromTop": 4
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Library",
+                        "positionFromTop": 4
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -243,44 +243,47 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "artifact"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "artifact"
+                                },
+                                "storeAs": "hoardSearchable"
                             },
-                            "storeAs": "hoardSearchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "hoardSearchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hoardSearchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "hoardFound",
+                                "prompt": "Search for an artifact card to exile"
                             },
-                            "storeSelected": "hoardFound",
-                            "prompt": "Search for an artifact card to exile"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "hoardFound",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Exile"
+                            {
+                                "type": "MoveCollection",
+                                "from": "hoardFound",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
                             },
-                            "linkToSource": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             },
             {
                 "id": "ability_2",
@@ -290,24 +293,27 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": "FromLinkedExile",
-                            "storeAs": "hoardExiled"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "hoardExiled",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "FromLinkedExile",
+                                "storeAs": "hoardExiled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "hoardExiled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                }
                             }
-                        }
-                    ]
-                },
-                "optional": true
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -317,15 +317,18 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Graveyard",
-                    "byDestruction": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/M15.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M15.json
@@ -17,15 +17,18 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Graveyard",
-                    "byDestruction": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -17,43 +17,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland Plains"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland Plains"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ],
         "activatedAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/MOR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOR.json
@@ -164,12 +164,15 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/MRD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MRD.json
@@ -3426,14 +3426,17 @@
                 "id": "ability_1",
                 "trigger": "BecomesBlockedEvent",
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target card named Groffskithur from your graveyard"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target card named Groffskithur from your graveyard"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -4054,13 +4057,16 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "GainLife",
-                    "amount": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },
@@ -4762,13 +4768,16 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "TapUntap",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -4834,20 +4843,23 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "CreateToken",
-                    "power": 1,
-                    "toughness": 1,
-                    "colors": [
-                        "WHITE"
-                    ],
-                    "creatureTypes": [
-                        "Spirit"
-                    ],
-                    "keywords": [
-                        "FLYING"
-                    ]
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "CreateToken",
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [
+                            "WHITE"
+                        ],
+                        "creatureTypes": [
+                            "Spirit"
+                        ],
+                        "keywords": [
+                            "FLYING"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -5356,14 +5368,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "card"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "card"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -6926,13 +6941,16 @@
                 "id": "ability_1",
                 "trigger": "BlockEvent",
                 "effect": {
-                    "type": "DrawCards",
-                    "count": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },
@@ -8474,43 +8492,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
                                 }
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Battlefield",
-                                "placement": "Tapped"
-                            }
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             },
             {
                 "id": "ability_2",
@@ -8520,13 +8541,16 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "DrawCards",
-                    "count": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },
@@ -11328,14 +11352,17 @@
                     "recipient": "AnyPlayer"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target creature card"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature card"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/NEM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NEM.json
@@ -1044,43 +1044,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "name:Nesting Wurm"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "name:Nesting Wurm"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 3
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -2255,43 +2258,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "name:Skyshroud Sentinel"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "name:Skyshroud Sentinel"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 3
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/ODY.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ODY.json
@@ -367,14 +367,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -549,13 +552,16 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "DrawCards",
-                    "count": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -670,15 +670,18 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Library",
-                    "placement": "Top"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Library",
+                        "placement": "Top"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -2958,13 +2961,16 @@
                 "id": "ability_1",
                 "trigger": "CycleEvent",
                 "effect": {
-                    "type": "TapUntap",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -5807,25 +5813,32 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "MoveToZone",
-                            "target": {
-                                "type": "BoundVariable",
-                                "name": "target"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                },
+                                "destination": "Exile"
                             },
-                            "destination": "Exile"
-                        },
-                        {
-                            "type": "AddCounters",
-                            "counterType": "+1/+1",
-                            "count": 1,
-                            "target": "Self"
-                        }
-                    ]
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        ]
+                    },
+                    "otherwise": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -5833,10 +5846,6 @@
                         "zone": "Graveyard"
                     },
                     "id": "target"
-                },
-                "elseEffect": {
-                    "type": "TapUntap",
-                    "target": "Self"
                 }
             }
         ]
@@ -10992,33 +11001,36 @@
                 "binding": "ANY",
                 "effect": {
                     "type": "Gated",
-                    "gate": {
-                        "type": "Gate.WhenCondition",
-                        "condition": {
-                            "type": "Compare",
-                            "left": {
-                                "type": "Count",
-                                "player": "You",
-                                "zone": "Graveyard",
-                                "filter": "creature"
-                            },
-                            "operator": "GTE",
-                            "right": {
-                                "type": "Fixed",
-                                "amount": 4
-                            }
-                        }
-                    },
+                    "gate": "Gate.MayDecide",
                     "then": {
-                        "type": "MoveToZone",
-                        "target": {
-                            "type": "BoundVariable",
-                            "name": "target"
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "Compare",
+                                "left": {
+                                    "type": "Count",
+                                    "player": "You",
+                                    "zone": "Graveyard",
+                                    "filter": "creature"
+                                },
+                                "operator": "GTE",
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            }
                         },
-                        "destination": "Hand"
+                        "then": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            },
+                            "destination": "Hand"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -434,15 +434,18 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Graveyard",
-                    "byDestruction": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -491,14 +494,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -3044,13 +3044,16 @@
                     "byOpponent": true
                 },
                 "effect": {
-                    "type": "DrawCards",
-                    "count": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ],
         "staticAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/POR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/POR.json
@@ -1731,50 +1731,53 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Hand",
-                                "player": {
-                                    "type": "ContextPlayer",
-                                    "index": 0
-                                }
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
                             },
-                            "storeAs": "hand"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "hand",
-                            "selection": {
-                                "type": "ChooseExactly",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 1 card to discard"
                             },
-                            "chooser": "TargetPlayer",
-                            "storeSelected": "discarded",
-                            "prompt": "Choose 1 card to discard"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "discarded",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Graveyard",
-                                "player": {
-                                    "type": "ContextPlayer",
-                                    "index": 0
-                                }
-                            },
-                            "moveType": "Discard"
-                        }
-                    ]
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetOpponent",
                     "id": "target"
@@ -2525,14 +2528,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -4419,13 +4425,16 @@
                 "id": "ability_1",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "TapUntap",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
@@ -4466,15 +4475,18 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Graveyard",
-                    "byDestruction": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -605,13 +605,16 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "GainLife",
-                    "amount": {
-                        "type": "Fixed",
-                        "amount": 3
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },
@@ -646,43 +649,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -3585,13 +3591,16 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "DrawCards",
-                    "count": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/ROE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ROE.json
@@ -18,21 +18,24 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "ModifyStats",
-                    "powerModifier": {
-                        "type": "Fixed",
-                        "amount": 2
-                    },
-                    "toughnessModifier": {
-                        "type": "Fixed",
-                        "amount": 0
-                    },
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
                     }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/SCG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SCG.json
@@ -582,14 +582,17 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Battlefield"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Battlefield"
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/SHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SHM.json
@@ -17,43 +17,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
                                 }
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Battlefield",
-                                "placement": "Tapped"
-                            }
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -4809,43 +4809,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -16019,43 +16022,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -16671,13 +16677,16 @@
                     "byOpponent": true
                 },
                 "effect": {
-                    "type": "DrawCards",
-                    "count": {
-                        "type": "Fixed",
-                        "amount": 1
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
                     }
-                },
-                "optional": true
+                }
             }
         ],
         "staticAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -1794,10 +1794,13 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "AttachEquipment",
-                    "target": "TriggeringEntity"
-                },
-                "optional": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AttachEquipment",
+                        "target": "TriggeringEntity"
+                    }
+                }
             }
         ],
         "activatedAbilities": [
@@ -9555,44 +9558,47 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        "ShuffleLibrary",
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Library",
-                                "placement": "Top"
+                            "ShuffleLibrary",
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -94,44 +94,47 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        "ShuffleLibrary",
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Library",
-                                "placement": "Top"
+                            "ShuffleLibrary",
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -631,15 +631,18 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Graveyard",
-                    "byDestruction": true
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -7676,48 +7676,51 @@
                 "id": "ability_1",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
                             },
-                            "storeAs": "hand"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "hand",
-                            "selection": {
-                                "type": "ChooseExactly",
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded",
+                                "prompt": "Choose a card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            },
+                            {
+                                "type": "DrawCards",
                                 "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
+                                    "type": "VariableReference",
+                                    "variableName": "discarded_count"
                                 }
-                            },
-                            "storeSelected": "discarded",
-                            "prompt": "Choose a card to discard"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "discarded",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Graveyard"
-                            },
-                            "moveType": "Discard"
-                        },
-                        {
-                            "type": "DrawCards",
-                            "count": {
-                                "type": "VariableReference",
-                                "variableName": "discarded_count"
                             }
-                        }
-                    ]
-                },
-                "optional": true
+                        ]
+                    }
+                }
             }
         ],
         "staticAbilities": [
@@ -8678,10 +8681,13 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "AttachEquipment",
-                    "target": "TriggeringEntity"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AttachEquipment",
+                        "target": "TriggeringEntity"
+                    }
                 },
-                "optional": true,
                 "descriptionOverride": "Whenever a Ninja you control enters, you may attach this Equipment to it."
             }
         ],

--- a/mtg-sets/src/test/resources/snapshots/cards/UDS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/UDS.json
@@ -2487,43 +2487,46 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 2
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ],
         "activatedAbilities": [

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -6245,50 +6245,53 @@
                 "id": "ability_1",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": {
-                                    "cardPredicates": [
-                                        "IsBasicLand",
-                                        {
-                                            "type": "DoesNotShareLandTypeWithPermanentYouControl",
-                                            "filter": "land"
-                                        }
-                                    ]
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": {
+                                        "cardPredicates": [
+                                            "IsBasicLand",
+                                            {
+                                                "type": "DoesNotShareLandTypeWithPermanentYouControl",
+                                                "filter": "land"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
                                 }
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
-                            },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Battlefield"
-                            }
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ],
         "activatedAbilities": [
@@ -14902,43 +14905,46 @@
                     "to": "Graveyard"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "name:Wretched Throng"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "name:Wretched Throng"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -3986,13 +3986,16 @@
                 },
                 "binding": "ANY",
                 "effect": {
-                    "type": "Sacrifice",
-                    "filter": "artifact|enchantment|token"
-                },
-                "optional": true,
-                "elseEffect": {
-                    "type": "TapUntap",
-                    "target": "Self"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Sacrifice",
+                        "filter": "artifact|enchantment|token"
+                    },
+                    "otherwise": {
+                        "type": "TapUntap",
+                        "target": "Self"
+                    }
                 }
             }
         ]
@@ -16171,23 +16174,26 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "MoveToZone",
-                            "target": {
-                                "type": "BoundVariable",
-                                "name": "target"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                },
+                                "destination": "Hand"
                             },
-                            "destination": "Hand"
-                        },
-                        {
-                            "type": "Scry",
-                            "count": 2
-                        }
-                    ]
+                            {
+                                "type": "Scry",
+                                "count": 2
+                            }
+                        ]
+                    }
                 },
-                "optional": true,
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -254,43 +254,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "basicland"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                }
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Hand"
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
                             },
-                            "revealed": true
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -571,43 +571,46 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "GatherCards",
-                            "source": {
-                                "type": "FromZone",
-                                "zone": "Library",
-                                "filter": "land Plains"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "land Plains"
+                                },
+                                "storeAs": "searchable"
                             },
-                            "storeAs": "searchable"
-                        },
-                        {
-                            "type": "SelectFromCollection",
-                            "from": "searchable",
-                            "selection": {
-                                "type": "ChooseUpTo",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
                                 }
                             },
-                            "storeSelected": "found"
-                        },
-                        {
-                            "type": "MoveCollection",
-                            "from": "found",
-                            "destination": {
-                                "type": "ToZone",
-                                "zone": "Battlefield",
-                                "placement": "Tapped"
-                            }
-                        },
-                        "ShuffleLibrary",
-                        "EmitLibrarySearchedEvent"
-                    ]
-                },
-                "optional": true
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
             }
         ]
     },

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -480,8 +480,7 @@ Found the way all five were, by running it on a card class it had never reached.
     Blood Celebrant, Goblin Clearcutter and Wirewood Channeler instant-speed abilities that use the
     stack. Chromatic Sphere remains, because its mana step is inside a composite.
   - **"You may" on a triggered ability (~10).** `optional = true` versus a `MayEffect` wrapping the
-    effect. `Triggers` lowers the English into the flag, which is what most cards carry; the rest
-    are the minority spelling.
+    effect. *Since resolved by removing the flag from the SDK — see the closed finding below.*
   - **A mass effect written as a pipeline (~19).** `ForEachInGroup` versus a `Patterns.Group` recipe
     for the same sweep, and the already-documented `DealDamage(n, PlayerRef(Each))` versus
     `ForEachPlayer` split for "each creature and each player".
@@ -629,6 +628,19 @@ Found the way all five were, by running it on a card class it had never reached.
   text as two abilities, which is how all but one card in the corpus writes it — Ureni, the Song
   Unending uses `Colors`. The scope is engine-supported (`CardEntityFactory`, `PlayerProtectionRules`)
   so nothing is broken; it is one card and one type away from the corpus having a single spelling.
+- **Closed, by deleting the field: a trigger's "you may" said itself twice.** `TriggeredAbility`
+  carried an `optional: Boolean` beside its effect, and 106 cards used it where 214 wrapped the
+  effect in a `MayEffect` — one sentence, two SDK spellings, bridged here by a `liftTriggerConsent`
+  fold. The fold's own justification was the argument for removing the flag: it cited
+  `TriggerProcessor.putOnStack` *building* `GatedEffect(Gate.MayDecide, then, otherwise)` from the
+  flag on every game, which is a lowering, not an equivalence someone asserted. So the flag went and
+  the gate is the model; `optional = true` survives only as a DSL shorthand that lowers in `build()`.
+  Both halves of `Triggers.abilityFor`/`scriptFor` lost their lowering, `Granted` lost the same three
+  lines, and the fold was deleted. The divergence count did not move, which is what proves the fold
+  was folding nothing but the spelling. Two further conflations came out with it, both engine-side:
+  a targeted "you may" used to carry its consent by forcing every target slot's minimum to zero
+  (so "target creature" silently became "up to one", against CR 603.3d), and the single-legal-player
+  target auto-select had to be disabled for optional abilities to stop that consent being skipped.
 - **Open: a mana ability says so twice, and 24 abilities say it once.** `ActivatedAbility` carries
   `isManaAbility: Boolean` *and* `timing: TimingRule.ManaAbility`, and `TimingRule.ManaAbility`'s own
   KDoc claims the rules meaning — "does NOT go on the stack (Rule 605.3a)", "can be activated during

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Differential.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Differential.kt
@@ -281,10 +281,8 @@ class Differential(private val touchstone: Touchstone = Touchstone()) {
             JsonElement.serializer(),
             sortKeys(
                 Folds.dropPresentation(
-                    Folds.liftTriggerConsent(
-                        Folds.flattenComposites(
-                            canonicalizeGrantedAbilities(canonicalizeAbilities(normalizeSlots(tree))),
-                        ),
+                    Folds.flattenComposites(
+                        canonicalizeGrantedAbilities(canonicalizeAbilities(normalizeSlots(tree))),
                     ),
                 ),
             ),
@@ -534,51 +532,12 @@ internal object Folds {
 
     private val PRESENTATION_KEYS = setOf("imageUri", "message", "prompt", "descriptionOverride")
 
-    /**
-     * **A trigger's `optional` flag is a `Gate.MayDecide` around its effect — the engine says so.**
-     *
-     * "Whenever this creature deals combat damage to a player, **you may** draw a card." has two
-     * spellings in `mtg-sdk`: `TriggeredAbility.optional = true` (106 cards) and a `MayEffect`
-     * wrapped round the effect (214 cards). Neither is a house style anyone chose — and the reason
-     * they are the same value is not an argument made here but code in the engine:
-     * `TriggerProcessor.putOnStack` reads the flag and *builds the other spelling*, wrapping the
-     * effect in `GatedEffect(Gate.MayDecide, then = effect, otherwise = elseEffect)` before the
-     * ability ever reaches the stack — and skips the wrap when the effect `ownsConsentGate()`
-     * already, precisely so the two spellings don't double-prompt. One lowers into the other on
-     * every game, which is what this fold list's bar asks for.
-     *
-     * Normalized toward the flag, because that is the form Assay's [Triggers] lowering produces:
-     * the gate is unwrapped, `optional` is stamped, and a gate's `otherwise` becomes the ability's
-     * `elseEffect` — the same three moves the engine makes, run backwards.
-     *
-     * **Only a bare `Gate.MayDecide` folds.** A gate carrying a `feasibility` (Provisions Merchant)
-     * or a `prompt` says something the flag form cannot, and the engine *derives* feasibility from
-     * the effect rather than copying it — so folding those would be claiming an equivalence the
-     * lowering does not establish. They stay divergent, which is correct: they are a third thing.
-     */
-    fun liftTriggerConsent(element: JsonElement): JsonElement = when (element) {
-        is JsonObject -> {
-            val walked = JsonObject(element.mapValues { liftTriggerConsent(it.value) })
-            if ("trigger" in walked) unwrapMayEffect(walked) else walked
-        }
-
-        is JsonArray -> JsonArray(element.map(::liftTriggerConsent))
-        else -> element
-    }
-
-    private fun unwrapMayEffect(ability: JsonObject): JsonObject {
-        if (ability["optional"] != null || "elseEffect" in ability) return ability
-        val effect = ability["effect"] as? JsonObject ?: return ability
-        if ((effect["type"] as? JsonPrimitive)?.content != "Gated") return ability
-        // A bare `Gate.MayDecide` is `{"type": "Gate.MayDecide"}` and nothing else; a gate with a
-        // `feasibility` or a `prompt` carries fields the flag form has nowhere to put.
-        val gate = effect["gate"] as? JsonObject ?: return ability
-        if ((gate["type"] as? JsonPrimitive)?.content != "Gate.MayDecide" || gate.size != 1) return ability
-        if (effect.keys.any { it !in setOf("type", "gate", "then", "otherwise") }) return ability
-        val lifted = ability + ("effect" to effect.getValue("then")) +
-            ("optional" to JsonPrimitive(true))
-        return JsonObject(effect["otherwise"]?.let { lifted + ("elseEffect" to it) } ?: lifted)
-    }
+    // `liftTriggerConsent` used to live here, bridging `TriggeredAbility.optional = true` (106 cards)
+    // and a `MayEffect` around the effect (214 cards) — two SDK spellings of "you may" that the
+    // engine already lowered one into the other on every game. It is gone because the *SDK* is: the
+    // flag was deleted and the gate is the model, so both sides now produce the same value and there
+    // is nothing left to fold. That is the outcome a fold entry should be aiming at; the fold list
+    // shrinks when the thing it was hiding gets fixed.
 
     /**
      * **A parameterless marker implied by a parameterized ability of the same keyword.**

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Granted.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Granted.kt
@@ -128,27 +128,24 @@ object Granted {
     private val ID = AbilityId("granted")
 
     /**
-     * Build the granted ability, lowering "may" into the ability's `optional` flag exactly as
-     * [Triggers] does for a card's own trigger — and for the same reason, since the two spellings
-     * are the same sentence written inside and outside a grant.
+     * Build the granted ability. A "may" needs no lowering — `TriggeredAbility.optional` is gone and
+     * the consent gate is the model, so a granted clause is the same value the ungranted one is
+     * (see [Triggers.abilityFor], which lost the same three lines).
      */
     private fun abilityFor(spec: TriggerSpec, script: CardScript): TriggeredAbility? {
         val effect = script.spellEffect ?: return null
         if (script.targetRequirements.size > 1) return null
-        val gated = effect as? GatedEffect
-        val optional = gated != null && gated.gate is Gate.MayDecide && gated == MayEffect(gated.then)
         return TriggeredAbility(
             id = ID,
             trigger = spec.event,
             binding = spec.binding,
-            effect = if (optional) (effect as GatedEffect).then else effect,
+            effect = effect,
             targetRequirement = script.targetRequirements.singleOrNull(),
-            optional = optional,
         )
     }
 
     private fun scriptFor(ability: TriggeredAbility): CardScript = CardScript(
-        spellEffect = if (ability.optional) MayEffect(ability.effect) else ability.effect,
+        spellEffect = ability.effect,
         targetRequirements = listOfNotNull(ability.targetRequirement),
     )
 

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Triggers.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Triggers.kt
@@ -16,7 +16,6 @@ import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.effects.GatedEffect
-import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.TriggeredAbility
@@ -84,23 +83,19 @@ object Triggers {
     }
 
     /**
-     * Build the ability a trigger's effect clause denotes — **including the lowering of "you may".**
+     * Build the ability a trigger's effect clause denotes.
      *
-     * A triggered ability spells the controller's choice with its own `optional` flag, which is what
-     * every hand-written card sets; a spell spells the identical English as a `MayEffect` around the
-     * effect, because a spell has no such flag. Both are real SDK spellings of one sentence, so
-     * reading "you may …" here has to *lower* one into the other rather than register a second rule:
-     * a rule per spelling would be two readings of one text, which is the ambiguity the design says
-     * never to resolve by picking one.
-     *
-     * The lowering runs in both directions — [scriptFor] wraps `optional` back into a `MayEffect`
-     * before the comparison — so the round trip is over the same value in both halves.
+     * **"You may …" needs nothing done to it here, and that is new.** A triggered ability used to
+     * spell the controller's choice with an `optional` flag of its own while a spell spelled the
+     * identical English as a `MayEffect`, so this function had to lower one into the other — one
+     * sentence, two SDK spellings, and a rule per spelling would have been two readings of one text.
+     * `TriggeredAbility.optional` is gone; the gate the engine always built from it is the model
+     * now, and a trigger's effect clause is the same value a spell's clause is. The lowering, its
+     * inverse in [scriptFor], and the differential fold that bridged the two spellings all deleted
+     * together.
      */
     private fun abilityFor(spec: TriggerSpec, script: CardScript): TriggeredAbility? {
         val effect = script.spellEffect ?: return null
-        val gated = effect as? GatedEffect
-        val optional = gated != null && gated.gate is Gate.MayDecide &&
-            gated == MayEffect(gated.then)
         return TriggeredAbility(
             id = ID,
             trigger = spec.event,
@@ -124,14 +119,13 @@ object Triggers {
             // Cavalry and Seasoned Warrenguard have scenario tests asserting exactly that — and
             // ~100 for other trigger-time restrictions. Rechecking all of them uniformly fails
             // those two tests, so the engine fix needs "if" and "while" separated first.
-            effect = liftInterveningIf(if (optional) (effect as GatedEffect).then else effect),
+            effect = liftInterveningIf(effect),
             triggerCondition = interveningIf(effect),
             // A `TriggeredAbility` keeps its first requirement in a field of its own and the rest in
             // a list beside it, which is the shape a clause declaring two targets lands in —
             // Chromeshell Crab's exchange. The split is the SDK's; nothing in the text says it.
             targetRequirement = script.targetRequirements.firstOrNull(),
             additionalTargetRequirements = script.targetRequirements.drop(1),
-            optional = optional,
         )
     }
 
@@ -154,21 +148,18 @@ object Triggers {
         if (interveningIf(effect) != null) (effect as GatedEffect).then else effect
 
     /**
-     * The inverse of the lowering: the clause script an ability's effect and targets denote.
+     * The clause script an ability's effect and targets denote — the inverse of [abilityFor].
      *
-     * The two wrappers go back on in the order [abilityFor] took them off — the intervening-if
-     * inside, "you may" outside — so the round trip is over the same value in both halves.
+     * One wrapper to put back, the intervening-if [abilityFor] lifted, so the round trip is over the
+     * same value in both halves.
      */
-    private fun scriptFor(ability: TriggeredAbility): CardScript {
-        val conditioned = ability.triggerCondition
+    private fun scriptFor(ability: TriggeredAbility): CardScript = CardScript(
+        spellEffect = ability.triggerCondition
             ?.let { ConditionalEffect(condition = it, effect = ability.effect) }
-            ?: ability.effect
-        return CardScript(
-            spellEffect = if (ability.optional) MayEffect(conditioned) else conditioned,
-            targetRequirements = listOfNotNull(ability.targetRequirement) +
-                ability.additionalTargetRequirements,
-        )
-    }
+            ?: ability.effect,
+        targetRequirements = listOfNotNull(ability.targetRequirement) +
+            ability.additionalTargetRequirements,
+    )
 
     /**
      * The trigger events with an unambiguous one-clause surface form.

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/TriggersTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/TriggersTest.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.dsl.Triggers as SdkTriggers
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -101,16 +102,16 @@ class TriggersTest : StringSpec({
             "At the beginning of each upkeep, draw a card."
     }
 
-    // "You may …" is not unspellable content: a triggered ability's `optional` flag and a spell's
-    // `MayEffect` are two SDK spellings of one sentence, and `Triggers.abilityFor` lowers between
-    // them so the printed form is the same either way.
-    "the optional flag is the trigger's spelling of \"you may\"" {
+    // "You may …" is one sentence with one model. A triggered ability used to spell it with an
+    // `optional` flag where a spell used a `MayEffect`, and `Triggers.abilityFor` had to lower
+    // between the two; the flag is gone from the SDK and a trigger's consent is the same gate a
+    // spell's is, so this now asserts that nothing special happens at all.
+    "a trigger's \"you may\" is the same consent gate a spell's is" {
         val optional = TriggeredAbility(
             id = AbilityId("trigger"),
             trigger = SdkTriggers.EntersBattlefield.event,
             binding = SdkTriggers.EntersBattlefield.binding,
-            effect = Effects.DrawCards(1),
-            optional = true,
+            effect = MayEffect(Effects.DrawCards(1)),
         )
 
         Grammar.abilityLine.printLine(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerProcessor.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FeasibilityCheck
 import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.isConsentGate
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
 import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
 import com.wingedsheep.engine.handlers.effects.composite.ModalEffectExecutor
@@ -348,59 +349,42 @@ class TriggerProcessor(
             return processTargetedTrigger(currentState, trigger, targetRequirement)
         }
 
-        // A no-target optional trigger has no target-selection step to carry the decline through,
-        // so the targeted path's may handling never runs and `optional` (plus any `elseEffect`)
-        // was silently dropped — the trigger resolved as mandatory (the latent bug that made
-        // Yawgmoth Demon do nothing and Song of Stupefaction mill without asking). Lower it into
-        // the unified GatedEffect(Gate.MayDecide) frame so GatedEffectExecutor owns the
-        // resolution-time yes/no and runs `elseEffect` (if any) on decline. Skip the wrap when the
-        // effect already carries its own consent gate (a May* GatedEffect, e.g. `Effects.May` or
-        // an optional mana payment) — double-wrapping would prompt twice. Feasibility derived from
-        // the may-action lets an impossible "may" (e.g. "you may sacrifice an artifact" with no
-        // artifact) fall straight to the else with no prompt — the no-target analogue of
-        // "no legal targets → else".
-        if (ability.optional && !ability.effect.ownsConsentGate()) {
-            val gated = GatedEffect(
-                gate = Gate.MayDecide(feasibility = impliedMayFeasibility(ability.effect)),
-                then = ability.effect,
-                otherwise = ability.elseEffect
-            )
-            return putTriggerOnStack(currentState, trigger, emptyList(), gated)
-        }
-
-        // No targets required - put directly on stack
-        return putTriggerOnStack(currentState, trigger, emptyList())
+        // No targets required — put directly on stack, with one derivation applied on the way.
+        return putTriggerOnStack(
+            currentState,
+            trigger,
+            emptyList(),
+            ability.effect.withImpliedMayFeasibility()
+        )
     }
 
     /**
-     * Does this effect already carry its own consent gate — a `May*` [GatedEffect] the executor will
-     * turn into a resolution-time yes/no? Used to keep `optional` from wrapping a second "you may"
-     * around an effect that already asks, which would prompt twice.
+     * Stamp the feasibility a no-target "you may [action]" implies onto its consent gate, so
+     * "you may … If you don't, …" skips the prompt and runs its else branch when the action is
+     * impossible — the player can't, so they "don't". The no-target analogue of
+     * "no legal targets → else".
      *
-     * Looks through a [Gate.OnceEachTurn] because `withEffectBudgetGate` lowers a capped optional
-     * ability to `OnceEachTurn(spend = false) → May… → OnceEachTurn() → effect`; the consent gate is
-     * still there, one level down.
+     * **Derived here rather than stored on the card**, and that is the point. Nothing in the printed
+     * text says it: "you may sacrifice an artifact" and "you may draw a card" are the same sentence
+     * shape, and which one is unanswerable follows from the *effect*, not from the wording. A card
+     * that spelled it would be recording a fact it does not know, and a second card written the
+     * other way would then mean something different by accident. Only a gate with no feasibility of
+     * its own is touched — a card that states one (Provisions Merchant) is saying something the
+     * effect cannot imply, and it wins.
+     *
+     * A [SacrificeEffect] is always controller-self and needs the controller to control enough
+     * matching permanents; other actions (draw, gain life, add a counter) are always feasible
+     * (`null` → always prompt). Extend as further impossible-when-empty may-actions appear.
      */
-    private fun Effect.ownsConsentGate(): Boolean {
-        val gated = this as? GatedEffect ?: return false
-        return when (gated.gate) {
-            is Gate.MayDecide, is Gate.MayPay, is Gate.MayPayX -> true
-            is Gate.OnceEachTurn -> gated.then.ownsConsentGate()
-            else -> false
+    private fun Effect.withImpliedMayFeasibility(): Effect {
+        val gated = this as? GatedEffect ?: return this
+        val gate = gated.gate as? Gate.MayDecide ?: return this
+        if (gate.feasibility != null) return this
+        val implied = when (val action = gated.then) {
+            is SacrificeEffect -> FeasibilityCheck.ControlsPermanentMatching(action.filter, action.count)
+            else -> return this
         }
-    }
-
-    /**
-     * The feasibility a no-target "may" action implies, so a "you may [action]. If you don't, …"
-     * trigger skips the prompt and runs its else branch when the action is impossible (the player
-     * can't, so they "don't"). A [SacrificeEffect] is always controller-self and needs the
-     * controller to control enough matching permanents; other actions (draw, gain life, add a
-     * counter) are always feasible (`null` → always prompt). Extend as further
-     * impossible-when-empty may-actions appear.
-     */
-    private fun impliedMayFeasibility(effect: Effect): FeasibilityCheck? = when (effect) {
-        is SacrificeEffect -> FeasibilityCheck.ControlsPermanentMatching(effect.filter, effect.count)
-        else -> null
+        return gated.copy(gate = gate.copy(feasibility = implied))
     }
 
     /**
@@ -664,8 +648,16 @@ class TriggerProcessor(
         for ((index, req) in allRequirements.withIndex()) {
             val legalTargets = allLegalTargets[index] ?: emptyList()
             if (legalTargets.isEmpty() && req.effectiveMinCount > 0) {
-                if (ability.elseEffect != null) {
-                    return putTriggerOnStack(state, trigger, emptyList(), ability.elseEffect)
+                // The else branch is in one of two places, and both are the same printed clause.
+                // A mandatory ability writes "…; otherwise, X" as `elseEffect`. A "you may … If you
+                // don't, X" ability keeps its else inside the consent gate, because that is where
+                // *declining* is decided — but a target it cannot choose is the other way of not
+                // doing it (Entrails Feaster taps when no graveyard holds a creature card), so the
+                // clause has to run from here too rather than be lost with the fizzled ability.
+                val declineBranch = ability.elseEffect
+                    ?: (ability.effect as? GatedEffect)?.takeIf { it.gate.isConsentGate }?.otherwise
+                if (declineBranch != null) {
+                    return putTriggerOnStack(state, trigger, emptyList(), declineBranch)
                 }
                 return ExecutionResult.success(
                     state,
@@ -683,15 +675,14 @@ class TriggerProcessor(
         // Auto-select player targets when there's exactly one legal target and requirement is for exactly one target.
         // Only applies for single-target abilities (not multi-target).
         //
-        // NOT when the ability is `optional`. A targeted "you may" carries its consent solely through
-        // the target-selection decision's `minTargets = 0` (see `requirementInfos` below) — skipping
-        // that decision skips the decline, and the trigger goes on the stack as mandatory. That is
-        // fail-open: in a two-player game "you may have target opponent discard a card" (Ebon Dragon)
-        // never asked, it just made them discard. The optimization's premise — "there is only one
-        // choice, so don't prompt" — is false here: declining is a second choice. (An `optional`
-        // *requirement*, `TargetPlayer(optional = true)` for "up to one target player", already skips
-        // this branch via `effectiveMinCount == 0`.)
-        if (allRequirements.size == 1 && !ability.optional) {
+        // Safe for a "you may" ability now that consent is a gate rather than a flag: either the
+        // yes/no was already asked and answered before this ran (`processMayThenTargetTrigger`
+        // unwraps the gate and calls back in), or the gate is still on the effect and will ask at
+        // resolution. Neither reading is "there is only one choice, so don't prompt" applied to the
+        // decline — which is what made this branch fail open while the flag existed, so that
+        // "you may have target opponent discard a card" (Ebon Dragon) never asked in a two-player
+        // game. An "up to one target player" requirement skips this via `effectiveMinCount == 0`.
+        if (allRequirements.size == 1) {
             val isPlayerTarget = targetRequirement is com.wingedsheep.sdk.scripting.targets.TargetPlayer ||
                                  targetRequirement is com.wingedsheep.sdk.scripting.targets.TargetOpponent
             val legalTargets = allLegalTargets[0] ?: emptyList()
@@ -702,10 +693,17 @@ class TriggerProcessor(
             }
         }
 
-        // Create target requirement infos for the decision
-        // If the ability is optional (e.g., "you may"), allow selecting 0 targets to decline
+        // Create target requirement infos for the decision.
+        //
+        // A slot's minimum is the *requirement's* — "up to one" allows zero, "target creature" does
+        // not. A "you may" ability used to force every slot to zero here so that choosing nothing
+        // was how you declined; that was the `optional` flag's second, unrelated meaning, and it was
+        // wrong twice over. CR 603.3d chooses targets for a "you may" trigger like any other and
+        // puts the choice at resolution, and an ability whose target is mandatory has to be removed
+        // from the stack when there is no legal one (the loop above) rather than resolve targetless.
+        // Consent is now a gate on the effect, answered on its own — either before this method runs
+        // (`processMayThenTargetTrigger`) or as the ability resolves.
         val requirementInfos = allRequirements.mapIndexed { index, req ->
-            val effectiveMinTargets = if (ability.optional) 0 else req.effectiveMinCount
             // "Any number of target ..." (unlimited) caps at however many legal targets exist,
             // mirroring the cast-time path (TargetEnumerationUtils). Using req.count (always 1
             // for an unlimited requirement) would wrongly clamp the decision to a single target.
@@ -713,7 +711,7 @@ class TriggerProcessor(
             TargetRequirementInfo(
                 index = index,
                 description = req.description,
-                minTargets = effectiveMinTargets,
+                minTargets = req.effectiveMinCount,
                 maxTargets = maxTargets,
                 sameOwner = (req as? com.wingedsheep.sdk.scripting.targets.TargetObject)?.sameOwner == true,
                 totalManaValueAtMost = resolveTotalManaValueAtMost(state, trigger, req),
@@ -1577,10 +1575,6 @@ class TriggerProcessor(
      * rather than only being exercised when a capped ability happens to trigger in a game.
      */
     companion object {
-
-        /** Gates that represent the printed "you may" — the ones a budget must be spent *inside* of. */
-        private val Gate.isConsentGate: Boolean
-            get() = this is Gate.MayDecide || this is Gate.MayPay || this is Gate.MayPayX
 
         /**
          * Wrap [effect] in the [Gate.OnceEachTurn] budget gates for `effectOncePerTurn` — the

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/EtbSuspectUpToOneTargetCreatureTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/EtbSuspectUpToOneTargetCreatureTest.kt
@@ -7,10 +7,10 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -41,8 +41,11 @@ class EtbSuspectUpToOneTargetCreatureTest : FunSpec({
 
         triggeredAbility {
             trigger = Triggers.EntersBattlefield
-            optional = true
-            val t = target("target creature", Targets.Creature)
+            // "*Up to one* target creature" is an optional **requirement**, not an optional
+            // ability: the ability is mandatory and the slot may be left empty. The two used to be
+            // spelled the same way — `optional = true` on the ability forced every slot's minimum
+            // to zero — and this card was written the wrong way round because of it.
+            val t = target("target creature", TargetCreature(optional = true))
             effect = Effects.Suspect(t)
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GravediggerCombatDeathTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GravediggerCombatDeathTest.kt
@@ -87,9 +87,10 @@ class GravediggerCombatDeathTest : FunSpec({
         // Gravedigger should be on battlefield
         driver.findPermanent(activePlayer, "Gravedigger") shouldNotBe null
 
-        // The ETB trigger should fire - should prompt for target selection
+        // The ETB trigger fires and asks its "you may" first; accepting prompts for the target
         driver.isPaused shouldBe true
         driver.pendingDecision.shouldNotBeNull()
+        driver.submitYesNo(activePlayer, true)
         driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
 
         val targetDecision = driver.pendingDecision as ChooseTargetsDecision


### PR DESCRIPTION
`TriggeredAbility.optional` was a second spelling of `Gate.MayDecide`, and the argument for that was
not made here — it was already in the engine. `TriggerProcessor.putOnStack` read the flag and
*built* `GatedEffect(Gate.MayDecide, then = effect, otherwise = elseEffect)` from it before the
ability ever reached the stack, skipping the wrap when the effect already `ownsConsentGate()`. One
spelling lowered into the other on every game. The flag is gone; the gate is the model.

`optional = true` survives as a **DSL shorthand** on `TriggeredAbilityBuilder`, lowered in `build()`
to `MayEffect(effect, otherwise = elseEffect)`. That keeps 149 card definitions unedited while the
serialized model has exactly one shape — which is what the differential fold existed to paper over.
Setting it on an effect that already owns a consent gate is now a build-time `require` rather than a
double prompt. Outside the DSL there is no shorthand: `TriggeredAbility.create` takes no `optional`,
and the five call sites that passed it (three Legions Slivers, Grothama, soulbond) write
`MayEffect(...)`.

## Settling `TriggerProcessor.kt:708` first, as asked

```kotlin
val effectiveMinTargets = if (ability.optional) 0 else req.effectiveMinCount
```

**Verdict: a third meaning, and a wrong one. Deleted rather than rehoused.**

It is load-bearing — it was the *only* consent mechanism for the 54 targeted `optional` abilities,
which is exactly what the neighbouring comment at :686 said ("carries its consent solely through the
target-selection decision's `minTargets = 0`"). But the claim it makes is not "the controller may
decline the effect", it is "every target slot is *up to* N", and that is wrong twice:

- **CR 603.3d** chooses targets for a "you may" trigger like any other, and the choice to decline
  comes on resolution. Reclamation Sage's "you may destroy target artifact or enchantment" targets
  mandatorily.
- An ability whose target is mandatory and has no legal target is **removed from the stack**. With
  `minTargets = 0` it went on the stack targetless and resolved doing nothing — indistinguishable for
  most of these cards, not indistinguishable in general.

It also collided with the *real* "up to N", which is `optional` on the **requirement**
(`TargetCreature(optional = true)`). `EtbSuspectUpToOneTargetCreatureTest`'s card was written with
the ability flag for "up to one target creature" precisely because the two were spelled the same
way; it is fixed here, and the two statements now have two spellings.

So there is nowhere for it to live, because it should not have existed. A slot's minimum is now the
requirement's, full stop.

The second read (`:694`) fell out with it. The single-legal-player-target auto-select was disabled
for optional abilities because skipping the target decision skipped the consent riding on it (the
Ebon Dragon fail-open). Consent is now asked *before* targeting is reached, so the guard is
unnecessary and the optimization is back.

## What changes at the table

The 54 targeted "you may" triggers move onto the may-then-target path that the 214 hand-written
`MayEffect` triggers already used. That is a strict improvement in four ways, none of which is new
code:

- an explicit yes/no instead of "select zero targets to decline" — a decline you could stumble into
- a proper fizzle when no legal target exists (CR 603.3d)
- eligibility for **run batching** (`BatchYesNoDecision`) — `batchKeyOf` requires `asMayDecide()`, so
  the flag spelling could never batch
- eligibility for **remembered auto-answers** (`autoAnswerFor`), same reason

Two behaviours are preserved deliberately:

- **Entrails Feaster** ("you may exile a creature card from a graveyard … If you don't, tap this") is
  the one targeted optional with an `elseEffect`. Its else moves inside the gate, and `asMayDecide()`
  already refuses gates carrying an `otherwise`, so it routes through `processTargetedTrigger` and
  the gate asks at resolution — CR-correct. The no-legal-target branch now reads the else from the
  gate as well as from `elseEffect`, so it still taps with every graveyard empty.
- **Feasibility stays derived, never stored.** `withImpliedMayFeasibility` stamps it onto a no-target
  `Gate.MayDecide` from the effect, so Yawgmoth Demon and Devouring Sugarmaw still skip an
  unanswerable "you may sacrifice" without any card recording a fact its text does not state. A gate
  that declares its own feasibility (Provisions Merchant) keeps it.

## Assay

`Triggers.abilityFor`/`scriptFor` and `Granted`'s pair lose the lowering entirely — a trigger's
effect clause is now the same value a spell's clause is — and **`Folds.liftTriggerConsent` is
deleted**.

The `gated == MayEffect(gated.then)` fail-closed check goes with it, and is not missed: nothing is
discarded any more, so nothing can be dropped.

## Gates

| Gate | Result |
|---|---|
| `just build` | green (full, including all tests) |
| `just test-scenarios` | green — the real check, since the flag was read on every triggered ability |
| `just assay-gate` | MISMATCH 0, AMBIGUOUS 0, redundant readings 0 |
| `just assay-differential` | 2,431 compared / 2,425 confirmed / **6 divergent** |
| `just rebless-cards` | 109 abilities across 106 cards reshape `"optional": true` → a `Gate.MayDecide` wrapper; 109 removed, 109 added, no other key moved |

**On the divergence count.** The task quoted 2 as today's number. My branch point (`a4a62e1a45`) is
not that tree: I ran the differential on a clean detached worktree at that exact commit and it
reports **6** — 2,431 compared, 2,425 confirmed, and the *same six cards* (Mm'menon, Zombie Master,
Lavaborn Muse, Donatello, Tattered Ratter, Kalastria Highborn). After this change it is byte-for-byte
the same. So the number is unmoved and the fold really was redundant. (Two of the six, Mm'menon and
Donatello, are the `TriggerBinding.OTHER` cards fixed in the shared checkout's uncommitted work,
which is not in this branch; the other four are unrelated to consent — a grant filter's
`IsCreature`/`IsPermanent`, and the bare-tribal-noun family.)

## Test changes

Eleven scenario tests asserted the old flow and now assert the new one. Four are worth reading rather
than skimming, because they are where the semantics changed:

- **`EbonDragonScenarioTest`** — was the regression test for the auto-select fail-open. Its guard was
  "the target decision offers `minTargets = 0`"; it is now "the may-question is raised at all", which
  is what the auto-select can no longer skip.
- **`SerpentAssassinTest`** — "can be declined by selecting no targets" becomes "can be declined at
  the may-question", and the sibling test now asserts `minTargets == 1`: a targeted "you may" is not
  an "up to one".
- **`EntrailsFeasterTest`** — targets first, may at resolution. All four tests pass, including
  "no creature cards in any graveyard - gets tapped automatically", which is what proves the
  else-from-the-gate path.
- **`EtbSuspectUpToOneTargetCreatureTest`** — the test card is re-authored with an optional
  *requirement*, which is what "up to one target creature" always meant.

Docs: `card-sdk-language-reference.md`'s `optional` section rewritten (shorthand, not a field; the
three consequences); `oracle-assay/README.md` records the finding as closed and marks the Legions
band's "~10 cards" bullet resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
