### PR TITLE
Assay: rank declines by the parse's tail, and probe a band before writing it

### DIFF
--- a/oracle-assay/AGENTS.md
+++ b/oracle-assay/AGENTS.md
@@ -326,22 +326,34 @@ ranking in ways that change the work. The step triggers are the worked example: 
 the other 387 were blocked on their effect clause all along.
 
 **The ranking that has actually held up is over the parse's *tail*, and it is two measurements.**
-The spell-cast band is the worked example and the method is reusable verbatim:
+Both are now in the tool — `just assay-report --rank tail`, and the probe box on the explorer's
+decline-family page — because the spell-cast band had to be picked with a throwaway probe outside it.
+That band is the worked example and the method is reusable verbatim:
 
-1. `just assay-report --declines` (add `--implemented` for the grammar backlog), re-parse every
-   declined line, take the decline's `position`, and key the families on **the text from that offset
-   on**. That is neither the token ranking (which over-weights a missing prefix) nor the shape
-   ranking (which counts cards a family *mentions*): it names the piece of grammar that would have
-   to exist for the line to get further. Then count, per family, the cards **all** of whose declined
-   lines fall in it — the honest "sole-blocked" number.
+1. Key each declined line on **the text from the decline's `position` on**, skeletonized and cut to
+   its first three words (`DeclineKey.TAIL`). That is neither the token ranking (which over-weights a
+   missing prefix) nor the shape ranking (which counts cards a family *mentions*): it names the piece
+   of grammar that would have to exist for the line to get further. Then count, per family, the cards
+   **all** of whose declined lines fall in it — the honest "sole-blocked" number, which the report
+   prints as `sole` and the explorer as a column beside `Blocks`.
 2. Before writing anything, **substitute a known-good prefix for the family** into those cards'
    declined lines and re-parse. That says how many payoffs the rest of the grammar can already read,
    which is the number the band will actually deliver. The spell-cast family predicted 234 whole
    cards and delivered 183; modal spells, which both other rankings put first, measured 126.
+   Landfall is the standing example on the live grammar: 189 cards blocked, 104 sole-blocked, and the
+   probe says **48** whole cards would be finished.
 
-Every ranking that skipped step 2 has overstated its band, three times in the same direction. Step 2
-costs one throwaway probe over `Grammar.abilityLine.parseLine`, and it is what turns "which cards
-does this family reach" into "which lines does it finish".
+Every ranking that skipped step 2 has overstated its band, four times in the same direction. Step 2
+is family-specific, so it cannot be precomputed and does not belong in a report — but it is one
+`PrefixProbe.run` over the live grammar, and it is what turns "which cards does this family reach"
+into "which lines does it finish".
+
+**Three keyings, three biases, and knowing which to read.** `DeclineKey` holds all of them and the
+gate computes all three in the one sweep, so the CLI and the explorer cannot disagree about a family.
+Read the tail by default. Read `SHAPE` when the family's sentence *is* the whole line. Read `TOKEN`
+when the parse dies at offset 0 — a line that read nothing has no tail short of itself, so `TAIL`
+degenerates to `SHAPE` there and only the dead token holds the family together. The modal bullets are
+the case: 2,015 declined `•` lines are one token family and hundreds of tail rows.
 
 The split re-weights the list rather than reordering it wholesale, which is itself the finding: the
 top families are the same in both populations, so the grammar backlog and the SDK backlog are being
@@ -432,7 +444,12 @@ implementation of the thing it displays.
 `FinenessReport`, `Touchstone` or `Differential` — the same objects the CLI renders as text. If the
 explorer needs a number the gates do not produce, the number goes in the *gate* and both read it.
 An explorer that computed its own fineness would make two reports that can disagree, and the one
-people look at would be the one nobody gates on.
+people look at would be the one nobody gates on. The decline rankings are the worked example of the
+rule being applied rather than argued about: the keying (`gate/DeclineKey.kt`), the family counts and
+the sole-blocked number all live in `FinenessReport`, so `assay report --rank tail` and the page are
+one ranking. What stays in `AssayIndex` is the *link table* — which card names, a dozen example
+lines, the hand-written split — which is not a number and would make a corpus run's memory grow with
+the corpus for a question no gate asks.
 
 **It calls the live grammar; it never precomputes a payload.** The mtgish model explorer this is
 modelled on had to embed its data and ship the parser as WebAssembly, because the parser lived in
@@ -477,6 +494,8 @@ just assay explain "Wall of Omens"  # the same, with a caret on the token a decl
 just assay-gate                     # touchstone over the corpus; exit 1 on a bug
 just assay-gate --limit 2000        # fast smoke run while iterating
 just assay-report --top 40          # the same numbers, always exit 0 — the SDK gap report
+just assay-report --rank tail       # …keyed on the parse's tail, with the sole-blocked count
+just assay-report --rank tail --tail-words 4   # re-measure the tail's one design parameter
 just assay-differential             # Assay's readings vs. the hand-written cards
 just assay-explore                  # all of the above in a browser, on the live grammar
 ```

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -66,6 +66,7 @@ just assay-report --top 40          # the same numbers, always exit 0
 just assay-report --scope           # restricted to Phase 1's own target class
 just assay-report --implemented     # restricted to cards that already have a golden — the *grammar* backlog
 just assay-report --set POR         # restricted to one set — every card *printed* in it
+just assay-report --rank tail       # declines keyed on the parse's tail, with the sole-blocked count
 just assay-differential             # Assay's readings vs. the hand-written cards
 just assay-explore                  # all of the above in a browser, on the live grammar
 just assay corpus --refresh         # re-download the Scryfall Oracle bulk (~24 MB, cached 7 days)
@@ -988,17 +989,24 @@ just edited is one restart away from being re-measured, and a custom card runs t
 stripping and the invertibility check included — instead of an approximation of it.
 `com.sun.net.httpserver` is in the JDK, so the SDK-only dependency rule is untouched.
 
-Two things it shows that no CLI report does:
+Three things it shows that no CLI report does:
 
 - **Which cards are behind a decline family**, and how many of those already have a hand-written
   golden. `assay report` ranks the families; clicking one is the backlog it names, split into the
   grammar gaps (answer already written, differential confirms it the moment it parses) and the
   possible SDK gaps.
-- **Both rankings side by side.** Keying declines by the token a line *died on* answers "what is the
-  grammar missing"; keying them by the **sentence shape** — the line with numbers and mana symbols
-  collapsed — answers "what should I write next", and they disagree sharply. The token ranking's top
-  row is `Whenever` at 5,070 cards, which names no piece of work; the shape ranking's is
-  `Enchant creature` at 921 cards, which is one rule.
+- **All three rankings side by side.** Keying declines by the token a line *died on* answers "what is
+  the grammar missing"; by the **sentence shape** — the line with numbers and mana symbols collapsed
+  — answers "which whole sentence needs a rule"; and by the **parse's tail** — the text from the
+  decline's own offset on, cut to three words — answers "what construct would let these lines get
+  further", which is the one that decides work. They disagree sharply, and the page says why.
+  `assay report --rank <token|shape|tail>` prints the same three tables.
+- **Whether writing a family would actually finish its cards.** The sole-blocked count says which
+  cards a band *reaches*; the probe on a family's page substitutes a known-good prefix for the
+  family's own span, re-parses every declined line of every card behind it on the live grammar, and
+  says how many whole cards come into coverage. Landfall reads 189 cards blocked and 104
+  sole-blocked, and the probe says **48**. That gap is why every band picked without this step has
+  been overstated.
 
 The corpus sweep (~5s) runs in the background at startup, so the live parser and the rule tree are
 usable before the numbers land; the differential runs on first request and is then cached, because

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/cli/Main.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/cli/Main.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.assay.corpus.ImplementedCorpus
 import com.wingedsheep.assay.corpus.OracleCard
 import com.wingedsheep.assay.corpus.OracleCorpus
 import com.wingedsheep.assay.corpus.SetMembership
+import com.wingedsheep.assay.gate.DeclineKey
 import com.wingedsheep.assay.gate.Differential
 import com.wingedsheep.assay.gate.FinenessReport
 import com.wingedsheep.assay.gate.LineVerdict
@@ -87,6 +88,12 @@ private fun usage() = System.err.println(
       --implemented    restrict to cards that already have a hand-written golden, so the decline
                        table becomes the *grammar* backlog: gaps whose answer is already written
                        and which the differential confirms the moment they parse
+      --rank KEY       how the decline table is keyed: token (default — the token each line died
+                       on), shape (the whole line, skeletonized), or tail (the text from the decline
+                       onward — the ranking that names a piece of work, and the only one that also
+                       reports how many cards a family is the *sole* blocker of)
+      --tail-words N   how many words of the tail make a family (default 3). A design parameter that
+                       was measured rather than chosen; this is how to re-measure it
       --top N          how many decline families (or divergences) to list
       --refresh        re-download the bulk file before running
       --declines       after the report, list every declined line (long)
@@ -311,7 +318,21 @@ private const val DEFAULT_EXPLORE_PORT = 7345
 
 private fun gate(flags: Flags, gating: Boolean): Int {
     val touchstone = Touchstone()
-    val builder = FinenessReport.builder()
+    // The tail ranking is the one that decides work, and the reason it is reachable from here at all
+    // is that the band it named had to be measured with a throwaway probe because `assay report`
+    // could not print it. The default stays TOKEN: this command is also the gate's own diagnostic.
+    val ranking = DeclineKey.byName(flags.str("rank")) ?: run {
+        val given = flags.str("rank")
+        if (given != null) {
+            System.err.println(
+                "assay: unknown --rank \"$given\" — one of ${DeclineKey.entries.joinToString(", ") { it.name.lowercase() }}"
+            )
+            return 2
+        }
+        DeclineKey.TOKEN
+    }
+    val tailWords = flags.int("tail-words") ?: DeclineKey.TAIL_WORDS
+    val builder = FinenessReport.builder(tailWords = tailWords)
     val setFilter = flags.str("set")?.uppercase()
     val limit = flags.int("limit")
 
@@ -367,7 +388,7 @@ private fun gate(flags: Flags, gating: Boolean): Int {
         "vanilla + keyword-only (Phase 1 scope)".takeIf { scopeOnly },
         setCards?.let { "set ${it.code.uppercase()} — ${it.size} cards printed in it" },
     ).joinToString(" · ").ifEmpty { null }
-    println(report.render(topDeclines = flags.int("top") ?: 20, population = population))
+    println(report.render(topDeclines = flags.int("top") ?: 20, population = population, ranking = ranking))
 
     if (declineLines.isNotEmpty()) {
         println()

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/explore/AssayIndex.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/explore/AssayIndex.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.assay.corpus.ImplementedCorpus
 import com.wingedsheep.assay.corpus.OracleCard
 import com.wingedsheep.assay.corpus.OracleCorpus
 import com.wingedsheep.assay.gate.CardResult
+import com.wingedsheep.assay.gate.DeclineKey
 import com.wingedsheep.assay.gate.FinenessReport
 import com.wingedsheep.assay.gate.LineVerdict
 import com.wingedsheep.assay.gate.Touchstone
@@ -27,12 +28,18 @@ import java.util.Locale
  * The one thing here that the CLI reports cannot: **which cards are behind a decline family**, and
  * how many of those already have a hand-written golden. The report ranks the families; the point of
  * a browser is to click one and see the backlog it names.
+ *
+ * That split is deliberate and it is where the "a view, never a second source of truth" rule lands
+ * here. The *keying* and the *counts* are [FinenessReport]'s, under [DeclineKey], so
+ * `assay report --rank tail` and the page below are the same ranking by construction. What this adds
+ * is a **link table** — which card names, a dozen example lines, the hand-written split — which is
+ * not a number the gate has any use for and would only make its memory unbounded.
  */
 class AssayIndex(
     val report: FinenessReport,
-    val declines: List<DeclineFamily>,
-    val shapes: List<DeclineFamily>,
-    val unlockCurves: Map<Ranking, List<Int>>,
+    /** Every keying's families, in the gate's own rank order, with the backlog joined onto each. */
+    val families: Map<DeclineKey, List<DeclineFamily>>,
+    val unlockCurves: Map<DeclineKey, List<Int>>,
     val cards: List<OracleCard>,
     val rows: List<CardRow>,
     /** Cards per [Companion.state] — the corpus in four buckets, which is the headline picture. */
@@ -71,11 +78,10 @@ class AssayIndex(
     fun hasGolden(name: String): Boolean =
         name in goldenNames || name.substringBefore(" // ") in goldenNames
 
-    fun families(ranking: Ranking): List<DeclineFamily> =
-        if (ranking == Ranking.SHAPE) shapes else declines
+    fun families(ranking: DeclineKey): List<DeclineFamily> = families[ranking].orEmpty()
 
-    fun decline(token: String, ranking: Ranking): DeclineFamily? =
-        families(ranking).firstOrNull { it.token == token }
+    fun decline(key: String, ranking: DeclineKey): DeclineFamily? =
+        families(ranking).firstOrNull { it.key == key }
 
     /**
      * Prefix-and-substring name search, ranked so an exact prefix wins.
@@ -121,8 +127,7 @@ class AssayIndex(
 
             val cards = mutableListOf<OracleCard>()
             val rows = mutableListOf<CardRow>()
-            val byToken = Grouping()
-            val byShape = Grouping()
+            val backlog = DeclineKey.entries.associateWith { Backlog() }
 
             var seen = 0
             var fraction = 0.0
@@ -132,16 +137,17 @@ class AssayIndex(
                 cards.add(card)
 
                 val declined = result.lines.filter { it.verdict == LineVerdict.DECLINED }
-                // Interned through the grouping's own key set, so a card's shape list holds the same
-                // String instances the ranking does rather than 52,463 fresh copies.
-                val tokens = declined.mapNotNull { it.declineToken }.distinct()
-                val shapes = declined.map { skeleton(it.line) }.distinct()
-                rows.add(row(card, result, tokens, shapes))
+                val keys = DeclineKey.entries.associateWith { dimension ->
+                    // Interned through the backlog's own key set, so a card's key list holds the
+                    // same String instances the ranking does rather than 52,463 fresh copies.
+                    declined.map { line -> backlog.getValue(dimension).intern(dimension.of(line)) }
+                }
+                rows.add(row(card, result, keys.mapValues { (_, list) -> list.distinct() }))
                 attribution.observe(result)
 
-                for ((index, line) in declined.withIndex()) {
-                    byToken.add(line.declineToken ?: "<unknown>", card.name, line.line)
-                    byShape.add(shapes.getOrElse(index) { skeleton(line.line) }, card.name, line.line)
+                for ((dimension, list) in keys) {
+                    val into = backlog.getValue(dimension)
+                    list.forEachIndexed { index, key -> into.add(key, card.name, declined[index].line) }
                 }
 
                 seen++
@@ -154,22 +160,19 @@ class AssayIndex(
             // Cheap — reads the goldens' `// name` headers without decoding a single definition, so
             // the implemented/unimplemented split of every decline family costs one directory read.
             val goldens = runCatching { ImplementedCorpus.names() }.getOrDefault(emptySet())
-
-            // Unlocks and the curve are computed for the SHAPE ranking only, and that restriction is
-            // the finding rather than a shortcut. Both numbers are claims about *work*: "write this
-            // and that many cards become covered". A sentence shape is a unit of work — one rule
-            // reads every line of it. A dead token is not: a line dies at its first unknown token,
-            // so "every declined line of this card died at `Whenever`" says nothing has been read
-            // and implies no rule. Computing it anyway produced a curve claiming the top 400 token
-            // families cover 93% of Magic, against 15% for the top 400 shapes. The token ranking
-            // keeps its own honest question — what is the grammar missing — and gives up this one.
-            val shapeFamilies = Unlocks.annotate(byShape.build(goldens), rows) { it.declineShapes }
+            val report = fineness.build()
+            val families = DeclineKey.entries.associateWith { dimension ->
+                backlog.getValue(dimension).join(report.declines(dimension), goldens)
+            }
 
             return AssayIndex(
-                report = fineness.build(),
-                declines = byToken.build(goldens),
-                shapes = shapeFamilies,
-                unlockCurves = mapOf(Ranking.SHAPE to Unlocks.curve(shapeFamilies, rows) { it.declineShapes }),
+                report = report,
+                families = families,
+                // The curve is a claim about work, so it exists exactly where a family names one —
+                // see DeclineKey.namesWork for why the token ranking gives this question up.
+                unlockCurves = DeclineKey.entries.filter { it.namesWork }.associateWith { dimension ->
+                    UnlockCurve.of(families.getValue(dimension), rows, dimension)
+                },
                 cards = cards,
                 rows = rows,
                 stateCounts = rows.groupingBy(::state).eachCount(),
@@ -193,30 +196,10 @@ class AssayIndex(
             else -> "declined"
         }
 
-        /**
-         * The sentence a declined line *is*, with the parts that differ between two printings of it
-         * collapsed: mana and tap symbols to `{§}`, numbers to `#`. Self-reference is already
-         * abstracted to `~` by [com.wingedsheep.assay.normalize.Normalizer], so a card's own name
-         * does not fragment its shape.
-         *
-         * This is the second ranking, and it exists because the first one answers a different
-         * question than the one someone choosing work is asking. A line dies on its *first* unknown
-         * token, so a trigger whose prefix is already known dies somewhere after the comma while a
-         * trigger whose prefix is unknown dies on "At" — one missing verb lands in several token
-         * buckets, and a missing prefix looks larger than it is. Ranking by shape puts the whole
-         * sentence in one row, which is the unit a rule is actually written for.
-         */
-        internal fun skeleton(line: String): String =
-            line.replace(SYMBOL, "{§}").replace(NUMBER, "#")
-
-        private val SYMBOL = Regex("""\{[^}]*}""")
-        private val NUMBER = Regex("""\b\d+\b""")
-
         private fun row(
             card: OracleCard,
             result: CardResult,
-            tokens: List<String>,
-            shapes: List<String>,
+            declineKeys: Map<DeclineKey, List<String>>,
         ) = CardRow(
             name = card.name,
             oracleId = card.oracleId,
@@ -228,66 +211,34 @@ class AssayIndex(
             covered = result.covered,
             inScope = result.inPhase1Scope,
             vanilla = card.isVanilla,
-            declineTokens = tokens,
-            declineShapes = shapes,
+            declineKeys = if (declineKeys.values.all { it.isEmpty() }) emptyMap() else declineKeys,
         )
     }
 }
 
 /**
- * How the decline list is keyed.
+ * Cards covered after implementing the top *N* families in rank order, cumulatively.
  *
- * Two rankings because they answer two questions, and the module's guidance is explicit that they
- * disagree in ways that change what you write next. [TOKEN] is "what is the grammar missing";
- * [SHAPE] is "what sentence should I write a rule for".
+ * The number the sole-blocked column is to one family, this is to a *plan*: each declined card is
+ * given the worst rank among its own families, so it joins the covered set at exactly the N where
+ * its last blocker is reached. That is why the curve sits far below the sum of the cards-blocked
+ * column, and why it is the one worth planning against.
+ *
+ * It exists only where [DeclineKey.namesWork] — the same restriction, for the same reason, as the
+ * sole-blocked count itself.
  */
-enum class Ranking { TOKEN, SHAPE }
-
-/**
- * **Cards blocked is not cards unlocked**, and the gap between them is the most useful number here.
- *
- * A card is covered only when *every* one of its lines parses, so a family's card count says how
- * many cards mention it — not how many would come into coverage if it were written. The module's
- * own worked example: 410 cards decline on "At the beginning of…", and adding every step-trigger
- * prefix moved whole-card coverage by 23, because the other 387 were blocked on their effect clause
- * all along. A ranked list showing only the 410 sends you at the wrong work.
- *
- * Two derived numbers close that gap, and both are exact rather than estimated:
- *
- * - [DeclineFamily.unlocks] — cards this family is the *only* thing blocking. Write this one rule
- *   and exactly that many cards become covered.
- * - [AssayIndex.unlockCurve] — cards covered after implementing the top *N* families in rank order,
- *   cumulatively. Computed by giving each declined card the worst rank among its own families: a
- *   card joins the covered set at exactly the N where its last blocker is reached.
- *
- * Both are computed for [Ranking.SHAPE] only; see the note at the call site for why applying them to
- * dead tokens yields a number that is well-defined and means nothing.
- */
-private object Unlocks {
+private object UnlockCurve {
 
     /** How far down the ranked list the curve is reported. Beyond this the tail is flat and long. */
     private const val CURVE_LENGTH = 400
 
-    fun annotate(
-        families: List<DeclineFamily>,
-        rows: List<CardRow>,
-        keysOf: (CardRow) -> List<String>,
-    ): List<DeclineFamily> {
-        val soleBlocker = HashMap<String, Int>()
-        for (row in rows) {
-            val keys = keysOf(row)
-            if (keys.size == 1) soleBlocker.merge(keys.single(), 1, Int::plus)
-        }
-        return families.map { it.copy(unlocks = soleBlocker[it.token] ?: 0) }
-    }
-
-    /** Cards covered after the top *N* families, for N = 1..[CURVE_LENGTH]. Index 0 is N = 1. */
-    fun curve(families: List<DeclineFamily>, rows: List<CardRow>, keysOf: (CardRow) -> List<String>): List<Int> {
-        val rank = families.withIndex().associate { (index, family) -> family.token to index }
+    /** For N = 1..[CURVE_LENGTH]. Index 0 is N = 1. */
+    fun of(families: List<DeclineFamily>, rows: List<CardRow>, dimension: DeclineKey): List<Int> {
+        val rank = families.withIndex().associate { (index, family) -> family.key to index }
         val length = minOf(families.size, CURVE_LENGTH)
         val joiningAt = IntArray(length)
         for (row in rows) {
-            val keys = keysOf(row)
+            val keys = row.declineKeys[dimension].orEmpty()
             if (keys.isEmpty()) continue
             // The card becomes covered once its *last* remaining blocker is written; a card with any
             // blocker outside the reported prefix simply never joins within it.
@@ -299,39 +250,47 @@ private object Unlocks {
     }
 }
 
-/** Accumulates one keying of the declined lines: counts, the cards behind them, example lines. */
-private class Grouping {
+/**
+ * The browsable half of one keying: which cards are behind each family, and a handful of its lines.
+ *
+ * Kept here rather than in [FinenessReport] on purpose. The counts are the gate's — this joins onto
+ * them — but a card-name list per family is a *link table for a page*, and putting it in a report
+ * whose whole cost model is "counters and bounded examples" would make a corpus run's memory grow
+ * with the corpus for a question no gate asks.
+ */
+private class Backlog {
 
-    private val lines = LinkedHashMap<String, Int>()
+    private val keys = HashMap<String, String>()
     private val cards = LinkedHashMap<String, MutableSet<String>>()
     private val examples = LinkedHashMap<String, MutableSet<String>>()
 
+    /** One String instance per family, so 35,000 card rows hold references rather than copies. */
+    fun intern(key: String): String = keys.getOrPut(key) { key }
+
     fun add(key: String, cardName: String, line: String) {
-        lines.merge(key, 1, Int::plus)
-        // Uncapped, because this set is what the *ranking* is computed from — capping it made the
-        // top of the list a plateau of families that all reported exactly the cap. It costs nothing:
-        // the total number of (family, card) pairs is bounded by the number of declined lines.
+        // Uncapped, for the reason the gate's own card sets are: this list is what the family page's
+        // hand-written split and the feasibility probe are computed from, and a cap would silently
+        // turn both into a measurement over the first 400 cards. Bounded by the declined line count.
         cards.getOrPut(key) { LinkedHashSet() }.add(cardName)
         examples.getOrPut(key) { LinkedHashSet() }.let { if (it.size < MAX_EXAMPLES) it.add(line) }
     }
 
-    fun build(goldens: Set<String>): List<DeclineFamily> =
-        lines.map { (key, count) ->
-            val blocked = cards[key].orEmpty()
+    /** Joins onto the gate's ranked families, preserving its order and its counts. */
+    fun join(ranked: List<FinenessReport.Decline>, goldens: Set<String>): List<DeclineFamily> =
+        ranked.map { family ->
+            val blocked = cards[family.key].orEmpty()
             DeclineFamily(
-                token = key,
-                cards = blocked.size,
-                lines = count,
+                key = family.key,
+                cards = family.cards,
+                lines = family.lines,
+                soleBlocked = family.soleBlocked,
                 implemented = blocked.count { it in goldens || it.substringBefore(" // ") in goldens },
-                // The *shown* list is bounded — a page does not need 900 names — but the count above
-                // is the real one, and the page says so when it is showing fewer.
-                cardNames = blocked.take(MAX_SHOWN_CARDS),
-                examples = examples[key].orEmpty().toList(),
+                cardNames = blocked.toList(),
+                examples = examples[family.key].orEmpty().toList(),
             )
-        }.sortedWith(compareByDescending<DeclineFamily> { it.cards }.thenByDescending { it.lines })
+        }
 
     private companion object {
-        const val MAX_SHOWN_CARDS = 400
         const val MAX_EXAMPLES = 12
     }
 }
@@ -353,9 +312,11 @@ data class CardRow(
     val covered: Boolean,
     val inScope: Boolean,
     val vanilla: Boolean,
-    val declineTokens: List<String>,
-    val declineShapes: List<String>,
-)
+    /** This card's distinct family keys under each keying. Empty when nothing declined. */
+    val declineKeys: Map<DeclineKey, List<String>>,
+) {
+    fun declineKeys(dimension: DeclineKey): List<String> = declineKeys[dimension].orEmpty()
+}
 
 /**
  * A decline family with the backlog behind it.
@@ -368,13 +329,17 @@ data class CardRow(
  * population; carrying the count per family answers it for every family at once.
  */
 data class DeclineFamily(
-    val token: String,
+    val key: String,
     /** Cards that mention this family — how big the gap looks. */
     val cards: Int,
     val lines: Int,
     val implemented: Int,
-    /** Cards this family is the *only* blocker of — how big the gap actually is. See [Unlocks]. */
-    val unlocks: Int = 0,
+    /**
+     * Cards this family is the *only* blocker of — how big the gap actually is. Null under
+     * [DeclineKey.TOKEN], where it would be well-defined and mean nothing.
+     */
+    val soleBlocked: Int?,
+    /** Every blocked card, uncapped — the probe measures over all of them. Capped at the view. */
     val cardNames: List<String>,
     val examples: List<String>,
 )

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/explore/ExploreServer.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/explore/ExploreServer.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.assay.explore
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
 import com.wingedsheep.assay.corpus.SetMembership
+import com.wingedsheep.assay.gate.DeclineKey
 import com.wingedsheep.assay.gate.Differential
 import com.wingedsheep.assay.gate.DifferentialReport
 import com.wingedsheep.assay.gate.Touchstone
@@ -84,6 +85,7 @@ class ExploreServer(private val port: Int, private val refresh: Boolean = false)
             }
         }
         server.createContext("/api/decline") { exchange -> exchange.json { decline(exchange) } }
+        server.createContext("/api/probe") { exchange -> exchange.json { probe(exchange) } }
         server.createContext("/api/grammar") { exchange -> exchange.json { Views.grammar(index) } }
         server.createContext("/api/parse") { exchange -> exchange.json { parse(exchange) } }
         server.createContext("/api/differential") { exchange -> exchange.json { differential() } }
@@ -168,17 +170,41 @@ class ExploreServer(private val port: Int, private val refresh: Boolean = false)
     }
 
     private fun decline(exchange: HttpExchange): JsonElement = ready { index ->
-        val token = exchange.param("token").orEmpty()
-        Views.decline(index, exchange.ranking(), token)
-            ?: JsonObject(mapOf("error" to JsonPrimitive("no decline family \"$token\"")))
+        val key = exchange.param("key").orEmpty()
+        Views.decline(index, exchange.ranking(), key)
+            ?: JsonObject(mapOf("error" to JsonPrimitive("no decline family \"$key\"")))
     }
 
-    private fun HttpExchange.ranking(): Ranking =
-        if (param("by") == "shape") Ranking.SHAPE else Ranking.TOKEN
+    /**
+     * The feasibility probe. A POST because the span and its replacement are free text — a regex of
+     * Oracle punctuation in a query string is a URL-encoding accident waiting to happen — and
+     * because it is the one endpoint here that runs a measurement rather than reading one.
+     */
+    private fun probe(exchange: HttpExchange): JsonElement = ready { index ->
+        val fields = exchange.body() ?: return@ready JsonObject(
+            mapOf("error" to JsonPrimitive("expected a JSON object"))
+        )
+        fun field(key: String) = (fields[key] as? JsonPrimitive)?.content.orEmpty()
+        Views.probe(
+            index = index,
+            touchstone = touchstone,
+            ranking = DeclineKey.byName(field("by")) ?: DeclineKey.TAIL,
+            key = field("key"),
+            find = field("find"),
+            replace = field("replace"),
+            regex = field("regex") == "true",
+        )
+    }
+
+    private fun HttpExchange.ranking(): DeclineKey = DeclineKey.byName(param("by")) ?: DeclineKey.TOKEN
+
+    private fun HttpExchange.body(): JsonObject? {
+        val text = requestBody.readBytes().toString(StandardCharsets.UTF_8)
+        return runCatching { json.parseToJsonElement(text) as JsonObject }.getOrNull()
+    }
 
     private fun parse(exchange: HttpExchange): JsonElement {
-        val body = exchange.requestBody.readBytes().toString(StandardCharsets.UTF_8)
-        val fields = runCatching { json.parseToJsonElement(body) as JsonObject }.getOrNull()
+        val fields = exchange.body()
             ?: return JsonObject(mapOf("error" to JsonPrimitive("expected a JSON object")))
         fun field(key: String) = (fields[key] as? JsonPrimitive)?.content.orEmpty()
         return Views.parsed(

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/explore/Views.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/explore/Views.kt
@@ -5,12 +5,14 @@ import com.wingedsheep.assay.corpus.OracleFace
 import com.wingedsheep.assay.corpus.SetCards
 import com.wingedsheep.assay.gate.CardComparison
 import com.wingedsheep.assay.gate.CardResult
+import com.wingedsheep.assay.gate.DeclineKey
 import com.wingedsheep.assay.gate.Differential
 import com.wingedsheep.assay.gate.DifferentialReport
 import com.wingedsheep.assay.gate.FinenessReport
 import com.wingedsheep.assay.gate.LineResult
 import com.wingedsheep.assay.gate.LineVerdict
 import com.wingedsheep.assay.gate.Population
+import com.wingedsheep.assay.gate.PrefixProbe
 import com.wingedsheep.assay.gate.Touchstone
 import com.wingedsheep.assay.grammar.Grammar
 import com.wingedsheep.assay.syntax.Phrase
@@ -60,8 +62,9 @@ internal object Views {
         put("cardsCovered", report.cardsCovered)
         put("cardsRoundTripped", report.cardsRoundTripped)
         put("redundantReadingLines", report.redundantReadingLines)
-        put("declineFamilies", index.declines.size)
-        put("shapeFamilies", index.shapes.size)
+        put("declineFamilies", index.families(DeclineKey.TOKEN).size)
+        put("shapeFamilies", index.families(DeclineKey.SHAPE).size)
+        put("tailFamilies", index.families(DeclineKey.TAIL).size)
         put("states", counts(index.stateCounts))
         put("verdicts", counts(LineVerdict.entries.associate { it.name to report.instancesByVerdict[it].orZero() }))
         put("uniqueVerdicts", counts(LineVerdict.entries.associate { it.name to report.uniqueByVerdict[it].orZero() }))
@@ -91,19 +94,18 @@ internal object Views {
     // Declines — the ranked SDK / grammar gap report
     // -------------------------------------------------------------------------------------------
 
-    fun declines(index: AssayIndex, ranking: Ranking, query: String?, limit: Int): JsonObject {
+    fun declines(index: AssayIndex, ranking: DeclineKey, query: String?, limit: Int): JsonObject {
         val needle = query?.trim()?.lowercase(Locale.ROOT).orEmpty()
         val all = index.families(ranking)
         val matching = all.filter {
             needle.isEmpty() ||
-                it.token.lowercase(Locale.ROOT).contains(needle) ||
+                it.key.lowercase(Locale.ROOT).contains(needle) ||
                 it.examples.any { line -> line.lowercase(Locale.ROOT).contains(needle) }
         }
         return buildJsonObject {
             put("ranking", ranking.name)
             put("total", all.size)
-            put("tokenFamilies", index.declines.size)
-            put("shapeFamilies", index.shapes.size)
+            put("familyCounts", counts(DeclineKey.entries.associate { it.name to index.families(it).size }))
             put("matching", matching.size)
             put("declinedLines", index.report.instancesByVerdict[LineVerdict.DECLINED].orZero())
             put("goldensAvailable", index.goldenNames.isNotEmpty())
@@ -111,18 +113,18 @@ internal object Views {
             put("corpusCards", index.report.cards)
             // Over the *unfiltered* ranking: it answers "what does working the top of this list
             // buy", and a text filter does not change the list you would work. Absent for the token
-            // ranking, deliberately — see AssayIndex.build.
+            // ranking, deliberately — see DeclineKey.namesWork.
             put("unlockCurve", JsonArray(index.unlockCurves[ranking].orEmpty().map(::JsonPrimitive)))
-            put("hasUnlocks", ranking == Ranking.SHAPE)
+            put("hasUnlocks", ranking.namesWork)
             put(
                 "families",
                 buildJsonArray {
                     matching.take(limit).forEach { family ->
                         add(
                             buildJsonObject {
-                                put("token", family.token)
+                                put("key", family.key)
                                 put("cards", family.cards)
-                                put("unlocks", family.unlocks)
+                                put("unlocks", family.soleBlocked ?: 0)
                                 put("lines", family.lines)
                                 put("implemented", family.implemented)
                                 put("examples", strings(family.examples))
@@ -134,26 +136,89 @@ internal object Views {
         }
     }
 
-    fun decline(index: AssayIndex, ranking: Ranking, token: String): JsonObject? {
-        val family = index.decline(token, ranking) ?: return null
+    /**
+     * One family's page. [DeclineFamily.cardNames] is uncapped in the index because the probe
+     * measures over all of it; the cap is here, where it is a statement about what a page can show.
+     */
+    fun decline(index: AssayIndex, ranking: DeclineKey, key: String): JsonObject? {
+        val family = index.decline(key, ranking) ?: return null
         return buildJsonObject {
             put("ranking", ranking.name)
-            put("hasUnlocks", ranking == Ranking.SHAPE)
-            put("token", family.token)
+            put("hasUnlocks", ranking.namesWork)
+            put("key", family.key)
             put("cards", family.cards)
-            put("unlocks", family.unlocks)
+            put("unlocks", family.soleBlocked ?: 0)
             put("lines", family.lines)
             put("implemented", family.implemented)
             put("examples", strings(family.examples))
+            put("probeFind", PrefixProbe.suggestedSpan(ranking, family.examples.firstOrNull().orEmpty(), family.key))
             put(
                 "blocked",
                 buildJsonArray {
-                    family.cardNames.forEach { name ->
+                    family.cardNames.take(MAX_SHOWN_CARDS).forEach { name ->
                         add(
                             buildJsonObject {
                                 put("name", name)
                                 put("golden", index.hasGolden(name))
                                 put("set", index.card(name)?.setCode ?: "")
+                            }
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    /**
+     * The feasibility probe over one family, run on the request thread against the live grammar.
+     *
+     * Re-assaying every blocked card is the cost, and it is the right one: the alternative is
+     * keeping every declined line of every card in the index so this could be answered from a
+     * snapshot, which would be both larger and — the moment a rule is edited — wrong. At sweep rates
+     * this is a fraction of a second for the largest family in the corpus.
+     */
+    fun probe(
+        index: AssayIndex,
+        touchstone: Touchstone,
+        ranking: DeclineKey,
+        key: String,
+        find: String,
+        replace: String,
+        regex: Boolean,
+    ): JsonObject {
+        val family = index.decline(key, ranking)
+            ?: return buildJsonObject { put("error", "no decline family \"$key\"") }
+        val cards = family.cardNames.mapNotNull(index::card)
+        val started = System.currentTimeMillis()
+        val result = PrefixProbe.run(
+            touchstone = touchstone,
+            cards = cards,
+            family = ranking,
+            key = key,
+            substitution = PrefixProbe.Substitution(find = find, replace = replace, regex = regex),
+        )
+        return buildJsonObject {
+            result.error?.let { put("error", it) }
+            put("find", find)
+            put("replace", replace)
+            put("regex", regex)
+            put("familyLines", result.familyLines)
+            put("familyLinesParsing", result.familyLinesParsing)
+            put("unmatched", result.unmatched)
+            put("cardsConsidered", result.cardsConsidered)
+            put("cardsFinished", result.cardsFinished)
+            put("soleBlocked", family.soleBlocked ?: 0)
+            put("millis", System.currentTimeMillis() - started)
+            put(
+                "examples",
+                buildJsonArray {
+                    result.examples.forEach {
+                        add(
+                            buildJsonObject {
+                                put("card", it.card)
+                                put("before", it.before)
+                                put("after", it.after)
+                                put("parses", it.parses)
                             }
                         )
                     }
@@ -192,7 +257,7 @@ internal object Views {
                                 put("state", state(row))
                                 put("inScope", row.inScope)
                                 put("golden", index.hasGolden(row.name))
-                                put("declines", strings(row.declineTokens))
+                                put("declines", strings(row.declineKeys(DeclineKey.TOKEN)))
                             }
                         )
                     }
@@ -223,13 +288,13 @@ internal object Views {
             "declines",
             buildJsonArray {
                 val needle = query.trim().lowercase(Locale.ROOT)
-                index.declines.asSequence()
-                    .filter { it.token.lowercase(Locale.ROOT).contains(needle) }
+                index.families(DeclineKey.TOKEN).asSequence()
+                    .filter { it.key.lowercase(Locale.ROOT).contains(needle) }
                     .take(6)
                     .forEach {
                         add(
                             buildJsonObject {
-                                put("token", it.token)
+                                put("key", it.key)
                                 put("cards", it.cards)
                             }
                         )
@@ -534,6 +599,9 @@ internal object Views {
 
     private fun script(script: CardScript) =
         JsonPrimitive(CardSerialization.json.encodeToString(CardScript.serializer(), script))
+
+    /** A page does not need 900 card names; the family's own count above says when it is showing fewer. */
+    private const val MAX_SHOWN_CARDS = 400
 
     private fun strings(values: List<String>) = JsonArray(values.map(::JsonPrimitive))
 

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/DeclineKey.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/DeclineKey.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.assay.gate
+
+/**
+ * How a declined line becomes a **family** — the three keyings the decline list can be ranked by.
+ *
+ * This lives in `gate/` rather than in the explorer because the explorer is a view and never a
+ * second source of truth: `assay report --rank tail` and the explorer's tail page must be the same
+ * ranking, and the cheapest guarantee of that is one key function that both call.
+ *
+ * The three answer three different questions, and they disagree in ways that change what gets
+ * written next. That is not a defect of any of them; it is why there are three.
+ *
+ * | Key | Question | Bias |
+ * |---|---|---|
+ * | [TOKEN] | what is the grammar missing? | over-weights a missing **prefix** |
+ * | [SHAPE] | which whole sentence needs a rule? | under-weights a missing **prefix or clause** |
+ * | [TAIL]  | what construct would let these lines get further? | — |
+ */
+enum class DeclineKey {
+
+    /**
+     * The token the parse died on.
+     *
+     * The right key for "what is the grammar missing" and the wrong one for "what should I write".
+     * A line dies at its *first* unknown token, so a trigger whose prefix is already read dies
+     * somewhere after the comma while a trigger whose prefix is unknown dies on "At" — one missing
+     * verb therefore lands in several buckets, and a missing prefix looks larger than it is.
+     */
+    TOKEN {
+        override fun of(line: LineResult, tailWords: Int) = line.declineToken ?: NO_DECLINE
+    },
+
+    /**
+     * The whole line, skeletonized — numbers to `#`, mana and tap symbols to `{§}`.
+     *
+     * Aggregates perfectly for a family whose sentence **is** the whole line: the modal header
+     * `Choose one —` is identical on every card that prints it, which is why it sits at the top of
+     * this ranking. It fragments completely for a family whose sentence **continues into an
+     * arbitrary payload** — every spell-cast trigger's line ends in a different effect clause, so
+     * that family splits into hundreds of rows of one to six cards each and never appears near the
+     * top. In the implemented population this table read `Choose one —` at 100 cards and then
+     * nothing above 27, with 504 cards of cast triggers invisible underneath it.
+     *
+     * So it systematically under-ranks exactly the families worth the most — the ones whose missing
+     * construct is a prefix or a clause that the rest of the grammar continues past. That is the
+     * opposite bias to [TOKEN]'s, and both are wrong in the same situation. [TAIL] is the one that
+     * is not.
+     */
+    SHAPE {
+        override fun of(line: LineResult, tailWords: Int) = skeleton(line.line)
+    },
+
+    /**
+     * The parse's **tail**: the text from the decline's own offset onward, skeletonized and cut to
+     * its first [tailWords] words.
+     *
+     * This is the ranking that has actually decided work. It is neither of the other two: it does
+     * not name the token the line stopped at, and it does not name a sentence — it names **the
+     * construct that would have to exist for the line to get further**, which is what a rule is
+     * written for. A family here is a unit of work in the way a dead token is not, so
+     * [FinenessReport.Decline.soleBlocked] and the explorer's unlock curve apply to it.
+     *
+     * The spell-cast trigger family is the worked example of why it was needed: 504 cards
+     * sole-blocked against 263 for the next family, and *neither* other ranking showed it. [TOKEN]
+     * smeared it across `you`, which "Whenever you gain life…" and "Whenever you attack…" also die
+     * at; [SHAPE] shattered it across one row per payload. The band that closed it was picked with a
+     * throwaway probe outside the tool, which is the reason this key exists in it now.
+     *
+     * **Why three words.** Measured over the corpus rather than chosen: at two, `When ~` swallows
+     * several unrelated events into one family that names no single construct; at four and five the
+     * families start splitting on the first word of the payload, which is precisely the fragmenting
+     * [SHAPE] already does. Three is where a family names a construct and nothing more. It is a real
+     * design parameter and it is re-measurable — `assay report --rank tail --tail-words N` prints
+     * the table at any N, which is how it was picked.
+     */
+    TAIL {
+        override fun of(line: LineResult, tailWords: Int): String {
+            val decline = line.decline ?: return NO_DECLINE
+            val rest = line.line.drop(decline.position.coerceIn(0, line.line.length)).trimStart()
+            if (rest.isEmpty()) return "<end of line>"
+            return firstWords(skeleton(rest), tailWords)
+        }
+    };
+
+    abstract fun of(line: LineResult, tailWords: Int = TAIL_WORDS): String
+
+    /**
+     * Whether a family under this keying names a **piece of work**, which is what makes the
+     * sole-blocked count and the unlock curve mean anything.
+     *
+     * False for [TOKEN] alone, and that restriction is a finding rather than a shortcut. Both those
+     * numbers are claims of the form "write this and that many cards become covered". A sentence
+     * shape is a unit of work — one rule reads every line of it — and so is a tail, which names the
+     * construct the rule would be. A dead token is not: "every declined line of this card died at
+     * `Whenever`" says nothing has been read and implies no rule. Computing it anyway produced a
+     * curve claiming the top 400 token families cover 93% of Magic, against 15% for the top 400
+     * shapes.
+     */
+    val namesWork: Boolean get() = this != TOKEN
+
+    companion object {
+
+        /** See [TAIL]'s KDoc: measured, not chosen. Overridable so it stays re-measurable. */
+        const val TAIL_WORDS = 3
+
+        /** `--rank <name>`, and the explorer's `by=` query parameter. */
+        fun byName(name: String?): DeclineKey? =
+            entries.firstOrNull { it.name.equals(name, ignoreCase = true) }
+
+        /**
+         * A line with the parts that differ between two printings of it collapsed: mana and tap
+         * symbols to `{§}`, numbers to `#`. Self-reference is already abstracted to `~` by
+         * [com.wingedsheep.assay.normalize.Normalizer], so a card's own name does not fragment
+         * anything keyed through here.
+         */
+        fun skeleton(text: String): String = text.replace(SYMBOL, "{§}").replace(NUMBER, "#")
+
+        /** The first [count] whitespace-separated words, marked as a prefix when it cut anything. */
+        private fun firstWords(text: String, count: Int): String {
+            val words = text.split(WHITESPACE)
+            return if (words.size <= count) text else words.take(count).joinToString(" ") + " …"
+        }
+
+        /** A [LineResult] that is not a decline has no family; only a bug can put one here. */
+        private const val NO_DECLINE = "<not declined>"
+
+        private val SYMBOL = Regex("""\{[^}]*}""")
+        private val NUMBER = Regex("""\b\d+\b""")
+        private val WHITESPACE = Regex("""\s+""")
+    }
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Fineness.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Fineness.kt
@@ -28,14 +28,40 @@ class FinenessReport private constructor(
     val restoreFailures: List<String>,
     val ambiguities: List<String>,
     val mismatches: List<String>,
-    val declines: List<Decline>,
+    val declineFamilies: Map<DeclineKey, List<Decline>>,
     val glossCounts: Map<GlossVerdict, Int>,
     val glossDifferences: List<GlossResult>,
     val redundantReadingLines: Int,
 ) {
 
-    /** One decline family: the token the grammar died on, and how much is behind it. */
-    data class Decline(val token: String, val cards: Int, val lines: Int, val example: String)
+    /**
+     * One decline family, under one [DeclineKey].
+     *
+     * **Cards blocked is not cards unlocked**, and the gap between them is the most useful pair of
+     * numbers here. A card is covered only when *every* one of its lines parses, so [cards] says how
+     * many cards a family is *mentioned by* — not how many would come into coverage if it were
+     * written. The module's own worked example: 410 cards decline on "At the beginning of…", and
+     * adding every step-trigger prefix moved whole-card coverage by 23, because the other 387 were
+     * blocked on their effect clause all along. A list showing only the 410 sends you at the wrong
+     * work.
+     *
+     * @param soleBlocked cards this family is the *only* thing blocking — the honest count. Null
+     *   under [DeclineKey.TOKEN], where the number is well-defined and means nothing; see
+     *   [DeclineKey.namesWork].
+     */
+    data class Decline(
+        val key: String,
+        val cards: Int,
+        val lines: Int,
+        val soleBlocked: Int?,
+        val example: String,
+    )
+
+    /** The families under one keying, ranked by cards blocked. */
+    fun declines(key: DeclineKey): List<Decline> = declineFamilies[key].orEmpty()
+
+    /** The token ranking, which is what "the decline list" has always meant without qualification. */
+    val declines: List<Decline> get() = declines(DeclineKey.TOKEN)
 
     val fineness: Double get() = permil(instancesByVerdict[LineVerdict.ROUND_TRIP] ?: 0, lineInstances)
     val uniqueFineness: Double get() = permil(uniqueByVerdict[LineVerdict.ROUND_TRIP] ?: 0, uniqueLines)
@@ -50,8 +76,16 @@ class FinenessReport private constructor(
      * @param population names the subset the numbers were measured over, when it is not the whole
      *   corpus. A fineness number without its denominator's *definition* beside it is the easiest
      *   way for two runs to be compared that never measured the same thing.
+     * @param ranking which keying the decline table is grouped by. [DeclineKey.TOKEN] is the
+     *   default because it is what this report has always printed and what the gate's own diagnostic
+     *   value rests on; [DeclineKey.TAIL] is the one to pass when the question is what to write
+     *   next.
      */
-    fun render(topDeclines: Int = 20, population: String? = null): String = buildString {
+    fun render(
+        topDeclines: Int = 20,
+        population: String? = null,
+        ranking: DeclineKey = DeclineKey.TOKEN,
+    ): String = buildString {
         appendLine("Argentum Assay — fineness")
         appendLine("=".repeat(78))
         appendLine()
@@ -126,27 +160,60 @@ class FinenessReport private constructor(
         }
 
         appendLine()
-        appendLine("TOP DECLINES, ranked by cards blocked")
+        appendLine(declineTable(topDeclines, ranking))
+    }
+
+    /**
+     * The ranked gap report — the module's primary product, in whichever keying was asked for.
+     *
+     * `sole` is printed beside `cards` rather than instead of it, and only where it means something,
+     * because the pair *is* the finding: a family with 819 cards and 126 sole-blocked is a different
+     * piece of work from one with 504 of each, and a table showing either number alone hides which
+     * one you are looking at.
+     */
+    private fun declineTable(top: Int, ranking: DeclineKey): String = buildString {
+        val families = declines(ranking)
+        val sole = ranking.namesWork
+        appendLine("TOP DECLINES, keyed on ${keyingNote(ranking)}, ranked by cards blocked")
         appendLine("-".repeat(78))
-        if (declines.isEmpty()) {
+        if (families.isEmpty()) {
             appendLine("  (none)")
-        } else {
-            appendLine("  %-6s %-6s %-22s %s".format(Locale.ROOT, "cards", "lines", "died on", "example"))
-            declines.take(topDeclines).forEach {
-                appendLine(
-                    "  %-6d %-6d %-22s %s".format(
-                        Locale.ROOT,
-                        it.cards,
-                        it.lines,
-                        it.token.take(22),
-                        it.example.take(44),
-                    )
-                )
-            }
-            if (declines.size > topDeclines) {
-                appendLine("  … and ${declines.size - topDeclines} more decline families")
-            }
+            return@buildString
         }
+        val header = if (sole) {
+            "  %-6s %-6s %-6s %-26s %s".format(Locale.ROOT, "cards", "sole", "lines", ranking.name.lowercase(), "example")
+        } else {
+            "  %-6s %-6s %-26s %s".format(Locale.ROOT, "cards", "lines", ranking.name.lowercase(), "example")
+        }
+        appendLine(header)
+        families.take(top).forEach {
+            appendLine(
+                if (sole) {
+                    "  %-6d %-6d %-6d %-26s %s".format(
+                        Locale.ROOT, it.cards, it.soleBlocked ?: 0, it.lines, it.key.take(26), it.example.take(40)
+                    )
+                } else {
+                    "  %-6d %-6d %-26s %s".format(
+                        Locale.ROOT, it.cards, it.lines, it.key.take(26), it.example.take(40)
+                    )
+                }
+            )
+        }
+        if (families.size > top) appendLine("  … and ${families.size - top} more decline families")
+        if (sole) {
+            appendLine()
+            appendLine("  `sole` is cards *all* of whose declined lines fall in the family — the number a")
+            appendLine("  band actually delivers, against `cards`, which is the number it merely reaches.")
+            appendLine("  It is still an upper bound: it says which cards the family blocks, not which")
+            appendLine("  lines the rest of the grammar could finish. `just assay-explore` has the probe")
+            appendLine("  that measures that, on the decline family's own page.")
+        }
+    }
+
+    private fun keyingNote(ranking: DeclineKey) = when (ranking) {
+        DeclineKey.TOKEN -> "the token each line died on"
+        DeclineKey.SHAPE -> "the whole line, skeletonized"
+        DeclineKey.TAIL -> "the parse's tail — the text from the decline onward"
     }
 
     private fun count(v: LineVerdict) = instancesByVerdict[v] ?: 0
@@ -169,10 +236,15 @@ class FinenessReport private constructor(
     companion object {
         fun permil(part: Int, whole: Int): Double = if (whole == 0) 0.0 else part * 1000.0 / whole
 
-        fun builder() = Builder()
+        /**
+         * @param tailWords how many words of [DeclineKey.TAIL] make a family. Threaded rather than
+         *   read from the constant so the parameter stays re-measurable from the command line — see
+         *   [DeclineKey.TAIL] for why it is a measurement and not a magic number.
+         */
+        fun builder(tailWords: Int = DeclineKey.TAIL_WORDS) = Builder(tailWords)
     }
 
-    class Builder {
+    class Builder(private val tailWords: Int = DeclineKey.TAIL_WORDS) {
         private var cards = 0
         private var faces = 0
         private var vanillaFaces = 0
@@ -192,9 +264,16 @@ class FinenessReport private constructor(
         private val glossCounts = mutableMapOf<GlossVerdict, Int>()
         private val glossDifferences = mutableListOf<GlossResult>()
 
-        private val declineLines = mutableMapOf<String, Int>()
-        private val declineCards = mutableMapOf<String, MutableSet<String>>()
-        private val declineExample = mutableMapOf<String, String>()
+        /**
+         * All three keyings, accumulated in the one pass.
+         *
+         * Every keying costs a hash lookup per declined line and a card-name set whose total size is
+         * bounded by the number of declined line *instances*, so keeping three where there used to
+         * be one does not change the builder's "counters and bounded examples" cost model — and
+         * keeping them here rather than in the explorer is what stops the tail ranking being a
+         * second implementation the gate cannot print.
+         */
+        private val families = DeclineKey.entries.associateWith { Families() }
 
         fun add(result: CardResult) = apply {
             cards++
@@ -230,14 +309,21 @@ class FinenessReport private constructor(
                         LineVerdict.MISMATCH ->
                             record(mismatches, "${result.card.name}: \"${line.line}\" -> \"${line.printed}\"")
 
-                        LineVerdict.DECLINED -> {
-                            val token = line.declineToken ?: "<unknown>"
-                            declineLines.merge(token, 1, Int::plus)
-                            declineCards.getOrPut(token) { mutableSetOf() }.add(result.card.name)
-                            declineExample.putIfAbsent(token, line.line)
-                        }
-
                         else -> Unit
+                    }
+                }
+            }
+
+            // Keyed off the whole card rather than per face, because "sole-blocked" is a statement
+            // about a *card*: a two-faced card whose back is read and whose front is not is blocked
+            // by one family, and counting faces separately would say two.
+            val declined = result.lines.filter { it.verdict == LineVerdict.DECLINED }
+            if (declined.isNotEmpty()) {
+                for ((dimension, family) in families) {
+                    val keys = declined.map { dimension.of(it, tailWords) }
+                    keys.forEachIndexed { i, key -> family.observe(key, result.card.name, declined[i].line) }
+                    if (dimension.namesWork) {
+                        keys.distinct().singleOrNull()?.let { family.soleBlocked.merge(it, 1, Int::plus) }
                     }
                 }
             }
@@ -245,14 +331,7 @@ class FinenessReport private constructor(
 
         fun build(): FinenessReport {
             val uniqueByVerdict = seenLines.values.groupingBy { it }.eachCount()
-            val declines = declineLines.map { (token, lines) ->
-                Decline(
-                    token = token,
-                    cards = declineCards[token]?.size ?: 0,
-                    lines = lines,
-                    example = declineExample[token].orEmpty(),
-                )
-            }.sortedWith(compareByDescending<Decline> { it.cards }.thenByDescending { it.lines })
+            val declines = families.mapValues { (dimension, family) -> family.build(dimension) }
 
             return FinenessReport(
                 cards = cards,
@@ -270,7 +349,7 @@ class FinenessReport private constructor(
                 restoreFailures = restoreFailures.toList(),
                 ambiguities = ambiguities.toList(),
                 mismatches = mismatches.toList(),
-                declines = declines,
+                declineFamilies = declines,
                 glossCounts = glossCounts.toMap(),
                 glossDifferences = glossDifferences.toList(),
                 redundantReadingLines = redundantReadingLines,
@@ -280,6 +359,38 @@ class FinenessReport private constructor(
         /** Examples are bounded: a corpus-wide failure should not print 38k identical rows. */
         private fun <T> record(into: MutableList<T>, item: T) {
             if (into.size < MAX_EXAMPLES) into.add(item)
+        }
+
+        /**
+         * One keying's families, accumulated card by card.
+         *
+         * The card sets are **uncapped** on purpose: they are what the ranking is computed from, and
+         * capping them made the top of the list a plateau of families that all reported exactly the
+         * cap. It costs nothing — the total number of (family, card) pairs is bounded by the number
+         * of declined lines.
+         */
+        private class Families {
+            private val lines = LinkedHashMap<String, Int>()
+            private val cards = HashMap<String, MutableSet<String>>()
+            private val example = HashMap<String, String>()
+            val soleBlocked = HashMap<String, Int>()
+
+            fun observe(key: String, cardName: String, line: String) {
+                lines.merge(key, 1, Int::plus)
+                cards.getOrPut(key) { LinkedHashSet() }.add(cardName)
+                example.putIfAbsent(key, line)
+            }
+
+            fun build(dimension: DeclineKey): List<Decline> =
+                lines.map { (key, count) ->
+                    Decline(
+                        key = key,
+                        cards = cards[key]?.size ?: 0,
+                        lines = count,
+                        soleBlocked = if (dimension.namesWork) soleBlocked[key] ?: 0 else null,
+                        example = example[key].orEmpty(),
+                    )
+                }.sortedWith(compareByDescending<Decline> { it.cards }.thenByDescending { it.lines })
         }
 
         private companion object {

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/PrefixProbe.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/PrefixProbe.kt
@@ -1,0 +1,191 @@
+package com.wingedsheep.assay.gate
+
+import com.wingedsheep.assay.corpus.OracleCard
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.assay.syntax.parseLine
+
+/**
+ * The **feasibility probe** — the second half of the ranking, and the half that makes the first one
+ * honest.
+ *
+ * A family's sole-blocked count says which cards a band *reaches*. It does not say which lines the
+ * band *finishes*, and those are different numbers because a declined line is a prefix the grammar
+ * could not read followed by a payload it may or may not already read. Every ranking this module has
+ * used that skipped the difference has overstated its band, four times in the same direction — the
+ * spell-cast family predicted 234 whole cards and delivered 183.
+ *
+ * The measurement that closes it is a substitution: put a **known-good prefix** where the family's
+ * own span is, re-parse, and count what got through. If "Whenever you cast a noncreature spell,
+ * draw a card." becomes "When ~ enters, draw a card." and that parses, then the only thing between
+ * that card and coverage is the cast-trigger prefix. If it still declines, the payload is missing
+ * too and writing the prefix buys nothing on that card.
+ *
+ * ## What it is and is not
+ *
+ * It is a **prediction**, and it assumes the construct you would write reads everything the family's
+ * own span does. Substituting `When ~ enters,` for `Whenever you cast a noncreature spell,` tests
+ * whether the *rest* of each line is readable; it cannot tell you that a cast trigger is expressible
+ * in `mtg-sdk` at all. A family whose span turns out to be an SDK gap will measure exactly as well
+ * as one whose span is an afternoon of grammar, which is why this is one number beside the others
+ * rather than the ranking itself.
+ *
+ * It is also not precomputable — the substitution is chosen per family by whoever is looking at it —
+ * which is exactly why it belongs on a page that calls the live grammar rather than in a report.
+ * The computation lives here in `gate/` all the same, so the explorer is calling a measurement
+ * rather than being one.
+ */
+object PrefixProbe {
+
+    /**
+     * @param find the family's own span. [regex] false means a literal substring, which is the
+     *   default because Oracle text is dense with `{`, `(`, `.` and `+` and a literal typed into a
+     *   regex box is a silent mis-measurement rather than an error. Regex is there because the
+     *   families worth the most vary in the middle — `Whenever you cast [^,]*,` is one span and
+     *   twelve hundred spellings of it.
+     * @param replace the known-good prefix, always literal.
+     */
+    data class Substitution(val find: String, val replace: String, val regex: Boolean = false)
+
+    /**
+     * @param familyLines the family's own declined lines, over every card behind it.
+     * @param familyLinesParsing how many of those parse after the substitution — the fraction of the
+     *   family the rest of the grammar can already finish.
+     * @param unmatched lines the [Substitution.find] span did not occur in at all. Reported rather
+     *   than folded into the failures, because a large number here means the span is wrong and the
+     *   whole measurement is about a different family than the one on screen.
+     * @param cardsFinished cards **all** of whose declined lines parse after the substitution. This
+     *   is the number the card counts hide and the one a band is actually worth.
+     * @param examples a handful of before/after pairs, so the substitution can be eyeballed rather
+     *   than trusted.
+     */
+    data class Result(
+        val familyLines: Int,
+        val familyLinesParsing: Int,
+        val unmatched: Int,
+        val cardsConsidered: Int,
+        val cardsFinished: Int,
+        val examples: List<Example>,
+        val error: String? = null,
+    )
+
+    data class Example(val card: String, val before: String, val after: String, val parses: Boolean)
+
+    /** How many before/after pairs a page needs to believe the substitution. */
+    private const val MAX_EXAMPLES = 8
+
+    fun failed(message: String) = Result(0, 0, 0, 0, 0, emptyList(), error = message)
+
+    /**
+     * Re-assays [cards] and applies [substitution] to every declined line of each.
+     *
+     * Every declined line is substituted, not only the family's own: "whole cards finished" is a
+     * claim about a *card*, so a second declined line on it has to be accounted for. It normally
+     * fails to match and therefore fails to parse, which is the correct answer — that card is
+     * blocked by something else as well.
+     */
+    fun run(
+        touchstone: Touchstone,
+        cards: List<OracleCard>,
+        family: DeclineKey,
+        key: String,
+        substitution: Substitution,
+        tailWords: Int = DeclineKey.TAIL_WORDS,
+    ): Result {
+        if (substitution.find.isEmpty()) return failed("give the span to replace")
+        val pattern = if (substitution.regex) {
+            runCatching { Regex(substitution.find) }.getOrElse { return failed("not a regex: ${it.message}") }
+        } else {
+            null
+        }
+
+        var familyLines = 0
+        var familyLinesParsing = 0
+        var unmatched = 0
+        var cardsConsidered = 0
+        var cardsFinished = 0
+        val examples = mutableListOf<Example>()
+
+        for (card in cards) {
+            val result = touchstone.assay(card)
+            val declined = result.lines.filter { it.verdict == LineVerdict.DECLINED }
+            // By position rather than by value: a card can print the same declined line twice, and
+            // two equal LineResults would then both count as the one this family owns.
+            val mine = declined.indices.filterTo(HashSet()) { family.of(declined[it], tailWords) == key }
+            if (mine.isEmpty()) continue
+            cardsConsidered++
+
+            var wholeCard = result.lines.none {
+                it.verdict == LineVerdict.MISMATCH || it.verdict == LineVerdict.AMBIGUOUS
+            }
+            declined.forEachIndexed { index, line ->
+                val substituted = substitute(line.line, pattern, substitution)
+                val parses = substituted != null && reads(touchstone, substituted)
+                if (!parses) wholeCard = false
+                if (index in mine) {
+                    familyLines++
+                    if (substituted == null) unmatched++ else if (parses) familyLinesParsing++
+                    if (examples.size < MAX_EXAMPLES) {
+                        examples.add(Example(card.name, line.line, substituted ?: "", parses))
+                    }
+                }
+            }
+            if (wholeCard) cardsFinished++
+        }
+
+        return Result(
+            familyLines = familyLines,
+            familyLinesParsing = familyLinesParsing,
+            unmatched = unmatched,
+            cardsConsidered = cardsConsidered,
+            cardsFinished = cardsFinished,
+            examples = examples,
+        )
+    }
+
+    /**
+     * A substituted line reads if the grammar gets through it — **or if the substitution consumed
+     * all of it**.
+     *
+     * The empty case is not a loophole, it is the modal header. `Choose one —` is a whole line that
+     * is nothing but the missing construct, and a band that reads modal spells reads it by the same
+     * assumption under which `When ~ enters,` stands in for `Whenever you cast a noncreature spell,`
+     * — the construct exists, so its own span is read. Refusing it would report zero finished cards
+     * for every family whose span is the entire line, which is precisely the family shape the tail
+     * ranking exists to surface. It does mean `find = ".*"` measures nothing but itself; this is an
+     * exploratory box whose output is labelled a prediction, not a gate.
+     */
+    private fun reads(touchstone: Touchstone, line: String): Boolean =
+        line.isBlank() || touchstone.grammar.parseLine(line) !is ParseOutcome.Declined
+
+    /** Null when the span does not occur — a distinct outcome from "substituted and still declines". */
+    private fun substitute(line: String, pattern: Regex?, substitution: Substitution): String? =
+        if (pattern != null) {
+            pattern.find(line)?.let { line.replaceRange(it.range, substitution.replace) }
+        } else {
+            val at = line.indexOf(substitution.find)
+            if (at < 0) null else line.replaceRange(at, at + substitution.find.length, substitution.replace)
+        }
+
+    /**
+     * A first guess at the family's span, for the box to open with.
+     *
+     * Under [DeclineKey.TAIL] the key is the tail's first few words, so the span the user wants is
+     * the example line's own prefix *plus* that tail — the grammar died at the start of the tail, so
+     * everything before it already reads and everything the family owns starts there. Under
+     * [DeclineKey.SHAPE] the whole line is the key and its opening words are the closest thing to a
+     * span. Either way it is a starting point to extend, not an answer: the span usually runs a few
+     * words past where the key stops, and only the person reading the examples knows how far.
+     */
+    fun suggestedSpan(family: DeclineKey, example: String, key: String): String = when (family) {
+        DeclineKey.TAIL -> {
+            val tail = key.removeSuffix(" …")
+            // The skeleton collapsed numbers and symbols, so the key is not literally in the line;
+            // fall back to the tail itself, which the user will edit anyway.
+            val at = example.indexOf(tail)
+            if (at >= 0) example.take(at + tail.length) else tail
+        }
+
+        DeclineKey.SHAPE -> example.split(" ").take(4).joinToString(" ")
+        DeclineKey.TOKEN -> key
+    }
+}

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Touchstone.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/gate/Touchstone.kt
@@ -36,7 +36,14 @@ import com.wingedsheep.assay.grammar.CardFragment
  *   printed line whose model does **not** survive reparsing is a [LineVerdict.MISMATCH], and that
  *   number must be zero.
  */
-class Touchstone(private val grammar: Phrase<CardFragment> = Grammar.abilityLine) {
+class Touchstone(
+    /**
+     * Exposed so a caller that re-parses *substituted* text — [PrefixProbe] — reads with the grammar
+     * this instance assayed with, rather than reaching for [Grammar.abilityLine] and quietly
+     * measuring against a different one than the numbers beside it came from.
+     */
+    val grammar: Phrase<CardFragment> = Grammar.abilityLine,
+) {
 
     fun assay(card: OracleCard): CardResult {
         val faces = card.faces.map { assayFace(card, it) }

--- a/oracle-assay/src/main/resources/explorer/index.html
+++ b/oracle-assay/src/main/resources/explorer/index.html
@@ -445,7 +445,8 @@ function setStatus(cls, text) {
 const SECTIONS = [
   ["", "Overview", () => null],
   ["cards", "Cards", (o) => o && fmt(o.cards)],
-  ["declines", "Declines", (o) => o && fmt(o.declineFamilies)],
+  // The tail count, because that is the ranking the declines page opens on.
+  ["declines", "Declines", (o) => o && fmt(o.tailFamilies)],
   ["grammar", "Grammar", () => null],
   ["differential", "Differential", (o) => o && fmt(o.goldens)],
   ["parse", "Parse text", () => null],
@@ -486,7 +487,8 @@ function route() {
   else if (h.startsWith("#d/")) {
     const rest = h.slice(3);
     const cut = rest.indexOf("/");
-    viewDecline(rest.slice(0, cut) === "shape" ? "shape" : "token", decodeURIComponent(rest.slice(cut + 1)));
+    const by = rest.slice(0, cut);
+    viewDecline(RANKINGS.includes(by) ? by : "token", decodeURIComponent(rest.slice(cut + 1)));
   }
   else if (h.startsWith("#g/")) viewGrammar(decodeURIComponent(h.slice(3)));
   else if (h.startsWith("#cards")) {
@@ -527,7 +529,7 @@ async function viewOverview() {
       <div class="stat"><span class="v">${pct(d.fineness)}</span><span class="k">Lines round-tripped</span>
         <span class="s">${fmt(v.ROUND_TRIP)} / ${fmt(d.lineInstances)}</span></div>
       <div class="stat"><span class="v">${fmt(v.DECLINED)}</span><span class="k">Declined lines</span>
-        <span class="s">${fmt(d.shapeFamilies)} sentence shapes</span></div>
+        <span class="s">${fmt(d.tailFamilies)} tail families</span></div>
       <div class="stat"><span class="v ${bugs ? "bad" : "ok"}">${fmt(bugs)}</span><span class="k">Must be zero</span>
         <span class="s">mismatch + ambiguity</span></div>
     </div>
@@ -578,13 +580,17 @@ async function viewOverview() {
     b.onclick = () => go("#cards/" + b.dataset.state);
   }
 
-  const dec = await api("declines", { by: "shape", limit: 12 });
+  const dec = await api("declines", { by: "tail", limit: 12 });
   if (!indexing(dec)) {
-    el("topdeclines").innerHTML = "<h2>Top declines, by sentence shape</h2>" +
+    el("topdeclines").innerHTML = "<h2>Top declines, by the parse&rsquo;s tail</h2>" +
+      '<p class="note" style="margin-bottom:.6rem">Keyed on the text from each decline onward — the ' +
+      'construct that would have to exist for the line to get further. <b>Sole</b> is the cards a ' +
+      'family is the <em>only</em> blocker of, which is the number a band delivers.</p>' +
       declineTable(dec.families, dec.goldensAvailable, dec.ranking, dec.hasUnlocks) +
       '<p class="note" style="margin-top:.5rem">' + fmt(dec.total) +
-      ' shapes in all, ' + fmt(dec.tokenFamilies) + ' families keyed by the token they died on — ' +
-      '<a href="#declines">both rankings, and why they disagree</a>.</p>';
+      ' tail families in all, against ' + fmt(dec.familyCounts.TOKEN) + ' keyed by the token they died ' +
+      'on and ' + fmt(dec.familyCounts.SHAPE) + ' by whole sentence — ' +
+      '<a href="#declines">all three rankings, and why they disagree</a>.</p>';
   }
 }
 
@@ -646,22 +652,24 @@ function bugList(title, items) {
 
 /* =========================== declines =========================== */
 
+const RANKING_LABEL = { TOKEN: "Died on", SHAPE: "Sentence shape", TAIL: "Tail — what has to exist" };
+
 function declineTable(families, showImplemented, ranking, showUnlocks) {
   const max = families.reduce((m, f) => Math.max(m, f.cards), 1);
-  const by = ranking === "SHAPE" ? "shape" : "token";
+  const by = (ranking || "TOKEN").toLowerCase();
   return '<div class="tablewrap"><table><thead><tr>' +
-    "<th>" + (ranking === "SHAPE" ? "Sentence shape" : "Died on") + "</th>" +
+    "<th>" + (RANKING_LABEL[ranking] || "Died on") + "</th>" +
     '<th class="num" title="cards that mention it — how big the gap looks">Blocks</th>' +
-    (showUnlocks ? '<th class="num" title="cards this is the ONLY remaining blocker of — write it and exactly this many become covered">Unlocks</th>' : "") +
+    (showUnlocks ? '<th class="num" title="cards this is the ONLY remaining blocker of — write it and exactly this many become covered">Sole</th>' : "") +
     (showImplemented ? '<th class="num" title="of the blocked cards, how many already have a hand-written golden">Hand-written</th>' : "") +
     '<th class="num">Lines</th><th></th><th>Example line</th>' +
     "</tr></thead><tbody>" +
     families.map((f) => {
       const w = Math.round(100 * Math.sqrt(f.cards / max));
       const iw = f.cards ? Math.round(w * f.implemented / f.cards) : 0;
-      const link = "#d/" + by + "/" + encodeURIComponent(f.token);
+      const link = "#d/" + by + "/" + encodeURIComponent(f.key);
       return '<tr class="clickrow" onclick="go(\'' + link + "')\">" +
-        '<td class="nm"><a href="' + link + '">' + esc(f.token.slice(0, 70)) + "</a></td>" +
+        '<td class="nm"><a href="' + link + '">' + esc(f.key.slice(0, 70)) + "</a></td>" +
         '<td class="num">' + fmt(f.cards) + "</td>" +
         (showUnlocks ? '<td class="num" style="color:' + (f.unlocks ? "var(--accent)" : "var(--faint)") + '">' +
           (f.unlocks ? fmt(f.unlocks) : "—") + "</td>" : "") +
@@ -712,12 +720,15 @@ function unlockCurve(curve, covered, total) {
   </div>`;
 }
 
-let declineQuery = "", declineBy = "token";
+const RANKINGS = ["token", "shape", "tail"];
+let declineQuery = "", declineBy = "tail";
 
 async function viewDeclines() {
   const d = await api("declines", { by: declineBy, q: declineQuery, limit: 250 });
   if (indexing(d)) { el("view").innerHTML = indexingHTML(d); return; }
-  const shape = d.ranking === "SHAPE";
+  const seg = (by, label) => '<button data-by="' + by + '"' +
+    (d.ranking === by.toUpperCase() ? ' class="on"' : "") + ">" + label + " · " +
+    fmt(d.familyCounts[by.toUpperCase()]) + "</button>";
 
   el("view").innerHTML = `
     <div class="crumb"><a href="#">overview</a> <span>/</span> <span>declines</span></div>
@@ -725,20 +736,27 @@ async function viewDeclines() {
     <p class="lead" style="margin-top:.5rem">Every declined line, ranked by cards blocked. This is the
     module's primary product: a decline names a missing capability in Argentum's own vocabulary rather
     than in a third ontology's.</p>
-    <p>The two rankings answer <em>different questions</em> and they disagree in ways that change the
+    <p>The three rankings answer <em>different questions</em> and they disagree in ways that change the
     work. <b>Died on</b> keys each line by the token its parse stopped at — the right key for "what is
-    the grammar missing". <b>Sentence shape</b> keys it by the whole line with numbers and symbols
-    collapsed — the right key for "what should I write next", because a line dies on its <em>first</em>
-    unknown token, so one missing verb scatters across several token buckets and a missing prefix looks
-    larger than it is.</p>
+    the grammar missing", and the wrong one for choosing a band: a line dies at its <em>first</em>
+    unknown token, so one missing verb scatters across several buckets and a missing prefix looks
+    larger than it is. <b>Sentence shape</b> keys it by the whole line with numbers and symbols
+    collapsed, which aggregates a family whose sentence <em>is</em> the whole line — every printing of
+    <code>Choose one —</code> is one row — and shatters one whose sentence continues into an arbitrary
+    payload, because each payload gets its own row.</p>
+    <p><b>Tail</b> is the one that has decided work. It keys on the text from the decline's own offset
+    onward: not the token it stopped at and not the sentence it sits in, but <em>the construct that
+    would have to exist for the line to get further</em>. The spell-cast triggers are the worked
+    example — 504 cards sole-blocked, more than twice the next family, and neither other ranking
+    showed it. Died-on smeared them across <code>you</code>, which "whenever you gain life" also dies
+    at; sentence shape split them into hundreds of rows of one to six cards.</p>
     <p><b>Implemented</b> is the other split worth working from. A declined line on a card that already
     has a hand-written golden is a <em>grammar</em> gap whose known-good answer is already written, and
     the differential confirms it the moment it parses. A declined line on a card nobody has implemented
     may be an <em>SDK</em> gap, which is far longer work.</p>
     <div class="toolrow" style="margin-top:1.1rem">
       <div class="seg">
-        <button data-by="token"${shape ? "" : ' class="on"'}>died on · ${fmt(d.tokenFamilies)}</button>
-        <button data-by="shape"${shape ? ' class="on"' : ""}>sentence shape · ${fmt(d.shapeFamilies)}</button>
+        ${seg("tail", "tail")}${seg("shape", "sentence shape")}${seg("token", "died on")}
       </div>
       <input id="df" class="grow" placeholder="filter…" value="${esc(declineQuery)}"
              autocomplete="off" spellcheck="false">
@@ -752,8 +770,8 @@ async function viewDeclines() {
         not a unit of work: a line stops at its <em>first</em> unknown token, so "every declined line
         of this card died at <code>Whenever</code>" says nothing has been read and implies no rule.
         Computing it anyway claimed the top 400 token families cover 93% of Magic, against 15% for the
-        top 400 sentence shapes. <button class="linky" style="color:var(--accent)" data-by="shape">Switch
-        to sentence shape</button> to see the honest one.</div>`}
+        top 400 sentence shapes. <button class="linky" style="color:var(--accent)" data-by="tail">Switch
+        to the tail</button> to see the honest one.</div>`}
     </div>
     <div class="block">
     ${d.families.length ? declineTable(d.families, d.goldensAvailable, d.ranking, d.hasUnlocks)
@@ -777,31 +795,40 @@ async function viewDeclines() {
   };
 
   rail("Top families", d.families.slice(0, 60).map((f) =>
-    '<button class="rl" data-go="#d/' + declineBy + "/" + encodeURIComponent(f.token) +
-    '"><span>' + esc(f.token.slice(0, 44)) + '</span><span class="n">' + fmt(f.cards) + "</span></button>"));
+    '<button class="rl" data-go="#d/' + declineBy + "/" + encodeURIComponent(f.key) +
+    '"><span>' + esc(f.key.slice(0, 44)) + '</span><span class="n">' + fmt(f.cards) + "</span></button>"));
 }
 
-async function viewDecline(by, token) {
-  const d = await api("decline", { by, token });
+const DECLINE_BLURB = {
+  TAIL: (d) => "The text from each decline's own offset onward — <em>the construct that would have to " +
+    "exist for these " + fmt(d.lines) + " lines to get further</em>. That is what makes this a piece of " +
+    "work rather than a bucket: everything before it already reads, and everything after it is the " +
+    "payload the rest of the grammar may or may not already handle. Which of those it is, is the " +
+    "question the probe below answers.",
+  SHAPE: (d) => "Every line of this shape, with numbers and mana symbols collapsed. They are one row " +
+    "because one rule would read all " + fmt(d.lines) + " of them.",
+  TOKEN: (d) => "Every one of these lines parsed as far as this token and stopped. They are one family " +
+    "because they died in the same place, which is what makes them one piece of work rather than " +
+    fmt(d.cards) + ".",
+};
+const DECLINE_TAG = { TAIL: "parse tail", SHAPE: "sentence shape", TOKEN: "decline family" };
+
+async function viewDecline(by, key) {
+  const d = await api("decline", { by, key });
   if (indexing(d)) { el("view").innerHTML = indexingHTML(d); return; }
   if (d.error) { el("view").innerHTML = '<div class="empty">' + esc(d.error) + "</div>"; return; }
-  const shape = d.ranking === "SHAPE";
 
   el("view").innerHTML = `
     <div class="crumb"><a href="#">overview</a> <span>/</span> <a href="#declines">declines</a></div>
-    <div class="headline"><h1 style="font-size:1.1rem">${esc(d.token)}</h1>
-      <span class="tag">${shape ? "sentence shape" : "decline family"}</span></div>
-    <p>${shape
-      ? "Every line of this shape, with numbers and mana symbols collapsed. They are one row because " +
-        "one rule would read all " + fmt(d.lines) + " of them."
-      : "Every one of these lines parsed as far as this token and stopped. They are one family because " +
-        "they died in the same place, which is what makes them one piece of work rather than " + fmt(d.cards) + "."}</p>
+    <div class="headline"><h1 style="font-size:1.1rem">${esc(d.key)}</h1>
+      <span class="tag">${DECLINE_TAG[d.ranking] || "decline family"}</span></div>
+    <p>${DECLINE_BLURB[d.ranking](d)}</p>
 
     <div class="stats" style="margin-top:1rem">
       <div class="stat"><span class="v">${fmt(d.cards)}</span><span class="k">Cards blocked</span>
         <span class="s">how big it looks</span></div>
       ${d.hasUnlocks ? `<div class="stat"><span class="v ok">${fmt(d.unlocks)}</span>
-        <span class="k">Cards unlocked</span><span class="s">the only thing blocking them</span></div>` : ""}
+        <span class="k">Sole-blocked</span><span class="s">the only thing blocking them</span></div>` : ""}
       <div class="stat"><span class="v">${fmt(d.lines)}</span><span class="k">Lines</span></div>
       <div class="stat"><span class="v" style="color:var(--ochre)">${fmt(d.implemented)}</span>
         <span class="k">Already hand-written</span><span class="s">grammar gap, not SDK gap</span></div>
@@ -809,6 +836,8 @@ async function viewDecline(by, token) {
     ${d.hasUnlocks ? '<p class="note" style="margin-top:.6rem">The other ' + fmt(d.cards - d.unlocks) +
       " cards decline on something else as well, so writing this alone does not cover them — it is " +
       "still progress on every one of them, just not the whole of any.</p>" : ""}
+
+    ${probeHTML(d)}
 
     <div class="block">
       <h2>Example lines</h2>
@@ -829,7 +858,81 @@ async function viewDecline(by, token) {
       ${d.blocked.length < d.cards ? '<p class="note" style="margin-top:.5rem">Showing ' +
         fmt(d.blocked.length) + " of " + fmt(d.cards) + " — the list is capped.</p>" : ""}
     </div>`;
+  wireProbe(by, d);
   rail("", []);
+}
+
+/* =========================== the feasibility probe =========================== */
+
+/* Cards blocked says which cards a band REACHES. It does not say which lines it FINISHES, and every
+   ranking this module has used that skipped the difference overstated its band — four times in the
+   same direction. This box is the measurement that closes it: put a known-good prefix where the
+   family's own span is, re-parse on the live grammar, count what got through. */
+function probeHTML(d) {
+  return `
+    <div class="block">
+      <h2>Would writing it finish these cards?</h2>
+      <p class="note" style="margin-bottom:.7rem">Substitute a construct the grammar already reads for
+      this family's own span, and re-parse every declined line of every card behind it. What comes back
+      is how much of the payload the rest of the grammar can already handle — the number a band actually
+      delivers, against the card counts above, which are the number it merely reaches.</p>
+      <div class="form">
+        <div class="pair">
+          <label>Replace this span<input id="pb-find" value="${esc(d.probeFind || "")}"
+            autocomplete="off" spellcheck="false"></label>
+          <label>With this<input id="pb-repl" placeholder="When ~ enters,"
+            autocomplete="off" spellcheck="false"></label>
+        </div>
+        <div class="toolrow" style="margin-top:.2rem">
+          <label style="flex-direction:row;align-items:center;gap:.4rem;text-transform:none;letter-spacing:normal;font-size:.72rem;color:var(--muted)">
+            <input type="checkbox" id="pb-rx" style="width:auto"> regex — for a span that varies in the
+            middle, e.g. <code>Whenever you cast [^,]*,</code>
+          </label>
+          <button id="pb-run" class="linky" style="color:var(--accent)">Measure</button>
+        </div>
+      </div>
+      <div id="pb-out"></div>
+    </div>`;
+}
+
+function wireProbe(by, d) {
+  const run = async () => {
+    const find = el("pb-find").value, replace = el("pb-repl").value;
+    el("pb-out").innerHTML = '<p class="note" style="margin-top:.8rem">re-parsing…</p>';
+    const r = await post("probe", { by, key: d.key, find, replace, regex: el("pb-rx").checked ? "true" : "false" });
+    el("pb-out").innerHTML = r.error ? '<div class="empty">' + esc(r.error) + "</div>" : probeResultHTML(r);
+  };
+  el("pb-run").onclick = run;
+  for (const id of ["pb-find", "pb-repl"]) {
+    el(id).onkeydown = (e) => { if (e.key === "Enter") { e.preventDefault(); run(); } };
+  }
+}
+
+function probeResultHTML(r) {
+  return `
+    <div class="stats" style="margin-top:1rem">
+      <div class="stat"><span class="v ok">${fmt(r.cardsFinished)}</span><span class="k">Cards finished</span>
+        <span class="s">every declined line reads</span></div>
+      <div class="stat"><span class="v">${fmt(r.familyLinesParsing)} / ${fmt(r.familyLines)}</span>
+        <span class="k">Lines that now parse</span>
+        <span class="s">${share(r.familyLinesParsing, r.familyLines)} of the family</span></div>
+      <div class="stat"><span class="v" style="color:${r.unmatched ? "var(--bad)" : "var(--faint)"}">${fmt(r.unmatched)}</span>
+        <span class="k">Span not found</span><span class="s">lines the pattern missed</span></div>
+      <div class="stat"><span class="v">${fmt(r.cardsConsidered)}</span><span class="k">Cards re-assayed</span>
+        <span class="s">${fmt(r.millis)} ms on the live grammar</span></div>
+    </div>
+    <p class="note" style="margin-top:.7rem"><b>This is a prediction.</b> It assumes the construct you
+    would write reads everything this family's span does — it measures whether the <em>rest</em> of each
+    line is readable, and cannot tell you the span itself is expressible in <code>mtg-sdk</code> at all.
+    A large "span not found" means the pattern is describing a different family than this one.</p>
+    ${r.examples.length ? `<div class="tablewrap" style="margin-top:.8rem"><table>
+      <thead><tr><th>Card</th><th>Declined line</th><th>After substitution</th><th></th></tr></thead>
+      <tbody>${r.examples.map((e) => `<tr>
+        <td class="nm"><a href="#c/${encodeURIComponent(e.card)}">${esc(e.card)}</a></td>
+        <td class="mono" style="font-size:.72rem;color:var(--muted)">${esc(e.before)}</td>
+        <td class="mono" style="font-size:.72rem">${esc(e.after)}</td>
+        <td><span class="tag${e.parses ? " w" : ""}">${e.parses ? "reads" : "still declines"}</span></td>
+      </tr>`).join("")}</tbody></table></div>` : ""}`;
 }
 
 /* =========================== cards =========================== */
@@ -1355,8 +1458,8 @@ async function search(text) {
   if (d.declines.length) {
     html += '<div class="sec">Decline families</div>';
     for (const t of d.declines) {
-      rows.push("#d/token/" + encodeURIComponent(t.token));
-      html += '<button class="row"><span class="mono">' + esc(t.token) +
+      rows.push("#d/token/" + encodeURIComponent(t.key));
+      html += '<button class="row"><span class="mono">' + esc(t.key) +
         '</span><span class="rt">' + fmt(t.cards) + " cards</span></button>";
     }
   }

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/gate/DeclineKeyTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/gate/DeclineKeyTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.assay.gate
+
+import com.wingedsheep.assay.corpus.OracleCard
+import com.wingedsheep.assay.corpus.OracleFace
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The three keyings, on hand-built cards — what each one *claims about the same line*, which is the
+ * only thing that distinguishes them and the whole reason there are three.
+ */
+class DeclineKeyTest : StringSpec({
+
+    fun card(name: String, text: String, typeLine: String = "Creature — Angel") = OracleCard(
+        name = name,
+        oracleId = null,
+        layout = "normal",
+        setCode = "TST",
+        scryfallKeywords = emptyList(),
+        faces = listOf(OracleFace(name = name, oracleText = text, typeLine = typeLine)),
+    )
+
+    val touchstone = Touchstone()
+
+    fun declined(name: String, text: String) =
+        touchstone.assay(card(name, text)).lines.first { it.verdict == LineVerdict.DECLINED }
+
+    "the tail starts where the parse stopped, not where the line did" {
+        // The trigger prefix reads; the effect clause is what is missing. TOKEN names the one token,
+        // SHAPE names the whole sentence *including* the half that already parsed, and TAIL names
+        // exactly the construct that would have to exist for the line to get further.
+        val line = declined("Probe", "Flying\nWhen ~ enters, frobnicate target creature.")
+
+        DeclineKey.TAIL.of(line) shouldBe "frobnicate target creature."
+        DeclineKey.SHAPE.of(line) shouldBe "When ~ enters, frobnicate target creature."
+        DeclineKey.TOKEN.of(line) shouldBe "frobnicate"
+    }
+
+    "one missing construct under two payloads is one tail family and two shapes" {
+        // This is the bias SHAPE has and TAIL does not. A family whose sentence continues into an
+        // arbitrary payload gets a shape row per payload and never rises; the tail holds it together.
+        val drawing = declined("Drawing", "When ~ enters, frobnicate target creature and draw a card.")
+        val gaining = declined("Gaining", "When ~ enters, frobnicate target creature and gain 2 life.")
+
+        DeclineKey.TAIL.of(drawing) shouldBe DeclineKey.TAIL.of(gaining)
+        (DeclineKey.SHAPE.of(drawing) == DeclineKey.SHAPE.of(gaining)) shouldBe false
+    }
+
+    "the tail is the whole line when the parse read nothing, and that is not a defect" {
+        // A line that dies at offset 0 has no tail short of itself, so TAIL degenerates to SHAPE
+        // here — the honest answer, since nothing was read and so everything has to be written. It
+        // is also why the modal bullets are the one large family the TOKEN ranking names best.
+        val line = declined("Bullet", "• Frobnicate target creature.")
+
+        DeclineKey.TAIL.of(line) shouldBe "• Frobnicate target …"
+        DeclineKey.TOKEN.of(line) shouldBe "•"
+    }
+
+    "the tail collapses numbers and mana symbols so two printings are one family" {
+        val red = declined("Red", "When ~ enters, frobnicate for {R}{R} and 2 life.")
+        val green = declined("Green", "When ~ enters, frobnicate for {G}{G} and 3 life.")
+
+        DeclineKey.TAIL.of(red) shouldBe DeclineKey.TAIL.of(green)
+        DeclineKey.TAIL.of(red) shouldBe "frobnicate for {§}{§} …"
+    }
+
+    "the word count is a parameter, because it is a measurement rather than a constant" {
+        val line = declined("Probe", "When ~ enters, frobnicate target creature.")
+
+        DeclineKey.TAIL.of(line, tailWords = 1) shouldBe "frobnicate …"
+        DeclineKey.TAIL.of(line, tailWords = 2) shouldBe "frobnicate target …"
+        // No marker when nothing was cut: a truncated key must be distinguishable from a whole one.
+        DeclineKey.TAIL.of(line, tailWords = 20) shouldBe "frobnicate target creature."
+    }
+
+    "only the token ranking gives up the sole-blocked count" {
+        DeclineKey.TOKEN.namesWork shouldBe false
+        DeclineKey.SHAPE.namesWork shouldBe true
+        DeclineKey.TAIL.namesWork shouldBe true
+    }
+
+    "sole-blocked counts cards, not lines — every declined line has to fall in the one family" {
+        val report = FinenessReport.builder()
+            .add(touchstone.assay(card("One Blocker", "When ~ enters, frobnicate target creature.")))
+            .add(touchstone.assay(card("Blocker And Keyword", "When ~ enters, frobnicate target creature.\nFlying")))
+            .add(
+                touchstone.assay(
+                    card(
+                        "Two Blockers",
+                        "When ~ enters, frobnicate target creature.\nWhen ~ dies, blorp target creature.",
+                    )
+                )
+            )
+            .build()
+
+        val frobnicate = report.declines(DeclineKey.TAIL).single { it.key.startsWith("frobnicate") }
+        frobnicate.cards shouldBe 3
+        // The third card declines somewhere else too, so writing this family alone leaves it blocked.
+        frobnicate.soleBlocked shouldBe 2
+        report.declines(DeclineKey.TOKEN).first().soleBlocked shouldBe null
+    }
+
+    "--rank takes the key by name, and refuses one it does not know" {
+        DeclineKey.byName("tail") shouldBe DeclineKey.TAIL
+        DeclineKey.byName("TAIL") shouldBe DeclineKey.TAIL
+        DeclineKey.byName("sentence") shouldBe null
+        DeclineKey.byName(null) shouldBe null
+    }
+})

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/gate/PrefixProbeTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/gate/PrefixProbeTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.assay.gate
+
+import com.wingedsheep.assay.corpus.OracleCard
+import com.wingedsheep.assay.corpus.OracleFace
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * The half that makes the ranking honest: which lines a band *finishes*, not which cards it reaches.
+ */
+class PrefixProbeTest : StringSpec({
+
+    fun card(name: String, text: String) = OracleCard(
+        name = name,
+        oracleId = null,
+        layout = "normal",
+        setCode = "TST",
+        scryfallKeywords = emptyList(),
+        faces = listOf(OracleFace(name = name, oracleText = text, typeLine = "Creature — Angel")),
+    )
+
+    val touchstone = Touchstone()
+
+    fun keyOf(card: OracleCard) = DeclineKey.TAIL.of(
+        touchstone.assay(card).lines.first { it.verdict == LineVerdict.DECLINED }
+    )
+
+    "a card is finished only when every one of its declined lines reads after the substitution" {
+        // Both cards decline on the same unknown prefix. The first's payload is grammar the parser
+        // already has; the second's second line is blocked by something the substitution never
+        // touches, which is exactly the difference the card counts hide.
+        val readable = card("Readable", "Whenever ~ frobnicates, draw a card.")
+        val alsoBlocked = card("Also Blocked", "Whenever ~ frobnicates, draw a card.\nWhenever ~ blorps, draw a card.")
+
+        val result = PrefixProbe.run(
+            touchstone = touchstone,
+            cards = listOf(readable, alsoBlocked),
+            family = DeclineKey.TAIL,
+            key = keyOf(readable),
+            substitution = PrefixProbe.Substitution(find = "Whenever ~ frobnicates,", replace = "When ~ enters,"),
+        )
+
+        result.cardsConsidered shouldBe 2
+        result.familyLines shouldBe 2
+        result.familyLinesParsing shouldBe 2
+        result.cardsFinished shouldBe 1
+    }
+
+    "a payload the grammar still cannot read is counted, not assumed away" {
+        val card = card("Unreadable Payload", "Whenever ~ frobnicates, blorp target creature.")
+
+        val result = PrefixProbe.run(
+            touchstone = touchstone,
+            cards = listOf(card),
+            family = DeclineKey.TAIL,
+            key = keyOf(card),
+            substitution = PrefixProbe.Substitution(find = "Whenever ~ frobnicates,", replace = "When ~ enters,"),
+        )
+
+        result.familyLinesParsing shouldBe 0
+        result.cardsFinished shouldBe 0
+    }
+
+    "a span that does not occur is its own outcome — the pattern is describing another family" {
+        val card = card("Elsewhere", "Whenever ~ frobnicates, draw a card.")
+
+        val result = PrefixProbe.run(
+            touchstone = touchstone,
+            cards = listOf(card),
+            family = DeclineKey.TAIL,
+            key = keyOf(card),
+            substitution = PrefixProbe.Substitution(find = "At the beginning of your upkeep,", replace = "When ~ enters,"),
+        )
+
+        result.unmatched shouldBe 1
+        result.familyLinesParsing shouldBe 0
+    }
+
+    "a substitution that consumes the whole line reads it — the family's span IS the line" {
+        // The modal header is the worked example: `Choose one —` is nothing but the missing
+        // construct, so a band that reads modal spells reads it by the same assumption that lets
+        // `When ~ enters,` stand in for any other span.
+        val card = card("Whole Line", "Frobnicate —\nFlying")
+
+        val result = PrefixProbe.run(
+            touchstone = touchstone,
+            cards = listOf(card),
+            family = DeclineKey.TAIL,
+            key = keyOf(card),
+            substitution = PrefixProbe.Substitution(find = "Frobnicate —", replace = ""),
+        )
+
+        result.familyLinesParsing shouldBe 1
+        result.cardsFinished shouldBe 1
+    }
+
+    "regex is opt-in, so Oracle punctuation typed as a literal cannot silently mis-measure" {
+        val card = card("Symbols", "{T}: Frobnicate target creature.")
+        val key = keyOf(card)
+
+        // `{T}` as a literal is a literal; as a regex it would be a repetition operator.
+        PrefixProbe.run(
+            touchstone, listOf(card), DeclineKey.TAIL, key,
+            PrefixProbe.Substitution(find = "{T}: Frobnicate", replace = "{T}: Destroy"),
+        ).unmatched shouldBe 0
+
+        PrefixProbe.run(
+            touchstone, listOf(card), DeclineKey.TAIL, key,
+            PrefixProbe.Substitution(find = "Frobnicate [", replace = "Destroy", regex = true),
+        ).error!! shouldContain "not a regex"
+    }
+})

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/gate/TouchstoneTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/gate/TouchstoneTest.kt
@@ -119,7 +119,7 @@ class TouchstoneTest : StringSpec({
         report.instancesByVerdict[LineVerdict.DECLINED] shouldBe 1
         report.cardsCovered shouldBe 2
         report.clean shouldBe true
-        report.declines.single().token shouldBe "Cumulative"
+        report.declines.single().key shouldBe "Cumulative"
         report.declines.single().cards shouldBe 1
     }
 


### PR DESCRIPTION
The explorer offered two decline rankings and **both mis-ranked the largest family in the corpus**.
The spell-cast triggers — "Whenever you cast a noncreature spell, …" — were **504 cards sole-blocked
against 263 for the next family**, and neither ranking showed it. `TOKEN` smeared them across `you`,
which "Whenever you gain life…" and "Whenever you attack…" also die at; `SHAPE` shattered them into
one row per effect clause, so the shape table read `Choose one —` at 100 cards and then nothing above
27, with 504 cards of cast triggers invisible underneath. The band that closed it (#1843) was picked
with a throwaway probe written outside the tool.

Both halves of that probe are now in the tool.

## 1. A third key: the parse's tail

`gate/DeclineKey.TAIL` keys a family on the text from the decline's own `position` onward,
skeletonized and cut to its first *K* words. Not the token the line stopped at, and not the sentence
it sits in — **the construct that would have to exist for the line to get further**. That is a unit
of work in the way a dead token is not, so the sole-blocked count and the unlock curve apply to it;
`DeclineKey.namesWork` replaces the hand-placed SHAPE-only restriction and carries the reason with it.

### Picking K by measuring

`assay report --rank tail --tail-words N`. Family counts: **1,847 / 5,699 / 10,122 / 14,149 /
17,471** for K = 1…5.

<details><summary><b>K = 1</b> — the TOKEN failure mode reproduced exactly</summary>

```
  cards  sole   lines  tail                       example
  1664   782    1742   you …                      Whenever you gain life, each opponent lo
  1114   640    1161   ~ …                        As long as ~ is untapped, players can't
  1061   515    1082   When …                     When ~ enters and whenever you cast your
  898    272    908    Choose …                   Choose one —
  819    0      2040   • …                        • Return target permanent card from your
  651    294    666    a …                        If a source you control would deal nonco
  570    346    581    Each …                     {4}{B}{B}: Each opponent with no cards i
  535    382    541    that …                     Whenever ~ deals combat damage to a crea
  534    288    539    and …                      Enchanted creature gets +2/+2 and has tr
  528    238    534    one …                      Whenever one or more creatures you contr
```
Names no construct at all. `you …` is three unrelated trigger families in one row.
</details>

<details><summary><b>K = 2</b> — over-merged: <code>When ~ …</code> swallows several unrelated events</summary>

```
  cards  sole   lines  tail                       example
  534    267    543    When ~ …                   When ~ enters and whenever you cast your
  436    1      436    Choose one …               Choose one —
  352    130    356    one or …                   Whenever one or more creatures you contr
  318    176    322    for each …                 {T}: Add {C} for each storage counter on
  304    184    323    enchanted creature …       Whenever enchanted creature or another m
  245    171    247    Until end …                Until end of turn, lands you control gai
  243    106    243    This spell …               This spell costs {3} less to cast if you
  234    45     239    As ~ …                     As ~ enters, you may reveal a Mountain o
  227    92     228    's power …                 ~'s power and toughness are each equal t
  215    83     224    Enchanted creature …       Enchanted creature doesn't untap during
  212    115    222    ~ is …                     As long as ~ is untapped, players can't
  210    165    211    Each player …              {T}, Exile ~: Each player exiles the top
  201    140    220    until end …                {1}{W}: ~ gains first strike until end o
  197    0      271    • Target …                 • Target creature gets +3/-3 until end o
  195    98     198    At the …                   At the beginning of the end step, sacrif
  195    65     195    As an …                    As an additional cost to cast this spell
  194    108    194    Landfall — …               Landfall — Whenever a land you control e
  187    137    195    Discard a …                {T}, Discard a nonblack card: Draw a car
  186    79     196    Remove a …                 {T}, Remove a +1/+1 counter from ~: Put
  184    82     188    When you …                 When ~ enters, you may sacrifice a creat
```
`When ~ …` at 534 is enters-triggers, cast-triggers and attack-triggers in one bucket — a row that
names no single piece of work, which is the defect the tail key exists to avoid.
</details>

<details open><summary><b>K = 3</b> — shipped: every row names one construct</summary>

```
  cards  sole   lines  tail                       example
  357    0      357    Choose one —               Choose one —
  344    124    348    one or more …              Whenever one or more creatures you contr
  245    171    247    Until end of …             Until end of turn, lands you control gai
  233    102    233    This spell costs …         This spell costs {3} less to cast if you
  228    117    230    When ~ enters …            When ~ enters and whenever you cast your
  209    37     214    As ~ enters, …             As ~ enters, you may reveal a Mountain o
  201    140    220    until end of …             {1}{W}: ~ gains first strike until end o
  195    65     195    As an additional …         As an additional cost to cast this spell
  193    98     196    At the beginning …         At the beginning of the end step, sacrif
  189    104    189    Landfall — Whenever …      Landfall — Whenever a land you control e
  179    69     183    ~ enters or …              Whenever ~ enters or attacks, put an eve
  159    112    159    cards of your …            When ~ enters, look at the top five card
  157    0      194    • Destroy target …         • Destroy target artifact.
  150    108    153    Discard a card: …          {2}{R}, {T}, Discard a card: ~ deals 2 d
  144    60     145    's power and …             ~'s power and toughness are each equal t
  134    14     134    Devoid                     Devoid
  118    0      118    choose one —               When ~ enters, choose one —
  114    51     116    .                          ~ gets +1/+0 for each artifact you contr
  112    0      129    • ~ deals …                • ~ deals 4 damage to target player or p
  111    55     113    Spend this mana …          {T}: Add {U} or {R}. Spend this mana onl
```
</details>

<details><summary><b>K = 4</b> — the payload starts splitting families</summary>

```
  cards  sole   lines  tail                       example
  357    0      357    Choose one —               Choose one —
  245    171    247    Until end of turn, …       Until end of turn, lands you control gai
  228    100    228    This spell costs {§} …     This spell costs {3} less to cast if you
  195    65     195    As an additional cost …    As an additional cost to cast this spell
  193    98     196    At the beginning of …      At the beginning of the end step, sacrif
  189    104    189    Landfall — Whenever a …    Landfall — Whenever a land you control e
  169    122    184    until end of turn.         {1}{W}: ~ gains first strike until end o
  159    64     161    ~ enters or attacks, …     Whenever ~ enters or attacks, put an eve
  147    104    147    cards of your library. …   When ~ enters, look at the top five card
  144    60     145    's power and toughness …   ~'s power and toughness are each equal t
  134    14     134    Devoid                     Devoid
  121    2      126    As ~ enters, choose …      As ~ enters, choose a card name.
  118    0      118    choose one —               When ~ enters, choose one —
  114    51     116    .                          ~ gets +1/+0 for each artifact you contr
  111    55     113    Spend this mana only …     {T}: Add {U} or {R}. Spend this mana onl
  106    47     107    When ~ enters the …        When ~ enters the battlefield, create a
  104    37     104    X +#/+# counters on …      ~ enters with X +1/+1 counters on it.
  95     68     95     card with mana value …     Search your library for a creature card
  93     0      108    • ~ deals # …              • ~ deals 4 damage to target player or p
  91     59     91     Gain control of target …   Gain control of target Aura that's attac
```
`one or more …` (344 at K=3) is gone from the top: split by what follows. `As ~ enters, choose …`
has separated from `As ~ enters, …` on nothing but its payload's first word.
</details>

<details><summary><b>K = 5</b> — fragmenting outright</summary>

```
  cards  sole   lines  tail                       example
  357    0      357    Choose one —               Choose one —
  224    98     224    This spell costs {§} less  This spell costs {3} less to cast if you
  195    65     195    As an additional cost to … As an additional cost to cast this spell
  189    104    189    Landfall — Whenever a land Landfall — Whenever a land you control e
  169    122    184    until end of turn.         {1}{W}: ~ gains first strike until end o
  144    60     145    's power and toughness are ~'s power and toughness are each equal t
  134    14     134    Devoid                     Devoid
  132    91     132    cards of your library. You When ~ enters, look at the top five card
  118    0      118    choose one —               When ~ enters, choose one —
  114    51     116    .                          ~ gets +1/+0 for each artifact you contr
  109    53     111    Spend this mana only to …  {T}: Add {U} or {R}. Spend this mana onl
  101    45     102    When ~ enters the battlefi When ~ enters the battlefield, create a
  99     52     99     At the beginning of the …  At the beginning of the end step, sacrif
  94     71     94     Until end of turn, target  {1}: Until end of turn, target token you
  93     0      108    • ~ deals # damage …       • ~ deals 4 damage to target player or p
  89     54     89     token that's a copy of …   Whenever a nontoken creature you control
  85     36     85     When ~ is put into …       When ~ is put into a graveyard from the
  82     31     82     's power is equal to …     ~'s power is equal to the number of land
  81     47     81     Treasure token.            Whenever a player casts their second spe
  80     0      81     −#: You get an emblem …    −6: You get an emblem with "At the end o
```
`At the beginning of the …` has fallen from 193 to 99 and `Until end of turn, …` from 245 to 94 —
one family becoming several, which is the SHAPE bias creeping back in.
</details>

### What the new ranking is worth

Cards *covered* after writing the top N families, cumulatively — the unlock curve, over the same
corpus:

| top N | SHAPE | TAIL |
|---|---|---|
| 10 | 19.09% (+76) | **21.65%** (+969) |
| 25 | 19.34% (+162) | **23.98%** (+1,782) |
| 50 | 19.98% (+386) | **27.38%** (+2,968) |
| 100 | 20.67% (+627) | **32.90%** (+4,893) |
| 200 | 22.13% (+1,136) | **39.21%** (+7,094) |
| 400 | 24.08% (+1,815) | **47.56%** (+10,007) |

The tail's top 400 is worth **5.5×** the shape's, on the same corpus and the same definition of
covered.

## 2. The feasibility probe

Sole-blocked says which cards a band *reaches*. It does not say which lines it *finishes*, and every
ranking here that skipped the difference overstated its band — four times in the same direction.
`gate/PrefixProbe` closes it, on each family's page: substitute a known-good prefix for the family's
own span, re-parse **every declined line of every card behind it** on the live grammar, and report
lines that now parse and **whole cards finished** (a card counts only when all of its declined lines
read).

The standing example, one click on the Landfall family:

| | |
|---|---|
| Cards blocked | 189 |
| Sole-blocked | 104 |
| **Probe: whole cards finished** | **48** |

80 of 189 lines parse after `Landfall — ` → ``. The band is worth less than half what the
sole-blocked column promises, and it took 113 ms to find that out.

Design notes:
- **Literal by default, regex opt-in.** Oracle text is dense with `{`, `(`, `.` and `+`; a literal
  typed into a regex box is a silent mis-measurement rather than an error. Regex is there because the
  families worth the most vary in the middle — `Whenever you cast [^,]*,` is one span and twelve
  hundred spellings of it.
- **A substitution that consumes the whole line reads it.** That is the modal header: `Choose one —`
  is nothing but the missing construct. Refusing it would report zero finished cards for every family
  whose span is the entire line — the family shape this ranking exists to surface.
- **Labelled a prediction, in the page.** It assumes the construct you would write reads everything
  the family's span does; it cannot tell you the span is expressible in `mtg-sdk` at all. "Span not
  found" is reported separately, because a large count there means the pattern describes a different
  family than the one on screen.

## 3. Where it lives — the decision the module's rules force

`oracle-assay/AGENTS.md`: *"The explorer is a view, never a second source of truth. If the explorer
needs a number the gates do not produce, the number goes in the gate and both read it."* SHAPE lived
only in `AssayIndex`, which was a precedent not to extend.

So the **keying** and the **counts** went into the gate:

- new `gate/DeclineKey.kt` holds all three key functions and `namesWork` — one definition the CLI and
  the explorer both call, so they cannot rank differently;
- `FinenessReport` computes all three families in the one sweep, with `soleBlocked` per family, and
  `render(ranking = …)` prints whichever was asked for. SHAPE moved with TAIL;
- `assay report --rank <token|shape|tail>` and `--tail-words N` expose it. The reason `--rank` exists
  at all is that a throwaway probe got written because `assay-report` could not print this.

`AssayIndex` keeps only the **link table** — which card names, a dozen example lines, the
hand-written split. That is not a number a gate has any use for, and putting a per-family card-name
list into a report whose cost model is "counters and bounded examples" would make a corpus run's
memory grow with the corpus. The card-name list is now uncapped there (the probe measures over all of
it) and capped at the view instead.

The probe computation is in `gate/` too, even though only the explorer calls it — it re-parses on
request and is family-specific, so it cannot be precomputed, but it is a *measurement* and the
explorer should be calling one rather than being one. No new dependency: `com.sun.net.httpserver`,
`:mtg-sdk` still the module's only production dep.

## 4. A finding the three-way split produced

`TAIL` degenerates to `SHAPE` when the parse dies at offset 0 — a line that read nothing has no tail
short of itself. That is the honest answer, and it means **the modal bullets are the one large family
`TOKEN` names best**: 2,015 declined `•` lines are one token family and hundreds of tail rows. The
three rankings are complementary rather than ordered, and `AGENTS.md` now says which to read when.

## Verification

**The gates are unmoved — this change touches no rule.**

```
just assay-gate          MISMATCH 0 · AMBIGUOUS 0 · normalization 0 · inverse 0
                         24,139 round-trips (361.4‰) · 6,583 / 34,882 cards covered
                         1,444 / 1,712 Phase 1 target class (843.5‰)
just assay-gate --set POR    200 / 200   1000.0‰
just assay-gate --set LGN    145 / 145   1000.0‰
:oracle-assay:test           242 tests, all green (13 new)
```

**Fixture 1 — modal spells, still open, so the numbers should still be there.** Measured immediately
before the spell-cast band landed: 819 cards touch a modal line, 609 sole-blocked, and the probe said
613 of 1,514 bullets parse and 126 whole cards would be finished.

| | expected | measured |
|---|---|---|
| cards touching a modal line | 819 | **823** |
| sole-blocked by modal lines | 609 | **613** |
| bullets on those cards | 1,514 | **1,514** |
| whole cards the probe finishes | 126 | **126** |

The last two are exact. The probe was run through the new box on the `TOKEN` / `•` family with
`(?i)^• \|^.*\bchoose\b[^—]*—.*$` → `` — which is also what turned up the offset-0 finding above,
since the modal family is a token family rather than a tail one. Over that whole family (817 cards,
not the 613 sole-blocked subset) the line ratio reads 745 of 2,015, i.e. 37.0% against the fixture's
40.5% on its narrower denominator — the expected direction, since sole-blocked cards are the easier
ones.

**Fixture 2 — spell-cast triggers, now read, so they should have vanished.** They have. No `you cast
a …` family appears anywhere near the top of the tail ranking; filtering the 10,122 tail families for
`you cast` returns nothing above `When ~ enters …` at 228 cards, which is a different family that
merely mentions the phrase. The key is doing what it claims.

**By hand in the browser:** the three-way toggle, the tail table with `Sole` beside `Blocks`, the
unlock curve, the probe box on a family page (screenshots taken of the declines list and the Landfall
family mid-probe), and no console errors.

## Files

| | |
|---|---|
| `gate/DeclineKey.kt` | **new** — the three keyings, `namesWork`, `skeleton`, the K parameter |
| `gate/PrefixProbe.kt` | **new** — the substitution measurement |
| `gate/Fineness.kt` | families per keying, `soleBlocked`, `render(ranking)` |
| `gate/Touchstone.kt` | `grammar` exposed so the probe re-parses with the same instance |
| `cli/Main.kt` | `--rank`, `--tail-words` |
| `explore/AssayIndex.kt` | reads the gate's families; keeps the link table; `Ranking` deleted |
| `explore/Views.kt`, `ExploreServer.kt` | `by=tail`, `/api/probe` |
| `explorer/index.html` | three-way toggle, probe box, tail copy |
| `AGENTS.md`, `README.md` | the ranking section rewritten around what is now in the tool |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
