### PR TITLE
Assay: move SubtypesTest onto the bare-noun-is-permanents reading

### DIFF
--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Filters.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Filters.kt
@@ -443,7 +443,7 @@ object Filters {
             subtyped(named, "a permanent of a subtype$suffix"),
             notSubtyped(named, "a permanent of another subtype$suffix"),
             anySubtype(named, "a permanent of either subtype$suffix"),
-            bareSubtype(plural, "a creature of a subtype$suffix"),
+            bareSubtype(plural, "a subtype standing alone$suffix"),
         )
         val counted = oneOf(
             "a permanent or token$suffix",

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/SubtypesTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/SubtypesTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 /**
@@ -82,13 +83,20 @@ class SubtypesTest : StringSpec({
         roundTrips(line)
     }
 
-    // The bare noun denotes what the adjective form denotes, so exactly one of them may print. The
-    // adjective is canonical because it says what the model says; the bare one comes back as a
-    // variant rather than as a decline.
+    // A bare creature-type noun names every *permanent* with the subtype — the adjectival "Sliver
+    // creature" is what narrows it to creatures. So the bare noun denotes what "Sliver permanent"
+    // denotes, and exactly one of those two spellings may print: the adjective is canonical because
+    // it says what the model says, and the bare one comes back as a variant rather than a decline.
     "the bare noun parses and prints back as the adjective form" {
-        fragment("Slivers can't block.") shouldBe fragment("Sliver creatures can't block.")
+        fragment("Slivers can't block.") shouldBe fragment("Sliver permanents can't block.")
         Grammar.abilityLine.printLine(fragment("Slivers can't block.")) shouldBe
-            "Sliver creatures can't block."
+            "Sliver permanents can't block."
+    }
+
+    // …and the two spellings are not interchangeable, which is the whole point of the layer:
+    // "Sliver creatures" is the narrower filter and keeps its own reading.
+    "the bare noun and the creature adjective are different filters" {
+        fragment("Sliver creatures can't block.") shouldNotBe fragment("Slivers can't block.")
     }
 
     // A bare noun has to *imply* "creature", which is a guess — so it is offered only for words the


### PR DESCRIPTION
`SubtypesTest > the bare noun parses and prints back as the adjective form` has failed since the bare-tribal-noun migration: it asserts "Slivers can't block." reads as `IsCreature + HasSubtype(Sliver)`, which is the reading that migration deliberately replaced. The test was written before it and did not move with it.

The grammar is the correct side. `Filters.bareSubtype` builds `Permanent.withSubtype`, its KDoc states why (Zombie Master prints both spellings on one card, and the ability its bare-noun line grants says "Regenerate this permanent"), and the differential is 2,449/2,449 confirmed with the cards migrated to match. So the assertion moves to the permanent adjective — "Sliver permanents can't block." — which is what the bare noun now denotes and prints back as.

Added the negative half the old test never had: the bare noun and the creature adjective are *different* filters. That is the whole point of the layer, and nothing asserted it.

Also renamed the alternation entry from "a creature of a subtype" to "a subtype standing alone" — a stale name the migration left behind, visible in the explorer and in ambiguity diagnostics.

Verified: :oracle-assay:test green; just assay-gate 0 MISMATCH / 0 AMBIGUOUS / 0 non-invertible; just assay-differential 2,449 compared, 2,449 confirmed, 0 divergent.