### PR TITLE
Assay: the spell-cast band, and a noun phrase for a spell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ docs it points at; load those when the work needs them.
 | `gym` / `gym-server` / `gym-trainer` | RL/MCTS env + HTTP transport + self-play SPI | engine, sdk |
 | `game-server` | Spring Boot orchestration, WebSocket, state masking | engine, sdk |
 | `mtgish-tooling` | Predictive coverage / auto-gen analyzer | — (scans source as text) |
-| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 100% agreement over 2,449 compared cards after the divergence sweep and the CR 603.4 split — 0 divergences standing), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
+| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 2,494 of 2,495 compared cards agree — the one standing divergence is the open `ManaColorSet.Specific` finding), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
 | `web-client` | React UI (dumb terminal — no game logic) | — |
 
 **Key principle:** the engine is pure (no card-specific code), content is data-driven (no execution

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/AdelizTheCinderWind.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/AdelizTheCinderWind.kt
@@ -31,7 +31,11 @@ val AdelizTheCinderWind = card("Adeliz, the Cinder Wind") {
         effect = Patterns.Group.modifyStatsForAll(
             power = 1,
             toughness = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.youControl().withSubtype("Wizard"))
+            // A bare tribal noun ("Wizards you control") names every *permanent* with the subtype;
+            // "Wizard creatures you control" is what narrows it. See Zombie Master, which prints
+            // both spellings on one card. Argentum Assay's differential reported the creature-scoped
+            // reading here.
+            filter = GroupFilter(GameObjectFilter.Permanent.youControl().withSubtype("Wizard"))
         )
     }
 

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/DaringArchaeologist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/DaringArchaeologist.kt
@@ -33,9 +33,13 @@ val DaringArchaeologist = card("Daring Archaeologist") {
             filter = TargetFilter(
                 GameObjectFilter.Artifact.ownedByYou(),
                 zone = Zone.GRAVEYARD
-            ),
-            optional = true
+            )
         ))
+        // The "you may" is consent to *do it*, not permission to skip choosing a target. CR 603.3d
+        // routes a trigger's targets through CR 601.2c, which requires a choice for each target, and
+        // only "up to one target" makes one optional — which is exactly what `optional = true` on
+        // the requirement spells. So the consent belongs on the ability.
+        optional = true
         effect = Effects.Move(
             target = t,
             destination = Zone.HAND

--- a/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DaringArchaeologistScenarioTest.kt
+++ b/mtg-sets/2017-2022/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/DaringArchaeologistScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Daring Archaeologist (DOM #13) — "When this creature enters, you may return target artifact card
+ * from your graveyard to your hand."
+ *
+ * Proves where the "you may" lives. The consent is permission to perform the action; the *target* is
+ * a requirement of the ability, and CR 603.3d routes a trigger's targets through CR 601.2c, which
+ * requires a choice for each of them — only "up to one target" makes one optional. The card
+ * used to spell the consent as `optional = true` on the target requirement, which is the SDK's
+ * phrasing for "up to one target" — a strictly different ability, since it lets the controller
+ * decline to target at all and never asks for consent. Argentum Assay's differential reported it.
+ *
+ * Two artifact cards go in the graveyard rather than one, deliberately: with a single legal target
+ * the engine auto-selects it and no `ChooseTargetsDecision` is raised at all, so the requirement's
+ * minimum — the thing that changed — would not be observable.
+ */
+class DaringArchaeologistScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Plains" to 30))
+        return d
+    }
+
+    /** Cast the Archaeologist over two artifact cards in the graveyard, stopping at its ETB consent. */
+    fun GameTestDriver.castOverTwoArtifacts(): Triple<EntityId, EntityId, EntityId> {
+        val you = player1
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val golem = putCardInGraveyard(you, "Artifact Creature")
+        val myr = putCardInGraveyard(you, "Palladium Myr")
+        val archaeologist = putCardInHand(you, "Daring Archaeologist")
+        repeat(4) { putLandOnBattlefield(you, "Plains") }
+        submit(
+            CastSpell(
+                playerId = you,
+                cardId = archaeologist,
+                paymentStrategy = PaymentStrategy.AutoPay,
+            ),
+        ).isSuccess shouldBe true
+        bothPass() // the creature resolves and its ETB trigger asks whether you want to do this
+        return Triple(you, golem, myr)
+    }
+
+    test("consenting then asks for a target, and the target is mandatory") {
+        val d = driver()
+        val (you, golem, myr) = d.castOverTwoArtifacts()
+
+        d.submitYesNo(you, true)
+
+        val decision = d.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        decision.legalTargets[0].shouldNotBeNull() shouldContainAll listOf(golem, myr)
+        // The half that fails when the consent is spelled as `optional = true` on the requirement:
+        // that spelling makes this 0, i.e. "up to one target artifact card".
+        decision.targetRequirements.single().minTargets shouldBe 1
+
+        d.submitTargetSelection(you, listOf(golem))
+        while (d.stackSize > 0) d.bothPass()
+
+        d.getHand(you) shouldContain golem
+    }
+
+    test("declining asks for no target at all and both cards stay in the graveyard") {
+        val d = driver()
+        val (you, golem, myr) = d.castOverTwoArtifacts()
+
+        d.submitYesNo(you, false)
+        while (d.stackSize > 0) d.bothPass()
+
+        d.getGraveyard(you) shouldContainAll listOf(golem, myr)
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -192,7 +192,7 @@
                     "space": {
                         "type": "IterationSpace.Group",
                         "filter": {
-                            "baseFilter": "creature Wizard ctrl:you"
+                            "baseFilter": "permanent Wizard ctrl:you"
                         }
                     },
                     "body": {
@@ -2592,16 +2592,19 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "MoveToZone",
-                    "target": {
-                        "type": "BoundVariable",
-                        "name": "target"
-                    },
-                    "destination": "Hand"
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
                 },
                 "targetRequirement": {
                     "type": "TargetObject",
-                    "optional": true,
                     "filter": {
                         "baseFilter": "artifact own:you",
                         "zone": "Graveyard"

--- a/oracle-assay/AGENTS.md
+++ b/oracle-assay/AGENTS.md
@@ -325,6 +325,24 @@ ranking in ways that change the work. The step triggers are the worked example: 
 "At the beginning of…", and adding every step-trigger prefix moved whole-card coverage by 23, because
 the other 387 were blocked on their effect clause all along.
 
+**The ranking that has actually held up is over the parse's *tail*, and it is two measurements.**
+The spell-cast band is the worked example and the method is reusable verbatim:
+
+1. `just assay-report --declines` (add `--implemented` for the grammar backlog), re-parse every
+   declined line, take the decline's `position`, and key the families on **the text from that offset
+   on**. That is neither the token ranking (which over-weights a missing prefix) nor the shape
+   ranking (which counts cards a family *mentions*): it names the piece of grammar that would have
+   to exist for the line to get further. Then count, per family, the cards **all** of whose declined
+   lines fall in it — the honest "sole-blocked" number.
+2. Before writing anything, **substitute a known-good prefix for the family** into those cards'
+   declined lines and re-parse. That says how many payoffs the rest of the grammar can already read,
+   which is the number the band will actually deliver. The spell-cast family predicted 234 whole
+   cards and delivered 183; modal spells, which both other rankings put first, measured 126.
+
+Every ranking that skipped step 2 has overstated its band, three times in the same direction. Step 2
+costs one throwaway probe over `Grammar.abilityLine.parseLine`, and it is what turns "which cards
+does this family reach" into "which lines does it finish".
+
 The split re-weights the list rather than reordering it wholesale, which is itself the finding: the
 top families are the same in both populations, so the grammar backlog and the SDK backlog are being
 blocked by the same missing sentence shapes rather than by different ones. Where it does diverge is

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -20,10 +20,17 @@ and those are the two sentences on it. The **aura band** followed: `Enchant <fil
 attached-permanent statics, which opened `staticAbilities` — the largest `CardScript` slot the
 differential could not see into, and the one every later static family lands in.
 
-The most recent work is the **counters band**, and it is the first one picked by *ranking the
-backlog* rather than by picking a set: `just assay-report --implemented` says 656 cards with a
-hand-written golden decline on nothing but a counter sentence, which is the largest sole-blocked
-family in that population. See [the counters band](#the-counters-band) below.
+The most recent work is the **spell-cast band** — "Whenever you cast a noncreature spell, …" — which
+gives the grammar its first noun phrase for a *spell* rather than a permanent, and is the largest
+single family left in the corpus by the honest ranking: 504 cards decline on nothing but a
+spell-cast trigger, against 263 for the next one. See [the spell-cast band](#the-spell-cast-band)
+below; it is also where the ranking method itself changed, from the token a line died on to the
+**tail** the parse could not read.
+
+Before it came the **counters band**, the first one picked by *ranking the backlog* rather than by
+picking a set: `just assay-report --implemented` said 656 cards with a hand-written golden decline
+on nothing but a counter sentence, the largest sole-blocked family in that population. See
+[the counters band](#the-counters-band) below.
 
 Before that came the **Legions band**, the second set read end to end and the first *hard* one: `just assay-gate --set LGN` reads **145 of Legions' 145 cards**. Legions is every-card-a-
 creature, so it is a set made almost entirely of the things Portal had none of — morph payoffs,
@@ -87,10 +94,12 @@ its own population. The Set *column* still shows the representative printing, an
 syntax/     Phrase kernel — templates, slots, both directions, memoization, the parse cap
 normalize/  Scryfall text -> canonical ability lines, every pass with its inverse; reminder glosses
 corpus/     the Scryfall Oracle bulk: download, cache, stream; per-set membership for `--set`
-grammar/    the rules, by topic — Primitives, Keywords, Cardinals, Conditions, Filters, Targets,
-            Steps, Continuations, Triggers, Mana, Costs, Activated, Replacements, Statics,
+grammar/    the rules, by topic — Primitives, Keywords, Cardinals, Conditions, Filters, Spells,
+            Targets, Steps, Continuations, Triggers, Mana, Costs, Activated, Replacements, Statics,
             Restrictions, and the effect-topic files Library, Hand, Combat, Graveyard, Stack,
             SelfSteps
+            Filters is the noun phrase for a permanent and Spells the one for a spell — same
+            GameObjectFilter, different head noun, disjoint positions
             Steps is the clause vocabulary and the sentence/sequence machinery every other file
             slots into; Activated is the cost-colon-effect sentence; Statics is the continuous-
             ability slot; Restrictions is the three "when may this happen" vocabularies;
@@ -136,16 +145,16 @@ non-zero on. Declines are not failures.
 Cards assayed                    34882
 Ability lines                    66793  (38865 unique)
 
-Round-trips byte-exact           23861   357.2‰ (35.7%)
-Alternate spelling normalized    1110
-Declined                         41822
+Round-trips byte-exact           24139   361.4‰ (36.1%)
+Alternate spelling normalized    1120
+Declined                         41534
 Ambiguous — distinct readings    0
 Print mismatch                   0
 Normalization not invertible     0
 Full inverse not reproduced      0
 Redundant readings (same model)  0
 
-Cards fully covered              6400 / 34882   183.5‰ (18.3%)
+Cards fully covered              6583 / 34882   188.7‰ (18.9%)
 Vanilla + keyword-only cards     1444 / 1712   843.5‰ (84.3%)   <- Phase 1 target
 Portal (set POR)                 200 / 200     1000.0‰ (100%)   <- the Portal band's target
 Legions (set LGN)                145 / 145     1000.0‰ (100%)   <- the Legions band's target
@@ -362,6 +371,96 @@ but an "Enchanted creature …" sentence, and their tail is genuinely long — t
 the joined form is worth 22. There is no fourth large family hiding behind this one, which is the
 useful half of the finding.
 
+## The spell-cast band
+
+"Whenever you cast a noncreature spell, …" — the spell-cast triggers, and with them the first noun
+phrase the grammar has for a **spell** rather than a permanent. Whole-corpus coverage went
+6,400 → **6,583 cards**, byte-exact lines 23,861 → **24,139**, and the differential's compared
+population 2,449 → **2,495**.
+
+**It is the second band picked by ranking the backlog, and the ranking method is the part that
+changed.** The counters band ranked by "cards whose line dies at the verb"; this one ranks by *what
+the grammar could not read* — every declined line is re-parsed, the parse's death offset taken, and
+the **tail from that offset** is what the families are keyed on. That is the one key that neither
+over- nor under-counts a prefix: a line that dies at "you cast" has already read "Whenever ", so the
+family it names is the missing *event* rather than the word the report's table shows. By that
+measure a spell-cast event is far and away the largest family in the corpus — **504 cards decline on
+nothing but a spell-cast trigger**, against 263 for the next one, and 936 touch one.
+
+**And it was measured before it was written, which is the habit the equipment band's overstatement
+bought.** Substituting a known-good prefix ("When ~ enters, ") into all 712 of those cards' declined
+lines and re-parsing says how many payoffs the grammar can already read: **252 of the lines and 234
+whole cards**. The band delivered 183, and the residue is nameable rather than mysterious — the
+`SpellCastPredicate` riders ("from your hand", "a kicked spell", "a spell that targets ~"), the
+colour disjunction ("a blue or black spell"), "a colorless spell", and "your first spell during each
+opponent's turn", which is not an each-turn ordinal at all. For comparison, the same measurement run
+on modal spells — the family the token table and the shape table both rank first — says **126 whole
+cards**, because a modal card is finished only when *every* one of its bullets reads.
+
+**The whole band is rows plus one noun phrase, and no SDK change at all.** `SpellCastEvent`,
+`NthSpellCastEvent` and `CastThisSpellEvent` were already modelled with curated facades in front of
+them, so this is the cheapest thing the module can be doing: a grammar gap whose answer was already
+written, and which the differential confirms the moment it parses.
+
+- **The noun phrase is [`Spells`](src/main/kotlin/com/wingedsheep/assay/grammar/Spells.kt), and it is
+  a family rather than rows in `Filters` because of the head noun.** A permanent phrase's head is the
+  card type ("creature", "nonbasic land"); a spell phrase's head is the literal word "spell" with the
+  card type in front of it as an adjective. `GameObjectFilter.Creature` is therefore printed
+  "creature" in one file and "creature spell" in the other — one printed form per model in two
+  disjoint positions, not two forms for one. The layers are a deliberate *subset* of `Filters`',
+  because a spell has no controller, is never tapped or attacking, and has no power to compare: what
+  is left is the three axes a card carries on the stack, its types, its colour and its mana value.
+- **The subtype join is "or" here and "and/or" there, and that is not two spellings of one model.**
+  `Filters.anySubtype`'s inner is a type noun, so the value it builds always carries a card-type
+  predicate under the `Or`; this one never does. Deriving the join from the head noun would be a rule
+  reading a templating habit instead of a model.
+- **The caster is a field on the event, so "you" / "an opponent" / "a player" are three rows over one
+  skeleton** — not a subject vocabulary in a slot, which would also let the rule print "each player
+  casts", a sentence no card writes.
+- **The effect clause is `Steps.triggeredStep`, for the filtered-trigger reason.** The event names an
+  object of its own — the spell being cast — so "it" in the payoff is that spell, the third anaphor
+  position exactly as a filtered enters-trigger is. "When you cast this spell" is the one row that
+  takes the *source* cascade instead, and it has to: there the spell being cast **is** the source.
+- **Widening `filteredTriggerRule` is what made the family rows.** Its `article: Boolean` became a
+  noun-phrase parameter, so a cast trigger passes `Spells.indefinite` through the identical rule the
+  enters and becomes-blocked triggers use, and nothing about the shape was copied.
+
+**What the gate found: 46 newly-compared cards, and 4 divergences that are four different things** —
+which is roughly the ratio the differential is supposed to have, and the first time a band has
+produced one of each kind.
+
+- **A parser bug of the reversible-but-wrong class — Storyteller Pixie.** The subtype layer read
+  "an **Adventure** spell" as `Any.withSubtype(Adventure)`. The card is right and the grammar was
+  wrong: CR 715.3 makes an Adventure spell one *cast as* an Adventure, which is what
+  `SpellCastPredicate.CastAsAdventure` says in its own KDoc — "this is about how the card was cast,
+  not what the card is" — and the same adventurer card cast as its creature half does not satisfy it.
+  The reading round-tripped byte-perfectly and denoted a trigger the engine would never fire, which
+  is precisely what the touchstone structurally cannot see. Fixed by spelling the phrase as a row of
+  its own and having `Spells.spellSubtype` refuse the word, since one printed form with two models is
+  ambiguity by construction rather than a preference.
+- **A card bug of the bare-tribal-noun class — Adeliz, the Cinder Wind.** "Wizards you control get
+  +1/+1" filtered on `Creature.withSubtype(Wizard)`; a bare tribal noun names every *permanent* with
+  the subtype, which is the reading Zombie Master proves by printing both spellings on one card. It
+  is the residue of the migration that closed that finding: Adeliz was not in the compared population
+  then, and is now. Unobservable today, and fixed for the same reason the other 103 were.
+- **A card bug of the "you may" class — Daring Archaeologist.** "You may return target artifact card
+  from your graveyard to your hand" was spelled `optional = true` on the *target requirement*, which
+  is the SDK's phrasing for "up to one target" — a strictly different ability, and exactly the
+  conflation the trigger-`optional` collapse removed from the engine. The consent belongs on the
+  ability. Fixed with the scenario test that asserts the observable halves: the requirement's minimum
+  is 1, and declining asks for no target at all.
+- **The standing `ManaColorSet.Specific` finding, recurring — Spider Manifestation.** "{T}: Add {R}
+  or {G}." as one `AddManaOfChoiceEffect` where 165 cards write two abilities. The README's own note
+  said none of the thirteen was compared "because each one's rider declines anyway"; this band read
+  the rider. Still not folded, for the reason recorded below.
+
+**Where the ranking points next.** On the same tail ranking, the row under `you cast` at 504 was
+`When ~` at 263 and then a flat run — `enchanted creature` 183, `for each` 175, `Until end of` 170,
+`Each player` 165 — and none of those is one sentence the way a cast trigger is. (Those counts are
+the pre-band measurement and can only have risen, since a card blocked by two families was
+sole-blocked by neither.) A flat tail is the shape the equipment band's residue had, and it is the
+signal that the next target is a *set* rather than a family.
+
 ## What Phase 1 already found
 
 The report is two documents at once, and the second one is about `mtg-sdk`:
@@ -407,21 +506,24 @@ named population bucket instead and the denominator stays visible.
 
 ```
   Hand-written cards                 9127
-    compared                         2449
-    not yet covered by the grammar   6042
-    script slot not modelled yet      82
+    compared                         2495
+    not yet covered by the grammar   5995
+    script slot not modelled yet      83
     lines do not fold into one card   50
     multi-face (out of scope)        301
     Oracle text differs from golden  203
     golden would not decode            0
 
-  Confirmed — models agree           2449   1000.0‰ (100.0%)
-  DIVERGENT — read every one            0
+  Confirmed — models agree           2494    999.6‰ (100.0%)
+  DIVERGENT — read every one            1
 ```
 
-**Zero is where the sweep and the two findings after it landed**, and it is a checkpoint rather than
-a property — the number has gone up on the day the grammar reached every new card class but one, and
-it should be expected to again. The sweep took the count from 122 to 1: every divergence the gate had
+**The one standing divergence is the already-open `ManaColorSet.Specific` finding**, recurring on
+Spider Manifestation exactly as the note below predicted it would. The count was at zero after the
+sweep and the two findings after it; the spell-cast band took it to four and three of those are
+fixed here, which is the gate behaving the way it is supposed to — zero is a checkpoint, not a
+property, and it has risen on the day the grammar reached every new card class but one. The sweep
+itself took the count from 122 to 1: every divergence the gate had
 accumulated was read, classified as parser bug / card bug / fold, and acted on. The one it left
 standing was Lavaborn Muse, closed by the CR 603.4 split below. What the sweep found, by kind:
 
@@ -550,9 +652,11 @@ Cemetery and Edgar Markov — and the two models agree. `Triggers.abilityFor` wr
 and never `triggerRestriction`, so a "while" card declines rather than printing an "if" sentence that
 means something else.
 
-**The differential is at zero.** That is a checkpoint, not a destination: it means every card the
-grammar currently reads whole agrees with its golden, and the next band of rules is expected to move
-it off zero again.
+**The differential was at zero here, and the spell-cast band moved it off — exactly as this
+paragraph predicted.** Four divergences over 46 newly-compared cards, three of them fixed (one
+parser bug, two card bugs) and the fourth the standing `ManaColorSet.Specific` finding. Zero is a
+checkpoint, not a destination: it means every card the grammar reads whole agrees with its golden on
+the day it is measured, and the next band of rules is expected to move it off again.
 
 The divergence count is not meant to stay at zero — it rises every time the grammar reaches a new
 class of card, and each rise is the gate earning its keep. The five it opened with, the eight the

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Cardinals.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Cardinals.kt
@@ -50,4 +50,21 @@ object Cardinals {
 
     /** True for a count this vocabulary can spell as a word — the guard a counting rule builds on. */
     fun spellable(n: Int): Boolean = WORDS.any { it.second == n }
+
+    /**
+     * The ordinals — "your **second** spell each turn".
+     *
+     * A separate vocabulary rather than a suffix over [word], because English's ordinals are not
+     * derived from its cardinals by any rule a grammar could invert ("two" → "second", "three" →
+     * "third"), and because the two never stand in the same slot: a cardinal counts objects, an
+     * ordinal picks one out of a sequence. It starts at *one*, which is the other difference — "your
+     * first spell" is written, where "draw one card" is not.
+     *
+     * It stops at three for [word]'s reason: that is where the corpus stops. No card counts a
+     * fourth spell in a turn, and a rule that spelled one would round-trip against nothing.
+     */
+    val ordinal: Phrase<Int> = oneOf(
+        "an ordinal",
+        listOf("first" to 1, "second" to 2, "third" to 3).map { (text, value) -> constant(text, value) },
+    )
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Spells.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Spells.kt
@@ -1,0 +1,243 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.Phrase
+import com.wingedsheep.assay.syntax.bind
+import com.wingedsheep.assay.syntax.constant
+import com.wingedsheep.assay.syntax.oneOf
+import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * The noun phrase a *spell* is described by — "a creature spell", "a noncreature spell", "an instant
+ * or sorcery spell", "a blue spell", "a Spirit or Arcane spell", "a spell with mana value 4 or
+ * greater".
+ *
+ * It denotes the same type as [Filters], `mtg-sdk`'s [GameObjectFilter], and is written the same way
+ * — layers, never composition, each owning exactly one field and stripping precisely it. What makes
+ * it a family of its own rather than rows in [Filters] is the **head noun**. A permanent phrase's
+ * head is the card type ("creature", "nonbasic land"); a spell phrase's head is the literal word
+ * "spell", and the card type stands in front of it as an adjective. So "creature" names
+ * `GameObjectFilter.Creature` in both files and prints as two different strings, which is one printed
+ * form per model in two disjoint positions rather than two forms for one — the positions being a
+ * battlefield noun and a stack noun, and nothing reaching both.
+ *
+ * That is also why the layers here are a *subset* of [Filters]'. A spell has no controller clause
+ * ("a creature spell you control" is not printed — the caster is the trigger's subject, not the
+ * noun's), is never tapped, attacking or a token, and has no power to compare; every layer that owns
+ * one of those fields would be a rule with nothing in the corpus to read. What is left is the three
+ * axes a card carries on the stack: its types, its colour, and its mana value.
+ *
+ * ### The layers, innermost first
+ *
+ * | Layer | Owns | Surface |
+ * |---|---|---|
+ * | [head] | the whole predicate set of a named card-type quality | "spell", "creature spell" |
+ * | [subtyped] / [anySubtype] | the last [CardPredicate] when it is a subtype one | "Spirit spell" |
+ * | [colour] | the last [CardPredicate] when it is a colour one | "blue spell" |
+ * | [manaValueAtLeast] | the last [CardPredicate] when it is a mana-value one | "…with mana value 4 or greater" |
+ *
+ * The nesting is the order English uses and the order the fluent builders append in, exactly as
+ * [Filters] states: "an Eldrazi creature spell with mana value 7 or greater" builds
+ * `Creature.withSubtype(Eldrazi).manaValueAtLeast(7)`, and each layer strips its own top.
+ *
+ * ### The subtype join is "or" here and "and/or" in [Filters], and that is not two forms for one model
+ *
+ * [Filters.anySubtype] spells "Bird and/or Cleric permanent"; the corpus spells the same predicate
+ * shape on a spell as "a **Spirit or Arcane** spell". Both build a [CardPredicate.Or] of two
+ * `HasSubtype`s — but [Filters.anySubtype]'s inner is a *type noun*, so the value it produces always
+ * carries a card-type predicate under the `Or`, and the value this rule produces never does. The two
+ * are therefore different values and each has exactly one printed form. Deriving the join from the
+ * head noun would be the alternative, and it would be a rule that reads a templating habit rather
+ * than a model.
+ *
+ * ### Why "colorless" is absent
+ *
+ * `GameObjectFilter` publishes `Multicolored` and the whole colour vocabulary, but no colourless
+ * constant or builder — [CardPredicate.IsColorless] exists with nothing curated in front of it. This
+ * module builds through the SDK's facades and does not add to them, so the ten cards printing "a
+ * colorless spell" decline and the gap is named here rather than routed around with a raw `copy`.
+ *
+ * Compare [Stack], which enumerates a spell noun of its own: there the value is a `TargetFilter`
+ * carrying `Zone.STACK`, because a *target* on the stack is a requirement rather than an event's
+ * filter. Same English, different SDK slot, and neither position can reach the other's rules.
+ */
+object Spells {
+
+    /**
+     * The card-type qualities Oracle writes in front of "spell", each a curated `GameObjectFilter`.
+     *
+     * Enumerated for [Filters]' reason and not a weaker one: "instant or sorcery" is an ordered
+     * [CardPredicate.Or] and "artifact creature" would be two predicates, and English distinguishes
+     * them only by the words. "historic" is the clearest case — it is a defined term in the
+     * Comprehensive Rules' glossary meaning *artifact, legendary or Saga*, and no shape over the
+     * three predicates could recover the one word that names them.
+     */
+    private val QUALITIES: List<Pair<String, GameObjectFilter>> = listOf(
+        "creature" to GameObjectFilter.Creature,
+        "noncreature" to GameObjectFilter.Noncreature,
+        "artifact" to GameObjectFilter.Artifact,
+        "enchantment" to GameObjectFilter.Enchantment,
+        "instant" to GameObjectFilter.Instant,
+        "sorcery" to GameObjectFilter.Sorcery,
+        "planeswalker" to GameObjectFilter.Planeswalker,
+        "permanent" to GameObjectFilter.Permanent,
+        "instant or sorcery" to GameObjectFilter.InstantOrSorcery,
+        "multicolored" to GameObjectFilter.Multicolored,
+        "historic" to GameObjectFilter.Historic,
+        "legendary" to GameObjectFilter.Any.legendary(),
+    )
+
+    /**
+     * "spell", "creature spell" — the head noun, with the card-type quality that may precede it.
+     *
+     * The unqualified row builds [GameObjectFilter.Any], which is the value every cast-trigger facade
+     * defaults to, so "a spell" and "a creature spell" are one alternation rather than an optional
+     * literal that could print either way.
+     */
+    private val head: Phrase<GameObjectFilter> = oneOf(
+        "a spell",
+        listOf(constant("spell", GameObjectFilter.Any)) +
+            QUALITIES.map { (surface, filter) -> constant("$surface spell", filter) },
+    )
+
+    /** Strip the top of the predicate stack when it is the kind this layer owns. */
+    private inline fun <reified P : CardPredicate> GameObjectFilter.stripTop(): Pair<P, GameObjectFilter>? {
+        val top = cardPredicates.lastOrNull() as? P ?: return null
+        return top to copy(cardPredicates = cardPredicates.dropLast(1))
+    }
+
+    /**
+     * The subtype leaf this file reads, which is [Primitives.subtype] minus the words the SDK
+     * models as something other than a characteristic.
+     *
+     * There is exactly one today and it is not an exception to a rule, it *is* the rule: an
+     * "Adventure spell" is a spell **cast as** an Adventure (CR 715.3), which
+     * `SpellCastPredicate.CastAsAdventure` says in its own KDoc — "this is about how the card was
+     * cast, not what the card is", and an adventurer card cast as its creature half does not
+     * satisfy it. `Any.withSubtype(Adventure)` is a different claim, about the object on the stack,
+     * and the two select different spells. The differential caught it on Storyteller Pixie: the
+     * reading round-tripped byte-perfectly and meant a card the engine would never fire.
+     *
+     * So the word is spelled by [Triggers.castRules]' own row instead, and refusing it here is what
+     * keeps that one printed form from having two models — which is ambiguity by construction
+     * rather than a preference. Every other capitalized word in this position — Spirit, Arcane,
+     * Lesson, Omen, Aura, Equipment, and the fifty-odd creature types — is a characteristic of the
+     * card, so the leaf stays otherwise ungated for [Filters.subtyped]'s reason: the head noun
+     * supplies the card type and nothing is being guessed.
+     *
+     * Declared above the rule that reads it, per this module's ordering rule: object initializers
+     * run in declaration order.
+     */
+    private val MODELLED_ELSEWHERE: Set<Subtype> = setOf(Subtype("Adventure"))
+
+    /** [MODELLED_ELSEWHERE]'s gate applied to [Primitives.subtype]. */
+    private val spellSubtype: Phrase<Subtype> = phrase("{word}", name = "a spell's subtype") {
+        slot("word", Primitives.subtype)
+        build { it.value<Subtype>("word").takeIf { s -> s !in MODELLED_ELSEWHERE } }
+        match { subtype -> if (subtype in MODELLED_ELSEWHERE) null else bind("word" to subtype) }
+    }
+
+    /** "a Merfolk spell", "an Eldrazi creature spell" — one subtype in front of the head. */
+    private fun subtyped(inner: Phrase<GameObjectFilter>): Phrase<GameObjectFilter> =
+        phrase("{subtype} {spell}", name = "a spell of a subtype") {
+            slot("subtype", spellSubtype)
+            slot("spell", inner)
+            build { it.value<GameObjectFilter>("spell").withSubtype(it.value<Subtype>("subtype")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.HasSubtype>()
+                    ?.let { (predicate, rest) -> bind("subtype" to predicate.subtype, "spell" to rest) }
+            }
+        }
+
+    /** "a Spirit or Arcane spell" — two subtypes, either of which qualifies. */
+    private fun anySubtype(inner: Phrase<GameObjectFilter>): Phrase<GameObjectFilter> =
+        phrase("{first} or {second} {spell}", name = "a spell of either subtype") {
+            slot("first", spellSubtype)
+            slot("second", spellSubtype)
+            slot("spell", inner)
+            build {
+                it.value<GameObjectFilter>("spell")
+                    .withAnySubtype(it.value<Subtype>("first").value, it.value<Subtype>("second").value)
+            }
+            match { filter ->
+                val (predicate, rest) = filter.stripTop<CardPredicate.Or>() ?: return@match null
+                val subtypes = predicate.predicates.map {
+                    (it as? CardPredicate.HasSubtype)?.subtype ?: return@match null
+                }
+                if (subtypes.size != 2) return@match null
+                bind("first" to subtypes[0], "second" to subtypes[1], "spell" to rest)
+            }
+        }
+
+    /** "a blue spell", "a red creature spell". */
+    private fun colour(inner: Phrase<GameObjectFilter>): Phrase<GameObjectFilter> =
+        phrase("{color} {spell}", name = "a coloured spell") {
+            slot("color", Primitives.color)
+            slot("spell", inner)
+            build { it.value<GameObjectFilter>("spell").withColor(it.value("color")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.HasColor>()
+                    ?.let { (predicate, rest) -> bind("color" to predicate.color, "spell" to rest) }
+            }
+        }
+
+    /**
+     * "a spell with mana value 4 or greater" — a suffix in English and the top of the stack in the
+     * model, so it is the outermost layer.
+     *
+     * The number is [Primitives.cardinal] rather than [Cardinals.word] because Oracle writes this one
+     * in digits: "with mana value 4 or greater", never "with mana value four or greater".
+     */
+    private fun manaValueAtLeast(inner: Phrase<GameObjectFilter>): Phrase<GameObjectFilter> =
+        phrase("{spell} with mana value {n} or greater", name = "a spell with mana value at least") {
+            slot("spell", inner)
+            slot("n", Primitives.cardinal)
+            build { it.value<GameObjectFilter>("spell").manaValueAtLeast(it.int("n")) }
+            match { filter ->
+                filter.stripTop<CardPredicate.ManaValueAtLeast>()
+                    ?.let { (predicate, rest) -> bind("spell" to rest, "n" to predicate.min) }
+            }
+        }
+
+    /**
+     * The whole cascade — "spell", "noncreature spell", "blue Spirit spell with mana value 3 or
+     * greater".
+     *
+     * Each level carries the level below as its first alternative, so a filter using none of a
+     * layer's vocabulary is printed by the layer that owns what it does use.
+     */
+    val spell: Phrase<GameObjectFilter> = run {
+        val subtypes = oneOf("a spell of a card type or subtype", head, subtyped(head), anySubtype(head))
+        val coloured = oneOf("a coloured spell", subtypes, colour(subtypes))
+        oneOf("a spell noun phrase", coloured, manaValueAtLeast(coloured))
+    }
+
+    /**
+     * "a spell", "an instant or sorcery spell" — the same phrase with its indefinite article.
+     *
+     * The article is derived from [spell]'s own printed form in both directions, exactly as
+     * [Filters.indefinite] derives it: English picks it from the sound of the next word, which is a
+     * property of the spelling rather than of the model, so a rule whose article disagrees refuses in
+     * both directions and printing stays determined.
+     */
+    val indefinite: Phrase<GameObjectFilter> = oneOf(
+        "a spell with its article",
+        article("a"),
+        article("an"),
+    )
+
+    private fun article(article: String): Phrase<GameObjectFilter> =
+        phrase("$article {spell}", name = "\"$article\" plus a spell") {
+            slot("spell", spell)
+            build { it.value<GameObjectFilter>("spell").takeIf { f -> articleFor(f) == article } }
+            match { f -> if (articleFor(f) == article) bind("spell" to f) else null }
+        }
+
+    /** The article [spell] would print [f] with, or null when it cannot print it at all. */
+    private fun articleFor(f: GameObjectFilter): String? {
+        val head = spell.unparse(f)?.firstOrNull()?.lowercaseChar() ?: return null
+        return if (head in listOf('a', 'e', 'i', 'o', 'u')) "an" else "a"
+    }
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Triggers.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Triggers.kt
@@ -7,9 +7,11 @@ import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.EventPattern
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
@@ -70,9 +72,13 @@ object Triggers {
      * rather than printing a sentence that quietly drops it. Only the id is exempt, because the id
      * is not in the text.
      */
-    private fun triggerRule(surface: String, spec: TriggerSpec): Phrase<TriggeredAbility> {
+    private fun triggerRule(
+        surface: String,
+        spec: TriggerSpec,
+        effect: Phrase<CardScript> = Steps.step,
+    ): Phrase<TriggeredAbility> {
         return phrase("$surface, {effect}", name = surface) {
-            slot("effect", Steps.step)
+            slot("effect", effect)
             build { abilityFor(spec, it.value("effect")) }
             match { ability ->
                 val script = scriptFor(ability)
@@ -240,19 +246,21 @@ object Triggers {
      * the word "another" is the only thing in the text that says so. Two rows, not an optional
      * literal, so the model decides which prints.
      *
-     * [article] says which noun phrase the surface takes, and it is a property of the surface rather
+     * [noun] says which noun phrase the surface takes, and it is a property of the surface rather
      * than of the filter: "a Beast" carries its indefinite article and "another Beast" does not,
      * because "another" is already a determiner. [Filters.indefinite] owns the article in both
-     * directions, so a rule that took the wrong one would print "another a Beast".
+     * directions, so a rule that took the wrong one would print "another a Beast". A cast trigger
+     * passes [Spells.indefinite] through the same parameter — its event names a *spell*, and the
+     * noun phrase for one is a different vocabulary over the identical `GameObjectFilter`.
      */
     private fun filteredTriggerRule(
         surface: String,
         name: String,
-        article: Boolean,
+        noun: Phrase<GameObjectFilter>,
         spec: (GameObjectFilter) -> TriggerSpec,
     ): Phrase<TriggeredAbility> =
         phrase("$surface, {effect}", name = name) {
-            slot("filter", if (article) Filters.indefinite else Filters.filter)
+            slot("filter", noun)
             // [Steps.triggeredStep], not [Steps.step]: this trigger's event mentions an object of its
             // own, so "it" in the effect clause is that object rather than the source. See the
             // third-anaphor section on [SelfSteps]; the differential caught Tattered Ratter reading
@@ -278,7 +286,108 @@ object Triggers {
         when (val event = ability.trigger) {
             is EventPattern.ZoneChangeEvent -> event.filter
             is EventPattern.BecomesBlockedEvent -> event.filter
+            is EventPattern.SpellCastEvent -> event.spellFilter
             else -> null
+        }
+
+    /**
+     * "Whenever you cast a noncreature spell, …" — the spell-cast triggers.
+     *
+     * They are [filteredTriggerRule]s with [Spells.indefinite] in the noun slot rather than
+     * [Filters.indefinite], and that substitution is the whole of the first three rows: the event's
+     * filter is the same `GameObjectFilter` a battlefield trigger's is, and only the English for it
+     * differs. Widening the rule's `article: Boolean` into a noun-phrase parameter is what let the
+     * family be rows here instead of a second copy of the shape.
+     *
+     * **The caster is a parameter of the event and not of the noun.** "You", "an opponent" and "a
+     * player" are `Player.You` / `EachOpponent` / `Each` on `SpellCastEvent`, so they are three rows
+     * over one surface skeleton — not a subject vocabulary slotted into one rule, because a
+     * `Player` in that position would also let the rule print "each player casts", which no card
+     * writes.
+     *
+     * **The effect clause is [Steps.triggeredStep], for [filteredTriggerRule]'s reason.** This
+     * trigger's event names an object of its own — the spell being cast — so "it" in the payoff is
+     * that spell rather than the source, which is the third anaphor position exactly as a filtered
+     * enters-trigger is. "When you cast this spell" is the one row that uses the *source* cascade
+     * instead, and it has to: there the spell being cast **is** the source, so its "it" is the
+     * ordinary self-anaphor and reading it as the triggering entity would be a second spelling of
+     * one object.
+     */
+    private val castRules: List<Phrase<TriggeredAbility>> = listOf(
+        filteredTriggerRule(
+            "whenever you cast {filter}", "whenever you cast a spell", Spells.indefinite,
+        ) { SdkTriggers.youCastSpell(it) },
+        filteredTriggerRule(
+            "whenever an opponent casts {filter}", "whenever an opponent casts a spell", Spells.indefinite,
+        ) { SdkTriggers.opponentCasts(it) },
+        filteredTriggerRule(
+            "whenever a player casts {filter}", "whenever a player casts a spell", Spells.indefinite,
+        ) { SdkTriggers.anyPlayerCasts(it) },
+        triggerRule("when you cast this spell", SdkTriggers.WhenYouCastThisSpell()),
+        // "Adventure" is the one word in the spell noun's subtype slot that is not a
+        // characteristic — CR 715.3 makes an Adventure spell one *cast as* an Adventure, which is
+        // `SpellCastPredicate.CastAsAdventure` and not a subtype on the object. So the phrase is a
+        // row of its own and [Spells.spellSubtype] refuses the word, which is what keeps one
+        // printed form from having two models. See the leaf's KDoc for what the differential found.
+        triggerRule(
+            "whenever you cast an Adventure spell",
+            SdkTriggers.youCastSpell(requires = setOf(SpellCastPredicate.CastAsAdventure)),
+            effect = Steps.triggeredStep,
+        ),
+        nthCastRule("whenever you cast your", "whenever you cast your nth spell", Player.You),
+        nthCastRule("whenever a player casts their", "whenever a player casts their nth spell", Player.Each),
+    )
+
+    /**
+     * "Whenever you cast your second spell each turn, …" — the ordinal cast trigger.
+     *
+     * A rule of its own rather than a row above, because the event is a different SDK type:
+     * `NthSpellCastEvent` counts a caster's spells within the turn where `SpellCastEvent` watches
+     * every one. The possessive is part of the surface and tracks the subject — "you cast **your**
+     * second", "a player casts **their** second" — so it is baked into each row's prefix rather than
+     * being a vocabulary, for the same reason the caster is.
+     *
+     * **`GameObjectFilter.Any` is mapped to a null `spellFilter`, in both directions.** The SDK
+     * spells "count every spell" as `null` here and as `Any` on `SpellCastEvent`, and all 24
+     * hand-written ordinal triggers write the `null`. So the bare "spell" builds null and null reads
+     * back as the bare noun, which makes an event carrying `Any` **unprintable** by this rule — the
+     * fail-closed answer, since that value would be a second spelling of the same fact and nothing
+     * in the text chooses between them.
+     */
+    private fun nthCastRule(prefix: String, name: String, player: Player): Phrase<TriggeredAbility> =
+        phrase("$prefix {ordinal} {filter} each turn, {effect}", name = name) {
+            slot("ordinal", Cardinals.ordinal)
+            slot("filter", Spells.spell)
+            slot("effect", Steps.triggeredStep)
+            build { bindings ->
+                val filter = bindings.value<GameObjectFilter>("filter")
+                abilityFor(
+                    SdkTriggers.NthSpellCast(
+                        n = bindings.int("ordinal"),
+                        player = player,
+                        spellFilter = filter.takeIf { it != GameObjectFilter.Any },
+                    ),
+                    bindings.value("effect"),
+                )
+            }
+            match { ability ->
+                val event = ability.trigger as? EventPattern.NthSpellCastEvent ?: return@match null
+                val filter = event.spellFilter ?: GameObjectFilter.Any
+                val script = scriptFor(ability)
+                // Rebuilt through the *build* half's mapping, not through `event.spellFilter`:
+                // that is what makes an event carrying `Any` refuse to print rather than printing
+                // the bare noun that means `null`.
+                val rebuilt = abilityFor(
+                    SdkTriggers.NthSpellCast(
+                        event.nthSpell,
+                        player,
+                        filter.takeIf { it != GameObjectFilter.Any },
+                    ),
+                    script,
+                )
+                if (rebuilt?.copy(id = ability.id) != ability) return@match null
+                bind("ordinal" to event.nthSpell, "filter" to filter, "effect" to script)
+            }
         }
 
     private val rules: List<Phrase<TriggeredAbility>> = listOf(
@@ -313,10 +422,10 @@ object Triggers {
         triggerRule("when you cycle ${Normalizer.SELF}", SdkTriggers.YouCycleThis),
         triggerRule("whenever a player cycles a card", SdkTriggers.AnyPlayerCycles),
         filteredTriggerRule(
-            "whenever {filter} enters", "whenever a permanent enters", article = true,
+            "whenever {filter} enters", "whenever a permanent enters", Filters.indefinite,
         ) { SdkTriggers.entersBattlefield(it, TriggerBinding.ANY) },
         filteredTriggerRule(
-            "whenever another {filter} enters", "whenever another permanent enters", article = false,
+            "whenever another {filter} enters", "whenever another permanent enters", Filters.filter,
         ) { SdkTriggers.entersBattlefield(it, TriggerBinding.OTHER) },
         // "Whenever this creature or another Zombie enters" — Noxious Ghoul, Goblin Assassin. The
         // source is *in* the watched class, so the model is the plain `ANY` binding and the printed
@@ -326,10 +435,10 @@ object Triggers {
         filteredTriggerRule(
             "whenever ${Normalizer.SELF} or another {filter} enters",
             "whenever the source or another permanent enters",
-            article = false,
+            Filters.filter,
         ) { SdkTriggers.entersBattlefield(it, TriggerBinding.ANY) },
         filteredTriggerRule(
-            "whenever {filter} becomes blocked", "whenever a creature becomes blocked", article = true,
+            "whenever {filter} becomes blocked", "whenever a creature becomes blocked", Filters.indefinite,
         ) { SdkTriggers.becomesBlocked(it, TriggerBinding.ANY) },
         // "Whenever ~ or another creature dies, …" — Blood Artist, Skirk Drill Sergeant. One
         // ability with an `ANY` binding covers both halves, because the source is itself a member of
@@ -339,9 +448,9 @@ object Triggers {
         filteredTriggerRule(
             "whenever ${Normalizer.SELF} or another {filter} dies",
             "whenever the source or another permanent dies",
-            article = false,
+            Filters.filter,
         ) { SdkTriggers.leavesBattlefield(filter = it, to = Zone.GRAVEYARD, binding = TriggerBinding.ANY) },
-    ) + phaseRules
+    ) + castRules + phaseRules
 
     val trigger: Phrase<TriggeredAbility> = oneOf("a triggered ability", rules)
 

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/SpellCastTriggersTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/SpellCastTriggersTest.kt
@@ -1,0 +1,179 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.assay.syntax.parseLine
+import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.dsl.Triggers as SdkTriggers
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The spell-cast triggers and the [Spells] noun phrase they slot — the band that made a *spell* a
+ * thing the grammar can describe, rather than only a permanent.
+ */
+class SpellCastTriggersTest : StringSpec({
+
+    fun fragment(line: String): CardFragment =
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Accepted<CardFragment>>().value
+
+    fun roundTrips(line: String) {
+        Grammar.abilityLine.printLine(fragment(line)) shouldBe line
+    }
+
+    fun ability(line: String): TriggeredAbility =
+        fragment(line).script.triggeredAbilities.single()
+
+    // Spellgorger Weird's golden is this model exactly.
+    "a cast trigger is the ability a card author writes from the same sentence" {
+        ability("Whenever you cast a noncreature spell, put a +1/+1 counter on ~.") shouldBe
+            TriggeredAbility(
+                id = AbilityId("trigger"),
+                trigger = EventPattern.SpellCastEvent(
+                    spellFilter = GameObjectFilter.Noncreature,
+                    player = Player.You,
+                ),
+                binding = SdkTriggers.YouCastNoncreature.binding,
+                effect = Effects.AddCounters("+1/+1", 1, EffectTarget.Self),
+            )
+        roundTrips("Whenever you cast a noncreature spell, put a +1/+1 counter on ~.")
+    }
+
+    "the caster is a field on the event, so the three subjects are three rows" {
+        (ability("Whenever you cast a spell, draw a card.").trigger as EventPattern.SpellCastEvent)
+            .player shouldBe Player.You
+        (ability("Whenever an opponent casts a spell, draw a card.").trigger as EventPattern.SpellCastEvent)
+            .player shouldBe Player.EachOpponent
+        (ability("Whenever a player casts a spell, draw a card.").trigger as EventPattern.SpellCastEvent)
+            .player shouldBe Player.Each
+    }
+
+    "the effect clause is the whole step vocabulary, exactly as every other trigger's is" {
+        listOf(
+            "Whenever you cast a spell, draw a card.",
+            "Whenever you cast a creature spell, scry 2.",
+            "Whenever you cast an artifact spell, destroy target creature.",
+            "Whenever an opponent casts an enchantment spell, you gain 2 life.",
+            "Whenever a player casts a red spell, tap target creature.",
+        ).forEach { roundTrips(it) }
+    }
+
+    // The noun phrase is layered like [Filters]', over the three axes a card carries on the stack.
+    "the spell noun phrase layers type, subtype, colour and mana value" {
+        listOf(
+            "Whenever you cast a spell, draw a card.",
+            "Whenever you cast a noncreature spell, draw a card.",
+            "Whenever you cast an instant or sorcery spell, draw a card.",
+            "Whenever you cast a historic spell, draw a card.",
+            "Whenever you cast a multicolored spell, draw a card.",
+            "Whenever you cast a legendary spell, draw a card.",
+            "Whenever you cast a permanent spell, draw a card.",
+            "Whenever you cast a blue spell, draw a card.",
+            "Whenever you cast a Merfolk spell, draw a card.",
+            "Whenever you cast a Spirit or Arcane spell, draw a card.",
+            "Whenever you cast a spell with mana value 4 or greater, draw a card.",
+            "Whenever you cast a creature spell with mana value 5 or greater, draw a card.",
+        ).forEach { roundTrips(it) }
+    }
+
+    "the article is derived from the printed noun, in both directions" {
+        roundTrips("Whenever you cast an artifact spell, draw a card.")
+        roundTrips("Whenever you cast an enchantment spell, draw a card.")
+        roundTrips("Whenever you cast a creature spell, draw a card.")
+        // "an creature spell" is not English and must not parse either, which is what makes the
+        // article a function of the phrase rather than a choice the printer makes.
+        Grammar.abilityLine.parseLine("Whenever you cast an creature spell, draw a card.")
+            .shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+
+    // Storyteller Pixie. The reading round-tripped byte-perfectly as `Any.withSubtype(Adventure)`
+    // and meant a card the engine would never fire; the differential is what caught it.
+    "an Adventure spell is a cast-manner fact, not a subtype on the object" {
+        ability("Whenever you cast an Adventure spell, draw a card.").trigger shouldBe
+            EventPattern.SpellCastEvent(requires = setOf(SpellCastPredicate.CastAsAdventure))
+        roundTrips("Whenever you cast an Adventure spell, draw a card.")
+
+        // …and the subtype leaf must refuse the word, or one printed form would have two models.
+        Spells.spell.unparse(GameObjectFilter.Any.withSubtype(Subtype("Adventure"))) shouldBe null
+    }
+
+    "a cast trigger on the spell itself is a different event and keeps the source anaphor" {
+        ability("When you cast this spell, draw a card.").trigger shouldBe
+            EventPattern.CastThisSpellEvent
+        roundTrips("When you cast this spell, draw a card.")
+    }
+
+    "the ordinal cast trigger counts a caster's spells within the turn" {
+        ability("Whenever you cast your second spell each turn, draw a card.").trigger shouldBe
+            EventPattern.NthSpellCastEvent(nthSpell = 2, player = Player.You)
+        listOf(
+            "Whenever you cast your first spell each turn, draw a card.",
+            "Whenever you cast your second spell each turn, draw a card.",
+            "Whenever you cast your third spell each turn, draw a card.",
+            "Whenever a player casts their second spell each turn, draw a card.",
+            "Whenever a player casts their first noncreature spell each turn, draw a card.",
+        ).forEach { roundTrips(it) }
+    }
+
+    // The SDK spells "count every spell" as a null filter here and as `Any` on `SpellCastEvent`;
+    // every hand-written ordinal trigger writes the null, so `Any` must not print at all.
+    "an ordinal event carrying Any rather than null refuses to print" {
+        val script = CardScript(
+            triggeredAbilities = listOf(
+                TriggeredAbility(
+                    id = AbilityId("trigger"),
+                    trigger = EventPattern.NthSpellCastEvent(
+                        nthSpell = 2,
+                        player = Player.You,
+                        spellFilter = GameObjectFilter.Any,
+                    ),
+                    binding = SdkTriggers.YouCastSpell.binding,
+                    effect = Effects.DrawCards(1),
+                ),
+            ),
+        )
+        Grammar.abilityLine.printLine(CardFragment(script = script)) shouldBe null
+    }
+
+    // Guards the one failure mode a per-rule test cannot: a `match` half that quietly matches
+    // nothing, which surfaces on the corpus as a print mismatch far from its cause.
+    "every spell-cast rule can print what it parses" {
+        listOf(
+            "Whenever you cast a spell, draw a card.",
+            "Whenever you cast a creature spell, draw a card.",
+            "Whenever you cast a noncreature spell, draw a card.",
+            "Whenever you cast an instant or sorcery spell, draw a card.",
+            "Whenever you cast an artifact spell, draw a card.",
+            "Whenever you cast an enchantment spell, draw a card.",
+            "Whenever you cast a planeswalker spell, draw a card.",
+            "Whenever you cast a permanent spell, draw a card.",
+            "Whenever you cast an instant spell, draw a card.",
+            "Whenever you cast a sorcery spell, draw a card.",
+            "Whenever you cast a historic spell, draw a card.",
+            "Whenever you cast a multicolored spell, draw a card.",
+            "Whenever you cast a legendary spell, draw a card.",
+            "Whenever you cast a white spell, draw a card.",
+            "Whenever you cast a Knight spell, draw a card.",
+            "Whenever you cast an Aura or Equipment spell, draw a card.",
+            "Whenever you cast a spell with mana value 3 or greater, draw a card.",
+            "Whenever you cast an Adventure spell, draw a card.",
+            "Whenever an opponent casts a spell, draw a card.",
+            "Whenever an opponent casts a noncreature spell, draw a card.",
+            "Whenever a player casts a spell, draw a card.",
+            "Whenever a player casts a black spell, draw a card.",
+            "When you cast this spell, draw a card.",
+            "Whenever you cast your second spell each turn, draw a card.",
+            "Whenever a player casts their first spell each turn, draw a card.",
+        ).forEach { roundTrips(it) }
+    }
+})


### PR DESCRIPTION
The largest single family left in the corpus by the honest ranking. **Whole-corpus coverage
6,400 → 6,583 cards**, byte-exact lines 23,861 → 24,139, the differential's compared population
2,449 → 2,495. `MISMATCH`, `AMBIGUOUS` and non-invertible normalizations stay at **0**; Portal and
Legions still read 200/200 and 145/145.

## Picking it

The band was chosen by measurement, not by the report's table, and the method is the reusable half
(now recorded in `oracle-assay/AGENTS.md`):

1. **Key the decline families on the parse's *tail*.** Re-parse every declined line, take the
   decline's offset, and group on the text *from that offset on*. A line dying at `you cast` has
   already read "Whenever ", so the family it names is the missing **event** rather than the word the
   token table shows. By that key a spell-cast event is far and away the largest family: **504 cards
   decline on nothing but a spell-cast trigger**, against 263 for the next one.
2. **Substitute a known-good prefix and re-parse, before writing anything.** That says how many
   payoffs the rest of the grammar can already read — the number the band will actually deliver.
   Prediction: **234 whole cards**. Delivered: **183**, and the residue is nameable (the
   `SpellCastPredicate` riders, the colour disjunction, "a colorless spell", "your first spell during
   each opponent's turn"). The same measurement on **modal spells** — which both the token ranking
   and the shape ranking put first — says **126**.

Every ranking that skipped step 2 has overstated its band, three times in the same direction.

## The change

**`grammar/Spells.kt` — the first noun phrase the grammar has for a *spell*.** Same
`GameObjectFilter`, same layering discipline as `Filters`; what makes it a family rather than rows is
the head noun. A permanent phrase's head is the card type ("creature", "nonbasic land"); a spell
phrase's head is the literal word "spell" with the type in front of it as an adjective. So
`GameObjectFilter.Creature` prints "creature" in one file and "creature spell" in the other — one
printed form per model in two disjoint positions, not two forms for one. The layers are a deliberate
*subset* of `Filters`': a spell has no controller, is never tapped or attacking, and has no power to
compare, so what is left is the three axes a card carries on the stack — types, colour, mana value.

**The triggers are rows.** `filteredTriggerRule`'s `article: Boolean` became a noun-phrase parameter,
so a cast trigger passes `Spells.indefinite` through the identical rule the enters and
becomes-blocked triggers already use. The caster is a field on the event, so you / an opponent / a
player are three rows over one skeleton rather than a subject vocabulary in a slot (which would also
print "each player casts", a sentence no card writes). The effect clause is `Steps.triggeredStep`,
because the event names an object of its own — except "When you cast this spell", where that object
*is* the source and the ordinary self-anaphor is correct.

**No SDK change.** `SpellCastEvent`, `NthSpellCastEvent` and `CastThisSpellEvent` were already
modelled with curated facades in front of them, which makes this the cheapest thing the module can be
doing: a grammar gap whose answer was already written, confirmed by the differential the moment it
parses.

## What the differential found — four divergences, one of each kind

| | |
|---|---|
| **Parser bug** (Storyteller Pixie) | The subtype layer read "an **Adventure** spell" as `Any.withSubtype(Adventure)`. CR 715.3 makes an Adventure spell one *cast as* an Adventure — `SpellCastPredicate.CastAsAdventure`'s own KDoc says "this is about how the card was cast, not what the card is". The reading round-tripped byte-perfectly and denoted a trigger the engine would never fire, which is exactly what the touchstone structurally cannot see. **Fixed**: the phrase is a row of its own and `Spells.spellSubtype` refuses the word, since one printed form with two models is ambiguity by construction. |
| **Card bug** (Adeliz, the Cinder Wind) | "Wizards you control get +1/+1" filtered on `Creature.withSubtype(Wizard)`; a bare tribal noun names every *permanent* with the subtype (Zombie Master prints both spellings on one card). Residue of the migration that closed that finding — Adeliz was not in the compared population then. Unobservable today; **fixed** for the same reason the other 103 were. |
| **Card bug** (Daring Archaeologist) | "You may return target artifact card from your graveyard to your hand" spelled the consent as `optional = true` on the **target requirement** — the SDK's phrasing for "up to one target", a strictly different ability, and exactly the conflation the trigger-`optional` collapse removed from the engine. **Fixed**, with a scenario test asserting the observable halves: the requirement's minimum is 1, and declining asks for no target at all. |
| **Standing finding** (Spider Manifestation) | The open `ManaColorSet.Specific` split, recurring exactly as the README predicted — it said none of the thirteen was compared "because each one's rider declines anyway", and this band read the rider. **Not folded**, for the recorded reason. |

## Verification

- `just assay-gate` — `AMBIGUOUS` 0, `MISMATCH` 0, non-invertible 0, redundant readings 0; coverage
  6,400 → 6,583 cards. `--set POR` 200/200 and `--set LGN` 145/145 unchanged.
- `just assay-differential` — compared 2,449 → 2,495, confirmed 2,494, **1** divergent (the standing
  finding above).
- `:oracle-assay:test`, `just test-scenarios 2017-2022`, `:mtg-sets:test` (snapshot + lint),
  `just build` — all green. The `DOM.json` golden diff shows only the two cards that changed.

## Where the ranking points next

On the same tail ranking the row under `you cast` at 504 was `When ~` at 263, then a flat run —
`enchanted creature` 183, `for each` 175, `Until end of` 170, `Each player` 165 — and none of those
is one sentence the way a cast trigger is. A flat tail is the shape the equipment band's residue had,
and it is the signal that the next target is a *set* rather than a family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
