### PR TITLE
Show the printed token card for The Hobbit's tokens

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1533,15 +1533,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   object FoundationsSet : MtgSet {
       override val tokenArt = listOf(
           // tfdn #1 — Arahbo, the First Fang's 1/1 white Cat.
-          TokenPrinting(name = "Cat", imageUri = "https://cards.scryfall.io/art_crop/front/2/8/2885d54c-….jpg"),
+          TokenPrinting(name = "Cat", imageUri = "https://cards.scryfall.io/normal/front/2/8/2885d54c-….jpg"),
       )
   }
   ```
 
   `TokenPrinting` matches on `name`, plus `power` / `toughness` / `colors` when you pin them — only needed
-  when one set prints two tokens sharing a name. Use the Scryfall **`art_crop`** URL: the client renders a
-  token as a generated frame and drops this image into its art box, so a full-card `normal` image arrives
-  pre-framed and gets cropped to its middle band.
+  when one set prints two tokens sharing a name. Use the Scryfall **`normal`** URL — the whole token card,
+  the same form `just token-art-sync` writes, rendered by the client as-is. An `art_crop` URL still works
+  but takes the legacy path: the client recognises `/art_crop/` and draws the bare art inside a frame it
+  generates itself, so a token that has a real printed card comes out looking like a placeholder.
 
   **Several arts for one token:** a set that printed the same token with different illustrations declares
   **one row per art** — nothing on the row changes, the plurality lives in the list. A batch of tokens

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/TokenPrinting.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/TokenPrinting.kt
@@ -27,13 +27,16 @@ import com.wingedsheep.sdk.core.Color
  * Dogs show all four printed illustrations instead of one repeated four times.
  *
  * ## Image form
- * Use the Scryfall **`art_crop`** URL, not `normal`. The client renders a token as a generated
- * frame (name bar / art box / type bar) and drops this image into the art box, so a full-card
- * `normal` image arrives pre-framed and gets cropped to its middle band.
+ * Use the Scryfall **`normal`** URL — the whole token card, which is what the bulk sync writes and
+ * what the client renders as-is, printed frame and reminder text included. An `art_crop` URL still
+ * works but takes the *legacy* path: the client recognises `/art_crop/` and draws the art inside a
+ * generated frame of its own (name bar / art box / type bar), which is how a token that has a real
+ * printed card ends up looking like a placeholder. A set old enough to predate token cards has no
+ * `t<code>` set to draw from and falls back to self-hosted art under `/images/tokens/`.
  *
  * @property name Token name as printed — the creature type for a vanilla token ("Cat"), or the
  *   full name for a named one ("Marit Lage", "Zombie Druid").
- * @property imageUri Scryfall `art_crop` URL for this set's printing of the token.
+ * @property imageUri Scryfall `normal` URL for this set's printing of the token.
  * @property power Printed power, when needed to disambiguate. Null matches any.
  * @property toughness Printed toughness, when needed to disambiguate. Null matches any.
  * @property colors Printed colors, when needed to disambiguate. Null matches any; an empty set

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/FoundationsSet.kt
@@ -47,7 +47,7 @@ object FoundationsSet : MtgSet {
         // tfdn #1 — Arahbo, the First Fang's 1/1 white Cat (art by Leonardo Santanna).
         TokenPrinting(
             name = "Cat",
-            imageUri = "https://cards.scryfall.io/art_crop/front/2/8/2885d54c-9fb2-4f01-8937-54f8ac1ce5bc.jpg?1783908593",
+            imageUri = "https://cards.scryfall.io/normal/front/2/8/2885d54c-9fb2-4f01-8937-54f8ac1ce5bc.jpg?1783908593",
         ),
         // Release the Dogs is reprinted here, and the joke only lands if the four Dogs look like
         // four different dogs — so the FDN printing borrows Jumpstart's four Dog arts rather than

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/TheHobbitSet.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/TheHobbitSet.kt
@@ -34,25 +34,81 @@ object TheHobbitSet : MtgSet {
     }
 
     /**
-     * The set is too new to appear in the bulk `tokens.json` sync, so the tokens its cards actually
-     * mint are hand-authored here. Drop a row once `just token-art-sync` picks the same art up.
+     * The set is too new to appear in the bulk `tokens.json` sync, so every token `thob` prints is
+     * hand-authored here — one row per printed illustration, `normal` full-card images like the
+     * sync writes. Drop the block once `just token-art-sync` picks the same art up.
+     *
+     * These rows are the only place HOB token art lives: the cards themselves pass no `imageUri`,
+     * which is what lets a later reprint mint its own set's token.
      */
     override val tokenArt: List<TokenPrinting> = listOf(
-        // thob #12 — the Treasure minted by Long-Bodied Grey Dog and Dori, Bearer of Friends.
+        // thob #1 — the Bird Soldier The Eagles Are Coming! schedules for the next upkeep.
         TokenPrinting(
-            name = "Treasure",
-            imageUri = "https://cards.scryfall.io/art_crop/front/c/6/c6e096bb-ad9e-4a8b-8b42-26852fa32c1d.jpg?1783902770",
-        ),
-        // thob #3 — the Army that every "amass Goblins" card in the set puts its counters on
-        // (Down, Down to Goblin Town, Gathering of Darkness, Rage into the Valley, Clap! Snap!).
-        TokenPrinting(
-            name = "Goblin Army",
-            imageUri = "https://cards.scryfall.io/normal/front/2/e/2e2028b1-34c0-40b6-8f65-79f79a279996.jpg?1785497644",
+            name = "Bird Soldier",
+            imageUri = "https://cards.scryfall.io/normal/front/9/e/9ed2d2f3-e1b0-41e0-a29d-31624e5e9004.jpg?1785524352",
         ),
         // thob #2 — the Soldier every recruit card in the set mints.
         TokenPrinting(
             name = "Human Soldier",
-            imageUri = "https://cards.scryfall.io/art_crop/front/6/0/6007af81-4541-4b55-90ea-03d365362ae5.jpg?1785497653",
+            imageUri = "https://cards.scryfall.io/normal/front/6/0/6007af81-4541-4b55-90ea-03d365362ae5.jpg?1785497653",
+        ),
+        // thob #3 and #4 — the Army every "amass Goblins" card in the set puts its counters on
+        // (Down, Down to Goblin-town, Gathering of Darkness, Rage into the Valley, Tidings of War).
+        // Two illustrations, dealt out in order when a card mints more than one.
+        TokenPrinting(
+            name = "Goblin Army",
+            imageUri = "https://cards.scryfall.io/normal/front/2/e/2e2028b1-34c0-40b6-8f65-79f79a279996.jpg?1785497644",
+        ),
+        TokenPrinting(
+            name = "Goblin Army",
+            imageUri = "https://cards.scryfall.io/normal/front/0/0/0045408d-4ab9-48bf-84aa-c6d827682090.jpg?1785497563",
+        ),
+        // thob #5 — the Dragon The Misty Mountains Cold pays a sacrifice for.
+        TokenPrinting(
+            name = "Dragon",
+            imageUri = "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
+        ),
+        // thob #6 — the Dwarf of An Unexpected Party, Dwarven Shortsword, Fíli the Pathfinder and
+        // The Lonely Mountain.
+        TokenPrinting(
+            name = "Dwarf",
+            imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1786258756",
+        ),
+        // thob #7 — Dancing from Dark to Dawn's landfall Bear.
+        TokenPrinting(
+            name = "Bear",
+            imageUri = "https://cards.scryfall.io/normal/front/3/1/31661af9-a40a-418c-82e3-b74aa14cc7c4.jpg?1785497718",
+        ),
+        // thob #8 — the Elf of Down in the Valley and Thranduil, Sindarin Liege.
+        TokenPrinting(
+            name = "Elf",
+            imageUri = "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812",
+        ),
+        // thob #9 — the Wolf of Chief Warg's Company and Head of the Hunt.
+        TokenPrinting(
+            name = "Wolf",
+            imageUri = "https://cards.scryfall.io/normal/front/e/0/e07312b9-f3c1-4e36-88fc-b29cde581eb6.jpg?1785497932",
+        ),
+        // thob #10 — the Equipment Dáin Ironfoot and Iron Hills Blacksmith mint from
+        // PredefinedTokens.Axe.
+        TokenPrinting(
+            name = "Axe",
+            imageUri = "https://cards.scryfall.io/normal/front/6/f/6f7a3999-e341-43bb-9b8f-6c1a05b98906.jpg?1785497989",
+        ),
+        // thob #11 — Stone-Giant of High Pass's named Wall token.
+        TokenPrinting(
+            name = "Stone Boulder",
+            imageUri = "https://cards.scryfall.io/normal/front/3/4/3440e247-a733-4609-9d80-d4a5fc58ae46.jpg?1785502811",
+        ),
+        // thob #12 and #13 — the Treasure of Smaug the Magnificent, Dori, Bearer of Friends,
+        // Long-Bodied Grey Dog and the rest of the set's Treasure makers, in two illustrations.
+        TokenPrinting(
+            name = "Treasure",
+            imageUri = "https://cards.scryfall.io/normal/front/c/6/c6e096bb-ad9e-4a8b-8b42-26852fa32c1d.jpg?1783902770",
+        ),
+        TokenPrinting(
+            name = "Treasure",
+            imageUri = "https://cards.scryfall.io/normal/front/d/1/d1892b78-7663-4cbd-a732-9a4b0b18d4c8.jpg?1785498054",
         ),
     )
 

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/AnUnexpectedParty.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/AnUnexpectedParty.kt
@@ -60,7 +60,6 @@ val AnUnexpectedParty = card("An Unexpected Party") {
                 toughness = 2,
                 colors = setOf(Color.RED),
                 creatureTypes = setOf("Dwarf"),
-                imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1786258756",
             )
         }
     }

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ChiefWargsCompany.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ChiefWargsCompany.kt
@@ -66,7 +66,6 @@ val ChiefWargsCompany = card("Chief Warg's Company") {
             colors = setOf(Color.GREEN),
             creatureTypes = setOf("Wolf"),
             controller = EffectTarget.Controller,
-            imageUri = "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1783924694",
         )
         description = "At the beginning of your upkeep, create a 2/2 green Wolf creature token."
     }

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DancingFromDarkToDawn.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DancingFromDarkToDawn.kt
@@ -60,7 +60,6 @@ val DancingFromDarkToDawn = card("Dancing from Dark to Dawn") {
             colors = setOf(Color.GREEN),
             creatureTypes = setOf("Bear"),
             controller = EffectTarget.Controller,
-            imageUri = "https://cards.scryfall.io/normal/front/3/1/31661af9-a40a-418c-82e3-b74aa14cc7c4.jpg?1785497718",
         )
         description = "Landfall — Whenever a land you control enters, create a 2/2 green Bear " +
             "creature token."

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DownInTheValley.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DownInTheValley.kt
@@ -68,7 +68,6 @@ val DownInTheValley = card("Down in the Valley") {
                     toughness = 1,
                     colors = setOf(Color.GREEN),
                     creatureTypes = setOf("Elf"),
-                    imageUri = "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812",
                 ),
                 descriptionOverride = "Landfall — Whenever a land you control enters, create a 1/1 " +
                     "green Elf creature token."

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DwarvenShortsword.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/DwarvenShortsword.kt
@@ -33,7 +33,6 @@ val DwarvenShortsword = card("Dwarven Shortsword") {
             toughness = 2,
             colors = setOf(Color.RED),
             creatureTypes = setOf("Dwarf"),
-            imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537",
         ).then(Effects.AttachEquipment(EffectTarget.PipelineTarget(CREATED_TOKENS, 0)))
     }
 

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/FiliThePathfinder.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/FiliThePathfinder.kt
@@ -67,7 +67,6 @@ val FiliThePathfinder = card("Fíli the Pathfinder") {
             toughness = 2,
             colors = setOf(Color.RED),
             creatureTypes = setOf("Dwarf"),
-            imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537",
         )
     }
 

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/HeadOfTheHunt.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/HeadOfTheHunt.kt
@@ -49,7 +49,6 @@ val HeadOfTheHunt = card("Head of the Hunt") {
                 toughness = 2,
                 colors = setOf(Color.GREEN),
                 creatureTypes = setOf("Wolf"),
-                imageUri = "https://cards.scryfall.io/normal/front/e/0/e07312b9-f3c1-4e36-88fc-b29cde581eb6.jpg?1785497932",
             ),
             appliesTo = EventPattern.ZoneChangeEvent(
                 filter = GameObjectFilter.Creature.opponentControls(),

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StoneGiantOfHighPass.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/StoneGiantOfHighPass.kt
@@ -35,7 +35,6 @@ private fun stoneBoulderToken() = CreateTokenEffect(
     keywords = setOf(Keyword.DEFENDER),
     name = "Stone Boulder",
     artifactToken = true,
-    imageUri = "https://cards.scryfall.io/normal/front/3/4/3440e247-a733-4609-9d80-d4a5fc58ae46.jpg?1785502811",
 )
 
 val StoneGiantOfHighPass = card("Stone-Giant of High Pass") {

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheEaglesAreComing.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheEaglesAreComing.kt
@@ -96,7 +96,6 @@ val TheEaglesAreComing = card("The Eagles Are Coming!") {
                         colors = setOf(Color.WHITE),
                         creatureTypes = setOf("Bird", "Soldier"),
                         keywords = setOf(Keyword.FLYING),
-                        imageUri = "https://cards.scryfall.io/normal/front/9/e/9ed2d2f3-e1b0-41e0-a29d-31624e5e9004.jpg?1785524352"
                     )
                 )
             )

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheLonelyMountain.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheLonelyMountain.kt
@@ -60,7 +60,6 @@ val TheLonelyMountain = card("The Lonely Mountain") {
             toughness = 2,
             colors = setOf(Color.RED),
             creatureTypes = setOf("Dwarf"),
-            imageUri = "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537",
         )
         genericCostReduction = DynamicAmounts.battlefield(
             Player.You,

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheMistyMountainsCold.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/TheMistyMountainsCold.kt
@@ -74,7 +74,6 @@ private fun mistyMountainsChapter(): Effect =
                         creatureTypes = setOf("Dragon"),
                         keywords = setOf(Keyword.FLYING),
                         controller = EffectTarget.Controller,
-                        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
                     ),
                     successCriterion = SuccessCriterion.PermanentsSacrificed,
                 )

--- a/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilSindarinLiege.kt
+++ b/mtg-sets/2026/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hob/cards/ThranduilSindarinLiege.kt
@@ -71,7 +71,6 @@ val ThranduilSindarinLiege = card("Thranduil, Sindarin Liege") {
             toughness = 1,
             colors = setOf(Color.GREEN),
             creatureTypes = setOf("Elf"),
-            imageUri = "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812",
         )
         description = "Landfall — Whenever a land you control enters, create a 1/1 green Elf " +
             "creature token."

--- a/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TheHobbitTokenArtScenarioTest.kt
+++ b/mtg-sets/2026/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/TheHobbitTokenArtScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.registry.TokenArtRegistry
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.hob.TheHobbitSet
+import com.wingedsheep.mtg.sets.tokens.TokenArtData
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+/**
+ * The Hobbit's tokens show the token *card* the set printed.
+ *
+ * The client renders a token's `imageUri` as-is unless the URL says `/art_crop/`, in which case it
+ * takes the legacy path and draws the bare art inside a frame it generates itself. HOB rows were
+ * hand-authored as `art_crop`, so tokens with a perfectly good printed card — Treasure, the recruit
+ * Soldier — came out as generated placeholders instead. These tests pin the whole set to the
+ * `normal` full-card form the bulk sync writes.
+ *
+ * They also pin the *layering*: the cards pass no `imageUri` of their own, so the art has to come
+ * from [TheHobbitSet.tokenArt] through
+ * [com.wingedsheep.engine.registry.TokenArtRegistry]. That is what lets a reprint mint its own
+ * set's token, and it is why baking the URL into a card script is the wrong place for it.
+ */
+class TheHobbitTokenArtScenarioTest : ScenarioTestBase() {
+
+    /** `thob` #6 — The Hobbit's Dwarf token. */
+    private val hobbitDwarf = "9fcb3a3f-c0d4-43d4-8549-826a38bfa27d"
+
+    /** `thob` #12 — the first of The Hobbit's two Treasure illustrations. */
+    private val hobbitTreasure = "c6e096bb-ad9e-4a8b-8b42-26852fa32c1d"
+
+    private fun registry() = TokenArtRegistry().apply {
+        register(
+            TheHobbitSet.code,
+            TokenArtData.forSet(TheHobbitSet),
+            TheHobbitSet.cards.map { it.name },
+        )
+    }
+
+    init {
+        test("Dwarven Shortsword's Dwarf carries the printed Hobbit token card") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Dwarven Shortsword")
+                .withLandsOnBattlefield(1, "Plains", 4)
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            game.castSpell(1, "Dwarven Shortsword").error shouldBe null
+            game.resolveStack()
+
+            val dwarf = game.findPermanent("Dwarf Token")
+            dwarf shouldNotBe null
+            val art = game.state.getEntity(dwarf!!)?.get<CardComponent>()?.imageUri
+
+            art shouldNotBe null
+            art!! shouldContain hobbitDwarf
+            // The whole card, not the art box — anything under /art_crop/ takes the client's
+            // generated-frame path and renders as a placeholder.
+            art shouldContain "/normal/"
+            art shouldNotContain "/art_crop/"
+        }
+
+        test("a Treasure minted in The Hobbit shows the Hobbit Treasure card") {
+            // The predefined-token path (Effects.CreateTreasure) consults the same registry by token
+            // name, so this is where the set's rows have to reach a token that has no CreateToken
+            // effect to hang an override on.
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Long-Bodied Grey Dog")
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            game.castSpell(1, "Long-Bodied Grey Dog").error shouldBe null
+            game.resolveStack()
+
+            val treasure = game.findPermanent("Treasure")
+            treasure shouldNotBe null
+            val art = game.state.getEntity(treasure!!)?.get<CardComponent>()?.imageUri
+
+            art shouldNotBe null
+            art!! shouldContain hobbitTreasure
+            art shouldContain "/normal/"
+            art shouldNotContain "/art_crop/"
+        }
+
+        test("every Hobbit token row is a full-card image") {
+            // The regression this file exists for: one art_crop URL is enough to send a token back
+            // to the generated frame, and it looks fine in every test that only checks *which*
+            // printing the token resolved to.
+            TheHobbitSet.tokenArt.forEach { printing ->
+                withClue(printing.name) {
+                    printing.imageUri shouldContain "/normal/"
+                    printing.imageUri shouldNotContain "/art_crop/"
+                }
+            }
+        }
+
+        test("the set covers the tokens its cards actually mint") {
+            // Named and predefined tokens resolve by name alone, so they have no creature type for
+            // the engine-wide fallback to key on — without a row they would reach the client with
+            // whatever art the shared PredefinedTokens definition carries, from some other set.
+            val registry = registry()
+
+            for (token in listOf("Human Soldier", "Bird Soldier", "Dwarf", "Bear", "Elf", "Wolf", "Dragon")) {
+                withClue(token) {
+                    registry.resolve(sourceCardDefinitionId = "Dwarven Shortsword", tokenName = token)
+                        .shouldNotBeNull()
+                }
+            }
+            registry.resolve(sourceCardDefinitionId = "Iron Hills Blacksmith", tokenName = "Axe")
+                .shouldNotBeNull()
+            registry.resolve(sourceCardDefinitionId = "Stone-Giant of High Pass", tokenName = "Stone Boulder")
+                .shouldNotBeNull()
+        }
+
+        test("the two printed Goblin Army and Treasure illustrations are both declared") {
+            // Amass puts every Army counter on one token, but the Treasure makers can mint a batch,
+            // and a set that printed a token twice should deal out both arts rather than repeat one.
+            val registry = registry()
+
+            registry.resolveAll(
+                sourceCardDefinitionId = "Down, Down to Goblin-town",
+                tokenName = "Goblin Army",
+            ) shouldHaveSize 2
+            registry.resolveAll(
+                sourceCardDefinitionId = "Long-Bodied Grey Dog",
+                tokenName = "Treasure",
+            ) shouldHaveSize 2
+        }
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -136,8 +136,7 @@
                     ],
                     "creatureTypes": [
                         "Dwarf"
-                    ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1786258756"
+                    ]
                 }
             }
         }
@@ -2362,7 +2361,6 @@
                     "creatureTypes": [
                         "Wolf"
                     ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1783924694",
                     "controller": "Controller"
                 },
                 "descriptionOverride": "At the beginning of your upkeep, create a 2/2 green Wolf creature token."
@@ -2631,7 +2629,6 @@
                     "creatureTypes": [
                         "Bear"
                     ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/3/1/31661af9-a40a-418c-82e3-b74aa14cc7c4.jpg?1785497718",
                     "controller": "Controller"
                 },
                 "descriptionOverride": "Landfall — Whenever a land you control enters, create a 2/2 green Bear creature token."
@@ -2969,8 +2966,7 @@
                             ],
                             "creatureTypes": [
                                 "Elf"
-                            ],
-                            "imageUri": "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812"
+                            ]
                         },
                         "descriptionOverride": "Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token."
                     },
@@ -3577,8 +3573,7 @@
                             ],
                             "creatureTypes": [
                                 "Dwarf"
-                            ],
-                            "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537"
+                            ]
                         },
                         {
                             "type": "AttachEquipment",
@@ -4707,8 +4702,7 @@
                     ],
                     "creatureTypes": [
                         "Dwarf"
-                    ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537"
+                    ]
                 }
             }
         ],
@@ -6554,8 +6548,7 @@
                     ],
                     "creatureTypes": [
                         "Wolf"
-                    ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/e/0/e07312b9-f3c1-4e36-88fc-b29cde581eb6.jpg?1785497932"
+                    ]
                 },
                 "appliesTo": {
                     "type": "ZoneChangeEvent",
@@ -11267,7 +11260,6 @@
                         "DEFENDER"
                     ],
                     "name": "Stone Boulder",
-                    "imageUri": "https://cards.scryfall.io/normal/front/3/4/3440e247-a733-4609-9d80-d4a5fc58ae46.jpg?1785502811",
                     "artifactToken": true
                 },
                 "descriptionOverride": "Whenever this creature enters, create a 3/1 colorless Wall artifact creature token with defender named Stone Boulder."
@@ -11287,7 +11279,6 @@
                         "DEFENDER"
                     ],
                     "name": "Stone Boulder",
-                    "imageUri": "https://cards.scryfall.io/normal/front/3/4/3440e247-a733-4609-9d80-d4a5fc58ae46.jpg?1785502811",
                     "artifactToken": true
                 },
                 "descriptionOverride": "Whenever this creature attacks, create a 3/1 colorless Wall artifact creature token with defender named Stone Boulder."
@@ -11841,8 +11832,7 @@
                         ],
                         "keywords": [
                             "FLYING"
-                        ],
-                        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9ed2d2f3-e1b0-41e0-a29d-31624e5e9004.jpg?1785524352"
+                        ]
                     }
                 }
             ]
@@ -12022,8 +12012,7 @@
                     ],
                     "creatureTypes": [
                         "Dwarf"
-                    ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fcb3a3f-c0d4-43d4-8549-826a38bfa27d.jpg?1785497537"
+                    ]
                 },
                 "timing": "SorcerySpeed",
                 "descriptionOverride": "Create a 2/2 red Dwarf creature token.",
@@ -12250,7 +12239,6 @@
                                     "keywords": [
                                         "FLYING"
                                     ],
-                                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
                                     "controller": "Controller"
                                 }
                             }
@@ -12308,7 +12296,6 @@
                                     "keywords": [
                                         "FLYING"
                                     ],
-                                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
                                     "controller": "Controller"
                                 }
                             }
@@ -12366,7 +12353,6 @@
                                     "keywords": [
                                         "FLYING"
                                     ],
-                                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
                                     "controller": "Controller"
                                 }
                             }
@@ -12424,7 +12410,6 @@
                                     "keywords": [
                                         "FLYING"
                                     ],
-                                    "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e4408fa-8037-42f1-989e-2da84867f76c.jpg?1785497692",
                                     "controller": "Controller"
                                 }
                             }
@@ -13257,8 +13242,7 @@
                     ],
                     "creatureTypes": [
                         "Elf"
-                    ],
-                    "imageUri": "https://cards.scryfall.io/normal/front/7/6/761c7c31-c6c5-44e2-a845-f590542b6eda.jpg?1785497812"
+                    ]
                 },
                 "descriptionOverride": "Landfall — Whenever a land you control enters, create a 1/1 green Elf creature token."
             }


### PR DESCRIPTION
The Hobbit's tokens were rendering as generated placeholder frames instead of the token cards the set actually prints.

## Why

The client renders a token's `imageUri` as-is *unless* the URL contains `/art_crop/` — that substring is the switch into the legacy path, where it draws the bare art inside a frame it builds itself (name bar / art box / type bar). `GameCard.tsx:1380`, mirrored in `CardPreview.tsx:462`.

HOB's `tokenArt` was hand-authored with `art_crop` URLs, so Treasure and the recruit Soldier — tokens with a perfectly good printed card in `thob` — came out as placeholders. That was not a slip: `TokenPrinting`'s "Image form" KDoc and the language reference both still prescribed `art_crop`, even though `SyncTokenArt` has written `normal` full-card URLs for every one of the 13,625 synced rows for a while now.

## What changed

- **`TheHobbitSet.tokenArt`** now declares all thirteen `thob` printings as `normal` full-card images: the two art_crop rows corrected, plus both illustrations of Goblin Army and Treasure, plus Bird Soldier, Dragon, Dwarf, Bear, Elf, Wolf, **Axe** and **Stone Boulder**. The last two resolve by name only — no creature type for the engine-wide fallback to key on — so without a row they reached the client with whatever art the shared `PredefinedTokens` definition carries, from another set.
- **Twelve HOB cards drop the `imageUri` they baked into their token effects.** An effect-level override wins over the registry, so the set's rows would otherwise be dead code for exactly the tokens they describe. It also fixes Chief Warg's Company, which pointed at a Wolf from a different set (`d5f1e139`, not `thob` #9).
- **Foundations' Cat row** had the identical `art_crop` form. One line, and the SDK doc quotes it as *the* example, so it goes with this rather than leaving the doc prescribing one thing and its own example doing another.
- **`TokenPrinting` KDoc + `card-sdk-language-reference.md`** now prescribe `normal`, with `art_crop` described as the legacy generated-frame path.
- **`TheHobbitTokenArtScenarioTest`** — Dwarven Shortsword's Dwarf and Long-Bodied Grey Dog's Treasure (the predefined-token path) carry the `thob` card end-to-end; every HOB row is asserted full-card; the by-name tokens resolve; both duplicate illustrations are present.

## Verification

- `just test-class TheHobbitTokenArtScenarioTest` — 5/5 pass
- `just test-class SetScopedTokenArtScenarioTest` — 5/5 pass (the FDN Cat assertion is by Scryfall id, unaffected)
- `just test-scenarios 2026` — green
- `just rebless-cards` — the HOB golden diff is exactly the twelve removed `imageUri` keys, nothing else moved

Not run: `just build`. Left to CI.

## Noted, not fixed

Self-hosted token art (`/images/tokens/*.jpeg`, used by MRD/JMP/FDN) is art-crop shaped but its URL contains no `/art_crop/`, so it takes the full-card branch and gets stretched to card shape. Same family of bug, different sets — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)