### PR TITLE
Assay: the Bloomburrow band, and the count that belonged in the slot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ docs it points at; load those when the work needs them.
 | `gym` / `gym-server` / `gym-trainer` | RL/MCTS env + HTTP transport + self-play SPI | engine, sdk |
 | `game-server` | Spring Boot orchestration, WebSocket, state masking | engine, sdk |
 | `mtgish-tooling` | Predictive coverage / auto-gen analyzer | — (scans source as text) |
-| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 2,494 of 2,495 compared cards agree — the one standing divergence is the open `ManaColorSet.Specific` finding), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
+| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 2,697 of 2,698 compared cards agree — the one standing divergence is the open `ManaColorSet.Specific` finding), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
 | `web-client` | React UI (dumb terminal — no game logic) | — |
 
 **Key principle:** the engine is pure (no card-specific code), content is data-driven (no execution

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4026,7 +4026,9 @@ for any other (filter, binding, to/excludeTo) combination.
 
 - `EntersBattlefield` — SELF, no filter. ("When this permanent enters.")
 - `OtherCreatureEnters` — OTHER binding, filter = `Creature.youControl()`.
-- `LandYouControlEnters` — landfall: OTHER binding, filter = `Land.youControl()`.
+- `LandYouControlEnters` — landfall: **ANY** binding, filter = `Land.youControl()`. No landfall
+  ability prints "another", so a land carrying one sees itself enter; a card that *does* print
+  "another land you control" wants `entersBattlefield(..., TriggerBinding.OTHER)` instead.
 - `entersBattlefield(filter, binding)` — factory. Covers face-down filters,
   ANY-binding tribal scopes, permanent-you-control scopes, enchantment-enters scopes (Eerie), etc.
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -84,14 +84,23 @@ object Triggers {
 
     /**
      * Landfall — whenever a land you control enters the battlefield.
-     * (OTHER binding, filter = Land.youControl().)
+     * (ANY binding, filter = Land.youControl().)
+     *
+     * `ANY` and not `OTHER`, because no landfall ability prints the word "another": every one of the
+     * 29 cards using this spells "Whenever a land you control enters". The distinction is invisible
+     * on a creature or an enchantment — neither can be the land that entered — and load-bearing on a
+     * *land* with a landfall trigger, which under `OTHER` would silently not see itself enter. Found
+     * by the Assay differential once the ability-word prefix stopped blocking these lines.
+     *
+     * A card that does print "another land you control" wants
+     * [entersBattlefield] with `binding = TriggerBinding.OTHER`, not this constant.
      */
     val LandYouControlEnters: TriggerSpec = TriggerSpec(
         event = ZoneChangeEvent(
             filter = GameObjectFilter.Land.youControl(),
             to = Zone.BATTLEFIELD
         ),
-        binding = TriggerBinding.OTHER
+        binding = TriggerBinding.ANY
     )
 
     /**

--- a/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/VoiceOfTheWoods.kt
+++ b/mtg-sets/2000-2002/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/VoiceOfTheWoods.kt
@@ -24,7 +24,9 @@ val VoiceOfTheWoods = card("Voice of the Woods") {
     oracleText = "Tap five untapped Elves you control: Create a 7/7 green Elemental creature token with trample."
 
     activatedAbility {
-        cost = Costs.TapPermanents(5, GameObjectFilter.Creature.withSubtype("Elf"))
+        // "Elves" names the subtype and not the card type, so the cost counts Elf *permanents* — an
+        // animated Elf land pays it too. Found by the Assay differential.
+        cost = Costs.TapPermanents(5, GameObjectFilter.Permanent.withSubtype("Elf"))
         effect = CreateTokenEffect(
             power = 7,
             toughness = 7,

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CorsairCaptain.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CorsairCaptain.kt
@@ -37,7 +37,12 @@ val CorsairCaptain = card("Corsair Captain") {
         ability = ModifyStats(
             powerBonus = 1,
             toughnessBonus = 1,
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.PIRATE).youControl(), excludeSelf = true)
+            // "Other Pirates you control" names the subtype and not the card type, so the lord
+            // reaches Pirate *permanents*. Found by the Assay differential.
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.PIRATE).youControl(),
+                excludeSelf = true,
+            )
         )
     }
     metadata {

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KarganDragonrider.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KarganDragonrider.kt
@@ -22,6 +22,10 @@ import com.wingedsheep.sdk.scripting.GrantKeyword
  * Modeled as a conditional static ability: GrantKeyword(FLYING, Self) gated by
  * YouControl(a Dragon). The continuous keyword grant is re-evaluated by the layer system
  * whenever the controlled-Dragon condition changes, matching "as long as".
+ *
+ * The condition counts Dragon *permanents*, not Dragon creatures: a bare tribal noun names the
+ * subtype and not the card type, so an animated Dragon land or a noncreature Dragon permanent
+ * satisfies "you control a Dragon" too. Found by the Assay differential.
  */
 val KarganDragonrider = card("Kargan Dragonrider") {
     manaCost = "{1}{R}"
@@ -34,7 +38,7 @@ val KarganDragonrider = card("Kargan Dragonrider") {
     staticAbility {
         ability = ConditionalStaticAbility(
             ability = GrantKeyword(Keyword.FLYING, Filters.Self),
-            condition = Conditions.YouControl(GameObjectFilter.Creature.withSubtype(Subtype.DRAGON))
+            condition = Conditions.YouControl(GameObjectFilter.Permanent.withSubtype(Subtype.DRAGON))
         )
     }
 

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LathlissDragonQueen.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LathlissDragonQueen.kt
@@ -36,8 +36,10 @@ val LathlissDragonQueen = card("Lathliss, Dragon Queen") {
     toughness = 6
     keywords(Keyword.FLYING)
     triggeredAbility {
+        // Both nouns are bare tribal ones — "Dragon", "Dragons" — so they name the subtype and not
+        // the card type, and a noncreature Dragon permanent is one of them. Found by the differential.
         trigger = Triggers.entersBattlefield(
-            filter = GameObjectFilter.Creature.withSubtype(Subtype.DRAGON).nontoken().youControl(),
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.DRAGON).nontoken().youControl(),
             binding = TriggerBinding.OTHER
         )
         effect = Effects.CreateToken(
@@ -51,7 +53,7 @@ val LathlissDragonQueen = card("Lathliss, Dragon Queen") {
     activatedAbility {
         cost = Costs.Mana("{1}{R}")
         effect = Effects.ForEachInGroup(
-            GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.DRAGON).youControl()),
+            GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.DRAGON).youControl()),
             Effects.ModifyStats(1, 0, EffectTarget.Self)
         )
     }

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/FinneasAceArcher.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/FinneasAceArcher.kt
@@ -25,7 +25,7 @@ import com.wingedsheep.sdk.dsl.Effects
  * Legendary Creature — Rabbit Archer
  * 2/2
  *
- * Vigilance, reach
+ * Reach, vigilance
  * Whenever Finneas attacks, put a +1/+1 counter on each other creature you control
  * that's a token or a Rabbit. Then if creatures you control have total power 10 or
  * greater, draw a card.
@@ -36,9 +36,9 @@ val FinneasAceArcher = card("Finneas, Ace Archer") {
     typeLine = "Legendary Creature — Rabbit Archer"
     power = 2
     toughness = 2
-    oracleText = "Vigilance, reach\nWhenever Finneas attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card."
+    oracleText = "Reach, vigilance\nWhenever Finneas attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card."
 
-    keywords(Keyword.VIGILANCE, Keyword.REACH)
+    keywords(Keyword.REACH, Keyword.VIGILANCE)
 
     triggeredAbility {
         trigger = Triggers.Attacks

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/FrilledSparkshooter.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/FrilledSparkshooter.kt
@@ -12,7 +12,7 @@ import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
  * {3}{R}
  * Creature — Lizard Archer
  * 3/3
- * Menace, reach
+ * Reach, menace
  * This creature enters with a +1/+1 counter on it if an opponent lost life this turn.
  */
 val FrilledSparkshooter = card("Frilled Sparkshooter") {
@@ -21,9 +21,9 @@ val FrilledSparkshooter = card("Frilled Sparkshooter") {
     typeLine = "Creature — Lizard Archer"
     power = 3
     toughness = 3
-    oracleText = "Menace, reach\nThis creature enters with a +1/+1 counter on it if an opponent lost life this turn."
+    oracleText = "Reach, menace\nThis creature enters with a +1/+1 counter on it if an opponent lost life this turn."
 
-    keywords(Keyword.MENACE, Keyword.REACH)
+    keywords(Keyword.REACH, Keyword.MENACE)
 
     replacementEffect(EntersWithCounters(
         counterType = CounterTypeFilter.PlusOnePlusOne,

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/GalewindMoose.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/GalewindMoose.kt
@@ -11,7 +11,7 @@ import com.wingedsheep.sdk.model.Rarity
  * 6/6
  *
  * Flash
- * Vigilance, reach, trample
+ * Reach, vigilance, trample
  */
 val GalewindMoose = card("Galewind Moose") {
     manaCost = "{4}{G}{G}"
@@ -19,9 +19,9 @@ val GalewindMoose = card("Galewind Moose") {
     typeLine = "Creature — Elemental Elk"
     power = 6
     toughness = 6
-    oracleText = "Flash\nVigilance, reach, trample"
+    oracleText = "Flash\nReach, vigilance, trample"
 
-    keywords(Keyword.FLASH, Keyword.VIGILANCE, Keyword.REACH, Keyword.TRAMPLE)
+    keywords(Keyword.FLASH, Keyword.REACH, Keyword.VIGILANCE, Keyword.TRAMPLE)
 
     metadata {
         rarity = Rarity.UNCOMMON

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/HuntersTalent.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/HuntersTalent.kt
@@ -36,7 +36,7 @@ val HuntersTalent = card("Hunter's Talent") {
     manaCost = "{1}{G}"
     colorIdentity = "G"
     typeLine = "Enchantment — Class"
-    oracleText = "When this Class enters the battlefield, target creature you control deals damage equal to its power to target creature you don't control.\n{1}{G}: Level 2 — Whenever you attack, target attacking creature gets +1/+0 and gains trample until end of turn.\n{3}{G}: Level 3 — At the beginning of your end step, if you control a creature with power 4 or greater, draw a card."
+    oracleText = "When this Class enters, target creature you control deals damage equal to its power to target creature you don't control.\n{1}{G}: Level 2 — Whenever you attack, target attacking creature gets +1/+0 and gains trample until end of turn.\n{3}{G}: Level 3 — At the beginning of your end step, if you control a creature with power 4 or greater, draw a card."
 
     // Level 1: ETB — bite effect
     triggeredAbility {

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LumraBellowOfTheWoods.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LumraBellowOfTheWoods.kt
@@ -18,7 +18,7 @@ import com.wingedsheep.sdk.dsl.Patterns
 
 // Lumra, Bellow of the Woods - {4}{G}{G}
 // Legendary Creature — Elemental Bear - star/star
-// Vigilance, reach
+// Reach, vigilance
 // P/T equal to number of lands you control.
 // When Lumra enters, mill four cards. Then return all land cards from your graveyard
 // to the battlefield tapped.
@@ -26,11 +26,11 @@ val LumraBellowOfTheWoods = card("Lumra, Bellow of the Woods") {
     manaCost = "{4}{G}{G}"
     colorIdentity = "G"
     typeLine = "Legendary Creature — Elemental Bear"
-    oracleText = "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra, Bellow of the Woods enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped."
+    oracleText = "Reach, vigilance\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra, Bellow of the Woods enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped."
 
     dynamicStats(DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land))
 
-    keywords(Keyword.VIGILANCE, Keyword.REACH)
+    keywords(Keyword.REACH, Keyword.VIGILANCE)
 
     triggeredAbility {
         trigger = Triggers.EntersBattlefield

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/QuaketuskBoar.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/QuaketuskBoar.kt
@@ -17,6 +17,7 @@ val QuaketuskBoar = card("Quaketusk Boar") {
     typeLine = "Creature — Elemental Boar"
     power = 5
     toughness = 5
+    oracleText = "Reach, trample, haste"
     keywords(Keyword.REACH, Keyword.TRAMPLE, Keyword.HASTE)
 
     metadata {

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ShortBow.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ShortBow.kt
@@ -13,25 +13,25 @@ import com.wingedsheep.sdk.scripting.ModifyStats
  * {2}
  * Artifact — Equipment
  *
- * Equipped creature gets +1/+1 and has vigilance and reach.
+ * Equipped creature gets +1/+1 and has reach and vigilance.
  * Equip {1}
  */
 val ShortBow = card("Short Bow") {
     manaCost = "{2}"
     colorIdentity = ""
     typeLine = "Artifact — Equipment"
-    oracleText = "Equipped creature gets +1/+1 and has vigilance and reach.\nEquip {1}"
+    oracleText = "Equipped creature gets +1/+1 and has reach and vigilance.\nEquip {1}"
 
     staticAbility {
         ability = ModifyStats(+1, +1, Filters.EquippedCreature)
     }
 
     staticAbility {
-        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EquippedCreature)
+        ability = GrantKeyword(Keyword.REACH, Filters.EquippedCreature)
     }
 
     staticAbility {
-        ability = GrantKeyword(Keyword.REACH, Filters.EquippedCreature)
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EquippedCreature)
     }
 
     equipAbility("{1}")

--- a/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/InsideSource.kt
+++ b/mtg-sets/2024/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mkm/cards/InsideSource.kt
@@ -10,7 +10,7 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.TimingRule
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
-import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 
 /**
  * Inside Source — Murders at Karlov Manor #19
@@ -23,9 +23,10 @@ import com.wingedsheep.sdk.scripting.targets.TargetCreature
  * Two Detectives for three mana, then a mana sink that turns one of them into an attacker who
  * stays home. The pump targets *a Detective you control* — including the token it just made, and
  * including Inside Source itself only if something has made it a Detective, since a Human Citizen
- * isn't one. `TargetFilter.CreatureYouControl.withSubtype(DETECTIVE)` is evaluated against
- * projected state, so a creature that gained the type from a type-changing effect is a legal
- * target and one that lost it is not.
+ * isn't one. `TargetFilter.PermanentYouControl.withSubtype(DETECTIVE)` is evaluated against
+ * projected state, so a permanent that gained the type from a type-changing effect is a legal
+ * target and one that lost it is not. The noun is bare — "Detective", not "Detective creature" —
+ * so it names the subtype and not the card type; found by the Assay differential.
  *
  * "Activate only as a sorcery" is [TimingRule.SorcerySpeed] — your main phase, empty stack. Note
  * this bars the usual "pump at end of the opponent's turn to blank a blocker" line; the vigilance
@@ -59,7 +60,7 @@ val InsideSource = card("Inside Source") {
         timing = TimingRule.SorcerySpeed
         val detective = target(
             "target Detective you control",
-            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.DETECTIVE))
+            TargetPermanent(filter = TargetFilter.PermanentYouControl.withSubtype(Subtype.DETECTIVE))
         )
         effect = Effects.Composite(
             Effects.ModifyStats(2, 0, detective),

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SunstarExpansionist.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/SunstarExpansionist.kt
@@ -5,7 +5,6 @@ import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -25,13 +24,17 @@ val SunstarExpansionist = card("Sunstar Expansionist") {
     power = 2
     toughness = 3
 
-    // ETB: Create Lander token if opponent controls more lands
+    // ETB: Create Lander token if opponent controls more lands.
+    //
+    // The "if" stands *between* the trigger event and the effect, so CR 603.4's intervening-"if"
+    // rule applies: the ability triggers only when the condition already holds, and it is checked
+    // again as the ability resolves. It used to be a `ConditionalEffect`, which is the model for the
+    // *trailing* "if" ("create a Lander token if an opponent controls more lands than you") — that
+    // one always triggers and decides on resolution. Found by the Assay differential.
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
-        effect = ConditionalEffect(
-            condition = Conditions.OpponentControlsMoreLands,
-            effect = Effects.CreateLander()
-        )
+        interveningIf = Conditions.OpponentControlsMoreLands
+        effect = Effects.CreateLander()
     }
 
     // Landfall: +1/+0 until end of turn when land enters

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ShockingSharpshooter.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/ShockingSharpshooter.kt
@@ -6,7 +6,6 @@ import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
  * Shocking Sharpshooter — Tarkir: Dragonstorm #121
@@ -18,7 +17,10 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  * Whenever another creature you control enters, this creature deals 1 damage to
  * target opponent.
  *
- * The damage is dealt by this creature itself (damageSource = Self).
+ * The damage is dealt by this creature itself, which is `damageSource`'s documented default: "when
+ * null the engine attributes the damage to the resolving spell/ability's source (the trigger's
+ * source for triggered abilities)". The explicit `Self` override that used to be here said the same
+ * thing a second way, and the Assay differential reported the card against the sentence it prints.
  */
 val ShockingSharpshooter = card("Shocking Sharpshooter") {
     manaCost = "{1}{R}"
@@ -34,7 +36,7 @@ val ShockingSharpshooter = card("Shocking Sharpshooter") {
     triggeredAbility {
         trigger = Triggers.OtherCreatureEnters
         val t = target("target", Targets.Opponent)
-        effect = Effects.DealDamage(1, t, damageSource = EffectTarget.Self)
+        effect = Effects.DealDamage(1, t)
     }
 
     metadata {

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -6471,14 +6471,14 @@
     "name": "Finneas, Ace Archer",
     "manaCost": "{G}{W}",
     "typeLine": "Legendary Creature — Rabbit Archer",
-    "oracleText": "Vigilance, reach\nWhenever Finneas attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card.",
+    "oracleText": "Reach, vigilance\nWhenever Finneas attacks, put a +1/+1 counter on each other creature you control that's a token or a Rabbit. Then if creatures you control have total power 10 or greater, draw a card.",
     "creatureStats": {
         "power": 2,
         "toughness": 2
     },
     "keywords": [
-        "VIGILANCE",
-        "REACH"
+        "REACH",
+        "VIGILANCE"
     ],
     "script": {
         "triggeredAbilities": [
@@ -7158,14 +7158,14 @@
     "name": "Frilled Sparkshooter",
     "manaCost": "{3}{R}",
     "typeLine": "Creature — Lizard Archer",
-    "oracleText": "Menace, reach\nThis creature enters with a +1/+1 counter on it if an opponent lost life this turn.",
+    "oracleText": "Reach, menace\nThis creature enters with a +1/+1 counter on it if an opponent lost life this turn.",
     "creatureStats": {
         "power": 3,
         "toughness": 3
     },
     "keywords": [
-        "MENACE",
-        "REACH"
+        "REACH",
+        "MENACE"
     ],
     "script": {
         "replacementEffects": [
@@ -7205,15 +7205,15 @@
     "name": "Galewind Moose",
     "manaCost": "{4}{G}{G}",
     "typeLine": "Creature — Elemental Elk",
-    "oracleText": "Flash\nVigilance, reach, trample",
+    "oracleText": "Flash\nReach, vigilance, trample",
     "creatureStats": {
         "power": 6,
         "toughness": 6
     },
     "keywords": [
         "FLASH",
-        "VIGILANCE",
         "REACH",
+        "VIGILANCE",
         "TRAMPLE"
     ],
     "metadata": {
@@ -8963,7 +8963,7 @@
     "name": "Hunter's Talent",
     "manaCost": "{1}{G}",
     "typeLine": "Enchantment — Class",
-    "oracleText": "When this Class enters the battlefield, target creature you control deals damage equal to its power to target creature you don't control.\n{1}{G}: Level 2 — Whenever you attack, target attacking creature gets +1/+0 and gains trample until end of turn.\n{3}{G}: Level 3 — At the beginning of your end step, if you control a creature with power 4 or greater, draw a card.",
+    "oracleText": "When this Class enters, target creature you control deals damage equal to its power to target creature you don't control.\n{1}{G}: Level 2 — Whenever you attack, target attacking creature gets +1/+0 and gains trample until end of turn.\n{3}{G}: Level 3 — At the beginning of your end step, if you control a creature with power 4 or greater, draw a card.",
     "script": {
         "triggeredAbilities": [
             {
@@ -9468,7 +9468,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "DealDamage",
                     "amount": {
@@ -10965,7 +10965,7 @@
     "name": "Lumra, Bellow of the Woods",
     "manaCost": "{4}{G}{G}",
     "typeLine": "Legendary Creature — Elemental Bear",
-    "oracleText": "Vigilance, reach\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra, Bellow of the Woods enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
+    "oracleText": "Reach, vigilance\nLumra, Bellow of the Woods's power and toughness are each equal to the number of lands you control.\nWhen Lumra, Bellow of the Woods enters, mill four cards. Then return all land cards from your graveyard to the battlefield tapped.",
     "creatureStats": {
         "power": {
             "type": "Dynamic",
@@ -10985,8 +10985,8 @@
         }
     },
     "keywords": [
-        "VIGILANCE",
-        "REACH"
+        "REACH",
+        "VIGILANCE"
     ],
     "script": {
         "triggeredAbilities": [
@@ -14144,6 +14144,7 @@
     "name": "Quaketusk Boar",
     "manaCost": "{3}{R}{R}",
     "typeLine": "Creature — Elemental Boar",
+    "oracleText": "Reach, trample, haste",
     "creatureStats": {
         "power": 5,
         "toughness": 5
@@ -16853,7 +16854,7 @@
     "name": "Short Bow",
     "manaCost": "{2}",
     "typeLine": "Artifact — Equipment",
-    "oracleText": "Equipped creature gets +1/+1 and has vigilance and reach.\nEquip {1}",
+    "oracleText": "Equipped creature gets +1/+1 and has reach and vigilance.\nEquip {1}",
     "script": {
         "activatedAbilities": [
             {
@@ -16893,11 +16894,11 @@
             },
             {
                 "type": "GrantKeyword",
-                "keyword": "VIGILANCE"
+                "keyword": "REACH"
             },
             {
                 "type": "GrantKeyword",
-                "keyword": "REACH"
+                "keyword": "VIGILANCE"
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/BLC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLC.json
@@ -1802,7 +1802,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": "AddManaOfChoice"
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -15118,7 +15118,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "CreateToken",
                     "power": 3,

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -4696,7 +4696,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "GainLife",
                     "amount": {
@@ -4740,7 +4740,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "CreateToken",
                     "power": 2,
@@ -6186,7 +6186,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Gated",
                     "gate": {
@@ -6386,7 +6386,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ForEach",
                     "space": {
@@ -7304,7 +7304,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {
@@ -7350,7 +7350,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Composite",
                     "effects": [
@@ -9941,7 +9941,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {
@@ -12216,7 +12216,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {
@@ -13452,7 +13452,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "AddCounters",
                     "counterType": "+1/+1",
@@ -15376,27 +15376,21 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Gated",
-                    "gate": {
-                        "type": "Gate.WhenCondition",
-                        "condition": {
-                            "type": "Compare",
-                            "left": {
-                                "type": "AggregateBattlefield",
-                                "player": "EachOpponent",
-                                "filter": "land"
-                            },
-                            "operator": "GT",
-                            "right": {
-                                "type": "AggregateBattlefield",
-                                "player": "You",
-                                "filter": "land"
-                            }
-                        }
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Lander"
+                },
+                "interveningIf": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "EachOpponent",
+                        "filter": "land"
                     },
-                    "then": {
-                        "type": "CreatePredefinedToken",
-                        "tokenType": "Lander"
+                    "operator": "GT",
+                    "right": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
                     }
                 }
             },
@@ -15407,7 +15401,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {
@@ -16590,7 +16584,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Composite",
                     "effects": [
@@ -17106,7 +17100,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Composite",
                     "effects": [

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -6274,7 +6274,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "AddDynamicCounters",
                     "counterType": "+1/+1",

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -729,7 +729,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {
@@ -2978,7 +2978,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {
@@ -15336,7 +15336,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "AddCounters",
                     "counterType": "+1/+1",
@@ -15848,7 +15848,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Gated",
                     "gate": "Gate.MayDecide",
@@ -18340,7 +18340,7 @@
                         "filter": "land ctrl:you",
                         "to": "Battlefield"
                     },
-                    "binding": "OTHER",
+                    "binding": "ANY",
                     "effect": {
                         "type": "ForEach",
                         "space": {
@@ -23110,7 +23110,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {

--- a/mtg-sets/src/test/resources/snapshots/cards/HOB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOB.json
@@ -1037,7 +1037,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "AddCounters",
                     "counterType": "+1/+1",
@@ -2005,7 +2005,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {
@@ -2618,7 +2618,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "CreateToken",
                     "power": 2,
@@ -2956,7 +2956,7 @@
                             "filter": "land ctrl:you",
                             "to": "Battlefield"
                         },
-                        "binding": "OTHER",
+                        "binding": "ANY",
                         "effect": {
                             "type": "CreateToken",
                             "power": 1,
@@ -8084,7 +8084,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Gated",
                     "gate": "Gate.MayDecide",
@@ -10517,7 +10517,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Gated",
                     "gate": {
@@ -13102,7 +13102,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Composite",
                     "effects": [
@@ -13232,7 +13232,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "CreateToken",
                     "power": 1,

--- a/mtg-sets/src/test/resources/snapshots/cards/JMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JMP.json
@@ -28,7 +28,7 @@
                 "powerBonus": 1,
                 "toughnessBonus": 1,
                 "filter": {
-                    "baseFilter": "creature Pirate ctrl:you",
+                    "baseFilter": "permanent Pirate ctrl:you",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -20261,7 +20261,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": "Transform",
                 "interveningIf": {
                     "type": "Compare",

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -3265,7 +3265,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": "TheRingTemptsYou",
                 "interveningIf": {
                     "type": "Exists",
@@ -17105,7 +17105,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Composite",
                     "effects": [

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -253,7 +253,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "GainLife",
                     "amount": {

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -377,7 +377,7 @@
                     "type": "Exists",
                     "player": "You",
                     "zone": "Battlefield",
-                    "filter": "creature Dragon"
+                    "filter": "permanent Dragon"
                 }
             }
         ]
@@ -412,7 +412,7 @@
                 "id": "ability_1",
                 "trigger": {
                     "type": "ZoneChangeEvent",
-                    "filter": "creature Dragon nontoken ctrl:you",
+                    "filter": "permanent Dragon nontoken ctrl:you",
                     "to": "Battlefield"
                 },
                 "binding": "OTHER",
@@ -447,7 +447,7 @@
                     "space": {
                         "type": "IterationSpace.Group",
                         "filter": {
-                            "baseFilter": "creature Dragon ctrl:you"
+                            "baseFilter": "permanent Dragon ctrl:you"
                         }
                     },
                     "body": {

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -6092,7 +6092,7 @@
                     {
                         "type": "TargetObject",
                         "filter": {
-                            "baseFilter": "creature Detective ctrl:you"
+                            "baseFilter": "permanent Detective ctrl:you"
                         },
                         "id": "target Detective you control"
                     }

--- a/mtg-sets/src/test/resources/snapshots/cards/MSH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MSH.json
@@ -3473,7 +3473,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Composite",
                     "effects": [
@@ -10055,7 +10055,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "CreatePredefinedToken",
                     "tokenType": "Moloid"

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -16848,7 +16848,7 @@
                     "atom": {
                         "type": "AtomTapPermanents",
                         "count": 5,
-                        "filter": "creature Elf"
+                        "filter": "permanent Elf"
                     }
                 },
                 "effect": {

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -2650,7 +2650,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "AddCounters",
                     "counterType": "+1/+1",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -4035,7 +4035,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "CreatePredefinedToken",
                     "tokenType": "Clue"

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -16553,7 +16553,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": "BecomePrepared",
                 "descriptionOverride": "Landfall — Whenever a land you control enters, Tam becomes prepared."
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -4001,7 +4001,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "CreateToken",
                     "power": 4,
@@ -14217,8 +14217,7 @@
                     "target": {
                         "type": "BoundVariable",
                         "name": "target"
-                    },
-                    "damageSource": "Self"
+                    }
                 },
                 "targetRequirement": {
                     "type": "TargetOpponent",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -6915,7 +6915,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Composite",
                     "effects": [
@@ -15216,7 +15216,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Composite",
                     "effects": [

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -13090,7 +13090,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "AddCounters",
                     "counterType": "charge",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -13,7 +13,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "ModifyStats",
                     "powerModifier": {

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -181,7 +181,7 @@
                     "filter": "land ctrl:you",
                     "to": "Battlefield"
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Modal",
                     "modes": [

--- a/oracle-assay/AGENTS.md
+++ b/oracle-assay/AGENTS.md
@@ -151,6 +151,17 @@ both are worth knowing before touching a leaf: a subtype is a *proper noun* stan
 own type list — an ungated one reads "**Other** creatures you control get +0/+1." as a tribe called
 *Other*, byte-perfect and wrong, which the differential caught and the README records.
 
+The **Bloomburrow band** is the third, and it is the shape of a set picked *because it is already
+implemented*: every card in it has a golden, so every declined line is a grammar gap whose answer is
+written and whose fix the differential confirms on the same run. That is where it paid — four pieces
+of machinery moved 594 cards corpus-wide and surfaced sixteen bugs in the *corpus*, one of them in an
+`mtg-sdk` trigger facade that 29 cards share. Two of the four went outside `grammar/` again, and the
+reason is the one this file keeps stating: an ability word has no rules meaning (CR 207.2c), so it is
+printed shape and belongs to `normalize/`, exactly where the attachment noun went. The other lesson
+is subtractive — the keyword *run* deleted two rules while covering more, because the count belonged
+in the slot and not in the rule, and a family with a `pairForm` boolean in it is a family with an
+axis it has not named yet.
+
 ## Fail-closed matching — the rule that catches the dangerous bug class
 
 **A `match` half reconstructs what `build` would have produced and compares the whole model.** Not a

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -143,21 +143,22 @@ non-zero on. Declines are not failures.
 
 ```
 Cards assayed                    34882
-Ability lines                    66793  (38865 unique)
+Ability lines                    66793  (38843 unique)
 
-Round-trips byte-exact           24139   361.4‰ (36.1%)
-Alternate spelling normalized    1120
-Declined                         41534
+Round-trips byte-exact           24993   374.2‰ (37.4%)
+Alternate spelling normalized    1247
+Declined                         40553
 Ambiguous — distinct readings    0
 Print mismatch                   0
 Normalization not invertible     0
 Full inverse not reproduced      0
 Redundant readings (same model)  0
 
-Cards fully covered              6583 / 34882   188.7‰ (18.9%)
+Cards fully covered              7177 / 34882   205.8‰ (20.6%)
 Vanilla + keyword-only cards     1444 / 1712   843.5‰ (84.3%)   <- Phase 1 target
 Portal (set POR)                 200 / 200     1000.0‰ (100%)   <- the Portal band's target
 Legions (set LGN)                145 / 145     1000.0‰ (100%)   <- the Legions band's target
+Bloomburrow (set BLB)            58 / 280      207.1‰ (20.7%)   <- the Bloomburrow band, in progress
 Reminder-text glosses            2870 matched · 114 differed · 965 unglossed
 ```
 
@@ -461,6 +462,73 @@ the pre-band measurement and can only have risen, since a card blocked by two fa
 sole-blocked by neither.) A flat tail is the shape the equipment band's residue had, and it is the
 signal that the next target is a *set* rather than a family.
 
+## The Bloomburrow band
+
+Bloomburrow is 280 cards, every one of them implemented by hand here, which makes it the first set
+picked *because* the goldens exist: every line it declines is a grammar gap whose known-good answer
+is already written, and the differential confirms each one the moment it parses. The band took the
+set 42 → **58 cards** and the whole corpus 6,583 → **7,177**, and it is four pieces of machinery plus
+rows — the ratio the module's "cards covered per rule" curve is watching for.
+
+**A granted keyword is a run, not a keyword.** `Keywords.keywordRun` spells "trample",
+"lifelink and indestructible" and "trample, hexproof, and indestructible" as the list the model
+actually holds, and every grant position slots it: to a target, to a group, to the source, to the
+enchanted permanent. It *replaced* rules rather than adding them — `SelfSteps` carried a
+two-keyword rule with no singular sibling, which is what a family looks like before it is one, and
+`Statics.conditionalSelfStatic` collapsed a `pairForm` boolean into a three-member enum that also
+gained the keyword-only sentence ("As long as you've lost life this turn, ~ has flying and
+vigilance") for free. One grant is the bare effect and several are a composite, because that is what
+`CompositeEffect` means and what every hand-written card holds; a rule that printed the singular as
+a one-element composite would have disagreed with all of them.
+
+**A token's count, colours and keywords are slots.** Six rows out of two axes — the count ("a",
+a number word, "X") and the keyword rider — plus a colour *run* with `keywordRun`'s shape over
+`Set<Color>`. The sets have no order and the printed sentence needs one, so colours print WUBRG and
+keywords print in `Keyword`'s declaration order: both are `Color`/`Keyword`'s own, and a card that
+built its set the other way round still prints the sentence Oracle prints. The predefined nouns
+(Food, Treasure, Clue, Blood, Map, Lander, Shard) are a second family, each row calling the facade
+the SDK publishes for it — with "investigate" deliberately left out, because CR 701.36a makes it the
+same model as "create a Clue token" and two canonical spellings would leave printing undecided.
+
+**An ability word is printed shape, and belongs to normalization.** CR 207.2c: *"they have no
+special rules meaning and no individual entries in the Comprehensive Rules."* So `Landfall — `,
+`Threshold — ` and `Valiant — ` come off the line, are recorded per line index, and go back on in
+`restore` — the alternative being a grammar rule per ability word wrapping every sentence the grammar
+already reads, which is the multiplicative cost "lift, don't re-spell" exists to refuse. The list is
+**CR 207.2c's, verbatim, rather than a pattern**: CR 207.2d's *flavor* words have the identical
+printed shape and are unbounded, and so is a Saga's `I —` and a Class's `Level 2 —`. Worth 106 cards
+corpus-wide on its own, and it is what let the differential see the landfall bug below.
+
+Then three rows: Valiant's trigger (one `TriggerSpec` the SDK already publishes), "deals N damage to
+target opponent", and Threshold's graveyard count — which turned the hand-size comparison into a
+two-member shape over (player, zone, direction).
+
+**What it found.** Fifteen bugs in hand-written cards and one in `mtg-sdk`, every one surfaced by the
+differential on the day a line stopped declining:
+
+- **`Triggers.LandYouControlEnters` was `TriggerBinding.OTHER`** — one facade, 29 cards. No landfall
+  ability prints "another"; the distinction is invisible on a creature and load-bearing on a *land*
+  with a landfall trigger, which under `OTHER` would silently not see itself enter.
+- **Five more bare-noun-is-permanents cards** — Kargan Dragonrider, Corsair Captain, Lathliss,
+  Inside Source, Voice of the Woods, all `IsCreature` where the printed noun names only a subtype.
+  The same class the bare-tribal-noun migration fixed; these were never comparable before.
+- **Sunstar Expansionist read its intervening "if" as a resolution-time gate** — "When this creature
+  enters, **if** an opponent controls more lands than you, …" is CR 603.4, checked when the trigger
+  would go on the stack *and* again on resolution, not a `Gate.WhenCondition` that always triggers.
+- **Seven BLB cards printed text the card does not have** — five keyword runs in the wrong order
+  (Scryfall prints "Reach, vigilance"), Hunter's Talent on the pre-Bloomburrow "enters the
+  battlefield" wording, and Quaketusk Boar with no `oracleText` at all.
+- **Shocking Sharpshooter restated a documented default** — `damageSource = Self` is what `null`
+  already means for a permanent's own triggered ability. 72 other cards carry the same redundancy
+  and will surface as the grammar widens; it is *not* folded, because the field means something
+  when it is set to anything else.
+
+**Where the ranking points next, inside this set.** Gift is the largest family left by a wide margin
+— **17 BLB cards are sole-blocked by it** — and it is two halves rather than one: the `Gift a card`
+keyword line and the `If the gift was promised, …` rider, the second of which needs its base clause
+to read first. After it: the Class levels (`{3}{U}: Level 2`, 10 cards), modal spells (8), and
+"Spend this mana only to cast …" (6).
+
 ## What Phase 1 already found
 
 The report is two documents at once, and the second one is about `mtg-sdk`:
@@ -506,15 +574,15 @@ named population bucket instead and the denominator stays visible.
 
 ```
   Hand-written cards                 9127
-    compared                         2495
-    not yet covered by the grammar   5995
-    script slot not modelled yet      83
-    lines do not fold into one card   50
+    compared                         2698
+    not yet covered by the grammar   5789
+    script slot not modelled yet      88
+    lines do not fold into one card   54
     multi-face (out of scope)        301
-    Oracle text differs from golden  203
+    Oracle text differs from golden  197
     golden would not decode            0
 
-  Confirmed — models agree           2494    999.6‰ (100.0%)
+  Confirmed — models agree           2697    999.6‰ (100.0%)
   DIVERGENT — read every one            1
 ```
 

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Conditions.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Conditions.kt
@@ -89,31 +89,54 @@ object Conditions {
             SdkConditions.Not(SdkConditions.OpponentControls(it))
         },
         // Lavaborn Muse's intervening-if. "That player" is the one whose step triggered, which the
-        // SDK names as `Player.TriggeringPlayer`, so the condition is a hand-size comparison against
-        // that player and the only variable is the number. It is written as a `Compare` rather than
-        // through a facade because `Conditions` publishes no hand-size entry — the same situation
-        // [Replacements] and the combat statics are in, and reported as the small SDK finding it is.
-        phrase<Condition>(
+        // SDK names as `Player.TriggeringPlayer`.
+        zoneCount(
             "that player has {n} or fewer cards in hand",
-            name = "the triggering player's hand size",
-        ) {
+            "the triggering player's hand size",
+            Player.TriggeringPlayer,
+            Zone.HAND,
+            ComparisonOperator.LTE,
+        ),
+        // Threshold's own condition, and the second member of the shape above rather than a second
+        // rule: both count one zone for one player against a spelled number, and the two differ only
+        // in which zone, whose, and which way the comparison points.
+        zoneCount(
+            "there are {n} or more cards in your graveyard",
+            "your graveyard's size",
+            Player.You,
+            Zone.GRAVEYARD,
+            ComparisonOperator.GTE,
+        ),
+    )
+
+    /**
+     * "There are seven or more cards in your graveyard", "that player has two or fewer cards in
+     * hand" — a zone's card count against a number the text spells.
+     *
+     * Written as a `Compare` rather than through a facade because `Conditions` publishes no
+     * zone-count entry — the same situation [Replacements] and the combat statics are in, and
+     * reported as the small SDK finding it is rather than routed around.
+     */
+    private fun zoneCount(
+        template: String,
+        name: String,
+        player: Player,
+        zone: Zone,
+        operator: ComparisonOperator,
+    ): Phrase<Condition> {
+        fun conditionFor(limit: Int): Condition =
+            Compare(DynamicAmount.Count(player, zone), operator, DynamicAmount.Fixed(limit))
+        return phrase(template, name = name) {
             slot("n", Cardinals.word)
-            build { handSizeAtMost(it.int("n")) }
+            build { conditionFor(it.int("n")) }
             match { value ->
                 val compare = value as? Compare ?: return@match null
                 val limit = (compare.right as? DynamicAmount.Fixed)?.amount ?: return@match null
-                if (!Cardinals.spellable(limit) || value != handSizeAtMost(limit)) return@match null
+                if (!Cardinals.spellable(limit) || value != conditionFor(limit)) return@match null
                 bind("n" to limit)
             }
-        },
-    )
-
-    /** "That player has N or fewer cards in hand" — the comparison Lavaborn Muse checks twice. */
-    private fun handSizeAtMost(limit: Int): Condition = Compare(
-        DynamicAmount.Count(Player.TriggeringPlayer, Zone.HAND),
-        ComparisonOperator.LTE,
-        DynamicAmount.Fixed(limit),
-    )
+        }
+    }
 
     val condition: Phrase<Condition> = oneOf("a condition", all)
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Keywords.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Keywords.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.constant
 import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.assay.syntax.separated
 import com.wingedsheep.sdk.core.CardType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.ManaCost
@@ -173,6 +174,62 @@ object Keywords {
      */
     val keyword: Phrase<Keyword> =
         oneOf("a keyword", SIMPLE_KEYWORDS.map { (keyword, surface) -> constant(surface, keyword) })
+
+    /**
+     * "trample", "lifelink and indestructible", "trample, hexproof, and indestructible" — the
+     * keywords **one** grant clause hands out.
+     *
+     * A grant sentence names a list, not a keyword. CR 702's templating joins the members with the
+     * ordinary English series comma and a final "and", and the SDK models each member as its own
+     * `GrantKeyword` — so the printed run and the model's list are the same list, and every rule that
+     * grants (to a target, to a group, to the source, to an enchanted permanent) slots this instead
+     * of [keyword].
+     *
+     * This is [Primitives.scopeRun]'s shape one level up, with one member added: the run includes
+     * the **singleton**, because a grant rule has exactly one keyword slot and the count is what
+     * varies. The three alternatives take disjoint list sizes, so nothing is left for the printer to
+     * choose — which is what lets one rule replace the "gains X", "gains X and Y" pairs the file used
+     * to carry as separate rules, rather than adding a third.
+     */
+    private val keywordSingleton: Phrase<List<Keyword>> = phrase("{one}", name = "one keyword") {
+        slot("one", keyword)
+        build { listOf(it.value<Keyword>("one")) }
+        match { it.singleOrNull()?.let { only -> bind("one" to only) } }
+    }
+
+    private val keywordPair: Phrase<List<Keyword>> =
+        phrase("{first} and {second}", name = "two keywords") {
+            slot("first", keyword)
+            slot("second", keyword)
+            build { listOf(it.value<Keyword>("first"), it.value<Keyword>("second")) }
+            match { keywords ->
+                keywords.takeIf { it.size == 2 }?.let { bind("first" to it[0], "second" to it[1]) }
+            }
+        }
+
+    /** "trample, hexproof, and indestructible" — three or more, with the printed Oxford comma. */
+    private val keywordSeries: Phrase<List<Keyword>> =
+        phrase("{most}, and {last}", name = "three or more keywords") {
+            slot("most", separated("keywords", keyword, ", ", min = 2))
+            slot("last", keyword)
+            build { it.value<List<Keyword>>("most") + it.value<Keyword>("last") }
+            match { keywords ->
+                keywords.takeIf { it.size >= 3 }
+                    ?.let { bind("most" to it.dropLast(1), "last" to it.last()) }
+            }
+        }
+
+    /** One or more keywords, joined the way printed Oracle text joins them. See above. */
+    val keywordRun: Phrase<List<Keyword>> =
+        oneOf("one or more keywords", keywordSingleton, keywordPair, keywordSeries)
+
+    /**
+     * Two or more, for the one position where the singleton is spoken for: a static-ability *line*
+     * already has a single-ability rule ([Statics.attachedKeyword]) reached through the one-element
+     * lift, so admitting the singleton here would give one text two readings of the same model.
+     */
+    val severalKeywords: Phrase<List<Keyword>> =
+        oneOf("two or more keywords", keywordPair, keywordSeries)
 
     /**
      * Keywords the SDK models as their own object rather than as [KeywordAbility.Simple].

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/SelfSteps.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/SelfSteps.kt
@@ -76,7 +76,7 @@ object SelfSteps {
         val named = listOf(
             selfGets(target, subject, tag),
             selfGetsAndGains(target, subject, tag),
-            selfGainsTwoKeywords(target, subject, tag),
+            selfGainsKeywords(target, subject, tag),
             selfLosesKeyword(target, subject, tag),
             move("untap {self}", "untap$tag", Effects.Untap(target), subject),
             move("regenerate {self}", "regenerate$tag", RegenerateEffect(target), subject),
@@ -194,60 +194,55 @@ object SelfSteps {
         subject: Phrase<Unit>,
         tag: String,
     ): Phrase<CardScript> {
-        fun scriptFor(modifiers: Pair<Int, Int>, keyword: Keyword) = CardScript(
+        fun scriptFor(modifiers: Pair<Int, Int>, keywords: List<Keyword>) = CardScript(
             spellEffect = Effects.Composite(
-                listOf(
-                    Effects.ModifyStats(modifiers.first, modifiers.second, target),
-                    Effects.GrantKeyword(keyword, target),
-                )
+                listOf(Effects.ModifyStats(modifiers.first, modifiers.second, target)) +
+                    keywords.map { Effects.GrantKeyword(it, target) }
             )
         )
         return phrase(
-            "{self} gets {mod} and gains {kw} until end of turn",
+            "{self} gets {mod} and gains {kws} until end of turn",
             name = "$tag gets and gains".trim(),
         ) {
             slot("self", subject)
             slot("mod", Primitives.statModifiers)
-            slot("kw", Keywords.keyword)
-            build { scriptFor(it.value("mod"), it.value("kw")) }
+            slot("kws", Keywords.keywordRun)
+            build { scriptFor(it.value("mod"), it.value("kws")) }
             match { script ->
                 val effects = (script.spellEffect as? CompositeEffect)?.effects ?: return@match null
                 val modifiers = Steps.fixedModifiers(effects.firstOrNull()) ?: return@match null
-                val keyword = Steps.grantedKeyword(effects.getOrNull(1)) ?: return@match null
-                if (script != scriptFor(modifiers, keyword)) return@match null
-                bind("self" to Unit, "mod" to modifiers, "kw" to keyword)
+                val keywords = Steps.grantedKeywords(effects.drop(1)) ?: return@match null
+                if (script != scriptFor(modifiers, keywords)) return@match null
+                bind("self" to Unit, "mod" to modifiers, "kws" to keywords)
             }
         }
     }
 
-    /** "~ gains flying and shroud until end of turn." — Warped Researcher. Two grants, one sentence. */
-    private fun selfGainsTwoKeywords(
+    /**
+     * "~ gains trample until end of turn.", "~ gains flying and shroud until end of turn." — Warped
+     * Researcher and every card that grants itself a run.
+     *
+     * One rule over [Keywords.keywordRun] rather than one per count. It used to be a two-keyword
+     * rule with no singular sibling, which is the shape a family looks like before it is one: the
+     * count was in the rule instead of in the slot, so "gains trample" had nowhere to parse.
+     */
+    private fun selfGainsKeywords(
         target: EffectTarget,
         subject: Phrase<Unit>,
         tag: String,
     ): Phrase<CardScript> {
-        fun scriptFor(first: Keyword, second: Keyword) = CardScript(
-            spellEffect = Effects.Composite(
-                listOf(
-                    Effects.GrantKeyword(first, target),
-                    Effects.GrantKeyword(second, target),
-                )
-            )
-        )
+        fun scriptFor(keywords: List<Keyword>) = CardScript(spellEffect = Steps.grants(keywords, target))
         return phrase(
-            "{self} gains {kw} and {kw2} until end of turn",
-            name = "$tag gains two keywords".trim(),
+            "{self} gains {kws} until end of turn",
+            name = "$tag gains keywords".trim(),
         ) {
             slot("self", subject)
-            slot("kw", Keywords.keyword)
-            slot("kw2", Keywords.keyword)
-            build { scriptFor(it.value("kw"), it.value("kw2")) }
+            slot("kws", Keywords.keywordRun)
+            build { scriptFor(it.value("kws")) }
             match { script ->
-                val effects = (script.spellEffect as? CompositeEffect)?.effects ?: return@match null
-                val first = Steps.grantedKeyword(effects.firstOrNull()) ?: return@match null
-                val second = Steps.grantedKeyword(effects.getOrNull(1)) ?: return@match null
-                if (script != scriptFor(first, second)) return@match null
-                bind("self" to Unit, "kw" to first, "kw2" to second)
+                val keywords = Steps.grantedKeywords(script.spellEffect) ?: return@match null
+                if (script != scriptFor(keywords)) return@match null
+                bind("self" to Unit, "kws" to keywords)
             }
         }
     }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Statics.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Statics.kt
@@ -461,49 +461,73 @@ object Statics {
      * rather than a slot — a *conditional lord* is a different sentence with a noun phrase in it,
      * and it declines rather than being printed as one about this creature.
      */
+    /**
+     * What the conditional sentence says about the source: a stat change, a keyword run, or both.
+     *
+     * Three forms rather than three rules, for [Keywords.keywordRun]'s reason one level up — the
+     * count of granted keywords moved into the slot, and once it had, "gets +2/+0 and has trample"
+     * and "has flying and vigilance" were the same sentence with one clause missing. The forms take
+     * disjoint printed templates *and* disjoint ability lists (a pump is always first, and
+     * [KEYWORDS] has none), so nothing here is left for the printer to choose.
+     */
+    private enum class ConditionalForm(val pumps: Boolean, val grants: Boolean) {
+        PUMP(pumps = true, grants = false),
+        PUMP_AND_KEYWORDS(pumps = true, grants = true),
+        KEYWORDS(pumps = false, grants = true),
+    }
+
     private fun conditionalSelfStatic(
         leading: Boolean,
-        pairForm: Boolean,
+        form: ConditionalForm,
     ): Phrase<List<StaticAbility>> {
         fun abilitiesFor(
-            modifiers: Pair<Int, Int>,
-            keyword: Keyword?,
+            modifiers: Pair<Int, Int>?,
+            keywords: List<Keyword>,
             condition: Condition,
         ): List<StaticAbility> = listOfNotNull(
-            ConditionalStaticAbility(ModifyStats(modifiers.first, modifiers.second, GroupFilter.source()), condition),
-            keyword?.let { ConditionalStaticAbility(GrantKeyword(it, GroupFilter.source()), condition) },
-        )
+            modifiers?.let {
+                ConditionalStaticAbility(ModifyStats(it.first, it.second, GroupFilter.source()), condition)
+            },
+        ) + keywords.map { ConditionalStaticAbility(GrantKeyword(it, GroupFilter.source()), condition) }
 
-        val effect = "${Normalizer.SELF} gets {mod}" + if (pairForm) " and has {kw}" else ""
+        val effect = buildString {
+            append(Normalizer.SELF)
+            if (form.pumps) append(" gets {mod}")
+            if (form.grants) append(if (form.pumps) " and has {kws}" else " has {kws}")
+        }
         val template =
             if (leading) "as long as {cond}, $effect." else "$effect as long as {cond}."
-        val name = "the source gets" + (if (pairForm) " and has" else "") + " under a condition"
+        val name = "the source" + (if (form.pumps) " gets" else "") +
+            (if (form.grants) (if (form.pumps) " and has" else " has") else "") + " under a condition"
 
         val inner = phrase<List<StaticAbility>>(template, name = name) {
             slot("cond", Conditions.condition)
-            slot("mod", Primitives.statModifiers)
-            if (pairForm) slot("kw", Keywords.keyword)
+            if (form.pumps) slot("mod", Primitives.statModifiers)
+            if (form.grants) slot("kws", Keywords.keywordRun)
             build { bindings ->
                 abilitiesFor(
-                    bindings.value("mod"),
-                    if (pairForm) bindings.value<Keyword>("kw") else null,
+                    if (form.pumps) bindings.value<Pair<Int, Int>>("mod") else null,
+                    if (form.grants) bindings.value("kws") else emptyList(),
                     bindings.value("cond"),
                 )
             }
             match { abilities ->
-                if (abilities.size != (if (pairForm) 2 else 1)) return@match null
-                val first = abilities.first() as? ConditionalStaticAbility ?: return@match null
-                val stats = first.ability as? ModifyStats ?: return@match null
-                val keyword = if (pairForm) {
-                    val second = abilities[1] as? ConditionalStaticAbility ?: return@match null
-                    val grant = second.ability as? GrantKeyword ?: return@match null
-                    Keyword.entries.firstOrNull { it.name == grant.keyword } ?: return@match null
+                val first = abilities.firstOrNull() as? ConditionalStaticAbility ?: return@match null
+                val modifiers = if (form.pumps) {
+                    val stats = first.ability as? ModifyStats ?: return@match null
+                    stats.powerBonus to stats.toughnessBonus
                 } else {
                     null
                 }
-                val modifiers = stats.powerBonus to stats.toughnessBonus
-                if (abilities != abilitiesFor(modifiers, keyword, first.condition)) return@match null
-                bind("cond" to first.condition, "mod" to modifiers, "kw" to keyword)
+                val granted = abilities.drop(if (form.pumps) 1 else 0)
+                if (form.grants == granted.isEmpty()) return@match null
+                val keywords = granted.map { ability ->
+                    val conditional = ability as? ConditionalStaticAbility ?: return@match null
+                    val grant = conditional.ability as? GrantKeyword ?: return@match null
+                    Keyword.entries.firstOrNull { it.name == grant.keyword } ?: return@match null
+                }
+                if (abilities != abilitiesFor(modifiers, keywords, first.condition)) return@match null
+                bind("cond" to first.condition, "mod" to modifiers, "kws" to keywords)
             }
             canonical = !leading
         }
@@ -655,52 +679,87 @@ object Statics {
     }
 
     /**
-     * "Enchanted creature gets +2/+2 and has flying." — **two** static abilities from one sentence,
-     * the third time a printed phrase denotes several models rather than one.
+     * "Enchanted creature gets +2/+2 and has flying.", "…gets +2/+0 and has first strike, vigilance,
+     * trample, and haste." — a pump and **one static per granted keyword**, from one sentence.
      *
      * [Keywords.qualityRun] (CR 702.16g's joined protection) and [Mana.alternatives] ("{T}: Add {B}
-     * or {G}." as two abilities sharing a cost) are the other two, and the answer is the same one
-     * each time: the rule denotes a *list*, and the slot above lifts the ordinary single-ability
-     * line into the same shape so nothing downstream has to know which it got. What is emphatically
-     * not the answer is a compound SDK type meaning "pump and grant" — the model is already right,
-     * and there are exactly two abilities in it.
+     * or {G}." as two abilities sharing a cost) are the other rules that denote several models from
+     * one phrase, and the answer is the same one each time: the rule denotes a *list*, and [single]
+     * lifts the ordinary one-ability line into the same shape so nothing downstream has to know
+     * which it got. What is emphatically not the answer is a compound SDK type meaning "pump and
+     * grant" — the model is already right.
      *
-     * Written as one rule rather than as a family: it has one member. Twenty-seven hand-written
+     * The count of keywords is [Keywords.keywordRun]'s slot rather than the rule's, which is what
+     * makes Sword of Vengeance's four the same rule as Holy Strength's one. Twenty-seven hand-written
      * cards print this sentence and all twenty-seven order the statics as the text does, pump then
-     * grant, which is what makes the reconstruction below a comparison and not a convention. A card
-     * carrying them the other way round declines rather than being reordered into agreement.
+     * grants in printed order, which is what makes the reconstruction below a comparison and not a
+     * convention. A card carrying them the other way round declines rather than being reordered into
+     * agreement.
      */
     private val pumpAndKeyword: Phrase<List<StaticAbility>> = run {
-        fun abilitiesFor(modifiers: Pair<Int, Int>, keyword: Keyword) =
-            listOf(ModifyStats(modifiers.first, modifiers.second), GrantKeyword(keyword))
-        phrase("enchanted creature gets {mod} and has {kw}.", name = "enchanted creature gets and has") {
+        fun abilitiesFor(modifiers: Pair<Int, Int>, keywords: List<Keyword>) =
+            listOf<StaticAbility>(ModifyStats(modifiers.first, modifiers.second)) +
+                keywords.map { GrantKeyword(it) }
+        phrase("enchanted creature gets {mod} and has {kws}.", name = "enchanted creature gets and has") {
             slot("mod", Primitives.statModifiers)
-            slot("kw", Keywords.keyword)
-            build { abilitiesFor(it.value("mod"), it.value("kw")) }
+            slot("kws", Keywords.keywordRun)
+            build { abilitiesFor(it.value("mod"), it.value("kws")) }
             match { abilities ->
                 val stats = abilities.firstOrNull() as? ModifyStats ?: return@match null
-                val grant = abilities.getOrNull(1) as? GrantKeyword ?: return@match null
-                val keyword = Keyword.entries.firstOrNull { it.name == grant.keyword } ?: return@match null
+                val keywords = attachedKeywords(abilities.drop(1)) ?: return@match null
                 val modifiers = stats.powerBonus to stats.toughnessBonus
-                if (abilities != abilitiesFor(modifiers, keyword)) return@match null
-                bind("mod" to modifiers, "kw" to keyword)
+                if (abilities != abilitiesFor(modifiers, keywords)) return@match null
+                bind("mod" to modifiers, "kws" to keywords)
             }
         }
     }
 
     /**
-     * What one static-ability line denotes: usually one ability, and for [pumpAndKeyword] two.
+     * "Enchanted creature has reach and vigilance." — one sentence, one static *per keyword*.
      *
-     * The two alternatives take disjoint list sizes, so printing is decided by the model rather than
-     * by the alternation's order — the property every `oneOf` in this grammar is written to have.
+     * The line-level twin of [attachedKeyword], and two rules rather than one because a run of one
+     * is the single-ability rule reached through [single]: [Keywords.severalKeywords] therefore
+     * starts at two, so the two rules take disjoint list sizes and printing is decided by the model.
+     */
+    private val attachedKeywordRun: Phrase<List<StaticAbility>> =
+        phrase("enchanted creature has {kws}.", name = "enchanted creature has keywords") {
+            slot("kws", Keywords.severalKeywords)
+            build { it.value<List<Keyword>>("kws").map { keyword -> GrantKeyword(keyword) } }
+            match { abilities ->
+                if (abilities.size < 2) return@match null
+                val keywords = attachedKeywords(abilities) ?: return@match null
+                if (abilities != keywords.map { GrantKeyword(it) }) return@match null
+                bind("kws" to keywords)
+            }
+        }
+
+    /** The keywords a run of plain [GrantKeyword] statics names, or null if any is something else. */
+    private fun attachedKeywords(abilities: List<StaticAbility>): List<Keyword>? {
+        if (abilities.isEmpty()) return null
+        return abilities.map { ability ->
+            val grant = ability as? GrantKeyword ?: return null
+            Keyword.entries.firstOrNull { it.name == grant.keyword } ?: return null
+        }
+    }
+
+    /**
+     * What one static-ability line denotes: usually one ability, and for the rules that spell a
+     * keyword run, one per keyword — plus a pump where the sentence has one.
+     *
+     * The alternatives take disjoint list *shapes* — [single] is exactly one, [attachedKeywordRun]
+     * two or more grants, [pumpAndKeyword] a pump first, and each [ConditionalForm] a distinct
+     * combination of the two under a condition — so printing is decided by the model rather than by
+     * the alternation's order, the property every `oneOf` in this grammar is written to have.
      */
     val line: Phrase<List<StaticAbility>> = oneOf(
         "static abilities",
-        pumpAndKeyword,
-        conditionalSelfStatic(leading = false, pairForm = false),
-        conditionalSelfStatic(leading = true, pairForm = false),
-        conditionalSelfStatic(leading = false, pairForm = true),
-        conditionalSelfStatic(leading = true, pairForm = true),
-        single,
+        listOf(pumpAndKeyword, attachedKeywordRun) +
+            ConditionalForm.entries.flatMap { form ->
+                listOf(
+                    conditionalSelfStatic(leading = false, form = form),
+                    conditionalSelfStatic(leading = true, form = form),
+                )
+            } +
+            single,
     )
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Steps.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Steps.kt
@@ -324,6 +324,16 @@ object Steps {
             },
             count = ::damageDealt,
         ),
+        countedStep(
+            "{self} deals {n} damage to target opponent", "deals damage to target opponent",
+            script = {
+                CardScript(
+                    spellEffect = Effects.DealDamage(it, Targets.bound()),
+                    targetRequirements = listOf(Targets.opponent()),
+                )
+            },
+            count = ::damageDealt,
+        ),
         // "Target opponent or planeswalker" is the modern redirection wording, and it is a
         // requirement type of its own rather than a filter — so it is a row beside "target player"
         // rather than a case inside it.
@@ -688,22 +698,30 @@ object Steps {
         )
     }
 
-    /** "Target creature gains flying until end of turn." — the pump rule's keyword sibling. */
+    /**
+     * "Target creature gains flying until end of turn.", "…gains trample and lifelink until end of
+     * turn." — the pump rule's keyword sibling, over [Keywords.keywordRun] rather than one keyword.
+     *
+     * One grant is the bare effect and several are a composite, which is not a special case but the
+     * SDK's own shape: `CompositeEffect` means "these effects, in order", and a list of one has
+     * nothing to sequence. Reading it the other way would print every single-keyword card's model as
+     * a one-element composite and disagree with every hand-written card that spells it.
+     */
     private val grantToTargetPermanent: Phrase<CardScript> = run {
-        fun scriptFor(keyword: Keyword, filter: GameObjectFilter) = CardScript(
-            spellEffect = Effects.GrantKeyword(keyword, Targets.bound()),
+        fun scriptFor(keywords: List<Keyword>, filter: GameObjectFilter) = CardScript(
+            spellEffect = grants(keywords, Targets.bound()),
             targetRequirements = listOf(Targets.permanent(filter)),
         )
-        phrase("target {filter} gains {kw} until end of turn", name = "grant a keyword to a target") {
+        phrase("target {filter} gains {kws} until end of turn", name = "grant keywords to a target") {
             slot("filter", Filters.filter)
-            slot("kw", Keywords.keyword)
-            build { scriptFor(it.value("kw"), it.value("filter")) }
+            slot("kws", Keywords.keywordRun)
+            build { scriptFor(it.value("kws"), it.value("filter")) }
             match { script ->
-                val keyword = grantedKeyword(script.spellEffect) ?: return@match null
+                val keywords = grantedKeywords(script.spellEffect) ?: return@match null
                 val requirement = script.targetRequirements.singleOrNull() ?: return@match null
                 val filter = Targets.permanentFilter(requirement) ?: return@match null
-                if (script != scriptFor(keyword, filter)) return@match null
-                bind("filter" to filter, "kw" to keyword)
+                if (script != scriptFor(keywords, filter)) return@match null
+                bind("filter" to filter, "kws" to keywords)
             }
         }
     }
@@ -718,31 +736,33 @@ object Steps {
      * would buy is nothing.
      */
     private val pumpAndGrantTarget: Phrase<CardScript> = run {
-        fun scriptFor(modifiers: Pair<Int, Int>, keyword: Keyword, filter: GameObjectFilter) = CardScript(
+        fun scriptFor(
+            modifiers: Pair<Int, Int>,
+            keywords: List<Keyword>,
+            filter: GameObjectFilter,
+        ) = CardScript(
             spellEffect = Effects.Composite(
-                listOf(
-                    Effects.ModifyStats(modifiers.first, modifiers.second, Targets.bound()),
-                    Effects.GrantKeyword(keyword, Targets.bound()),
-                )
+                listOf(Effects.ModifyStats(modifiers.first, modifiers.second, Targets.bound())) +
+                    keywords.map { Effects.GrantKeyword(it, Targets.bound()) }
             ),
             targetRequirements = listOf(Targets.permanent(filter)),
         )
         phrase(
-            "target {filter} gets {mod} and gains {kw} until end of turn",
-            name = "pump and grant a keyword to a target",
+            "target {filter} gets {mod} and gains {kws} until end of turn",
+            name = "pump and grant keywords to a target",
         ) {
             slot("filter", Filters.filter)
             slot("mod", Primitives.statModifiers)
-            slot("kw", Keywords.keyword)
-            build { scriptFor(it.value("mod"), it.value("kw"), it.value("filter")) }
+            slot("kws", Keywords.keywordRun)
+            build { scriptFor(it.value("mod"), it.value("kws"), it.value("filter")) }
             match { script ->
                 val effects = (script.spellEffect as? CompositeEffect)?.effects ?: return@match null
                 val modifiers = fixedModifiers(effects.firstOrNull()) ?: return@match null
-                val keyword = grantedKeyword(effects.getOrNull(1)) ?: return@match null
+                val keywords = grantedKeywords(effects.drop(1)) ?: return@match null
                 val requirement = script.targetRequirements.singleOrNull() ?: return@match null
                 val filter = Targets.permanentFilter(requirement) ?: return@match null
-                if (script != scriptFor(modifiers, keyword, filter)) return@match null
-                bind("filter" to filter, "mod" to modifiers, "kw" to keyword)
+                if (script != scriptFor(modifiers, keywords, filter)) return@match null
+                bind("filter" to filter, "mod" to modifiers, "kws" to keywords)
             }
         }
     }
@@ -1060,29 +1080,31 @@ object Steps {
      * Two passes also gather twice, and nothing in the printed line says to.
      */
     private fun groupPumpAndGrant(prefix: String, name: String, canonicalForm: Boolean): Phrase<CardScript> {
-        fun scriptFor(modifiers: Pair<Int, Int>, keyword: Keyword, filter: GameObjectFilter) = CardScript(
+        fun scriptFor(
+            modifiers: Pair<Int, Int>,
+            keywords: List<Keyword>,
+            filter: GameObjectFilter,
+        ) = CardScript(
             spellEffect = Effects.ForEachInGroup(
                 GroupFilter(filter),
                 Effects.Composite(
-                    listOf(
-                        Effects.ModifyStats(modifiers.first, modifiers.second, EffectTarget.Self),
-                        Effects.GrantKeyword(keyword, EffectTarget.Self),
-                    )
+                    listOf(Effects.ModifyStats(modifiers.first, modifiers.second, EffectTarget.Self)) +
+                        keywords.map { Effects.GrantKeyword(it, EffectTarget.Self) }
                 ),
             )
         )
-        val rule = phrase<CardScript>("$prefix{filter} get {mod} and gain {kw} until end of turn", name = name) {
+        val rule = phrase<CardScript>("$prefix{filter} get {mod} and gain {kws} until end of turn", name = name) {
             slot("filter", Filters.plural)
             slot("mod", Primitives.statModifiers)
-            slot("kw", Keywords.keyword)
-            build { scriptFor(it.value("mod"), it.value("kw"), it.value("filter")) }
+            slot("kws", Keywords.keywordRun)
+            build { scriptFor(it.value("mod"), it.value("kws"), it.value("filter")) }
             match { script ->
                 val filter = iteratedGroup(script.spellEffect) ?: return@match null
                 val body = (iteratedBody(script.spellEffect) as? CompositeEffect)?.effects ?: return@match null
                 val modifiers = fixedModifiers(body.firstOrNull()) ?: return@match null
-                val keyword = grantedKeyword(body.getOrNull(1)) ?: return@match null
-                if (script != scriptFor(modifiers, keyword, filter)) return@match null
-                bind("filter" to filter, "mod" to modifiers, "kw" to keyword)
+                val keywords = grantedKeywords(body.drop(1)) ?: return@match null
+                if (script != scriptFor(modifiers, keywords, filter)) return@match null
+                bind("filter" to filter, "mod" to modifiers, "kws" to keywords)
             }
             canonical = canonicalForm
         }
@@ -1947,6 +1969,28 @@ object Steps {
     internal fun grantedKeyword(effect: Effect?): Keyword? {
         val grant = effect as? com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect ?: return null
         return Keyword.entries.firstOrNull { it.name == grant.keyword }
+    }
+
+    /**
+     * What a whole [Keywords.keywordRun] denotes: one grant per keyword, over one object.
+     *
+     * A list of one is the bare effect rather than a one-element `CompositeEffect`, because that is
+     * what the hand-written cards hold and what the SDK's composite means — an ordering of several
+     * effects, which one effect does not have.
+     */
+    internal fun grants(keywords: List<Keyword>, target: EffectTarget): Effect {
+        val effects = keywords.map { Effects.GrantKeyword(it, target) }
+        return effects.singleOrNull() ?: Effects.Composite(effects)
+    }
+
+    /** [grants]'s inverse: the keywords a grant — or a composite of nothing but grants — names. */
+    internal fun grantedKeywords(effect: Effect?): List<Keyword>? =
+        grantedKeywords((effect as? CompositeEffect)?.effects ?: listOfNotNull(effect))
+
+    /** The same over a clause's tail, for the rules whose first effect is a pump. */
+    internal fun grantedKeywords(effects: List<Effect>): List<Keyword>? {
+        if (effects.isEmpty()) return null
+        return effects.map { grantedKeyword(it) ?: return null }
     }
 
     /** The group a mass effect iterates, or null when the effect is not a plain battlefield sweep. */

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Tokens.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Tokens.kt
@@ -1,15 +1,20 @@
 package com.wingedsheep.assay.grammar
 
+import com.wingedsheep.assay.syntax.Bindings
 import com.wingedsheep.assay.syntax.Phrase
 import com.wingedsheep.assay.syntax.bind
 import com.wingedsheep.assay.syntax.constant
 import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
+import com.wingedsheep.assay.syntax.separated
 import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.values.TurnTracker
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -17,74 +22,264 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
 /**
  * "Create a 1/1 green Insect creature token." — the token clauses.
  *
- * One shape with three slots (the stats, the colour, the creature type) and a rule per *count*
- * surface, because the count is where the English differs: "a" is one token, "X" is the spell's own
- * variable, and "for each …" is a tally. Everything before the word "token" is the same phrase in
- * all three.
+ * One shape with four slots (the count, the stats, the colours, the creature type) plus an optional
+ * granted run, and a *row* per printed variation, because English changes several words at once: the
+ * article and the noun's number move with the count, and the keyword rider is a suffix the kernel's
+ * fixed templates cannot make optional. Six rows out of two axes is what the axes cost; nothing
+ * about the token's own description is written twice.
  *
- * ### The colour word is a rule, not [Primitives.color]
+ * ### The colour word is a run, not [Primitives.color]
  *
- * A token's colours are a `Set<Color>`, and "colorless" is the empty set rather than a colour — a
- * distinction [Primitives.color] cannot make, since it reads exactly one [Color]. One alternation
- * over "colorless" plus the five colour words keeps both halves total, and a multicoloured token
- * ("a 1/1 white and blue Spirit") is a printed form nobody wrote down here, so it declines.
+ * A token's colours are a `Set<Color>`, which [Primitives.color] cannot spell: "colorless" is the
+ * empty set rather than a colour, and "1/1 blue and red Otter" is two. So the slot is an alternation
+ * over the empty set, one colour, and [Keywords.keywordRun]'s shape over colours — four alternatives
+ * taking disjoint set *sizes*, which is what leaves printing determined by the model.
  *
- * ### `imageUri` is not in the text, and this is where that shows
+ * Printing a set needs an order the model does not carry, and Magic's is not arbitrary: Oracle text
+ * lists colours in WUBRG order on every card that names more than one, and [Color]'s own declaration
+ * order is that order. So the printed run is the set sorted by ordinal, and a card that happened to
+ * store its colours in another order still compares equal — sets have no order to disagree about.
+ *
+ * ### `imageUri` is not in the text, and the differential already knows it
  *
  * `CreateTokenEffect` carries an `imageUri` that no printed word determines — it is art, chosen when
- * the card was authored. The rules here build without one, so a hand-written card that names its
- * token's art round-trips its *text* perfectly and shows up as a differential divergence. That is
- * the honest split: the touchstone is about the text and the field is not in it, so the finding
- * belongs to the gate that compares models rather than to a rule that would have to invent a URL.
+ * the card was authored. The rules here build without one, and `Folds.dropPresentation` drops the
+ * field from both sides before comparing, alongside `descriptionOverride`, `message` and `prompt`:
+ * a parser can never produce a URL, so a card that inlines one would otherwise diverge for ever over
+ * its picture while agreeing about its token.
  */
 object Tokens {
 
-    /** "colorless", "green" — a token's colour set, which is empty for the colourless case. */
+    // ---------------------------------------------------------------------------------------
+    // The colour run
+    // ---------------------------------------------------------------------------------------
+
+    /** WUBRG — [Color]'s declaration order, which is the order printed Oracle text uses. */
+    private fun ordered(colours: Set<Color>): List<Color> = colours.sortedBy { it.ordinal }
+
+    private val colourPair: Phrase<Set<Color>> =
+        phrase("{first} and {second}", name = "two colours") {
+            slot("first", Primitives.color)
+            slot("second", Primitives.color)
+            build { setOf(it.value<Color>("first"), it.value<Color>("second")) }
+            match { colours ->
+                colours.takeIf { it.size == 2 }?.let {
+                    val order = ordered(it)
+                    bind("first" to order[0], "second" to order[1])
+                }
+            }
+        }
+
+    private val colourSeries: Phrase<Set<Color>> =
+        phrase("{most}, and {last}", name = "three or more colours") {
+            slot("most", separated("colours", Primitives.color, ", ", min = 2))
+            slot("last", Primitives.color)
+            build { (it.value<List<Color>>("most") + it.value<Color>("last")).toSet() }
+            match { colours ->
+                colours.takeIf { it.size >= 3 }?.let {
+                    val order = ordered(it)
+                    bind("most" to order.dropLast(1), "last" to order.last())
+                }
+            }
+        }
+
     private val colours: Phrase<Set<Color>> = oneOf(
-        "a token's colour",
-        constant("colorless", emptySet()),
-        *Color.entries.map { constant(it.displayName.lowercase(), setOf(it)) }.toTypedArray(),
+        "a token's colours",
+        listOf(
+            constant("colorless", emptySet()),
+            phrase<Set<Color>>("{one}", name = "one colour") {
+                slot("one", Primitives.color)
+                build { setOf(it.value<Color>("one")) }
+                match { it.singleOrNull()?.let { only -> bind("one" to only) } }
+            },
+            colourPair,
+            colourSeries,
+        ),
+    )
+
+    // ---------------------------------------------------------------------------------------
+    // Created creature tokens
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * How many tokens a clause makes, as the two things that vary with it: the printed count and
+     * the amount the model holds.
+     *
+     * A row rather than a slot because the noun's number changes with the count and the singular has
+     * no number word at all — [Cardinals.word] starts at two for exactly that reason, so "a" and
+     * "two" cannot be one slot without inventing a surface form for 1.
+     */
+    private class Count(
+        val surface: String,
+        val plural: Boolean,
+        /** The count slot's phrase, for the counted form; null where the amount is fixed by the row. */
+        val words: Phrase<Int>?,
+        private val fixed: DynamicAmount?,
+    ) {
+        /** The amount a parse of this row denotes: the row's own, or the number word it just read. */
+        fun amountFor(bindings: Bindings): DynamicAmount =
+            fixed ?: DynamicAmount.Fixed(bindings.int("n"))
+
+        /**
+         * Is this the row that spells [amount]?
+         *
+         * The three rows are disjoint by construction — one is `Fixed(1)`, one is `XValue`, one is
+         * any other spellable `Fixed` — so exactly one of them answers yes and printing is decided by
+         * the model rather than by the list's order.
+         */
+        fun spells(amount: DynamicAmount): Boolean =
+            if (words == null) amount == fixed
+            else wordFor(amount)?.let(Cardinals::spellable) == true
+
+        /** The number this row's slot would bind, or null on the rows that have no slot. */
+        fun wordFor(amount: DynamicAmount): Int? =
+            if (words == null) null else (amount as? DynamicAmount.Fixed)?.amount
+    }
+
+    private val counts: List<Count> = listOf(
+        Count("a", plural = false, words = null, fixed = DynamicAmount.Fixed(1)),
+        Count("{n}", plural = true, words = Cardinals.word, fixed = null),
+        Count("X", plural = true, words = null, fixed = DynamicAmount.XValue),
     )
 
     /**
-     * The shape: "create <count> P/T <colour> <type> creature token(s)".
+     * The shape: "create <count> P/T <colours> <type> creature token(s)[ with <keywords>]".
      *
-     * [count] is the whole of what varies between the members — the article and the noun's number
-     * change with it, so each member spells its own template rather than sharing one with a number
-     * slot.
+     * The keyword rider builds the same list [Keywords.keywordRun] does everywhere else, into
+     * `CreateTokenEffect.keywords` — one vocabulary for "gains flying and trample", "has flying and
+     * trample" and "token with flying and trample", which is the whole reason that run is a shared
+     * phrase rather than a rule inside one family.
      */
     private fun createToken(
-        template: String,
-        name: String,
-        count: DynamicAmount,
+        count: Count,
+        keywords: Boolean,
+        suffix: String = "",
+        suffixName: String = "",
     ): Phrase<CardScript> {
-        fun scriptFor(power: Int, toughness: Int, colours: Set<Color>, type: Subtype) = CardScript(
+        val noun = if (count.plural) "creature tokens" else "creature token"
+        val rider = if (keywords) " with {kws}" else ""
+        val name = "create " + (if (count.plural) "tokens" else "a token") +
+            (if (keywords) " with keywords" else "") + suffixName
+
+        fun scriptFor(
+            amount: DynamicAmount,
+            power: Int,
+            toughness: Int,
+            colours: Set<Color>,
+            type: Subtype,
+            granted: Set<Keyword>,
+        ) = CardScript(
             spellEffect = Effects.CreateToken(
-                count = count,
+                count = amount,
                 power = power,
                 toughness = toughness,
                 colors = colours,
                 creatureTypes = setOf(type.value),
+                keywords = granted,
             )
         )
-        return phrase(template, name = name) {
+
+        return phrase("create ${count.surface} {p}/{t} {color} {type} $noun$rider$suffix", name = name) {
+            if (count.words != null) slot("n", count.words)
             slot("p", Primitives.cardinal)
             slot("t", Primitives.cardinal)
             slot("color", colours)
             slot("type", Primitives.subtype)
-            build { scriptFor(it.int("p"), it.int("t"), it.value("color"), it.value("type")) }
+            if (keywords) slot("kws", Keywords.keywordRun)
+            build { bindings ->
+                val granted = if (keywords) bindings.value<List<Keyword>>("kws").toSet() else emptySet()
+                scriptFor(
+                    count.amountFor(bindings),
+                    bindings.int("p"),
+                    bindings.int("t"),
+                    bindings.value("color"),
+                    bindings.value("type"),
+                    granted,
+                )
+            }
             match { script ->
                 val token = script.spellEffect as? CreateTokenEffect ?: return@match null
+                if (!count.spells(token.count)) return@match null
+                if (keywords == token.keywords.isEmpty()) return@match null
                 val type = token.creatureTypes.singleOrNull() ?: return@match null
-                if (script != scriptFor(token.power, token.toughness, token.colors, Subtype(type))) {
+                if (script != scriptFor(
+                        token.count,
+                        token.power,
+                        token.toughness,
+                        token.colors,
+                        Subtype(type),
+                        token.keywords,
+                    )
+                ) {
                     return@match null
                 }
                 bind(
+                    "n" to count.wordFor(token.count),
                     "p" to token.power,
                     "t" to token.toughness,
                     "color" to token.colors,
                     "type" to Subtype(type),
+                    "kws" to token.keywords.sortedBy { it.ordinal },
                 )
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Predefined tokens
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * "Create a Food token.", "Create two Treasure tokens." — the tokens the rules define once and
+     * every card names by their noun alone.
+     *
+     * The SDK holds these as `CreatePredefinedTokenEffect(tokenType)` rather than as a spelled-out
+     * token, so the noun *is* the model and the row list is the vocabulary. It is deliberately the
+     * set of nouns the SDK publishes a facade for: a name with no facade would be a string this
+     * grammar invented, which is the one thing a rule building through the facades must not do.
+     *
+     * **The token noun is a proper noun.** It stands mid-sentence where [Subtype] words also do, and
+     * `SentenceCase` has already lowercased the line's first letter, so the templates are written
+     * exactly as printed and the capital is real rather than restored.
+     *
+     * ### A collision this file is deliberately one half of
+     *
+     * "Investigate" (CR 701.36a) *is* "create a Clue token" — `Effects.Investigate` and
+     * `Effects.CreateClue` are the same call — so the two printed forms denote one model. Only the
+     * noun form is registered here. The keyword-action spelling declines, which names the gap; what
+     * it must never become is a second canonical rule, because then one model would have two printed
+     * forms and nothing would decide which the printer emits. When the keyword-action family is
+     * written, "investigate" belongs in it as an `alternate`.
+     */
+    private val PREDEFINED: List<Pair<String, (Int) -> Effect>> = listOf(
+        "Treasure" to { n: Int -> Effects.CreateTreasure(count = n) },
+        "Food" to { n: Int -> Effects.CreateFood(count = n) },
+        "Clue" to { n: Int -> Effects.CreateClue(count = n) },
+        "Blood" to { n: Int -> Effects.CreateBlood(count = n) },
+        "Map" to { n: Int -> Effects.CreateMapToken(count = n) },
+        "Lander" to { n: Int -> Effects.CreateLander(count = n) },
+        "Shard" to { n: Int -> Effects.CreateShard(count = n) },
+    )
+
+    private fun createPredefined(count: Count, tokenType: String, effect: (Int) -> Effect): Phrase<CardScript> {
+        val noun = if (count.plural) "tokens" else "token"
+        fun scriptFor(amount: DynamicAmount): CardScript? {
+            val fixed = (amount as? DynamicAmount.Fixed)?.amount ?: return null
+            return CardScript(spellEffect = effect(fixed))
+        }
+        return phrase(
+            "create ${count.surface} $tokenType $noun",
+            name = "create ${if (count.plural) "$tokenType tokens" else "a $tokenType token"}",
+        ) {
+            if (count.words != null) slot("n", count.words)
+            build { bindings -> scriptFor(count.amountFor(bindings)) }
+            match { script ->
+                val token = script.spellEffect as? CreatePredefinedTokenEffect ?: return@match null
+                if (token.tokenType != tokenType) return@match null
+                val amount = DynamicAmount.Fixed(token.count)
+                if (!count.spells(amount)) return@match null
+                if (script != scriptFor(amount)) return@match null
+                bind("n" to count.wordFor(amount))
             }
         }
     }
@@ -92,25 +287,25 @@ object Tokens {
     /** One token clause, for the sentences that wrap it — see [Granted]. */
     val clause: Phrase<CardScript> get() = oneOf("a token clause", clauses)
 
-    val clauses: List<Phrase<CardScript>> = listOf(
-        createToken(
-            "create a {p}/{t} {color} {type} creature token",
-            "create a token",
-            DynamicAmount.Fixed(1),
-        ),
-        createToken(
-            "create X {p}/{t} {color} {type} creature tokens",
-            "create X tokens",
-            DynamicAmount.XValue,
-        ),
-        // Caller of the Claw. The tally is a *turn* tracker rather than a battlefield count, which
-        // is why it is a rule here and not a row in [Amounts.count]: nothing about the phrase is a
-        // noun the filter vocabulary could spell, and the whole clause names one tracked quantity.
-        createToken(
-            "create a {p}/{t} {color} {type} creature token for each nontoken creature put into " +
-                "your graveyard from the battlefield this turn",
-            "create a token per creature that died this turn",
-            DynamicAmount.TurnTracking(Player.You, TurnTracker.NONTOKEN_CREATURES_DIED),
-        ),
-    )
+    val clauses: List<Phrase<CardScript>> =
+        counts.flatMap { count -> listOf(createToken(count, keywords = false), createToken(count, keywords = true)) } +
+            // Caller of the Claw. The tally is a *turn* tracker rather than a battlefield count, which
+            // is why it is a row here and not one in [Amounts.count]: nothing about the phrase is a
+            // noun the filter vocabulary could spell, and the whole clause names one tracked quantity.
+            createToken(
+                Count(
+                    "a",
+                    plural = false,
+                    words = null,
+                    fixed = DynamicAmount.TurnTracking(Player.You, TurnTracker.NONTOKEN_CREATURES_DIED),
+                ),
+                keywords = false,
+                suffix = " for each nontoken creature put into your graveyard from the battlefield this turn",
+                suffixName = " per creature that died this turn",
+            ) +
+            // "X Food tokens" is not printed — the predefined nouns take the article and the number
+            // word only, so the X row is left out rather than written against nothing.
+            PREDEFINED.flatMap { (type, effect) ->
+                counts.dropLast(1).map { createPredefined(it, type, effect) }
+            }
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Triggers.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Triggers.kt
@@ -413,6 +413,17 @@ object Triggers {
             SdkTriggers.dealsDamage(damageType = DamageType.Combat),
         ),
         triggerRule("whenever ${Normalizer.SELF} is dealt damage", SdkTriggers.TakesDamage),
+        // Valiant, and one row rather than a shape over `BecomesTargetEvent`'s six flags: the SDK
+        // publishes the whole configuration as `Triggers.Valiant`, which is the lowering this file's
+        // rule says to call rather than restate. The other flag combinations (by an opponent, a
+        // filtered target, spells only) are separate printed sentences and become rows of their own
+        // when a card needs them — not a template with the flags as slots, which would print
+        // "for the first time each turn" as an optional phrase the model cannot decide.
+        triggerRule(
+            "whenever ${Normalizer.SELF} becomes the target of a spell or ability you control " +
+                "for the first time each turn",
+            SdkTriggers.Valiant,
+        ),
         // Morph's payoff. "Is turned face up" is a `When` rather than a `Whenever` because it can
         // happen once to a permanent, which is the property that decides the word (see [rules]).
         triggerRule("when ${Normalizer.SELF} is turned face up", SdkTriggers.TurnedFaceUp),

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/normalize/Normalizer.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/normalize/Normalizer.kt
@@ -19,6 +19,7 @@ import com.wingedsheep.assay.corpus.OracleFace
  * | Self-reference | the face's own name → `~`, longest-match first | put the recorded surface form back |
  * | Attachment noun | "equipped creature" → "enchanted creature" | put the recorded surface word back |
  * | Ability split | one ability per line | join with `\n` |
+ * | Ability word | strip a line's `Landfall — ` prefix | put the recorded word back on that line |
  *
  * Two passes named in the design are handled elsewhere on purpose:
  *
@@ -43,15 +44,63 @@ object Normalizer {
         val (stripped, reminders) = stripReminders(face.oracleText)
         val (abstracted, selfRefs) = abstractSelfReference(stripped, selfReferenceForms(face.name))
         val (canonicalNoun, attachmentNouns) = canonicalizeAttachmentNoun(abstracted)
+        val split = canonicalNoun.split("\n")
         return NormalizedFace(
             faceName = face.name,
-            lines = canonicalNoun.split("\n"),
+            lines = split.map(::stripAbilityWord),
             reminders = reminders,
             selfReferences = selfRefs,
             attachmentNouns = attachmentNouns,
+            abilityWords = split.map(::abilityWordOf),
             raw = face.oracleText,
         )
     }
+
+    /**
+     * "**Landfall —** Whenever a land you control enters, …" → the ability the line actually states.
+     *
+     * CR 207.2c: *"An ability word appears in italics at the beginning of some abilities. … they have
+     * no special rules meaning and no individual entries in the Comprehensive Rules."* So the word is
+     * printed-shape information of exactly the kind this file owns — the model has nowhere to put it,
+     * and the alternative is a grammar rule per ability word wrapping every sentence the grammar can
+     * already read, which is the multiplicative cost the module's "lift, don't re-spell" rule exists
+     * to refuse. Nine BLB cards and hundreds elsewhere are one prefix away from an ability the rest of
+     * the grammar reads whole.
+     *
+     * **Enumerated, and from the rule rather than from the corpus.** CR 207.2d's *flavor words* have
+     * the identical printed shape — an italic prefix and a spaced em dash — and are "tailored to the
+     * specific ability", so they are unbounded and mean nothing as a class. A pattern match on
+     * `<Word> — ` would strip those too, along with a Saga's `I —` and a Class's `Level 2 —`, and
+     * would be reading punctuation instead of a rule. So the list is CR 207.2c's, verbatim; an
+     * ability word printed after that rule was last read declines until the list is updated, which
+     * is the fail-closed direction.
+     *
+     * **Line-initial only.** Oracle puts one ability on a line and the word at its start, which is
+     * what makes the pass positional and its inverse exact.
+     */
+    private fun abilityWordOf(line: String): String? =
+        ABILITY_WORDS.firstOrNull { line.startsWith("$it$ABILITY_WORD_DASH") }
+
+    private fun stripAbilityWord(line: String): String =
+        abilityWordOf(line)?.let { line.substring(it.length + ABILITY_WORD_DASH.length) } ?: line
+
+    internal const val ABILITY_WORD_DASH = " — "
+
+    /**
+     * CR 207.2c's list, in the sentence case Oracle prints it at the start of a line. Sorted longest
+     * first so "Descend 8" is not read as a prefix of nothing and "Council's dilemma" wins over any
+     * shorter member it contains.
+     */
+    private val ABILITY_WORDS: List<String> = listOf(
+        "Adamant", "Addendum", "Alliance", "Battalion", "Bloodrush", "Celebration", "Channel",
+        "Chroma", "Cohort", "Constellation", "Converge", "Council's dilemma", "Coven", "Delirium",
+        "Descend 4", "Descend 8", "Domain", "Eerie", "Eminence", "Enrage", "Fateful hour",
+        "Fathomless descent", "Ferocious", "Formidable", "Grandeur", "Hellbent", "Heroic", "Imprint",
+        "Inspired", "Join forces", "Kinship", "Landfall", "Lieutenant", "Magecraft", "Metalcraft",
+        "Morbid", "Pack tactics", "Paradox", "Parley", "Radiance", "Raid", "Rally", "Revolt",
+        "Secret council", "Spell mastery", "Strive", "Survival", "Sweep", "Tempting offer",
+        "Threshold", "Undergrowth", "Valiant", "Will of the council",
+    ).sortedByDescending { it.length }
 
     /**
      * "**Equipped** creature gets +2/+0." → "**Enchanted** creature gets +2/+0.", the surface word
@@ -259,6 +308,11 @@ data class NormalizedFace(
      * an Equipment, "Enchanted" on an Aura. See [Normalizer.canonicalizeAttachmentNoun].
      */
     val attachmentNouns: List<String> = emptyList(),
+    /**
+     * The ability word each line was printed with, positionally — one entry per line, null where the
+     * line had none. See [Normalizer.abilityWordOf].
+     */
+    val abilityWords: List<String?> = emptyList(),
     /** The face's original Oracle text — the byte string the touchstone compares against. */
     val raw: String,
 ) {
@@ -274,7 +328,8 @@ data class NormalizedFace(
      * that cannot round-trip its own output would let any grammar look correct.
      */
     fun restore(printedLines: List<String>): String {
-        var text = printedLines.joinToString("\n")
+        // First, because every later inverse works on offsets measured before the words came off.
+        var text = restoreAbilityWords(printedLines).joinToString("\n")
         // Before the self-references, and therefore while card names are still `~`: a card called
         // "Enchanted Evening" would otherwise put its own name back and have this scan read it as an
         // attachment noun, shifting every later surface word by one.
@@ -286,6 +341,21 @@ data class NormalizedFace(
             text = text.substring(0, removal.offset) + removal.text + text.substring(removal.offset)
         }
         return text
+    }
+
+    /**
+     * Put each line's recorded ability word back in front of it.
+     *
+     * By line index rather than by scanning, because the word was stripped by index: the pass has one
+     * entry per line and nothing about the printed sentence can move it. A printed-line count that
+     * disagrees with the recorded one means the grammar produced a different number of abilities than
+     * it read, so the lines are returned untouched and the caller's byte comparison reports it.
+     */
+    private fun restoreAbilityWords(printedLines: List<String>): List<String> {
+        if (abilityWords.size != printedLines.size) return printedLines
+        return printedLines.mapIndexed { index, line ->
+            abilityWords[index]?.let { "$it${Normalizer.ABILITY_WORD_DASH}$line" } ?: line
+        }
     }
 
     /**

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/KeywordRunsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/KeywordRunsTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.assay.syntax.parseLine
+import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * A grant clause names a *run* of keywords, and the count lives in the slot rather than in the rule.
+ *
+ * The property that matters is the one the count-in-the-rule shape could not have: one grant is the
+ * bare effect and several are a composite, in every grant position — target, group, source, and the
+ * enchanted permanent — from a single vocabulary. The negative cases are the ones that keep printing
+ * determined: a one-element composite is not what a single grant means, and a run of one must not be
+ * reachable from the static *line* rule, where the single-ability rule already spells it.
+ */
+class KeywordRunsTest : StringSpec({
+
+    fun fragment(line: String): CardFragment =
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Accepted<CardFragment>>().value
+
+    fun roundTrips(line: String) {
+        Grammar.abilityLine.printLine(fragment(line)) shouldBe line
+    }
+
+    fun declines(line: String) {
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+
+    "a grant to a target is one effect for one keyword and a composite for several" {
+        fragment("Target creature gains flying until end of turn.").script.spellEffect shouldBe
+            Effects.GrantKeyword(Keyword.FLYING, Targets.bound())
+
+        (fragment("Target creature gains flying and trample until end of turn.")
+            .script.spellEffect as CompositeEffect).effects shouldBe listOf(
+            Effects.GrantKeyword(Keyword.FLYING, Targets.bound()),
+            Effects.GrantKeyword(Keyword.TRAMPLE, Targets.bound()),
+        )
+
+        roundTrips("Target creature gains flying until end of turn.")
+        roundTrips("Target creature gains flying and trample until end of turn.")
+        roundTrips("Target creature gains flying, trample, and lifelink until end of turn.")
+    }
+
+    // Overprotect and Scales of Shale — the pump keeps its place at the head of the composite and
+    // every keyword after it is its own grant.
+    "a pump and a run share one target and one composite" {
+        (fragment("Target creature you control gets +3/+3 and gains trample, hexproof, and indestructible until end of turn.")
+            .script.spellEffect as CompositeEffect).effects shouldBe listOf(
+            Effects.ModifyStats(3, 3, Targets.bound()),
+            Effects.GrantKeyword(Keyword.TRAMPLE, Targets.bound()),
+            Effects.GrantKeyword(Keyword.HEXPROOF, Targets.bound()),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, Targets.bound()),
+        )
+        roundTrips("Target creature you control gets +3/+3 and gains trample, hexproof, and indestructible until end of turn.")
+        roundTrips("Target creature gets +2/+0 and gains lifelink and indestructible until end of turn.")
+    }
+
+    // Sword of Vengeance. The static line denotes one ability per keyword, plus the pump.
+    "an equipment's run is one static per keyword" {
+        fragment("Enchanted creature gets +2/+0 and has first strike, vigilance, trample, and haste.")
+            .script.staticAbilities shouldBe listOf(
+            ModifyStats(2, 0),
+            GrantKeyword(Keyword.FIRST_STRIKE),
+            GrantKeyword(Keyword.VIGILANCE),
+            GrantKeyword(Keyword.TRAMPLE),
+            GrantKeyword(Keyword.HASTE),
+        )
+        roundTrips("Enchanted creature gets +2/+0 and has first strike, vigilance, trample, and haste.")
+        roundTrips("Enchanted creature gets +1/+1 and has reach and vigilance.")
+    }
+
+    "the keyword-only static line takes two or more, and one still goes through the single rule" {
+        fragment("Enchanted creature has reach and vigilance.").script.staticAbilities shouldBe
+            listOf(GrantKeyword(Keyword.REACH), GrantKeyword(Keyword.VIGILANCE))
+        fragment("Enchanted creature has flying.").script.staticAbilities shouldBe
+            listOf(GrantKeyword(Keyword.FLYING))
+        roundTrips("Enchanted creature has reach and vigilance.")
+        roundTrips("Enchanted creature has flying.")
+    }
+
+    // Skirk Outrider, and the keyword-only form the same shape gained with the run.
+    "a conditional self static carries a run in either printed order" {
+        roundTrips("~ gets +2/+2 and has trample as long as you control a Beast permanent.")
+        roundTrips("~ has flying and vigilance as long as you control a Beast permanent.")
+        // The leading form is the alternate: it parses to the same value and prints as the trailing one.
+        fragment("As long as you control a Beast, ~ has flying and vigilance.") shouldBe
+            fragment("~ has flying and vigilance as long as you control a Beast permanent.")
+    }
+
+    "a group's run iterates once and carries every grant" {
+        roundTrips("Creatures you control get +1/+1 and gain vigilance until end of turn.")
+        roundTrips("Creatures you control get +1/+1 and gain trample and haste until end of turn.")
+    }
+
+    // The trap the shape replaces: a rule that spelled the count would have printed a single grant
+    // as a one-element composite, which is not what any hand-written card holds.
+    "a one-element composite is not a single grant and refuses to print" {
+        val oneElement = CardFragment(
+            script = CardScript(
+                spellEffect = CompositeEffect(listOf(Effects.GrantKeyword(Keyword.FLYING, Targets.bound()))),
+                targetRequirements = listOf(Targets.permanent(GameObjectFilter.Creature)),
+            )
+        )
+        Grammar.abilityLine.printLine(oneElement) shouldBe null
+    }
+
+    "a keyword with a parameter is not in the run vocabulary" {
+        declines("Target creature gains ward {2} until end of turn.")
+    }
+})

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/StaticsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/StaticsTest.kt
@@ -5,11 +5,17 @@ import com.wingedsheep.assay.syntax.parseLine
 import com.wingedsheep.assay.syntax.printLine
 import com.wingedsheep.sdk.core.AbilityFlag
 import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
 import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
@@ -145,6 +151,23 @@ class StaticsTest : StringSpec({
     "the unfiltered form is a flag, not a static" {
         fragment("~ can't be blocked.") shouldBe CardFragment(flags = setOf(AbilityFlag.CANT_BE_BLOCKED))
         roundTrips("~ can't be blocked.")
+    }
+
+    // Threshold's condition, and the shape the hand-size comparison became when it got a second
+    // member: one zone, one player, one spelled number, and which way the comparison points.
+    "a zone-count condition compares the count the golden compares" {
+        fragment("~ gets +3/+0 as long as there are seven or more cards in your graveyard.")
+            .script.staticAbilities shouldBe listOf(
+            ConditionalStaticAbility(
+                ability = ModifyStats(3, 0, GroupFilter.source()),
+                condition = Compare(
+                    DynamicAmount.Count(Player.You, Zone.GRAVEYARD),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(7),
+                ),
+            )
+        )
+        roundTrips("~ gets +3/+0 as long as there are seven or more cards in your graveyard.")
     }
 
     // Every rule in the family can print what it parses — the meta-test each family gets, because a

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/StepsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/StepsTest.kt
@@ -144,6 +144,15 @@ class StepsTest : StringSpec({
         roundTrips("~ deals 2 damage to target creature.")
         roundTrips("~ deals 1 damage to target creature an opponent controls.")
         roundTrips("~ deals 5 damage to target player.")
+        // Kindlespark Duo. "Target opponent" is its own requirement type rather than a filter on
+        // "target player", which is why it is a row beside it.
+        fragment("~ deals 1 damage to target opponent.") shouldBe CardFragment(
+            script = CardScript(
+                spellEffect = Effects.DealDamage(1, Targets.bound()),
+                targetRequirements = listOf(Targets.opponent()),
+            )
+        )
+        roundTrips("~ deals 1 damage to target opponent.")
     }
 
     // Giant Growth's golden. `Duration.EndOfTurn` is ModifyStats's default, which is why the

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/TokensTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/TokensTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.assay.grammar
+
+import com.wingedsheep.assay.syntax.ParseOutcome
+import com.wingedsheep.assay.syntax.parseLine
+import com.wingedsheep.assay.syntax.printLine
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * The token band: the count, the colour run, the keyword rider, and the predefined nouns.
+ *
+ * Two properties are worth asserting beyond the round trips. The colour and keyword *sets* have no
+ * order of their own, so printing has to impose one and it has to be Magic's — WUBRG for colours,
+ * and the same declaration order for keywords; a card that stored them the other way round must
+ * print the same sentence rather than a different one. And a predefined token is a noun the SDK
+ * names, so it must build the value the facade builds and not a spelled-out token that happens to
+ * look like one.
+ */
+class TokensTest : StringSpec({
+
+    fun fragment(line: String): CardFragment =
+        Grammar.abilityLine.parseLine(line).shouldBeInstanceOf<ParseOutcome.Accepted<CardFragment>>().value
+
+    fun roundTrips(line: String) {
+        Grammar.abilityLine.printLine(fragment(line)) shouldBe line
+    }
+
+    "the count is a slot, and the noun's number moves with it" {
+        fragment("Create a 1/1 white Rabbit creature token.").script.spellEffect shouldBe
+            Effects.CreateToken(power = 1, toughness = 1, colors = setOf(Color.WHITE), creatureTypes = setOf("Rabbit"))
+        (fragment("Create two 1/1 white Rabbit creature tokens.").script.spellEffect as CreateTokenEffect)
+            .count shouldBe DynamicAmount.Fixed(2)
+
+        roundTrips("Create a 1/1 white Rabbit creature token.")
+        roundTrips("Create two 1/1 white Rabbit creature tokens.")
+        roundTrips("Create three 2/2 black Zombie creature tokens.")
+        roundTrips("Create X 1/1 green Saproling creature tokens.")
+    }
+
+    // Otterball Antics and Stormchaser's Talent — a two-colour token with a keyword.
+    "a token carries a colour run and a keyword run" {
+        fragment("Create a 1/1 blue and red Otter creature token with prowess.").script.spellEffect shouldBe
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.BLUE, Color.RED),
+                creatureTypes = setOf("Otter"),
+                keywords = setOf(Keyword.PROWESS),
+            )
+
+        roundTrips("Create a 1/1 blue and red Otter creature token with prowess.")
+        roundTrips("Create a 0/4 white Wall creature token with defender.")
+        roundTrips("Create a 5/5 red Dragon creature token with flying.")
+        roundTrips("Create a 7/7 green Elemental creature token with trample.")
+        roundTrips("Create a 1/1 colorless Sliver creature token.")
+    }
+
+    // The sets have no order; the printer imposes WUBRG and [Keyword]'s own, so a card that built
+    // them the other way round still prints the sentence Oracle prints.
+    "colour and keyword sets print in the order Oracle prints them" {
+        val reversed = CardFragment(
+            script = CardScript(
+                spellEffect = Effects.CreateToken(
+                    power = 2,
+                    toughness = 2,
+                    colors = setOf(Color.RED, Color.BLUE),
+                    creatureTypes = setOf("Otter"),
+                    keywords = setOf(Keyword.TRAMPLE, Keyword.FLYING),
+                )
+            )
+        )
+        Grammar.abilityLine.printLine(reversed) shouldBe
+            "Create a 2/2 blue and red Otter creature token with flying and trample."
+    }
+
+    "a predefined token is the noun the SDK names" {
+        fragment("Create a Food token.").script.spellEffect shouldBe Effects.CreateFood()
+        fragment("Create two Treasure tokens.").script.spellEffect shouldBe Effects.CreateTreasure(count = 2)
+
+        roundTrips("Create a Food token.")
+        roundTrips("Create a Treasure token.")
+        roundTrips("Create two Treasure tokens.")
+        roundTrips("Create three Clue tokens.")
+    }
+
+    // The two token effects are different SDK types, so neither may print the other's sentence.
+    "a spelled-out token and a predefined one do not print each other" {
+        val food = CardFragment(script = CardScript(spellEffect = CreatePredefinedTokenEffect("Food")))
+        Grammar.abilityLine.printLine(food) shouldBe "Create a Food token."
+
+        // A predefined noun the vocabulary does not carry has no sentence, rather than a wrong one.
+        val unknown = CardFragment(script = CardScript(spellEffect = CreatePredefinedTokenEffect("Junk")))
+        Grammar.abilityLine.printLine(unknown) shouldBe null
+    }
+
+    "the token clause is the same clause inside a trigger" {
+        roundTrips("When ~ enters, create a Food token.")
+        roundTrips("When ~ enters, create two 1/1 white Rabbit creature tokens.")
+    }
+})

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/TriggersTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/TriggersTest.kt
@@ -176,6 +176,26 @@ class TriggersTest : StringSpec({
         ) shouldBe null
     }
 
+    // Valiant. The whole configuration is one published `TriggerSpec`, so the rule calls the
+    // lowering rather than restating `BecomesTargetEvent`'s flags — and the once-each-turn cap is
+    // part of the event here rather than the ability's `oncePerTurn`, which the fail-closed match
+    // still refuses to print.
+    "the valiant trigger is the spec the SDK publishes" {
+        fragment(
+            "Whenever ~ becomes the target of a spell or ability you control for the first time " +
+                "each turn, draw a card."
+        ).script.triggeredAbilities.single().trigger shouldBe SdkTriggers.Valiant.event
+
+        roundTrips(
+            "Whenever ~ becomes the target of a spell or ability you control for the first time " +
+                "each turn, draw a card."
+        )
+        roundTrips(
+            "Whenever ~ becomes the target of a spell or ability you control for the first time " +
+                "each turn, ~ gets +0/+2 until end of turn."
+        )
+    }
+
     // The id is not in the text, so it must not stop a card's own ability from printing — the one
     // field the fail-closed comparison deliberately exempts.
     "an ability's arbitrary id does not stop it printing" {

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/normalize/NormalizerTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/normalize/NormalizerTest.kt
@@ -132,6 +132,40 @@ class NormalizerTest : StringSpec({
         n.restore(n.lines) shouldBe f.oracleText
     }
 
+    // CR 207.2c: an ability word has no rules meaning, so it is printed shape and lives here rather
+    // than as a grammar rule wrapping every sentence the grammar can already read.
+    "an ability word comes off the line and goes back on it" {
+        val f = face(
+            "Iridescent Vinelasher",
+            "Landfall — Whenever a land you control enters, this creature deals 1 damage to target opponent.",
+        )
+        val n = Normalizer.normalize(f)
+
+        n.lines shouldBe listOf("Whenever a land you control enters, ~ deals 1 damage to target opponent.")
+        n.abilityWords shouldBe listOf("Landfall")
+        n.restore(n.lines) shouldBe f.oracleText
+    }
+
+    "the word is recorded per line, so a card with one word and one plain line stays aligned" {
+        val f = face("Whatever", "Flying\nThreshold — This creature gets +3/+0.")
+        val n = Normalizer.normalize(f)
+
+        n.lines shouldBe listOf("Flying", "~ gets +3/+0.")
+        n.abilityWords shouldBe listOf(null, "Threshold")
+        n.restore(n.lines) shouldBe f.oracleText
+    }
+
+    // The list is CR 207.2c's rather than a pattern, because CR 207.2d's *flavor* words have the
+    // identical printed shape and are unbounded — and so does a Saga's chapter marker.
+    "a prefix that is not an ability word is left where it stands" {
+        val f = face("Whatever", "Bounty — Whenever this creature attacks, draw a card.")
+        val n = Normalizer.normalize(f)
+
+        n.lines shouldBe listOf("Bounty — Whenever ~ attacks, draw a card.")
+        n.abilityWords shouldBe listOf(null)
+        n.restore(n.lines) shouldBe f.oracleText
+    }
+
     "the self-reference noun follows the printed type line" {
         Reminders.selfNoun("Creature — Angel") shouldBe "this creature"
         Reminders.selfNoun("Artifact") shouldBe "this artifact"


### PR DESCRIPTION
Bloomburrow is the first set Assay targets *because* it is already implemented: all 280 cards have goldens, so every line it declines is a **grammar** gap whose known-good answer is already written, and the differential confirms each one the moment it parses.

| | before | after |
|---|---|---|
| BLB cards fully covered | 42 / 280 | **58 / 280** |
| Corpus cards fully covered | 6,583 | **7,177** |
| Byte-exact lines | 24,139 | **24,993** |
| Differential compared / confirmed | 2,495 / 2,494 | **2,698 / 2,697** |
| MISMATCH · AMBIGUOUS · non-invertible | 0 · 0 · 0 | 0 · 0 · 0 |

## Four pieces of machinery, plus rows

**A granted keyword is a run, not a keyword.** `Keywords.keywordRun` spells `trample`, `lifelink and indestructible` and `trample, hexproof, and indestructible` as the list the model already holds, and every grant position slots it — to a target, to a group, to the source, to the enchanted permanent. It *removed* rules rather than adding them: `SelfSteps` carried a two-keyword rule with no singular sibling, and `Statics.conditionalSelfStatic`'s `pairForm` boolean became a three-member enum that also gained the keyword-only sentence ("As long as you've lost life this turn, ~ has flying and vigilance") for free. A family with a `pairForm` flag in it is a family with an axis it has not named yet.

One grant is the bare effect and several are a composite, because that is what `CompositeEffect` means and what every hand-written card holds; a rule that printed the singular as a one-element composite would have disagreed with all of them.

**A token's count, colours and keywords are slots.** Six rows out of two axes (the count — `a` / a number word / `X` — and the keyword rider), plus a colour *run* with `keywordRun`'s shape over `Set<Color>`. The sets carry no order and the printed sentence needs one, so colours print WUBRG and keywords print in `Keyword`'s declaration order: both are the SDK's own, so a card that built its set the other way round still prints the sentence Oracle prints. The predefined nouns (Food, Treasure, Clue, Blood, Map, Lander, Shard) are a second family, each row calling the facade the SDK publishes — with `investigate` deliberately left out, because CR 701.36a makes it the same model as "create a Clue token" and two canonical spellings would leave printing undecided.

**An ability word is printed shape, and belongs to normalization.** CR 207.2c: ability words *"have no special rules meaning and no individual entries in the Comprehensive Rules."* So `Landfall — `, `Threshold — ` and `Valiant — ` come off the line, are recorded per line index, and go back on in `restore`. The alternative was a grammar rule per ability word wrapping every sentence the grammar already reads — the multiplicative cost "lift, don't re-spell" exists to refuse. The list is **CR 207.2c's, verbatim, rather than a `<Word> — ` pattern**: CR 207.2d's *flavor* words have the identical printed shape and are unbounded, and so is a Saga's `I —` and a Class's `Level 2 —`. Worth 106 cards corpus-wide on its own, and it is what let the differential see the landfall bug below.

Then three rows: Valiant's trigger (one `TriggerSpec` the SDK already publishes), `deals N damage to target opponent`, and Threshold's graveyard count — which turned the hand-size comparison into a two-member shape over (player, zone, direction).

## Sixteen bugs the differential found

Every one surfaced on the day a line stopped declining. That is the gate earning its keep, not a regression.

- **`Triggers.LandYouControlEnters` was `TriggerBinding.OTHER`** — one SDK facade, 29 cards. No landfall ability prints "another"; the distinction is invisible on a creature or an enchantment and load-bearing on a **land** with a landfall trigger, which under `OTHER` would silently not see itself enter. `docs/card-sdk-language-reference.md` updated with it.
- **Five more bare-noun-is-permanents cards** — Kargan Dragonrider, Corsair Captain, Lathliss, Inside Source, Voice of the Woods: all `IsCreature` where the printed noun names only a subtype. Same class the bare-tribal-noun migration fixed; these were never comparable before.
- **Sunstar Expansionist read its intervening "if" as a resolution-time gate** — "When this creature enters, **if** an opponent controls more lands than you, …" is CR 603.4: it triggers only when the condition already holds and is checked again on resolution, not a `Gate.WhenCondition` that always triggers.
- **Seven BLB cards printed text the card does not have** — five keyword runs in the wrong order (Oracle prints "Reach, vigilance"; the goldens said "Vigilance, reach"), Hunter's Talent on the pre-Bloomburrow "enters the battlefield" wording, and Quaketusk Boar with no `oracleText` at all.
- **Shocking Sharpshooter restated a documented default** — `damageSource = Self` is what `null` already means for a permanent's own triggered ability.

## Two things deliberately *not* done

- **`damageSource = Self` is not folded.** 72 other cards carry the same redundancy and will surface one at a time as the grammar widens. The field means something when it is set to anything else, so a blanket fold would hide a real difference; the SDK's KDoc reserves an LKI caveat that makes the identity less than total.
- **The Class-level line structure is left alone.** All eight BLB Talents (and every other Class card) write `{1}{G}: Level 2 — <ability>` on one line where Scryfall prints two. Reading it would not move coverage — `Level 2` declines either way — and rewording every Class card in the corpus is its own change. It is why the differential's `Oracle text differs from golden` bucket is still 197.

## Where the ranking points next, inside this set

Gift is the largest family left by a wide margin — **17 BLB cards are sole-blocked by it** — and it is two halves rather than one: the `Gift a card` keyword line and the `If the gift was promised, …` rider, the second of which needs its base clause to read first. After it: the Class levels (10 cards), modal spells (8), and "Spend this mana only to cast …" (6).

## Verification

- `just test` — green (full suite, including `:rules-engine:test` and every era's `scenarioTest`)
- `just assay-gate` — 0 MISMATCH / 0 AMBIGUOUS / 0 non-invertible normalizations / 0 redundant readings
- `just assay-differential` — 2,698 compared, 2,697 confirmed; the one standing divergence is still the open `ManaColorSet.Specific` finding on Spider Manifestation
- `:oracle-assay:test` — 249 tests, including new `KeywordRunsTest` and `TokensTest` families and the ability-word round trips in `NormalizerTest`
- Card snapshots re-blessed; the snapshot diff is 43 `binding` flips plus exactly the seven text fixes and five filter fixes above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
