### PR TITLE
Assay: the divergence that named a card, not a rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ docs it points at; load those when the work needs them.
 | `gym` / `gym-server` / `gym-trainer` | RL/MCTS env + HTTP transport + self-play SPI | engine, sdk |
 | `game-server` | Spring Boot orchestration, WebSocket, state masking | engine, sdk |
 | `mtgish-tooling` | Predictive coverage / auto-gen analyzer | — (scans source as text) |
-| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 2,697 of 2,698 compared cards agree — the one standing divergence is the open `ManaColorSet.Specific` finding), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
+| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, all 2,698 compared cards agree), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
 | `web-client` | React UI (dumb terminal — no game logic) | — |
 
 **Key principle:** the engine is pure (no card-specific code), content is data-driven (no execution

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderManifestation.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/spm/cards/SpiderManifestation.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
-import com.wingedsheep.sdk.scripting.values.ManaColorSet
 
 /**
  * Spider Manifestation
@@ -22,6 +21,12 @@ import com.wingedsheep.sdk.scripting.values.ManaColorSet
  * Reach
  * {T}: Add {R} or {G}.
  * Whenever you cast a spell with mana value 4 or greater, untap this creature.
+ *
+ * The dual mana line is two abilities sharing the tap cost, the spelling every unridered
+ * "{T}: Add {A} or {B}." uses.
+ * [ManaColorSet.Specific][com.wingedsheep.sdk.scripting.values.ManaColorSet.Specific] is the other
+ * spelling, and it is only needed when a rider ("Activate only once each turn") would be defeated
+ * by there being two abilities to activate. This line has no rider.
  */
 val SpiderManifestation = card("Spider Manifestation") {
     manaCost = "{1}{R/G}"
@@ -35,7 +40,14 @@ val SpiderManifestation = card("Spider Manifestation") {
 
     activatedAbility {
         cost = Costs.Tap
-        effect = Effects.AddManaOfChoice(ManaColorSet.Specific(setOf(Color.RED, Color.GREEN)))
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
         manaAbility = true
         timing = TimingRule.ManaAbility
     }

--- a/mtg-sets/2025/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderManifestationScenarioTest.kt
+++ b/mtg-sets/2025/tests/src/test/kotlin/com/wingedsheep/engine/scenarios/SpiderManifestationScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.spm.cards.SpiderManifestation
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Spider Manifestation (SPM #148) — {1}{R/G} Creature — Spider Avatar, 2/2.
+ *
+ *  - Reach.
+ *  - "{T}: Add {R} or {G}." — an unridered dual mana line, so it is *two* abilities sharing the tap
+ *    cost rather than one choice-of-color ability. That distinction is what this test pins: the
+ *    colour is picked by choosing which ability to activate, not by a decision on resolution, which
+ *    is the spelling Assay reads out of the printed text and the one 165 other cards use.
+ *  - "Whenever you cast a spell with mana value 4 or greater, untap this creature." — the rider that
+ *    makes the mana line worth having, and the reason the threshold matters.
+ */
+class SpiderManifestationScenarioTest : FunSpec({
+
+    val manaAbilities = SpiderManifestation.activatedAbilities.filter { it.isManaAbility }
+
+    fun pool(driver: GameTestDriver, player: EntityId): ManaPoolComponent =
+        driver.state.getEntity(player)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20, skipMulligans = true)
+        return driver
+    }
+
+    fun readySpider(driver: GameTestDriver, player: EntityId): EntityId {
+        val spider = driver.putCreatureOnBattlefield(player, "Spider Manifestation")
+        driver.removeSummoningSickness(spider)
+        driver.untapPermanent(spider)
+        return spider
+    }
+
+    test("has reach") {
+        SpiderManifestation.keywords.contains(Keyword.REACH) shouldBe true
+    }
+
+    test("the dual mana line is two abilities, not one colour choice") {
+        manaAbilities.size shouldBe 2
+    }
+
+    test("each mana ability taps for its own colour without asking for a choice") {
+        val expected = listOf(Color.RED, Color.GREEN)
+        for ((index, color) in expected.withIndex()) {
+            val driver = setup()
+            val p1 = driver.activePlayer!!
+            val spider = readySpider(driver, p1)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+            driver.submitSuccess(
+                ActivateAbility(playerId = p1, sourceId = spider, abilityId = manaAbilities[index].id)
+            )
+
+            // A two-ability dual resolves straight into the pool — nothing left to decide.
+            driver.pendingDecision.shouldBeNull()
+            driver.isTapped(spider) shouldBe true
+
+            val manaPool = pool(driver, p1)
+            manaPool.red shouldBe if (color == Color.RED) 1 else 0
+            manaPool.green shouldBe if (color == Color.GREEN) 1 else 0
+        }
+    }
+
+    test("casting a spell with mana value 4 or greater untaps it") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val spider = readySpider(driver, p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.tapPermanent(spider)
+
+        // Force of Nature is {3}{G}{G} — mana value 5.
+        val bigSpell = driver.putCardInHand(p1, "Force of Nature")
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.giveColorlessMana(p1, 3)
+        driver.castSpell(p1, bigSpell).error shouldBe null
+
+        // The trigger sits above the spell; resolving it untaps the Spider.
+        driver.bothPass()
+        driver.isTapped(spider) shouldBe false
+    }
+
+    test("casting a spell with mana value 3 does not untap it") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val spider = readySpider(driver, p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.tapPermanent(spider)
+
+        // Centaur Courser is {2}{G} — mana value 3, one under the threshold.
+        val smallSpell = driver.putCardInHand(p1, "Centaur Courser")
+        driver.giveMana(p1, Color.GREEN, 1)
+        driver.giveColorlessMana(p1, 2)
+        driver.castSpell(p1, smallSpell).error shouldBe null
+
+        driver.bothPass()
+        driver.isTapped(spider) shouldBe true
+    }
+})

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -9510,14 +9510,18 @@
                 "id": "ability_2",
                 "cost": "CostTap",
                 "effect": {
-                    "type": "AddManaOfChoice",
-                    "colorSet": {
-                        "type": "ManaColorSet.Specific",
-                        "colors": [
-                            "RED",
-                            "GREEN"
-                        ]
-                    }
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
                 },
                 "timing": "ManaAbility",
                 "isManaAbility": true

--- a/oracle-assay/AGENTS.md
+++ b/oracle-assay/AGENTS.md
@@ -84,9 +84,11 @@ review, it is a change to decline.
 - **Two SDK spellings of one thing get one rule, and a finding.** Registering both is genuine
   ambiguity. `Primitives.protectionScope` deliberately never emits
   `Simple(PROTECTION_FROM_EACH_OPPONENT)`; `ProtectionScope.Colors` is a scope the grammar never
-  produces; `Mana` never emits `ManaColorSet.Specific`, which 13 cards use for a dual land's line
-  where 165 use two abilities. Each such omission carries a KDoc paragraph naming it as an SDK
-  finding.
+  produces; `Mana` never emits `ManaColorSet.Specific`, which a handful of cards use for a dual
+  land's line where 165 use two abilities. Each such omission carries a KDoc paragraph naming it as
+  an SDK finding. Declining the minority spelling also polices the minority's membership: what earns
+  `Specific` is a rider, a rider is what makes the line decline, so a card in that group whose mana
+  line *reads* is in the wrong group. That is how Spider Manifestation's card bug surfaced.
 - **A value the SDK carries twice is derived, not spelled.** `ActivatedAbility` says a mana ability
   is one in `isManaAbility` *and* in `timing`; no printed word says either, and CR 605.1a defines it
   as a property of the effect and the target list. `Activated.abilityFor` therefore computes both,

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -454,7 +454,10 @@ produced one of each kind.
 - **The standing `ManaColorSet.Specific` finding, recurring — Spider Manifestation.** "{T}: Add {R}
   or {G}." as one `AddManaOfChoiceEffect` where 165 cards write two abilities. The README's own note
   said none of the thirteen was compared "because each one's rider declines anyway"; this band read
-  the rider. Still not folded, for the reason recorded below.
+  the rider. Read afterwards and classified a **card bug**: the note says `Specific` earns its place
+  on the riders the two-ability form cannot express, and this line has no rider — the card was in the
+  wrong group. Fixed to two abilities, with a scenario test. The finding below is unchanged and still
+  not folded.
 
 **Where the ranking points next.** On the same tail ranking, the row under `you cast` at 504 was
 `When ~` at 263 and then a flat run — `enchanted creature` 183, `for each` 175, `Until end of` 170,
@@ -574,25 +577,34 @@ partially-read card would count a keyword Assay never saw as agreement, so every
 named population bucket instead and the denominator stays visible.
 
 ```
-  Hand-written cards                 9127
+  Hand-written cards                 9131
     compared                         2698
-    not yet covered by the grammar   5789
+    not yet covered by the grammar   5793
     script slot not modelled yet      88
     lines do not fold into one card   54
     multi-face (out of scope)        301
     Oracle text differs from golden  197
     golden would not decode            0
 
-  Confirmed — models agree           2697    999.6‰ (100.0%)
-  DIVERGENT — read every one            1
+  Confirmed — models agree           2698   1000.0‰ (100.0%)
+  DIVERGENT — read every one            0
 ```
 
-**The one standing divergence is the already-open `ManaColorSet.Specific` finding**, recurring on
-Spider Manifestation exactly as the note below predicted it would. The count was at zero after the
-sweep and the two findings after it; the spell-cast band took it to four and three of those are
-fixed here, which is the gate behaving the way it is supposed to — zero is a checkpoint, not a
-property, and it has risen on the day the grammar reached every new card class but one. The sweep
-itself took the count from 122 to 1: every divergence the gate had
+**The count is back at zero, and the card that took it off zero was a card bug.** The Bloomburrow
+band's one standing divergence was the already-open `ManaColorSet.Specific` finding, recurring on
+Spider Manifestation exactly as the note below predicted it would: "{T}: Add {R} or {G}." written as
+one `AddManaOfChoiceEffect` where 165 cards write two abilities. What the finding's own note says
+justifies `Specific` is a *rider* the two-ability form cannot express correctly — and Spider
+Manifestation's mana line has no rider at all. It was the first of the thirteen to become comparable
+and the one that did not belong in the group; it is now two abilities, with the scenario test that
+asserts the observable half (activating adds the colour straight into the pool, with no colour
+decision to make). The finding itself stands, unchanged and still not folded: the other twelve keep
+their riders, and the grammar still never emits `Specific`.
+
+The count was at zero after the sweep and the two findings after it; the spell-cast band took it to
+four and three of those were fixed in that band, which is the gate behaving the way it is supposed to
+— zero is a checkpoint, not a property. The sweep itself took the count from 122 to 1: every
+divergence the gate had
 accumulated was read, classified as parser bug / card bug / fold, and acted on. The one it left
 standing was Lavaborn Muse, closed by the CR 603.4 split below. What the sweep found, by kind:
 
@@ -722,8 +734,10 @@ and never `triggerRestriction`, so a "while" card declines rather than printing 
 means something else.
 
 **The differential was at zero here, and the spell-cast band moved it off — exactly as this
-paragraph predicted.** Four divergences over 46 newly-compared cards, three of them fixed (one
-parser bug, two card bugs) and the fourth the standing `ManaColorSet.Specific` finding. Zero is a
+paragraph predicted.** Four divergences over 46 newly-compared cards, three of them fixed on the spot
+(one parser bug, two card bugs) and the fourth — Spider Manifestation, under the standing
+`ManaColorSet.Specific` finding — read afterwards and fixed as a third card bug, since that card's
+mana line carries none of the riders the finding says the type earns its place on. Zero is a
 checkpoint, not a destination: it means every card the grammar reads whole agrees with its golden on
 the day it is measured, and the next band of rules is expected to move it off again.
 
@@ -986,12 +1000,21 @@ Found the way all five were, by running it on a card class it had never reached.
   "Target creature gets +3/+3 until end of turn." Different polymorphic hierarchies, so nothing
   clashes, but one card's JSON can show both under one type name.
 - **Open: `ManaColorSet.Specific` is a second spelling of a dual land's line.** 165 cards write
-  "{T}: Add {B} or {G}." as two `AddManaEffect` abilities sharing a cost, and 13 write it as one
+  "{T}: Add {B} or {G}." as two `AddManaEffect` abilities sharing a cost, and a much smaller group —
+  13 when this was written, 16 goldens today — write it as one
   `AddManaOfChoiceEffect(ManaColorSet.Specific(...))`. Unlike the other entries in this list the
   split has a *reason*: every card in the smaller group carries a rider the two-ability form cannot
   express correctly — "Activate only once each turn" on two abilities permits two activations — so
   the type earns its place. The grammar emits the majority and never emits `Specific`, and none of
-  the 13 is compared today because each one's rider declines anyway.
+  the smaller group is compared today because each one's rider declines anyway.
+
+  **The divergence it threw off is also its membership test.** Spider Manifestation was in the
+  smaller group with a bare "{T}: Add {R} or {G}." and no rider on it at all — so its line parsed, so
+  the card was compared, so it diverged, and the finding's own reason for the type is what says it
+  belonged in the majority. It is now two abilities. Generalized: **a card in the smaller group whose
+  mana line *reads* is a card in the wrong group**, because a rider is exactly what makes the line
+  decline. That test costs nothing to run — it is the differential, unchanged — and it is why the
+  finding is worth leaving open rather than folding.
 
 And the gate paid for itself before its first report: writing it surfaced that "Plains"
 de-pluralized to `Subtype("Plain")` — the "Elves" → `Elve` failure, live on the basic land types,

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Mana.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Mana.kt
@@ -26,15 +26,21 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * ### `Add {B} or {G}.` is two abilities, and the SDK can say it two ways
  *
  * 165 hand-written cards spell a dual land's line as **two** `AddManaEffect` abilities sharing a
- * cost — Jungle Hollow's golden is two `CostTap` entries, one `BLACK` and one `GREEN` — and 13
- * spell it as one `AddManaOfChoiceEffect(ManaColorSet.Specific(...))`. Both work, and the split is
- * not arbitrary: every card in the second group carries a rider the first group cannot express
- * correctly ("Activate only once each turn" on two abilities would permit two activations), which
- * is a good reason for the type to exist and no reason for it to be a second spelling of the plain
- * case. The grammar therefore emits the majority form and never emits `ManaColorSet.Specific`, the
- * same treatment [Primitives.protectionScope] gives `ProtectionScope.Colors`. Registering both
+ * cost — Jungle Hollow's golden is two `CostTap` entries, one `BLACK` and one `GREEN` — and a much
+ * smaller group spells it as one `AddManaOfChoiceEffect(ManaColorSet.Specific(...))`. Both work, and
+ * the split is not arbitrary: every card in the second group carries a rider the first group cannot
+ * express correctly ("Activate only once each turn" on two abilities would permit two activations),
+ * which is a good reason for the type to exist and no reason for it to be a second spelling of the
+ * plain case. The grammar therefore emits the majority form and never emits `ManaColorSet.Specific`,
+ * the same treatment [Primitives.protectionScope] gives `ProtectionScope.Colors`. Registering both
  * would be genuine ambiguity — one text, two models — which the design says never to resolve by
  * picking one.
+ *
+ * Declining the minority form is also how the group polices its own membership. A rider is what
+ * makes the line decline, so a card in the smaller group whose mana line *reads* has no rider and
+ * therefore belongs in the majority. Spider Manifestation is the worked example: a bare
+ * "{T}: Add {R} or {G}." that parsed, got compared, and diverged against its own golden. The card
+ * was the bug, and it is now two abilities.
  *
  * A rule that denotes several things from one phrase is [Keywords.qualityRun]'s shape, which is why
  * [alternatives] hands back a list and [Activated] does the joining.


### PR DESCRIPTION
The Bloomburrow band (#1845) left the differential at 2,697 of 2,698, and the one standing divergence was the already-open `ManaColorSet.Specific` finding recurring on Spider Manifestation, exactly as the README's note predicted it would. Read and classified: it is a **card bug**.

## The divergence

Assay reads `{T}: Add {R} or {G}.` as two `AddMana` abilities sharing the tap cost. The card wrote one `AddManaOfChoice(ManaColorSet.Specific(RED, GREEN))`. Everything else on it — reach, the mana-value-4 cast trigger, the untap — matched exactly.

The finding's own reason for the type is what settles it. 165 cards write a dual line as two abilities; the small minority uses `Specific` because each of them carries a **rider the two-ability form cannot express correctly** — "Activate only once each turn" spread over two abilities permits two activations. Spider Manifestation's mana line carries no rider at all. It was the first of that group to become comparable, and the one that did not belong in it.

Neither of the other two dispositions was available. The grammar cannot emit both spellings — one printed form with two models is ambiguity by construction, which the design says never to resolve by picking one — and folding them in the differential would erase the rider distinction that makes the type worth having.

## The change

- `SpiderManifestation.kt` is two `Effects.AddMana` abilities, with a KDoc paragraph on why this one is not `Specific`.
- `SpiderManifestationScenarioTest.kt` asserts the observable half of the fix: two mana abilities exist, each taps for its own colour **with no pending colour decision**, mana value 5 untaps, mana value 3 does not.
- `SPM.json` re-blessed. The diff touches only this card.

## The finding stays open, and gains a test

Unchanged and unfolded — the other cards in the minority keep their riders, and the grammar still never emits `Specific`. What the divergence handed over is a free membership check, now recorded in the README, `oracle-assay/AGENTS.md` and `Mana.kt`'s KDoc:

> A rider is exactly what makes the line decline, so a card in the `Specific` minority whose mana line *reads* is a card in the wrong group.

That check is the differential, unchanged, running as it already does — which is itself an argument for leaving the finding open rather than folding it. The same pass retires the stale "13 cards" count in those three places (the goldens hold 16 today).

## Verification

- `just test-class SpiderManifestationScenarioTest` — 5/5 pass.
- `just assay-differential` — **2,698 of 2,698 compared cards agree, 0 divergences**, up from 2,697/2,698.
- `just assay-differential --set SPM` — 30/30.
- `:oracle-assay` compiles (KDoc-only change there).

Zero is a checkpoint, not a property: it means every card the grammar reads whole agrees with its golden on the day it is measured, and the next band of rules is expected to move it off again.

Note for the reviewer: this branch was cut from a working tree holding another agent's in-flight assay-explorer and coverage work. Only the seven files above are committed here; none of that is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
