### PR TITLE
Assay: the equipment band, and the noun that was never a rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ docs it points at; load those when the work needs them.
 | `gym` / `gym-server` / `gym-trainer` | RL/MCTS env + HTTP transport + self-play SPI | engine, sdk |
 | `game-server` | Spring Boot orchestration, WebSocket, state masking | engine, sdk |
 | `mtgish-tooling` | Predictive coverage / auto-gen analyzer | — (scans source as text) |
-| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 99.96% agreement over 2,431 compared cards after the divergence sweep — 1 classified divergence left), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
+| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 100% agreement over 2,449 compared cards after the divergence sweep and the CR 603.4 split — 0 divergences standing), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
 | `web-client` | React UI (dumb terminal — no game logic) | — |
 
 **Key principle:** the engine is pure (no card-specific code), content is data-driven (no execution

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -7476,7 +7476,13 @@ composite abilities).
   form optionally reduces the generic portion of the equip cost by a `DynamicAmount` evaluated at
   activation. Reductions that read the chosen equip target (e.g. `DynamicAmounts.targetColorCount()`
   for "costs {1} less to activate for each color of the creature it targets" — Dragonfire Blade)
-  resolve against the picked target. Backed by `ActivatedAbility.genericCostReduction`: the
+  resolve against the picked target. The lowering itself — CR 702.6a's "attach to target creature you
+  control, sorcery speed" ability — is `ActivatedAbility.equip(cost, quality?, targetFilter?,
+  genericCostReduction?, id?)`, which `equipAbility` calls and which Argentum Assay also calls when it
+  reads a printed "Equip {1}" line back into a model. Cards keep writing `equipAbility`; the factory
+  exists so there is exactly one definition of what that line lowers to, and so the differential gate
+  is comparing a shared lowering rather than two copies that agree today. Backed by
+  `ActivatedAbility.genericCostReduction`: the
   `ActivateAbilityHandler` locks the per-target reduction in before paying; the legal-action
   enumerator gates affordability on the cheapest reachable cost (largest reduction over the
   currently-legal targets) since the target isn't chosen until activation. The synthesized ability

--- a/docs/plans/oracle-assay.md
+++ b/docs/plans/oracle-assay.md
@@ -239,8 +239,9 @@ is the next work:
     slot, so it reads as an ordinary filtered target and the whole of `Filters` arrives with it.
     Equip lowers at authoring time into `CardDefinition.equipCost` *and* a synthesized activated
     ability carrying its own timing, effect and target requirement — a lowering to reproduce rather
-    than a sentence to read, and one that reaches past `CardScript` into a slot `CardFragment` does
-    not model. Reading it is a `CardFragment` design change, not a rule.
+    than a sentence to read, and one that reaches past `CardScript` into a slot `CardFragment` did
+    not model. Reading it was a `CardFragment` design change, not a rule. *Done*, as the equipment
+    band below.
 
    **The land band is the first family where whole-card coverage moved with line coverage.** Lands
    are one-to-three-line cards, so 819 mana-ability lines and 319 tapped-entry lines over cards that
@@ -266,6 +267,23 @@ the largest family in the implemented population: 1,025 cards carry a counter li
 not read, and 656 decline on nothing else. A verb is also multiplicative, since `Triggers`, `Activated` and the modal rules all
 slot `Steps.step` whole. Prefix versus verb now has a worked example on each side; read them
 together before picking the next band.
+
+**The equipment band is the third, and the first where the overstatement was measured *before* the
+work rather than after.** `Equip {§}` was the largest sentence shape in the corpus — 563 cards, next
+one 342 — and a 400-card sample of what it blocked said 248 of them declined on nothing but
+equipment-shaped lines, predicting ~350 whole cards. The band delivered **65** (6,335 → 6,400), and
+the gap is one word: the sample counted "Equipped creature gets +2/+2 and has trample **and**
+lifelink" as an equipment shape, where the grammar's joined sentence takes one keyword and not a run.
+So a per-card sample predicts which *cards* a band reaches and still says nothing about which *lines*
+it finishes — the same failure mode as the token rank, one level up. What the band did buy is not in
+the coverage number: `CardDefinition.equipCost` is the first field outside `CardScript` the
+differential compares, and the attachment-noun normalization means every present and future `Statics`
+rule reads Equipment and Auras alike without knowing there are two card classes.
+
+The residue is measured and small, which is the other half worth recording: 385 cards decline on
+nothing but an "Enchanted creature …" sentence, their largest single shape is 10 cards, and
+generalizing the joined form to a keyword *run* is worth 22. There is no fourth large family behind
+this one.
 
 **Acceptance:** POR, LEA and a modern set (DFT or FDN) each report fineness; the per-set whole-render
 rate is directly comparable to `:mtgish-tooling`'s `gN` figure in the coverage dashboard.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -647,21 +647,15 @@ class CardBuilder(private val name: String) {
         targetFilter: TargetFilter = TargetFilter.CreatureYouControl,
     ) {
         equipCost = ManaCost.parse(cost)
-        // The label doubles as the target requirement's id and as the bound-variable name the
-        // attach effect reads, so both halves must use the same string.
-        val targetLabel = if (quality == null) "creature you control" else "$quality creature you control"
+        // The lowering itself is `ActivatedAbility.equip`, not spelled out here, because Argentum
+        // Assay reads the printed "Equip {1}" line back into the same ability and compares it against
+        // the card — two copies of one lowering is precisely the drift that comparison exists to
+        // catch. The label that links the requirement to the bound variable lives there too.
         activatedAbilities.add(
-            ActivatedAbility(
-                id = AbilityId.generate(),
-                cost = AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost))),
-                effect = AttachEquipmentEffect(EffectTarget.BoundVariable(targetLabel)),
-                targetRequirements = listOf(
-                    TargetCreature(filter = targetFilter, id = targetLabel)
-                ),
-                isManaAbility = false,
-                isEquipAbility = true,
-                equipQuality = quality,
-                timing = TimingRule.SorcerySpeed,
+            ActivatedAbility.equip(
+                cost = ManaCost.parse(cost),
+                quality = quality,
+                targetFilter = targetFilter,
                 genericCostReduction = genericCostReduction,
             )
         )

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -1,10 +1,15 @@
 package com.wingedsheep.sdk.scripting
 
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.manaCostOrNull
+import com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
 import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import com.wingedsheep.sdk.scripting.text.TextReplaceable
 import com.wingedsheep.sdk.scripting.text.TextReplacer
@@ -201,6 +206,58 @@ data class ActivatedAbility(
         }
         return if (newCost !== cost || newEffect !== effect || trChanged)
             copy(cost = newCost, effect = newEffect, targetRequirements = newTargetReqs) else this
+    }
+
+    companion object {
+
+        /**
+         * The ability "Equip [cost]" *is* — CR 702.6a's "attach this Equipment to target creature you
+         * control. Activate only as a sorcery."
+         *
+         * Equip is a keyword ability the SDK **lowers** rather than stores: a card writes
+         * `equipAbility("{1}")` and gets `CardDefinition.equipCost` plus this synthesized ability.
+         * The lowering lives here rather than inside [com.wingedsheep.sdk.dsl.CardBuilder.equipAbility]
+         * because it has a second caller — Argentum Assay reads the printed "Equip {1}" line back into
+         * a model and compares it against the hand-written card — and two implementations of one
+         * lowering is exactly the drift that gate exists to catch. `equipAbility` is still the way a
+         * *card* spells it; this is the shared body underneath, and the reason it is public.
+         *
+         * [quality] is the wording of an "Equip [quality]" variant (CR 702.6c) and [targetFilter] is
+         * its rules half; see `CardBuilder.equipAbility` for why the two are unchecked against each
+         * other and which test holds them honest.
+         *
+         * [id] is a parameter because no printed word determines it: a card mints one from the DSL's
+         * counter, and a parser that reproduced a counter would be reading construction order rather
+         * than a card.
+         */
+        fun equip(
+            cost: ManaCost,
+            quality: String? = null,
+            targetFilter: TargetFilter = TargetFilter.CreatureYouControl,
+            genericCostReduction: DynamicAmount? = null,
+            id: AbilityId = AbilityId.generate(),
+        ): ActivatedAbility {
+            val label = equipTargetLabel(quality)
+            return ActivatedAbility(
+                id = id,
+                cost = AbilityCost.Atom(CostAtom.Mana(cost)),
+                effect = AttachEquipmentEffect(EffectTarget.BoundVariable(label)),
+                targetRequirements = listOf(TargetCreature(filter = targetFilter, id = label)),
+                isManaAbility = false,
+                isEquipAbility = true,
+                equipQuality = quality,
+                timing = TimingRule.SorcerySpeed,
+                genericCostReduction = genericCostReduction,
+            )
+        }
+
+        /**
+         * The label an equip ability's target requirement carries, which doubles as the name of the
+         * bound variable the attach effect reads. One function because both halves must use the same
+         * string or the effect reads a slot nothing declared.
+         */
+        fun equipTargetLabel(quality: String?): String =
+            if (quality == null) "creature you control" else "$quality creature you control"
     }
 }
 

--- a/oracle-assay/AGENTS.md
+++ b/oracle-assay/AGENTS.md
@@ -69,6 +69,14 @@ review, it is a change to decline.
   facades are the curated surface, and this is the half that would otherwise drift from how cards are
   actually written. `match` necessarily destructures concrete classes; that asymmetry is inherent to
   a bidirectional rule, which is exactly why the `build` half must not compound it.
+- **Where a keyword is *lowered* rather than stored, call the lowering — don't restate it.** Equip is
+  the worked example: a card writes `equipAbility("{1}")` and the DSL produces `equipCost` plus a
+  whole activated ability. `Grammar.equipLine` calls `ActivatedAbility.equip`, the factory that body
+  moved into, so both sides of the differential are one definition. Restating a lowering here would
+  agree with the cards exactly until someone edited one of them, and the gate would then report every
+  card with the mechanic over a change nobody made to a card. Note what this is *not* a licence for:
+  extracting an existing lowering into a factory is fine, and it is the one thing this module may
+  push into `mtg-sdk` on its own; **adding a type or a capability there is still `add-feature` work.**
 - **An SDK gap is reported, never routed around.** If the SDK cannot express a card, the rule
   declines and the report ranks it. Do not model it in Assay, do not approximate it with the nearest
   effect, and do not add a type to `mtg-sdk` from inside this module — that goes through
@@ -180,8 +188,10 @@ instantiation — not another `oneOf` branch, which would be ambiguity by constr
 
 ## Printed-shape information belongs to normalization
 
-Line grouping, the `;` separator, reminder text, and which noun a card uses for itself are properties
-of the *printed line*. The model has nowhere to put them and must not grow somewhere.
+Line grouping, the `;` separator, reminder text, which noun a card uses for itself, and which
+adjective it uses for the permanent it is attached to ("equipped creature" vs "enchanted creature",
+one model and two words chosen by the type line) are properties of the *printed line*. The model has
+nowhere to put them and must not grow somewhere.
 `normalize/Normalizer.kt` owns them, every pass is invertible by construction (it records what it
 removed and `restore` replays the inverses), and `NormalizedFace.restore(lines) == raw` is itself
 gated — a normalization that cannot round-trip its own output would let any grammar look correct.

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -134,18 +134,18 @@ non-zero on. Declines are not failures.
 
 ```
 Cards assayed                    34882
-Ability lines                    66793  (38943 unique)
+Ability lines                    66793  (38865 unique)
 
-Round-trips byte-exact           22940   343.4‰ (34.3%)
-Alternate spelling normalized    1114
-Declined                         42739
+Round-trips byte-exact           23861   357.2‰ (35.7%)
+Alternate spelling normalized    1110
+Declined                         41822
 Ambiguous — distinct readings    0
 Print mismatch                   0
 Normalization not invertible     0
 Full inverse not reproduced      0
 Redundant readings (same model)  0
 
-Cards fully covered              6335 / 34882   181.6‰ (18.2%)
+Cards fully covered              6400 / 34882   183.5‰ (18.3%)
 Vanilla + keyword-only cards     1444 / 1712   843.5‰ (84.3%)   <- Phase 1 target
 Portal (set POR)                 200 / 200     1000.0‰ (100%)   <- the Portal band's target
 Legions (set LGN)                145 / 145     1000.0‰ (100%)   <- the Legions band's target
@@ -309,6 +309,59 @@ and Eternal Witness, and the 22 the sweep turned up — was a clause lost *insid
 sentence*. A counter sentence is short and has one filter, which is the same reason the auras added
 none: there is very little in it to drop.
 
+## The equipment band
+
+`Equip {§}` was the **largest single sentence shape in the corpus** — 563 cards, against 342 for the
+next one — and the last of Phase 1's two headline findings still declining. It is now read, together
+with the two attached-permanent sentences an Equipment shares with an Aura. Whole-corpus coverage
+went 6,335 → **6,400 cards**, byte-exact lines 22,944 → **23,861**, and the differential's compared
+population 2,431 → **2,449**, every one of the 18 new cards confirmed.
+
+**The band is two changes in two different files, and which half went where is the whole point.**
+
+**The noun is normalization's.** An Equipment prints "Equipped creature gets +2/+0." for a model that
+is *byte-identical* to an Aura's: the static's affected set is `GroupFilter.attachedCreature()` —
+`Permanent` scoped to `AttachedTo` — which says "the thing this is attached to" and nothing about
+auras, so Bonesplitter's golden and Holy Strength's carry the same `ModifyStats`. Which word a card
+prints is a function of its type line, exactly like the self-reference noun, and the model has
+nowhere to keep it. A second grammar rule would therefore have given one value two printed forms and
+left `unparse` to choose — ambiguity by construction, which is invariant 2 rather than a preference.
+So `Normalizer.canonicalizeAttachmentNoun` abstracts "equipped creature" onto "enchanted creature"
+and restores the printed word positionally, and *every* static rule in `Statics` reads both card
+classes without knowing there are two. `Statics`' KDoc predicted this pass before it existed; the
+band carried the prediction out rather than revising it.
+
+**The keyword is a line rule, because equip is lowered rather than stored.** "Equip {1}" is
+`CardDefinition.equipCost` *plus* a synthesized activated ability carrying CR 702.6a's attach effect,
+sorcery timing and target requirement. That is one printed line filling two slots in two different
+objects, which is `Grammar.amplifyLine`'s shape and the reason `CardFragment` grew an `equipCost`
+field — a fragment is the only place a line's two contributions can meet.
+
+**The rule does not reproduce the lowering; it calls it.** `CardBuilder.equipAbility`'s body moved to
+`ActivatedAbility.equip` in the same change, and both callers use it. A second copy in `grammar/`
+would have agreed with the cards exactly until someone edited one of them, and the differential would
+then have reported every Equipment in the corpus over a change nobody made to a card. It is the one
+place the module's "build through an SDK facade" rule needed the facade to be *created* first, since
+equip's curated surface was a DSL method a parser cannot call.
+
+**`equipCost` is the first compared field outside `CardScript`.** Comparing only the ability would
+confirm an Equipment that can never be equipped: `CardValidator` requires an Equipment type line
+wherever the field is set and `CardLinter` reads it to decide whether a permanent can ever attach, so
+a card carrying the ability without the cost is a different — and worse — card. The differential's
+header now names it beside the script slots.
+
+**The band is also the third worked example of a decline rank overstating its work**, and this time
+the overstatement was measured in advance rather than after. Of a 400-card sample blocked by
+`Equip {§}`, 248 declined on *nothing but* equipment-shaped lines — which predicted ~350 whole cards.
+The actual figure is 65, and the gap is one word: the sample counted "Equipped creature gets +2/+2
+and has trample **and** lifelink" as an equipment shape, and the grammar's joined sentence takes one
+keyword rather than a run. So the prediction was right about which cards the band reaches and wrong
+about which *lines* it finishes. The residue is now visible and small: 385 cards decline on nothing
+but an "Enchanted creature …" sentence, and their tail is genuinely long — the largest single one is
+10 cards ("doesn't untap during its controller's untap step"), and a keyword-run generalization of
+the joined form is worth 22. There is no fourth large family hiding behind this one, which is the
+useful half of the finding.
+
 ## What Phase 1 already found
 
 The report is two documents at once, and the second one is about `mtg-sdk`:
@@ -323,8 +376,9 @@ The report is two documents at once, and the second one is about `mtg-sdk`:
   not rules. Equip is not the same shape at all: it lowers at authoring time into `equipCost` *and*
   a synthesized activated ability with its own timing, effect and target requirement, so reading it
   means reproducing a lowering rather than a sentence, and it reaches past `CardScript` into a slot
-  `CardFragment` does not model. That is why it is still declined, and why the pair stopped being
-  one finding.
+  `CardFragment` did not model. That is why the pair stopped being one finding — and the equipment
+  band below is what closing the second half cost: a new `CardFragment` field, a shared factory in
+  the SDK, and a normalization pass, against the aura band's one rule.
 - **`PROTECTION_FROM_EACH_OPPONENT` and `ProtectionScope.EachOpponent` are two spellings of one
   thing.** Registering both would be genuine ambiguity, so the grammar deliberately spells it only
   one way (see `Primitives.protectionScope`).
@@ -352,22 +406,24 @@ partially-read card would count a keyword Assay never saw as agreement, so every
 named population bucket instead and the denominator stays visible.
 
 ```
-  Hand-written cards                 9123
-    compared                         2431
-    not yet covered by the grammar   6056
+  Hand-written cards                 9127
+    compared                         2449
+    not yet covered by the grammar   6042
     script slot not modelled yet      82
     lines do not fold into one card   50
     multi-face (out of scope)        301
     Oracle text differs from golden  203
     golden would not decode            0
 
-  Confirmed — models agree           2430   999.6‰ (100.0%)
-  DIVERGENT — read every one            1
+  Confirmed — models agree           2449   1000.0‰ (100.0%)
+  DIVERGENT — read every one            0
 ```
 
-The one that remains is what the **sweep** left standing. The sweep took the count from 122 to 1: every divergence the
-gate had accumulated was read, classified as parser bug / card bug / fold, and acted on. What it
-found, by kind:
+**Zero is where the sweep and the two findings after it landed**, and it is a checkpoint rather than
+a property — the number has gone up on the day the grammar reached every new card class but one, and
+it should be expected to again. The sweep took the count from 122 to 1: every divergence the gate had
+accumulated was read, classified as parser bug / card bug / fold, and acted on. The one it left
+standing was Lavaborn Muse, closed by the CR 603.4 split below. What the sweep found, by kind:
 
 - **A bug in the gate itself, and a flaky one.** `AbilityId.generate()` is a global counter and
   `encodeDefaults` is false, so kotlinx re-evaluates the default to decide whether to emit an `id` —

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/compile/CardCompiler.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/compile/CardCompiler.kt
@@ -219,6 +219,10 @@ object CardCompiler {
         flags = fragment.flags,
         keywordAbilities = fragment.keywordAbilities,
         script = withDistinctAbilityIds(fragment.script),
+        // Derivation 3 (`CardBuilder.equipAbility`): "Equip {1}" is one line filling two slots, and
+        // the field half is not decoration — `CardValidator` requires an Equipment type line
+        // wherever it is set, and the engine's equip permissions read it.
+        equipCost = fragment.equipCost,
         oracleId = card.oracleId,
         setCode = card.setCode,
         metadata = ScryfallMetadata(imageUri = face.imageUri),

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Differential.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Differential.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.assay.corpus.OracleCorpus
 import com.wingedsheep.assay.corpus.OracleFace
 import com.wingedsheep.assay.normalize.Normalizer
 import com.wingedsheep.assay.grammar.CardFragment
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.KeywordAbility
@@ -156,6 +157,11 @@ class Differential(private val touchstone: Touchstone = Touchstone()) {
         val fromCard = CardFragment(
             keywordAbilities = printedKeywords(definition).toList(),
             script = modelledSlots(definition.script),
+            // The one compared field outside the script and outside the keyword set. "Equip {1}"
+            // lowers into this *and* an activated ability, so comparing only the ability would
+            // confirm an Equipment that can never be equipped: `CardValidator` and `CardLinter` both
+            // read this field, and a card carrying the ability without the cost is a different card.
+            equipCost = definition.equipCost,
         )
 
         // The other half of the modelled-slot guard, now that whole *ability lists* are slots the
@@ -176,8 +182,9 @@ class Differential(private val touchstone: Touchstone = Touchstone()) {
         val textKeywords = Folds.apply(fromText.keywordAbilities.toSet())
         val cardKeywords = Folds.apply(fromCard.keywordAbilities.toSet())
         val scriptsAgree = normalizeSlotNames(fromText.script) == normalizeSlotNames(fromCard.script)
+        val equipCostsAgree = fromText.equipCost == fromCard.equipCost
 
-        return if (textKeywords == cardKeywords && scriptsAgree) {
+        return if (textKeywords == cardKeywords && scriptsAgree && equipCostsAgree) {
             CardComparison(implemented, card, Population.COMPARED, Verdict.CONFIRMED)
         } else {
             CardComparison(
@@ -189,6 +196,9 @@ class Differential(private val touchstone: Touchstone = Touchstone()) {
                 onlyInCard = (cardKeywords - textKeywords).toList(),
                 textScript = fromText.script.takeUnless { scriptsAgree },
                 cardScript = fromCard.script.takeUnless { scriptsAgree },
+                textEquipCost = fromText.equipCost.takeUnless { equipCostsAgree },
+                cardEquipCost = fromCard.equipCost.takeUnless { equipCostsAgree },
+                equipCostsAgree = equipCostsAgree,
             )
         }
     }
@@ -664,6 +674,14 @@ data class CardComparison(
     /** Set only when the scripts disagree: Assay's reading, and the hand-written one. */
     val textScript: CardScript? = null,
     val cardScript: CardScript? = null,
+    /**
+     * The equip costs, when they disagree. Both are nullable *and* the disagreement is a third
+     * field, because "the card has one and the text does not" is the interesting case and it is the
+     * one a pair of nulls cannot tell from agreement.
+     */
+    val textEquipCost: ManaCost? = null,
+    val cardEquipCost: ManaCost? = null,
+    val equipCostsAgree: Boolean = true,
 )
 
 /**
@@ -693,7 +711,7 @@ class DifferentialReport private constructor(
     val clean: Boolean get() = undecodable.isEmpty()
 
     fun render(topDivergences: Int = 40): String = buildString {
-        appendLine("Argentum Assay — differential (${CardFragment.MODELLED_SLOTS_NOTE}, keywords)")
+        appendLine("Argentum Assay — differential (${CardFragment.MODELLED_SLOTS_NOTE}, keywords, equipCost)")
         appendLine("=".repeat(78))
         appendLine()
         appendLine(row("Hand-written cards", cards.toString()))
@@ -733,6 +751,10 @@ class DifferentialReport private constructor(
                 if (d.textScript != null || d.cardScript != null) {
                     appendLine("    script from text:      ${d.textScript?.let(::structural) ?: "(none)"}")
                     appendLine("    script on the card:    ${d.cardScript?.let(::structural) ?: "(none)"}")
+                }
+                if (!d.equipCostsAgree) {
+                    appendLine("    equip cost from text:  ${d.textEquipCost ?: "(none)"}")
+                    appendLine("    equip cost on card:    ${d.cardEquipCost ?: "(none)"}")
                 }
             }
             if (divergent > divergences.size) {

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/CardFragment.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/CardFragment.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.assay.grammar
 
 import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
@@ -34,6 +35,22 @@ data class CardFragment(
      * paper over, and holding both is what lets the differential see it.
      */
     val flags: Set<AbilityFlag> = emptySet(),
+    /**
+     * `CardDefinition.equipCost` — the fourth behavioural slot, and the second one outside the
+     * script.
+     *
+     * "Equip {1}" is a keyword ability the SDK **lowers** at authoring time rather than storing: the
+     * card gets this field *and* the activated ability `ActivatedAbility.equip` builds, so one
+     * printed line fills two slots in two different objects. That is the same shape
+     * [Grammar.amplifyLine] has — a keyword plus a replacement effect — and the same reason this type
+     * grew a field for it: the fragment is the only place a line's two contributions can meet.
+     *
+     * The field is not redundant with the ability beside it. `CardValidator` requires an Equipment
+     * type line wherever it is set and `CardLinter` reads it to decide whether a permanent can ever
+     * attach, so a card carrying the ability without the cost is a different — and worse — card than
+     * one carrying both. Holding it here is what lets the differential see that.
+     */
+    val equipCost: ManaCost? = null,
 ) {
 
     /**
@@ -58,9 +75,14 @@ data class CardFragment(
         // same collision as two spell effects: a card the grammar has misread, or a card shape it
         // has no model for. Neither line may be dropped silently.
         if (script.auraTarget != null && other.script.auraTarget != null) return null
+        // …and a card declares one equip cost, for the same reason. Two "Equip" lines on one card is
+        // a shape the SDK cannot hold — `CardDefinition.equipCost` is one field — so the fold
+        // declines and the card is counted rather than losing the second one silently.
+        if (equipCost != null && other.equipCost != null) return null
         return CardFragment(
             keywordAbilities = keywordAbilities + other.keywordAbilities,
             flags = flags + other.flags,
+            equipCost = equipCost ?: other.equipCost,
             script = CardScript(
                 spellEffect = script.spellEffect ?: other.script.spellEffect,
                 targetRequirements = script.targetRequirements + other.script.targetRequirements,
@@ -85,7 +107,8 @@ data class CardFragment(
         )
     }
 
-    val isEmpty: Boolean get() = keywordAbilities.isEmpty() && flags.isEmpty() && script == CardScript.EMPTY
+    val isEmpty: Boolean
+        get() = keywordAbilities.isEmpty() && flags.isEmpty() && equipCost == null && script == CardScript.EMPTY
 
     companion object {
         val EMPTY = CardFragment()

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Grammar.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Grammar.kt
@@ -10,7 +10,10 @@ import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.assay.syntax.separated
 import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
 import com.wingedsheep.sdk.scripting.EntersWithRevealCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 
@@ -250,6 +253,49 @@ object Grammar {
         }
     }
 
+    /**
+     * "Equip {1}" — the second line whose two halves land in **two different card slots**, and the
+     * largest single sentence shape in the corpus: 563 cards print it.
+     *
+     * Like [amplifyLine], and for the same reason it is here rather than in [Keywords]: the SDK
+     * lowers equip at authoring time into `CardDefinition.equipCost` *plus* a synthesized activated
+     * ability, and no single family can produce a fragment filling both. Unlike amplify, the second
+     * half is a whole ability with a cost, a timing, an effect and a target requirement — CR 702.6a's
+     * "attach this Equipment to target creature you control; activate only as a sorcery" — which is a
+     * *lowering to reproduce* rather than a sentence to read.
+     *
+     * So the rule does not reproduce it. `ActivatedAbility.equip` is the lowering, factored out of
+     * `CardBuilder.equipAbility` in the same change and called by both, because a second copy here
+     * would be a rule that agrees with the cards until the day someone edits one of them — and the
+     * differential would then report every Equipment in the corpus over a change nobody made to a
+     * card. The build half is the SDK facade, exactly as the module's rule asks; what makes it
+     * unusual is that the facade had to be *created*, since equip's curated surface was a DSL method
+     * a parser cannot call.
+     *
+     * The printed line carries no full stop — it is a keyword ability, not a sentence — and no
+     * quality: "Equip Human {1}" (CR 702.6c) pairs a printed word with a target filter that nothing
+     * checks against it, so reading one would be inventing the rules half from the wording. Those
+     * decline.
+     */
+    private val equipLine: Phrase<CardFragment> = run {
+        // The id this rule mints, for the reason `Activated`'s and `Triggers`' constants exist: no
+        // printed word determines it, and the differential renames both sides by position.
+        val equipId = AbilityId("equip")
+        fun fragmentFor(cost: ManaCost) = CardFragment(
+            equipCost = cost,
+            script = CardScript(activatedAbilities = listOf(ActivatedAbility.equip(cost, id = equipId))),
+        )
+        phrase("equip {cost}", name = "equip") {
+            slot("cost", Primitives.manaCost)
+            build { fragmentFor(it.value("cost")) }
+            match { fragment ->
+                val cost = fragment.equipCost ?: return@match null
+                if (fragment != fragmentFor(cost)) return@match null
+                bind("cost" to cost)
+            }
+        }
+    }
+
     /** A line that is one replacement effect — "~ enters tapped." */
     private val replacementLine: Phrase<CardFragment> = phrase("{replacement}", name = "a replacement effect line") {
         slot("replacement", Replacements.replacement)
@@ -368,6 +414,7 @@ object Grammar {
         keywordLine,
         semicolonKeywordLine,
         amplifyLine,
+        equipLine,
         spellLine,
         triggerLine,
         activatedLine,

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Statics.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Statics.kt
@@ -61,14 +61,17 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * fail-closed reading: a decline names the gap, a re-spelling would quietly change what the card
  * says.
  *
- * ### Why there is no "Equipped creature …" rule
+ * ### Why there is still no "Equipped creature …" rule, now that Equipment is read
  *
- * Same reason, one step further out. An Equipment prints "Equipped creature gets +1/+1." for a value
- * that is *byte-identical* to the Aura's, because which word a card uses is a function of its type
- * line — the same class of printed-shape information as the self-reference noun ("this creature" vs
- * "this Equipment"), which [com.wingedsheep.assay.normalize.Normalizer] owns and abstracts away. If
- * the equipment forms are ever read, they belong in that pass as a recorded-and-restored surface
- * form, not as a second rule here; a second rule would leave printing underdetermined between them.
+ * Same reason, one step further out — and the prediction this file made has since been carried out
+ * rather than revised. An Equipment prints "Equipped creature gets +1/+1." for a value that is
+ * *byte-identical* to the Aura's, because which word a card uses is a function of its type line: the
+ * same class of printed-shape information as the self-reference noun ("this creature" vs "this
+ * Equipment"). So it belongs to [com.wingedsheep.assay.normalize.Normalizer], and that is where it
+ * went — `canonicalizeAttachmentNoun` abstracts "equipped creature" onto "enchanted creature" and
+ * restores the printed word positionally, so every rule below reads both card classes and prints
+ * each one back byte-exact. A second rule here would have left printing underdetermined between two
+ * spellings of one model, which is the thing the module's second invariant forbids.
  *
  * ### No facade to build through
  *

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/normalize/Normalizer.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/normalize/Normalizer.kt
@@ -17,6 +17,7 @@ import com.wingedsheep.assay.corpus.OracleFace
  * |---|---|---|
  * | Reminder text | strip ` (…)` spans | re-insert at the recorded offsets (or regenerate — see [Reminders]) |
  * | Self-reference | the face's own name → `~`, longest-match first | put the recorded surface form back |
+ * | Attachment noun | "equipped creature" → "enchanted creature" | put the recorded surface word back |
  * | Ability split | one ability per line | join with `\n` |
  *
  * Two passes named in the design are handled elsewhere on purpose:
@@ -41,14 +42,90 @@ object Normalizer {
     fun normalize(face: OracleFace): NormalizedFace {
         val (stripped, reminders) = stripReminders(face.oracleText)
         val (abstracted, selfRefs) = abstractSelfReference(stripped, selfReferenceForms(face.name))
+        val (canonicalNoun, attachmentNouns) = canonicalizeAttachmentNoun(abstracted)
         return NormalizedFace(
             faceName = face.name,
-            lines = abstracted.split("\n"),
+            lines = canonicalNoun.split("\n"),
             reminders = reminders,
             selfReferences = selfRefs,
+            attachmentNouns = attachmentNouns,
             raw = face.oracleText,
         )
     }
+
+    /**
+     * "**Equipped** creature gets +2/+0." → "**Enchanted** creature gets +2/+0.", the surface word
+     * recorded and put back on the way out.
+     *
+     * An Aura and an Equipment print *different words* for the **same value**. The static's affected
+     * set is `GroupFilter.attachedCreature()` — `Permanent` scoped to `AttachedTo`, which says "the
+     * thing this is attached to" and nothing about auras — so Bonesplitter's golden and Holy
+     * Strength's carry the identical `ModifyStats`, and Behemoth Sledge's carries the identical
+     * `GrantKeyword` Spectral Flight's does. Which of the two words a card prints is a function of
+     * its type line, exactly like the self-reference noun above, and the model has nowhere to keep
+     * it.
+     *
+     * That leaves two possible homes, and [com.wingedsheep.assay.grammar.Statics] argued the point
+     * before this pass existed: a second grammar rule spelling "equipped creature" would give one
+     * value two printed forms and leave `unparse` to choose between them — ambiguity by
+     * construction, and the one thing the module's second invariant forbids. Normalization is the
+     * other home, and it is where every other printed-shape fact already lives. So the aura spelling
+     * is canonical because that is the rule that exists, the equipment spelling abstracts onto it,
+     * and the cards come back byte-exact rather than as variants — the reading was never in doubt,
+     * only the noun.
+     *
+     * **Only the exact phrase, and only these two nouns.** "Fortified land" is a third word for a
+     * third scope and still declines; "equipped creatures" (Ajani Vengeant's emblem) does not match,
+     * because the boundary check refuses a letter after the phrase, and its plural sentence is not
+     * one the grammar reads either way.
+     */
+    private fun canonicalizeAttachmentNoun(text: String): Pair<String, List<String>> {
+        val recorded = mutableListOf<String>()
+        val out = StringBuilder()
+        var i = 0
+        while (i < text.length) {
+            val hit = ATTACHMENT_ADJECTIVES.firstOrNull { (surface, _) -> attachmentPhraseAt(text, i, surface) }
+            if (hit != null) {
+                out.append(hit.second).append(' ').append(ATTACHED_NOUN)
+                recorded.add(hit.first)
+                i += hit.first.length + 1 + ATTACHED_NOUN.length
+            } else {
+                out.append(text[i])
+                i++
+            }
+        }
+        return out.toString() to recorded
+    }
+
+    /**
+     * The adjectives that mean "the permanent this is attached to", each paired with the canonical
+     * one it abstracts onto. The aura spellings map to themselves so that [NormalizedFace.restore]
+     * can walk the canonical occurrences positionally and put every surface word back — including
+     * the ones that never moved.
+     */
+    private val ATTACHMENT_ADJECTIVES = listOf(
+        "Equipped" to "Enchanted",
+        "equipped" to "enchanted",
+        "Enchanted" to "Enchanted",
+        "enchanted" to "enchanted",
+    )
+
+    /** The one noun the pass covers; see [canonicalizeAttachmentNoun] for why it is not a slot. */
+    internal const val ATTACHED_NOUN = "creature"
+
+    /** The canonical adjectives [NormalizedFace.restore] scans for, longest-match irrelevant. */
+    internal val CANONICAL_ATTACHMENT_ADJECTIVES = listOf("Enchanted", "enchanted")
+
+    /**
+     * Does "[adjective] creature" stand at [at] as a whole phrase? Shared by the forward pass and by
+     * [NormalizedFace.restore] so the two can never disagree about which occurrences they count —
+     * a restore that matched one the forward pass skipped would put every later word back one slot
+     * off, and the touchstone would report the mismatch far from its cause.
+     */
+    internal fun attachmentPhraseAt(text: String, at: Int, adjective: String): Boolean =
+        text.startsWith("$adjective $ATTACHED_NOUN", at) &&
+            !isNameChar(text.getOrNull(at - 1)) &&
+            !isNameChar(text.getOrNull(at + adjective.length + 1 + ATTACHED_NOUN.length))
 
     /**
      * The permanent nouns a card uses to refer to *itself* — "When **this creature** enters".
@@ -177,6 +254,11 @@ data class NormalizedFace(
     val lines: List<String>,
     val reminders: List<Removal>,
     val selfReferences: List<String>,
+    /**
+     * The adjective each "enchanted creature" in [lines] was printed with, in order — "Equipped" on
+     * an Equipment, "Enchanted" on an Aura. See [Normalizer.canonicalizeAttachmentNoun].
+     */
+    val attachmentNouns: List<String> = emptyList(),
     /** The face's original Oracle text — the byte string the touchstone compares against. */
     val raw: String,
 ) {
@@ -193,6 +275,10 @@ data class NormalizedFace(
      */
     fun restore(printedLines: List<String>): String {
         var text = printedLines.joinToString("\n")
+        // Before the self-references, and therefore while card names are still `~`: a card called
+        // "Enchanted Evening" would otherwise put its own name back and have this scan read it as an
+        // attachment noun, shifting every later surface word by one.
+        text = restoreAttachmentNouns(text)
         text = restoreSelfReferences(text)
         // Re-insert right to left so earlier offsets stay valid.
         for (removal in reminders.asReversed()) {
@@ -200,6 +286,32 @@ data class NormalizedFace(
             text = text.substring(0, removal.offset) + removal.text + text.substring(removal.offset)
         }
         return text
+    }
+
+    /**
+     * Put each recorded adjective back on the canonical "enchanted creature" it was abstracted from,
+     * positionally — the same treatment [restoreSelfReferences] gives a recorded name.
+     */
+    private fun restoreAttachmentNouns(text: String): String {
+        if (attachmentNouns.isEmpty()) return text
+        val out = StringBuilder()
+        var i = 0
+        var next = 0
+        while (i < text.length) {
+            // The same boundary test the forward pass makes, or the plural it declined to abstract
+            // ("enchanted creatures") would consume a recorded word here and shift every later one.
+            val canonical = Normalizer.CANONICAL_ATTACHMENT_ADJECTIVES.firstOrNull {
+                next < attachmentNouns.size && Normalizer.attachmentPhraseAt(text, i, it)
+            }
+            if (canonical != null) {
+                out.append(attachmentNouns[next++]).append(' ').append(Normalizer.ATTACHED_NOUN)
+                i += canonical.length + 1 + Normalizer.ATTACHED_NOUN.length
+            } else {
+                out.append(text[i])
+                i++
+            }
+        }
+        return out.toString()
     }
 
     private fun restoreSelfReferences(text: String): String {

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/EquipmentTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/EquipmentTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.corpus.OracleFace
+import com.wingedsheep.assay.normalize.Normalizer
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.assay.syntax.parseLine
+import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The equipment band: "Equip {1}", and the two sentences an Equipment shares with an Aura.
+ *
+ * The band is two changes in two different places on purpose, and the tests are split the same way.
+ * The *noun* is normalization's — an Equipment and an Aura print different words for the identical
+ * model, so [Normalizer] abstracts one onto the other and the grammar never learns a second spelling
+ * ([com.wingedsheep.assay.normalize.NormalizerTest] holds that half). The *keyword* is a line rule,
+ * because "Equip {1}" fills a `CardScript` slot and a `CardDefinition` field at once.
+ *
+ * The whole-card cases below are therefore run through normalization first: reading a real
+ * Equipment is exactly the composition of the two halves, and testing the line rule alone would
+ * prove the band works on text no card prints.
+ */
+class EquipmentTest : StringSpec({
+
+    fun fragment(line: String): CardFragment =
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Accepted<CardFragment>>().value
+
+    fun roundTrips(line: String) {
+        Grammar.abilityLine.printLine(fragment(line)) shouldBe line
+    }
+
+    /** A whole face, normalized and read line by line, as the touchstone does it. */
+    fun card(name: String, typeLine: String, text: String): CardFragment {
+        val normalized = Normalizer.normalize(OracleFace(name = name, oracleText = text, typeLine = typeLine))
+        // The face must also survive the inverse, or the reading below is about text no card printed.
+        normalized.restore(normalized.lines) shouldBe text
+        return normalized.lines
+            .map(::fragment)
+            .fold(CardFragment.EMPTY as CardFragment?) { acc, f -> acc?.merge(f) }!!
+    }
+
+    /**
+     * The id the equip rule mints. Read off a parse rather than restated, because no printed word
+     * determines it — a test that hard-coded the constant would be asserting the grammar's private
+     * naming instead of its reading.
+     */
+    val equipId: AbilityId = fragment("Equip {1}").script.activatedAbilities.single().id
+
+    // Equip is lowered, not stored: the card gets `equipCost` *and* the ability CR 702.6a describes.
+    // The rule builds it through `ActivatedAbility.equip`, the same factory `CardBuilder.equipAbility`
+    // calls, so this assertion is about the lowering being shared rather than about its contents.
+    "the equip line fills a script slot and a card field at once" {
+        val equip = fragment("Equip {1}")
+
+        equip.equipCost shouldBe ManaCost.parse("{1}")
+        equip.script.activatedAbilities.single().isEquipAbility shouldBe true
+        equip shouldBe CardFragment(
+            equipCost = ManaCost.parse("{1}"),
+            script = CardScript(
+                activatedAbilities = listOf(
+                    ActivatedAbility.equip(ManaCost.parse("{1}"), id = equip.script.activatedAbilities.single().id),
+                ),
+            ),
+        )
+        roundTrips("Equip {1}")
+        roundTrips("Equip {0}")
+        roundTrips("Equip {2}{W}")
+    }
+
+    // Bonesplitter, whole. Its static is byte-identical to Holy Strength's, which is the finding the
+    // normalization pass is built on rather than an accident of this card.
+    "an Equipment reads as the same statics an Aura does, plus its equip cost" {
+        card("Bonesplitter", "Artifact — Equipment", "Equipped creature gets +2/+0.\nEquip {1}") shouldBe
+            CardFragment(
+                equipCost = ManaCost.parse("{1}"),
+                script = CardScript(
+                    staticAbilities = listOf(ModifyStats(2, 0)),
+                    activatedAbilities = listOf(ActivatedAbility.equip(ManaCost.parse("{1}"), id = equipId)),
+                ),
+            )
+    }
+
+    "the granted-keyword sentence reads on an Equipment as it does on an Aura" {
+        val fromEquipment = card(
+            "Cobbled Wings",
+            "Artifact — Equipment",
+            "Equipped creature has flying.\nEquip {1}",
+        )
+        val fromAura = card("Flight", "Enchantment — Aura", "Enchant creature\nEnchanted creature has flying.")
+
+        fromEquipment.script.staticAbilities shouldBe listOf(GrantKeyword(Keyword.FLYING))
+        fromEquipment.script.staticAbilities shouldBe fromAura.script.staticAbilities
+    }
+
+    // The rule is fail-closed against the fields "Equip {1}" does not say. An equip ability whose
+    // target filter, quality or timing is anything other than the lowering's must not print as the
+    // bare printed line — a card whose "Equip Human {1}" came back as "Equip {1}" would be a
+    // different card, and the differential would confirm it.
+    "an equip ability the printed line does not describe refuses to print" {
+        val quality = CardFragment(
+            equipCost = ManaCost.parse("{1}"),
+            script = CardScript(
+                activatedAbilities = listOf(
+                    ActivatedAbility.equip(ManaCost.parse("{1}"), quality = "Human", id = equipId),
+                ),
+            ),
+        )
+        Grammar.abilityLine.printLine(quality) shouldBe null
+    }
+
+    // `CardDefinition.equipCost` is not decoration beside the ability: `CardValidator` requires an
+    // Equipment type line wherever it is set and the engine's equip permissions read it, so a
+    // fragment carrying only the ability is a different card and must not print the line.
+    "the ability without the cost is not the equip line" {
+        val abilityOnly = CardFragment(
+            script = CardScript(
+                activatedAbilities = listOf(
+                    ActivatedAbility.equip(ManaCost.parse("{1}"), id = equipId),
+                ),
+            ),
+        )
+        Grammar.abilityLine.printLine(abilityOnly) shouldBe null
+    }
+
+    // One card, one equip cost — `CardDefinition` has one field. Two "Equip" lines is a shape the
+    // SDK cannot hold, so the fold declines and the gate counts the card rather than losing one.
+    "two equip lines do not fold into one card" {
+        fragment("Equip {1}").merge(fragment("Equip {2}")) shouldBe null
+    }
+})

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/KeywordGrammarTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/KeywordGrammarTest.kt
@@ -164,12 +164,17 @@ class KeywordGrammarTest : StringSpec({
         Grammar.abilityLine.printLine(fragment) shouldBe "Flying, banding"
     }
 
-    // "Enchant creature" used to be this example and is now read by `Targets.enchant`. Equip is the
-    // other half of the same Phase 1 finding and is still the honest one: it lowers at authoring
-    // time into `CardDefinition.equipCost` *plus* a synthesized activated ability, so there is
-    // nothing for a keyword rule to parse it into and the decline names a real gap.
+    // Both of this test's earlier examples have since been read, and the pair is the module's own
+    // record of how a decline gets closed. "Enchant creature" turned out to be a plain
+    // `TargetRequirement` and went to `Targets.enchant`; "Equip {2}" was the harder half of the same
+    // Phase 1 finding — a keyword the SDK *lowers* at authoring time rather than storing — and is
+    // now `Grammar.equipLine`, which reproduces the lowering through the SDK's own factory instead
+    // of parsing it into a keyword.
+    //
+    // Exalted is the honest example left, and it is a different kind of gap: the decline is not the
+    // grammar missing a sentence but `Keyword` missing a constant, which no rule here can fix.
     "text outside the grammar declines, and says where" {
-        val declined = Grammar.abilityLine.parseLine("Equip {2}")
+        val declined = Grammar.abilityLine.parseLine("Exalted")
             .shouldBeInstanceOf<ParseOutcome.Declined>()
         declined.reason shouldBe com.wingedsheep.assay.syntax.DeclineReason.NO_PARSE
     }

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/normalize/NormalizerTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/normalize/NormalizerTest.kt
@@ -83,6 +83,55 @@ class NormalizerTest : StringSpec({
         n.restore(n.lines) shouldBe f.oracleText
     }
 
+    // An Equipment and an Aura print two words for one value: the static's affected set is
+    // "whatever this is attached to", which says nothing about auras. The word is a function of the
+    // type line, so it is normalization's, and the aura spelling is canonical because that is the
+    // rule the grammar has.
+    "the equipment attachment noun abstracts onto the aura's and comes back" {
+        val f = face("Bonesplitter", "Equipped creature gets +2/+0.\nEquip {1}", "Artifact — Equipment")
+        val n = Normalizer.normalize(f)
+
+        n.lines shouldBe listOf("Enchanted creature gets +2/+0.", "Equip {1}")
+        n.attachmentNouns shouldBe listOf("Equipped")
+        n.restore(n.lines) shouldBe f.oracleText
+    }
+
+    "an aura's own spelling is recorded too, so restore is positional either way" {
+        val f = face("Holy Strength", "Enchant creature\nEnchanted creature gets +1/+2.", "Enchantment — Aura")
+        val n = Normalizer.normalize(f)
+
+        n.lines shouldBe listOf("Enchant creature", "Enchanted creature gets +1/+2.")
+        n.attachmentNouns shouldBe listOf("Enchanted")
+        n.restore(n.lines) shouldBe f.oracleText
+    }
+
+    "mid-sentence occurrences keep their case, and each one is restored on its own" {
+        val f = face(
+            "Grafted Wargear",
+            "Equipped creature gets +3/+2.\nWhenever equipped creature becomes untapped, sacrifice it.",
+            "Artifact — Equipment",
+        )
+        val n = Normalizer.normalize(f)
+
+        n.lines shouldBe listOf(
+            "Enchanted creature gets +3/+2.",
+            "Whenever enchanted creature becomes untapped, sacrifice it.",
+        )
+        n.attachmentNouns shouldBe listOf("Equipped", "equipped")
+        n.restore(n.lines) shouldBe f.oracleText
+    }
+
+    // The boundary check is what keeps the two directions counting the same occurrences: a restore
+    // that matched a plural the forward pass skipped would put every later word back one slot off.
+    "the plural is not an attachment noun, in either direction" {
+        val f = face("Whatever", "Equipped creatures get +1/+1.", "Enchantment")
+        val n = Normalizer.normalize(f)
+
+        n.lines shouldBe listOf("Equipped creatures get +1/+1.")
+        n.attachmentNouns shouldBe emptyList()
+        n.restore(n.lines) shouldBe f.oracleText
+    }
+
     "the self-reference noun follows the printed type line" {
         Reminders.selfNoun("Creature — Angel") shouldBe "this creature"
         Reminders.selfNoun("Artifact") shouldBe "this artifact"


### PR DESCRIPTION
`Equip {§}` was the **largest single sentence shape in the whole Scryfall corpus** — 563 cards, against 342 for the next one — and the last of Assay Phase 1's two headline findings still declining. This reads it, together with the two attached-permanent sentences an Equipment shares with an Aura.

## Numbers

Measured against this branch's own merge-base (`1be0a1e`), both runs on the same tree:

| | before | after |
|---|---|---|
| Cards fully covered | 6,335 | **6,400** |
| …byte-exact | 5,652 | **5,715** |
| Lines round-tripping byte-exact | 22,944 | **23,861** |
| Declined lines | 42,739 | **41,822** |
| Differential: compared | 2,431 | **2,449** |
| Differential: confirmed | 2,431 | **2,449** |
| Differential: divergent | 0 | **0** |
| MISMATCH / AMBIGUOUS / normalization not invertible | 0 | **0** |

Unique lines drop 38,943 → 38,865, which is the attachment-noun pass collapsing two spellings of one sentence into one.

## The band is two changes in two files, and which half went where is the point

**The noun is normalization's.** An Equipment prints `Equipped creature gets +2/+0.` for a model that is *byte-identical* to an Aura's — `GroupFilter.attachedCreature()` is `Permanent` scoped to `AttachedTo`, which says "the thing this is attached to" and nothing about auras, so Bonesplitter's golden and Holy Strength's carry the same `ModifyStats`. Which word a card prints is a function of its type line, exactly like the self-reference noun. A second grammar rule would have given one value two printed forms and left `unparse` to choose between them — ambiguity by construction, which is the module's second invariant rather than a preference. So `Normalizer.canonicalizeAttachmentNoun` abstracts `equipped creature` onto `enchanted creature` and restores the printed word positionally, and *every* rule in `Statics` now reads both card classes without knowing there are two. `Statics`' KDoc predicted this pass before it existed; this carries the prediction out rather than revising it.

**The keyword is a line rule, because equip is lowered rather than stored.** `Equip {1}` is `CardDefinition.equipCost` *plus* a synthesized activated ability carrying CR 702.6a's attach effect, sorcery timing and target requirement — one printed line filling two slots in two different objects. That is `Grammar.amplifyLine`'s shape, and the reason `CardFragment` grew an `equipCost` field: a fragment is the only place a line's two contributions can meet.

**The rule calls the lowering; it does not restate it.** `CardBuilder.equipAbility`'s body moved to `ActivatedAbility.equip(cost, quality?, targetFilter?, genericCostReduction?, id?)`, and both callers use it. A second copy in `grammar/` would have agreed with the cards exactly until someone edited one of them, and the differential would then have reported every Equipment in the corpus over a change nobody made to a card. It is the one place the module's "build through an SDK facade" rule needed the facade to be *created* first, since equip's curated surface was a DSL method a parser cannot call. Cards keep writing `equipAbility` — the DSL surface is unchanged, and `CardDefinitionSnapshotTest` is green (320/320) against the existing goldens.

**`equipCost` is the first compared field outside `CardScript`.** Comparing only the ability would confirm an Equipment that can never be equipped: `CardValidator` requires an Equipment type line wherever the field is set and `CardLinter` reads it to decide whether a permanent can ever attach.

## Fail-closed, as usual

- `Equip Human {1}` (CR 702.6c) **declines**: the printed word and the target filter are unchecked against each other, so reading one would be inventing the rules half from the wording.
- A fragment carrying the ability without the cost, or an ability whose quality/filter/timing is anything other than the lowering's, **refuses to print**.
- Two `Equip` lines on one card **do not fold** — `CardDefinition.equipCost` is one field.
- `Fortified land` is a third word for a third scope and still declines; `equipped creatures` (plural) is not matched in either direction, which is what keeps the forward and restore passes counting the same occurrences.

## A third worked example of a rank overstating its work — this time measured in advance

Of a 400-card sample blocked by `Equip {§}`, 248 declined on *nothing but* equipment-shaped lines, predicting ~350 whole cards. The answer is 65, and the gap is one word: the sample counted `Equipped creature gets +2/+2 and has trample **and** lifelink` as an equipment shape, where the grammar's joined sentence takes one keyword rather than a run. So a per-card sample predicts which *cards* a band reaches and still says nothing about which *lines* it finishes — the same failure mode as the token rank, one level up.

The residue is measured and small, which is the useful half: 385 cards decline on nothing but an `Enchanted creature …` sentence, their largest single shape is 10 cards (`doesn't untap during its controller's untap step`), and generalizing the joined form to a keyword *run* is worth 22. There is no fourth large family hiding behind this one.

## Docs

`oracle-assay/README.md` (band write-up + refreshed fineness and differential blocks), `oracle-assay/AGENTS.md` (the "call the lowering" rule and its limits; the attachment noun added to the printed-shape list), `docs/plans/oracle-assay.md`, `docs/card-sdk-language-reference.md` (the `ActivatedAbility.equip` factory under the existing `Equip(cost)` entry), and the root `AGENTS.md` row, whose divergence figure was stale — the last standing divergence was closed by the CR 603.4 split on main, so it now reads 0 over 2,449.

## Verification

```
just assay-gate            # 0 MISMATCH / 0 AMBIGUOUS / 0 non-invertible, over 34,882 cards
just assay-differential    # 2,449 compared, 2,449 confirmed, 0 divergent
:oracle-assay:test         # 219 tests; new EquipmentTest + 4 NormalizerTest cases
:mtg-sdk:test              # green
CardDefinitionSnapshotTest # 320/320 — the SDK refactor changes no golden
compileKotlin compileTestKotlin (all modules)  # green
```

## Pre-existing failure, now fixed

`SubtypesTest > the bare noun parses and prints back as the adjective form` **already failed on `origin/main`** — verified by checking out the merge-base `1be0a1e` in the same worktree and running the class there. It asserted `Slivers can't block.` reads as `IsCreature + HasSubtype(Sliver)`; the grammar produces `IsPermanent + HasSubtype(Sliver)`. That is the bare-tribal-noun → permanents migration landing without the test moving with it.

The grammar is the correct side, and `Filters.bareSubtype`'s own KDoc says why: a bare creature-type noun names every *permanent* with the subtype, and Zombie Master prints both spellings on one card with its bare-noun line granting "Regenerate this **permanent**". The differential is 2,449/2,449 confirmed against cards that were migrated to match. So the assertion moves to the permanent adjective — `Sliver permanents can't block.` — and gains the negative half it never had: the bare noun and the creature adjective are *different* filters, which is the entire point of the layer and which nothing asserted. The alternation entry's stale name (`a creature of a subtype`, visible in the explorer and in ambiguity diagnostics) is renamed in the same commit.

No rule semantics changed; both corpus gates are unmoved — 0 MISMATCH / 0 AMBIGUOUS / 0 non-invertible, and 2,449 compared / 2,449 confirmed / 0 divergent.

