### PR TITLE
Assay: the cost band, and one cost language read as one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ docs it points at; load those when the work needs them.
 | `gym` / `gym-server` / `gym-trainer` | RL/MCTS env + HTTP transport + self-play SPI | engine, sdk |
 | `game-server` | Spring Boot orchestration, WebSocket, state masking | engine, sdk |
 | `mtgish-tooling` | Predictive coverage / auto-gen analyzer | — (scans source as text) |
-| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 2,697 of 2,698 compared cards agree — the one standing divergence is the open `ManaColorSet.Specific` finding), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
+| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 2,746 of 2,747 compared cards agree — the one standing divergence is the open `ManaColorSet.Specific` finding), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
 | `web-client` | React UI (dumb terminal — no game logic) | — |
 
 **Key principle:** the engine is pure (no card-specific code), content is data-driven (no execution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ docs it points at; load those when the work needs them.
 | `gym` / `gym-server` / `gym-trainer` | RL/MCTS env + HTTP transport + self-play SPI | engine, sdk |
 | `game-server` | Spring Boot orchestration, WebSocket, state masking | engine, sdk |
 | `mtgish-tooling` | Predictive coverage / auto-gen analyzer | — (scans source as text) |
-| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, 2,746 of 2,747 compared cards agree — the one standing divergence is the open `ManaColorSet.Specific` finding), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
+| [`oracle-assay`](oracle-assay/README.md) | Argentum Assay — bidirectional Oracle-text parser; touchstone gate (`just assay-gate`, `--set POR` and `--set LGN` both read 100%), differential gate against the hand-written cards (`just assay-differential`, all 2,747 compared cards agree), browser explorer over the live grammar (`just assay-explore`), and the Scenario Builder's dev-gated custom-card sandbox (`just assay compile`) | sdk |
 | `web-client` | React UI (dumb terminal — no game logic) | — |
 
 **Key principle:** the engine is pure (no card-specific code), content is data-driven (no execution

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/WirewoodSymbiote.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/scg/cards/WirewoodSymbiote.kt
@@ -24,7 +24,10 @@ val WirewoodSymbiote = card("Wirewood Symbiote") {
     toughness = 1
 
     activatedAbility {
-        cost = Costs.ReturnToHand(GameObjectFilter.Creature.withSubtype("Elf"))
+        // "an Elf you control" is a bare tribal noun: any permanent that's an Elf, not only a
+        // creature one. Unobservable today — every Elf printed is a creature — which is why it
+        // survived; Assay's differential found it the moment it could read a cost's noun phrase.
+        cost = Costs.ReturnToHand(GameObjectFilter.Permanent.withSubtype("Elf"))
         val t = target("creature", Targets.Creature)
         effect = TapUntapEffect(
             target = t,

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/FungalPlots.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/FungalPlots.kt
@@ -36,7 +36,9 @@ val FungalPlots = card("Fungal Plots") {
     }
 
     activatedAbility {
-        cost = Costs.SacrificeMultiple(2, GameObjectFilter.Creature.withSubtype("Saproling"))
+        // "two Saprolings" is a bare tribal noun — any permanent that's a Saproling, not only a
+        // creature one. See WirewoodSymbiote for the same correction.
+        cost = Costs.SacrificeMultiple(2, GameObjectFilter.Permanent.withSubtype("Saproling"))
         effect = Effects.GainLife(2)
             .then(Effects.DrawCards(1))
     }

--- a/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GenePollinator.kt
+++ b/mtg-sets/2025/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/GenePollinator.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 
 /**
  * Gene Pollinator
@@ -21,9 +22,13 @@ val GenePollinator = card("Gene Pollinator") {
     oracleText = "{T}, Tap an untapped permanent you control: Add one mana of any color."
 
     activatedAbility {
+        // "Tap an untapped permanent you control" — not "another", and the noun is "permanent"
+        // rather than the unqualified `Any` the no-argument facade defaults to. The `excludeSelf`
+        // this used to carry restated what the co-paid {T} already guarantees: the source is tapped
+        // by it, so it is never an untapped permanent when this half of the cost is chosen.
         cost = Costs.Composite(
             Costs.Tap,
-            Costs.TapAnotherPermanent()
+            Costs.TapPermanents(1, GameObjectFilter.Permanent)
         )
         effect = Effects.AddAnyColorMana(1)
         manaAbility = true

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -4200,7 +4200,7 @@
                     "type": "CostAtomWrapper",
                     "atom": {
                         "type": "AtomSacrifice",
-                        "filter": "creature Saproling",
+                        "filter": "permanent Saproling",
                         "count": 2
                     }
                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -6142,7 +6142,7 @@
                             "type": "CostAtomWrapper",
                             "atom": {
                                 "type": "AtomTapPermanents",
-                                "excludeSelf": true
+                                "filter": "permanent"
                             }
                         }
                     ]

--- a/mtg-sets/src/test/resources/snapshots/cards/SCG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SCG.json
@@ -7759,7 +7759,7 @@
                     "type": "CostAtomWrapper",
                     "atom": {
                         "type": "AtomReturnToHand",
-                        "filter": "creature Elf"
+                        "filter": "permanent Elf"
                     }
                 },
                 "effect": {

--- a/oracle-assay/AGENTS.md
+++ b/oracle-assay/AGENTS.md
@@ -110,6 +110,22 @@ ability, so every step rule enriches every trigger rule for free. Any new senten
 activated abilities, modal spells, "you may", delayed triggers — must slot the existing effect
 grammar rather than restating the verbs. The win is multiplicative; restating is additive and rots.
 
+The **cost band** is the same rule applied to a *vocabulary* rather than to a clause, and it is the
+one to copy when the SDK has already done the factoring. `CostAtom`'s KDoc calls itself "the one cost
+language" — one payable thing, carried into each context by that context's own `Atom` wrapper — and
+the grammar had it the other way round: `Costs` read a list of cost sentences and
+`Restrictions.additionalCostLine` read one of them again, separately. The fix was to make the
+vocabulary a `Phrase<CostAtom>` and the two contexts two lifts of it. Read the SDK's own type before
+writing a second vocabulary; if it already unifies the thing, the grammar's factoring should be the
+same shape, and what stays outside the shared part (the self-costs, which a spell cannot pay) is then
+a stated rule rather than a gap.
+
+The band's other transferable finding is about **case**. A construct that lives in one sentence
+position can spell its second capitalization as an `alternate` — parseable, never printed. The moment
+it reaches a second position that spelling may become *canonical* there, and an `alternate` would
+print the wrong one. Make the capitalization a parameter of the family and instantiate it per
+position, exactly as `SelfSteps.retargetable` is instantiated per anaphor position.
+
 **Layer over a predicate bag; never compose.** A `GameObjectFilter` is a bag with no canonical
 spelling, so two rules that can each print *part* of one value leave printing underdetermined. The
 answer in `Filters` is layering: one alternation spells the whole type phrase, exactly one optional

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -581,8 +581,8 @@ spelling could be an `alternate` — parseable, never printed. It no longer hold
 *canonical*. The vocabulary is therefore a function of its leading word's spelling, instantiated
 twice, which is also what stops a row existing in one capitalization only.
 
-**Three card bugs, all of the same kind, all invisible in play.** The differential went 1 → 4 the
-first time the gate could read a cost's noun phrase, and every new one was a hand-written card:
+**Three card bugs, all of the same kind, all invisible in play.** The differential went 0 → 3 the
+first time the gate could read a cost's noun phrase, and every one of them was a hand-written card:
 
 - **Wirewood Symbiote** and **Fungal Plots** spell "an Elf you control" and "two Saprolings" as
   `GameObjectFilter.Creature.withSubtype(…)`. A bare tribal noun means any *permanent* of that

--- a/oracle-assay/README.md
+++ b/oracle-assay/README.md
@@ -20,12 +20,21 @@ and those are the two sentences on it. The **aura band** followed: `Enchant <fil
 attached-permanent statics, which opened `staticAbilities` — the largest `CardScript` slot the
 differential could not see into, and the one every later static family lands in.
 
-The most recent work is the **spell-cast band** — "Whenever you cast a noncreature spell, …" — which
-gives the grammar its first noun phrase for a *spell* rather than a permanent, and is the largest
-single family left in the corpus by the honest ranking: 504 cards decline on nothing but a
+The most recent work is the **cost band** — what you pay, everywhere you pay it. It is the largest
+single delivery a family has made here (**+274 whole cards**, 7,177 → 7,451) and the first one that
+needed no new grammar *machinery* at all, only a refactoring: `CostAtom`'s own KDoc calls itself
+"the one cost language", and the grammar now reads it that way round — one `Phrase<CostAtom>`
+vocabulary lifted into an activated ability's cost and into a spell's additional cost, instead of
+two vocabularies over the same English. See [the cost band](#the-cost-band) below; it also found
+three hand-written cards whose noun phrases were wrong inside a cost, where nothing had ever looked.
+
+Before it came the **spell-cast band** — "Whenever you cast a noncreature spell, …" — which
+gives the grammar its first noun phrase for a *spell* rather than a permanent, and was the largest
+single family left in the corpus by the honest ranking: 504 cards declined on nothing but a
 spell-cast trigger, against 263 for the next one. See [the spell-cast band](#the-spell-cast-band)
 below; it is also where the ranking method itself changed, from the token a line died on to the
-**tail** the parse could not read.
+**tail** the parse could not read. Then the **Bloomburrow band** — the first set picked *because*
+its cards are already implemented, so every decline was a grammar gap with a written answer.
 
 Before it came the **counters band**, the first one picked by *ranking the backlog* rather than by
 picking a set: `just assay-report --implemented` said 656 cards with a hand-written golden decline
@@ -529,6 +538,75 @@ differential on the day a line stopped declining:
 keyword line and the `If the gift was promised, …` rider, the second of which needs its base clause
 to read first. After it: the Class levels (`{3}{U}: Level 2`, 10 cards), modal spells (8), and
 "Spend this mana only to cast …" (6).
+
+## The cost band
+
+What you pay, everywhere you pay it. Whole-corpus coverage went 7,177 → **7,451 cards**, byte-exact
+lines 24,993 → **25,377**, the differential's compared population 2,698 → **2,747** — and, being an
+`mtg-sdk`-shaped band, it needed no new SDK type at all: every atom it reads was already in
+`CostAtom`, waiting for a sentence.
+
+**It is the largest band the tail ranking has produced, and the probe agreed with it before a line
+was written.** Ranked by the parse's tail, the top rows are the modal bullets and a scatter of
+trigger prefixes; the cost family does not appear as a row at all, because a cost is *the text before
+a colon* and the tail keys on what came after. Ranking the colon lines directly — substituting `{T}: `
+for every cost the grammar could not read and re-parsing — says **465 whole cards are blocked on
+nothing but the cost clause**, against 104 for the modal band and 111 for cost reduction. A second
+probe, greedy over the individual atoms, ranked the rows: "Discard a card" alone finishes 86 cards,
+counter removal 49, the singular tap 35, "Sacrifice another" 35. The band delivered **274**, which is
+the sum of exactly the rows that were written; the residue is named below and each piece of it is a
+different band.
+
+**One vocabulary, two contexts, because the SDK says so.** `CostAtom`'s own KDoc calls itself "the
+one cost language": a payable thing is declared once and each *context* carries it through its own
+`Atom` wrapper. Assay had it the other way round — `Costs` read a list of cost sentences for an
+activated ability, and `Restrictions.additionalCostLine` was a separate rule that read
+"sacrifice {filter}" and nothing else. Two vocabularies over one English. So `Costs.atoms` is now a
+`Phrase<CostAtom>`, and the two contexts are two *lifts* of it. Adding "discard a card" to the
+activation side gave "As an additional cost to cast this spell, discard a card." for free, and the
+test for that property is one assertion in each of the two files.
+
+**What is deliberately *not* an atom is the other half of the argument.** "Sacrifice ~", "Exile ~",
+`{T}`, `{Q}`, "Exert ~" stay `AbilityCost` cases and are unreachable from the spell side — for the
+reason `CostAtom` gives for keeping `excludeSelf` off it: *a spell being cast has no source
+permanent*. That is a rule rather than a gap, and `RestrictionsTest` asserts the decline.
+
+**Capitalization stopped being an `alternate` and became a parameter.** A cost atom is the one clause
+Oracle capitalizes that is not a sentence start, so while costs lived in one position the lowercase
+spelling could be an `alternate` — parseable, never printed. It no longer holds: in
+"As an additional cost to cast this spell, **sacrifice** a creature." the lowercase form is
+*canonical*. The vocabulary is therefore a function of its leading word's spelling, instantiated
+twice, which is also what stops a row existing in one capitalization only.
+
+**Three card bugs, all of the same kind, all invisible in play.** The differential went 1 → 4 the
+first time the gate could read a cost's noun phrase, and every new one was a hand-written card:
+
+- **Wirewood Symbiote** and **Fungal Plots** spell "an Elf you control" and "two Saprolings" as
+  `GameObjectFilter.Creature.withSubtype(…)`. A bare tribal noun means any *permanent* of that
+  tribe — the same correction the 103-card migration made everywhere the grammar could already see,
+  and these two survived it because their nouns were inside a **cost**, which nothing read until now.
+  Unobservable today, since every printed Elf and Saproling is a creature.
+- **Gene Pollinator** writes `Costs.TapAnotherPermanent()` for "Tap an untapped permanent you
+  control" — a text with no "another" in it, and a filter left at the facade's unqualified default
+  where the noun is "permanent". The `excludeSelf` restated what the co-paid `{T}` already
+  guarantees.
+
+**Where the ranking points next, in this family.** The same greedy probe names the rows left, and
+they are three different bands rather than more rows:
+
+- **The self costs that are activated from another zone** — "Discard ~" (25 cards) and
+  "Exile ~ from your graveyard" (22). Both need `ActivatedAbility.activateFromZone`, which the cost
+  clause *determines* — you cannot discard a permanent, and "from your graveyard" says where the card
+  is. That makes the cost rule's result a pair of (cost, zone) rather than a cost, which is a change
+  to `Costs.cost`'s type and to `Activated`'s four call sites: a band of its own, not a row.
+- **The keyword-labelled costs** — "Exhaust — {5}{U}{U}" (6), "Power-up — {5}{G}{G}" (8),
+  "Boast — {4}{R}" (7), "Max speed — {3}" (10), "Renew —", "Forecast —", "Waterbend". Each is a flag
+  on `ActivatedAbility` plus a printed prefix; one shape, seven rows.
+- **Filter gaps, not cost gaps** — "Sacrifice a Food" (14) and "Sacrifice another creature or
+  artifact" decline in [`Filters`](src/main/kotlin/com/wingedsheep/assay/grammar/Filters.kt), not
+  here: the artifact subtypes the SDK publishes no list for, and the type disjunction.
+- **`{S}`** (20 cards) is an **SDK gap** — `ManaCost` cannot express snow mana, so `Primitives.manaCost`
+  declines rather than inventing a symbol. That one is `add-feature` work.
 
 ## What Phase 1 already found
 

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Costs.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Costs.kt
@@ -10,19 +10,43 @@ import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.assay.syntax.separated
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AdditionalCost
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.costs.CostAtom
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import com.wingedsheep.sdk.dsl.Costs as SdkCosts
 
 /**
- * What an activated ability costs — the clause before the colon.
+ * What you pay — the clause before an activated ability's colon, and the clause an
+ * "As an additional cost to cast this spell, …" line spells.
+ *
+ * ### One vocabulary, two contexts, because the SDK says so
+ *
+ * `CostAtom`'s own KDoc calls itself "the **one cost language**": a payable thing is declared once
+ * and each *context* carries it through its own `Atom` wrapper — `AbilityCost.Atom` for an activated
+ * ability, `AdditionalCost.Atom` for a spell's additional cost. This file is written the same way
+ * round. [atoms] is a `Phrase<CostAtom>` — "discard a card", "sacrifice another creature", "remove
+ * two spore counters from ~" — and the two contexts are two *lifts* of it, [cost] and [additional].
+ * A row added here reaches both, which is the property the previous shape lacked: an additional cost
+ * used to be a rule of its own that read "sacrifice a creature" and nothing else, while the
+ * activation side read a different, longer list of the same English.
+ *
+ * ### What is *not* an atom: the costs only a permanent can pay
+ *
+ * "Sacrifice ~", "Exile ~", `{T}`, `{Q}`, "Exert ~" are their own `AbilityCost` cases rather than
+ * atoms, and the reason is the same one `CostAtom` gives for keeping `excludeSelf` off the spell
+ * side: *a spell being cast has no source permanent*. So [abilityOnly] holds them, [cost] offers
+ * them alongside the lifted atoms, and [additional] does not offer them at all — which is not a gap
+ * but the rule. A mana cost is in the same group for a different reason: an additional cost that is
+ * mana is printed as part of the spell's own cost, never as this sentence.
  *
  * ### An atom, and a comma-joined run of them
  *
  * `{T}` is one cost, `{2}{B}, {T}, Sacrifice a Goblin` is three, and the SDK spells the second as
  * `AbilityCost.Composite` of the first kind. So this file is an **atom vocabulary** plus one run
  * rule, rather than a rule per whole cost shape: `{1}, {T}` stopped being a rule of its own the
- * moment a third atom appeared, and every future atom (a discard, a counter removal, an exile from
- * a graveyard) is a row in [atoms] that every multi-atom cost gets for free.
+ * moment a third atom appeared, and every future atom is a row in [atoms] that every multi-atom cost
+ * gets for free.
  *
  * The single-atom case is the atom itself and **not** a one-element `Composite`, because that is
  * what hand-written cards carry — `AbilityCost.Composite` with one member is a value no card in the
@@ -37,16 +61,18 @@ import com.wingedsheep.sdk.dsl.Costs as SdkCosts
  * it safe to generalize away from the enumerated pairs — reading it the other way round would
  * round-trip and disagree with every card, the reversible-but-wrong class.
  *
- * ### A cost is the one clause Oracle capitalizes that is not a sentence start
+ * ### Capitalization is a *parameter* of the vocabulary, not an alternate over it
  *
- * Every other template in this grammar is written mid-sentence, because
- * [com.wingedsheep.assay.syntax.SentenceCase] owns the capital at each sentence start and a clause
- * can appear at one or not. A cost atom is the opposite: Oracle capitalizes it *everywhere*
- * ("Sacrifice a Goblin: …", "{T}, Sacrifice a Forest: …"), and `SentenceCase` lowercases only the
- * one at the line's start. So the capitalized spelling is canonical, the lowercase one is an
- * [alternate] reachable only where the pass put it, and both print back byte-exactly — the line
- * start because `capitalize` restores it, and every other position because it was never touched.
- * [bothCases] is that pairing, and it is why a cost rule is a function of its verb's spelling.
+ * A cost atom is the one clause Oracle capitalizes that is not a sentence start
+ * ("Sacrifice a Goblin: …", "{T}, Sacrifice a Forest: …"), and
+ * [com.wingedsheep.assay.syntax.SentenceCase] lowercases only the one at the line's start. That was
+ * an [alternate] while costs lived in one position. They no longer do: in
+ * "As an additional cost to cast this spell, **sacrifice** a creature." the lowercase spelling is
+ * *canonical* and the capital would be a misprint. So [vocabulary] takes the leading word's
+ * spelling as an argument and is instantiated twice; [atoms] pairs the two the way the activation
+ * position needs them, and [additional] takes the lowercase instance alone. Writing it as one
+ * template per row instantiated twice is what keeps the two halves from drifting — a row cannot
+ * exist in one capitalization only.
  *
  * ### `{T}` is not a mana cost, and the SDK is what says so
  *
@@ -57,16 +83,392 @@ import com.wingedsheep.sdk.dsl.Costs as SdkCosts
  */
 object Costs {
 
+    // -------------------------------------------------------------------------------------------
+    // The shared atom vocabulary
+    // -------------------------------------------------------------------------------------------
+
+    /**
+     * The `CostAtom` an SDK cost factory builds.
+     *
+     * Every row below constructs through `dsl.Costs` rather than through `CostAtom` directly, so the
+     * facade stays the single place that decides what an atom's fields mean and a rule here cannot
+     * drift from it — the same reason a card is required to. Unwrapping is total for the factories
+     * used here, each of which returns an `AbilityCost.Atom`, and a facade that stopped doing so is
+     * a bug worth failing loudly on rather than declining quietly.
+     */
+    private fun atomOf(cost: AbilityCost): CostAtom =
+        requireNotNull((cost as? AbilityCost.Atom)?.atom) { "not an atom cost: $cost" }
+
+    /**
+     * The atom vocabulary in one capitalization.
+     *
+     * [lead] spells a row's leading word — `String::capitalized` for the activation position, the
+     * identity for a mid-sentence one. Nothing else in a row differs between the two, which is why
+     * this is a function returning the whole vocabulary rather than a per-row pairing helper.
+     */
+    private fun vocabulary(lead: (String) -> String): Phrase<CostAtom> {
+
+        /**
+         * "Sacrifice a Goblin", "Sacrifice a creature" — one permanent matching a filter.
+         *
+         * The article comes from [Filters.indefinite], which derives it from the noun's spelling in
+         * both directions; the model has nowhere to keep it. `count` is checked against 1 here and
+         * the plural rule below refuses 1, so the two take disjoint models and one printed form
+         * exists per value.
+         */
+        val sacrificeFiltered = phrase("${lead("sacrifice")} {filter}", name = "sacrifice a permanent") {
+            slot("filter", Filters.indefinite)
+            build { atomOf(SdkCosts.Sacrifice(it.value("filter"))) }
+            match { atom ->
+                val sacrifice = atom as? CostAtom.Sacrifice ?: return@match null
+                if (sacrifice.count != 1) return@match null
+                if (atom != atomOf(SdkCosts.Sacrifice(sacrifice.filter))) return@match null
+                bind("filter" to sacrifice.filter)
+            }
+        }
+
+        /**
+         * "Sacrifice another creature" — Nantuko Husk. The source is excluded from what may pay,
+         * which the SDK carries as `excludeSelf` and Oracle spells as the word "another".
+         *
+         * No article: "another" is a determiner, so this slots the bare noun phrase where
+         * [sacrificeFiltered] slots the one that carries its own "a"/"an".
+         */
+        val sacrificeAnother = phrase("${lead("sacrifice")} another {filter}", name = "sacrifice another permanent") {
+            slot("filter", Filters.filter)
+            build { atomOf(SdkCosts.SacrificeAnother(it.value("filter"))) }
+            match { atom ->
+                val sacrifice = atom as? CostAtom.Sacrifice ?: return@match null
+                if (atom != atomOf(SdkCosts.SacrificeAnother(sacrifice.filter))) return@match null
+                bind("filter" to sacrifice.filter)
+            }
+        }
+
+        /** "Sacrifice three Clerics" — Dark Supplicant. The counted sibling, over a plural noun. */
+        val sacrificeSeveral =
+            phrase("${lead("sacrifice")} {n} {filter}", name = "sacrifice several permanents") {
+                slot("n", Cardinals.word)
+                slot("filter", Filters.plural)
+                build { atomOf(SdkCosts.SacrificeMultiple(it.int("n"), it.value("filter"))) }
+                match { atom ->
+                    val sacrifice = atom as? CostAtom.Sacrifice ?: return@match null
+                    if (!Cardinals.spellable(sacrifice.count)) return@match null
+                    if (atom != atomOf(SdkCosts.SacrificeMultiple(sacrifice.count, sacrifice.filter))) {
+                        return@match null
+                    }
+                    bind("n" to sacrifice.count, "filter" to sacrifice.filter)
+                }
+            }
+
+        /**
+         * "Discard a card" — the single commonest non-mana cost in the corpus, and the one shape
+         * where the noun is not a filter at all.
+         *
+         * `GameObjectFilter.Any` is what an unqualified "card" means, and [Filters] deliberately has
+         * no noun for it — "card" is not a permanent type. So this is a constant rather than the
+         * `Any` case of the filtered rule below, which is also what keeps the two disjoint: the
+         * filtered rule cannot print `Any` because [Filters.indefinite] cannot.
+         */
+        val discardCard = constant("${lead("discard")} a card", atomOf(SdkCosts.DiscardCard))
+
+        /** "Discard a creature card" — Vampire Hounds. The noun a graveyard-facing filter spells. */
+        val discardFiltered = phrase("${lead("discard")} {filter} card", name = "discard a card of a kind") {
+            slot("filter", Filters.indefinite)
+            build { atomOf(SdkCosts.Discard(it.value("filter"))) }
+            match { atom ->
+                val discard = atom as? CostAtom.Discard ?: return@match null
+                if (discard.count != 1 || discard.filter == GameObjectFilter.Any) return@match null
+                if (atom != atomOf(SdkCosts.Discard(discard.filter))) return@match null
+                bind("filter" to discard.filter)
+            }
+        }
+
+        /** "Discard two cards" — the counted form, over the unqualified noun. */
+        val discardSeveral = phrase("${lead("discard")} {n} cards", name = "discard several cards") {
+            slot("n", Cardinals.word)
+            build { atomOf(SdkCosts.Discard(count = it.int("n"))) }
+            match { atom ->
+                val discard = atom as? CostAtom.Discard ?: return@match null
+                if (!Cardinals.spellable(discard.count)) return@match null
+                if (atom != atomOf(SdkCosts.Discard(count = discard.count))) return@match null
+                bind("n" to discard.count)
+            }
+        }
+
+        /** "Discard a card at random" — Pillaging Horde. The payer chooses nothing. */
+        val discardAtRandom =
+            constant("${lead("discard")} a card at random", atomOf(SdkCosts.DiscardAtRandom(1)))
+
+        /**
+         * "Mill a card" — Deranged Assistant. No selection and no filter: the milled card is the top
+         * of the library, so the count is the whole model.
+         */
+        val millCard = constant("${lead("mill")} a card", atomOf(SdkCosts.MillCard))
+
+        val millSeveral = phrase("${lead("mill")} {n} cards", name = "mill several cards") {
+            slot("n", Cardinals.word)
+            build { atomOf(SdkCosts.Mill(it.int("n"))) }
+            match { atom ->
+                val mill = atom as? CostAtom.Mill ?: return@match null
+                if (!Cardinals.spellable(mill.count)) return@match null
+                if (atom != atomOf(SdkCosts.Mill(mill.count))) return@match null
+                bind("n" to mill.count)
+            }
+        }
+
+        /**
+         * "Exile a creature card from your graveyard" — Cryptwailing, Deep Reconnaissance.
+         *
+         * The zone is a literal rather than a slot: the SDK's atom takes any `Zone`, but the only
+         * one Oracle spells in a cost is the graveyard, and a slot over the whole enum would read
+         * "exile a creature card from your battlefield". A second zone is a second row when a card
+         * prints one.
+         */
+        val exileFromGraveyard =
+            phrase("${lead("exile")} {filter} card from your graveyard", name = "exile a card from your graveyard") {
+                slot("filter", Filters.indefinite)
+                build { atomOf(SdkCosts.ExileFromGraveyard(1, it.value("filter"))) }
+                match { atom ->
+                    val exile = atom as? CostAtom.ExileFrom ?: return@match null
+                    if (exile.count != 1 || exile.filter == GameObjectFilter.Any) return@match null
+                    if (atom != atomOf(SdkCosts.ExileFromGraveyard(1, exile.filter))) return@match null
+                    bind("filter" to exile.filter)
+                }
+            }
+
+        /** "Exile a card from your graveyard" — the unqualified noun, for [discardCard]'s reason. */
+        val exileAnyFromGraveyard = constant(
+            "${lead("exile")} a card from your graveyard",
+            atomOf(SdkCosts.ExileFromGraveyard(1)),
+        )
+
+        /**
+         * "Exile two creature cards from your graveyard" — the counted form.
+         *
+         * The filter slot is the **singular** noun phrase even though the count is two, because
+         * Oracle pluralizes the head noun and leaves the qualifier alone: it is "two *creature*
+         * cards", not "two creatures cards". [Filters.plural] belongs where the noun phrase is the
+         * head; here "cards" is, and the filter is an adjective in front of it.
+         */
+        val exileSeveralFromGraveyard = phrase(
+            "${lead("exile")} {n} {filter} cards from your graveyard",
+            name = "exile several cards from your graveyard",
+        ) {
+            slot("n", Cardinals.word)
+            slot("filter", Filters.filter)
+            build { atomOf(SdkCosts.ExileFromGraveyard(it.int("n"), it.value("filter"))) }
+            match { atom ->
+                val exile = atom as? CostAtom.ExileFrom ?: return@match null
+                if (!Cardinals.spellable(exile.count)) return@match null
+                if (atom != atomOf(SdkCosts.ExileFromGraveyard(exile.count, exile.filter))) return@match null
+                bind("n" to exile.count, "filter" to exile.filter)
+            }
+        }
+
+        /**
+         * "Tap an untapped Cleric you control" — Nova Cleric, and the singular the plural rule below
+         * refuses.
+         *
+         * "Untapped" and "you control" are **literals** rather than parts of the noun phrase, for
+         * the plural rule's reason: `CostAtom.TapPermanents` carries neither, so slotting them would
+         * print a filter the atom cannot hold. The article is a literal too — it is fixed by
+         * "untapped", not by the noun, so no rule has to derive it.
+         */
+        val tapPermanent = phrase(
+            "${lead("tap")} an untapped {filter} you control",
+            name = "tap a permanent",
+        ) {
+            slot("filter", Filters.filter)
+            build { atomOf(SdkCosts.TapPermanents(1, it.value("filter"))) }
+            match { atom ->
+                val tap = atom as? CostAtom.TapPermanents ?: return@match null
+                if (tap.count != 1) return@match null
+                if (atom != atomOf(SdkCosts.TapPermanents(1, tap.filter))) return@match null
+                bind("filter" to tap.filter)
+            }
+        }
+
+        /** "Tap another untapped Rogue you control" — the source excluded, [sacrificeAnother]'s word. */
+        val tapAnotherPermanent = phrase(
+            "${lead("tap")} another untapped {filter} you control",
+            name = "tap another permanent",
+        ) {
+            slot("filter", Filters.filter)
+            build { atomOf(SdkCosts.TapAnotherPermanent(it.value("filter"))) }
+            match { atom ->
+                val tap = atom as? CostAtom.TapPermanents ?: return@match null
+                if (atom != atomOf(SdkCosts.TapAnotherPermanent(tap.filter))) return@match null
+                bind("filter" to tap.filter)
+            }
+        }
+
+        /** "Tap two untapped Birds you control" — Crookclaw Elder, Keeper of the Nine Gales. */
+        val tapPermanents = phrase(
+            "${lead("tap")} {n} untapped {filter} you control",
+            name = "tap several permanents",
+        ) {
+            slot("n", Cardinals.word)
+            slot("filter", Filters.plural)
+            build { atomOf(SdkCosts.TapPermanents(it.int("n"), it.value("filter"))) }
+            match { atom ->
+                val tap = atom as? CostAtom.TapPermanents ?: return@match null
+                if (!Cardinals.spellable(tap.count)) return@match null
+                if (atom != atomOf(SdkCosts.TapPermanents(tap.count, tap.filter))) return@match null
+                bind("n" to tap.count, "filter" to tap.filter)
+            }
+        }
+
+        /**
+         * "Return a land you control to its owner's hand" — Flooded Shoreline's singular sibling.
+         *
+         * "You control" is a literal for [tapPermanent]'s reason — `CostAtom.ReturnToHand` is
+         * defined over permanents you control and holds no controller predicate — while the article
+         * is inside [Filters.indefinite], because here it *does* vary with the noun.
+         */
+        val returnToHand = phrase(
+            "${lead("return")} {filter} you control to its owner's hand",
+            name = "return a permanent to its owner's hand",
+        ) {
+            slot("filter", Filters.indefinite)
+            build { atomOf(SdkCosts.ReturnToHand(it.value("filter"))) }
+            match { atom ->
+                val returned = atom as? CostAtom.ReturnToHand ?: return@match null
+                if (returned.count != 1) return@match null
+                if (atom != atomOf(SdkCosts.ReturnToHand(returned.filter))) return@match null
+                bind("filter" to returned.filter)
+            }
+        }
+
+        /**
+         * "Remove a spore counter from ~", "Remove three spore counters from ~" — the counters come
+         * off the ability's own source.
+         *
+         * `self = true` is what makes this the *direct* payment rather than a distribution across
+         * matching permanents, and the printed "from ~" is exactly that distinction: a cost that
+         * named a filter would print "from among … you control". So the two are different rows, and
+         * only the self one is written here — the filter form is a sentence no card in the backlog
+         * spells as a cost.
+         *
+         * The kind is [Primitives.singularCounterKind] in the singular, which carries its own
+         * "a"/"an", and [Primitives.counterKind] in the counted forms, where the number supplies
+         * the determiner.
+         */
+        val removeCounterFromSelf = phrase(
+            "${lead("remove")} {kind} counter from ${Normalizer.SELF}",
+            name = "remove a counter from this permanent",
+        ) {
+            slot("kind", Primitives.singularCounterKind)
+            build { atomOf(SdkCosts.RemoveCounterFromSelf(it.text("kind"))) }
+            match { atom ->
+                val remove = atom as? CostAtom.RemoveCounters ?: return@match null
+                val kind = remove.counterType ?: return@match null
+                if (atom != atomOf(SdkCosts.RemoveCounterFromSelf(kind))) return@match null
+                bind("kind" to kind)
+            }
+        }
+
+        val removeCountersFromSelf = phrase(
+            "${lead("remove")} {n} {kind} counters from ${Normalizer.SELF}",
+            name = "remove several counters from this permanent",
+        ) {
+            slot("n", Cardinals.word)
+            slot("kind", Primitives.counterKind)
+            build { atomOf(SdkCosts.RemoveCounterFromSelf(it.text("kind"), it.int("n"))) }
+            match { atom ->
+                val remove = atom as? CostAtom.RemoveCounters ?: return@match null
+                val kind = remove.counterType ?: return@match null
+                val count = (remove.count as? DynamicAmount.Fixed)?.amount ?: return@match null
+                if (!Cardinals.spellable(count)) return@match null
+                if (atom != atomOf(SdkCosts.RemoveCounterFromSelf(kind, count))) return@match null
+                bind("n" to count, "kind" to kind)
+            }
+        }
+
+        /** "Remove X storage counters from ~" — Calciform Pools. The count is the ability's X. */
+        val removeXCountersFromSelf = phrase(
+            "${lead("remove")} X {kind} counters from ${Normalizer.SELF}",
+            name = "remove X counters from this permanent",
+        ) {
+            slot("kind", Primitives.counterKind)
+            build { atomOf(SdkCosts.RemoveXCounters(counterType = it.text("kind"), self = true)) }
+            match { atom ->
+                val remove = atom as? CostAtom.RemoveCounters ?: return@match null
+                val kind = remove.counterType ?: return@match null
+                if (remove.count != DynamicAmount.XValue) return@match null
+                if (atom != atomOf(SdkCosts.RemoveXCounters(counterType = kind, self = true))) return@match null
+                bind("kind" to kind)
+            }
+        }
+
+        /** "Pay 1 life" — Blood Celebrant. A numeral, per Oracle's convention for quantities of life. */
+        val payLife = phrase("${lead("pay")} {n} life", name = "pay life") {
+            slot("n", Primitives.cardinal)
+            build { atomOf(SdkCosts.PayLife(it.int("n"))) }
+            match { atom ->
+                val pay = atom as? CostAtom.PayLife ?: return@match null
+                if (atom != atomOf(SdkCosts.PayLife(pay.amount))) return@match null
+                bind("n" to pay.amount)
+            }
+        }
+
+        return oneOf(
+            "a cost atom",
+            sacrificeFiltered,
+            sacrificeAnother,
+            sacrificeSeveral,
+            discardCard,
+            discardFiltered,
+            discardSeveral,
+            discardAtRandom,
+            millCard,
+            millSeveral,
+            exileFromGraveyard,
+            exileAnyFromGraveyard,
+            exileSeveralFromGraveyard,
+            tapPermanent,
+            tapAnotherPermanent,
+            tapPermanents,
+            returnToHand,
+            removeCounterFromSelf,
+            removeCountersFromSelf,
+            removeXCountersFromSelf,
+            payLife,
+        )
+    }
+
+    /** The vocabulary as Oracle prints it everywhere but a line's first word. */
+    private val capitalized: Phrase<CostAtom> = vocabulary { it.replaceFirstChar { c -> c.uppercaseChar() } }
+
+    /** …and as [com.wingedsheep.assay.syntax.SentenceCase] leaves it when it *is* that first word. */
+    private val lowercased: Phrase<CostAtom> = vocabulary { it }
+
+    /**
+     * One shared cost atom, in the activation position.
+     *
+     * The lowercase instance is an [alternate] here — reachable only where the line-start pass put
+     * it, never printed — which is what keeps one printed form per model. In [additional] the two
+     * are the other way round.
+     */
+    val atoms: Phrase<CostAtom> = oneOf("a cost atom", capitalized, alternate(lowercased))
+
+    // -------------------------------------------------------------------------------------------
+    // Lifted into an activated ability's cost
+    // -------------------------------------------------------------------------------------------
+
     /**
      * A cost rule in both the spelling Oracle prints and the one the line-start pass leaves behind.
      *
      * [rule] is a function of its leading word so that the two halves cannot drift: there is one
-     * template, instantiated twice, and the lowercase instance can never print.
+     * template, instantiated twice, and the lowercase instance can never print. The atom vocabulary
+     * takes the same argument in bulk; this stays for the handful of rows that are not atoms.
      */
     private fun bothCases(word: String, name: String, rule: (String) -> Phrase<AbilityCost>): Phrase<AbilityCost> =
         oneOf(name, rule(word.replaceFirstChar { it.uppercaseChar() }), alternate(rule(word)))
 
     private val tap: Phrase<AbilityCost> = constant("{T}", AbilityCost.Tap)
+
+    /** `{Q}`, the untap symbol — the mirror of `{T}`, and a symbol `ManaCost.parse` also rejects. */
+    private val untap: Phrase<AbilityCost> = constant("{Q}", AbilityCost.Untap)
 
     private val mana: Phrase<AbilityCost> = phrase("{cost}", name = "a mana cost") {
         slot("cost", Primitives.manaCost)
@@ -78,7 +480,8 @@ object Costs {
      * "Sacrifice this creature", "Exile this creature" — the source paying with itself.
      *
      * Their own `AbilityCost` cases rather than a `Sacrifice` over a source-scoped filter, which is
-     * why they are constants here and not rows of [sacrificeFiltered].
+     * why they are constants here and not rows of the atom vocabulary — and why they are unreachable
+     * from [additional], which has no source to pay with.
      */
     private val sacrificeSelf: Phrase<AbilityCost> =
         bothCases("sacrifice", "sacrifice this permanent") { verb ->
@@ -90,91 +493,32 @@ object Costs {
             constant("$verb ${Normalizer.SELF}", AbilityCost.ExileSelf)
         }
 
-    /**
-     * "Sacrifice a Goblin", "Sacrifice a creature" — one permanent matching a filter.
-     *
-     * The article comes from [Filters.indefinite], which derives it from the noun's spelling in both
-     * directions; the model has nowhere to keep it. `count` is checked against 1 here and the plural
-     * rule below refuses 1, so the two take disjoint models and one printed form exists per value.
-     */
-    private val sacrificeFiltered: Phrase<AbilityCost> =
-        bothCases("sacrifice", "sacrifice a permanent") { verb ->
-            phrase("$verb {filter}", name = "sacrifice a permanent") {
-                slot("filter", Filters.indefinite)
-                build { SdkCosts.Sacrifice(it.value("filter")) }
-                match { cost ->
-                    val atom = sacrificeAtom(cost) ?: return@match null
-                    if (atom.count != 1 || cost != SdkCosts.Sacrifice(atom.filter)) return@match null
-                    bind("filter" to atom.filter)
-                }
-            }
+    /** "Exert ~" — CR 701.39. The source pays by not untapping, so it is a self cost too. */
+    private val exertSelf: Phrase<AbilityCost> =
+        bothCases("exert", "exert this permanent") { verb ->
+            constant("$verb ${Normalizer.SELF}", AbilityCost.Exert)
         }
 
-    /** "Sacrifice three Clerics" — Dark Supplicant. The counted sibling, over a plural noun. */
-    private val sacrificeSeveral: Phrase<AbilityCost> =
-        bothCases("sacrifice", "sacrifice several permanents") { verb ->
-            phrase("$verb {n} {filter}", name = "sacrifice several permanents") {
-                slot("n", Cardinals.word)
-                slot("filter", Filters.plural)
-                build { SdkCosts.SacrificeMultiple(it.int("n"), it.value("filter")) }
-                match { cost ->
-                    val atom = sacrificeAtom(cost) ?: return@match null
-                    if (!Cardinals.spellable(atom.count)) return@match null
-                    if (cost != SdkCosts.SacrificeMultiple(atom.count, atom.filter)) return@match null
-                    bind("n" to atom.count, "filter" to atom.filter)
-                }
-            }
-        }
-
-    /**
-     * "Tap two untapped Birds you control" — Crookclaw Elder, Keeper of the Nine Gales.
-     *
-     * "Untapped" and "you control" are **literals** rather than parts of the noun phrase, because
-     * `CostAtom.TapPermanents` carries neither: a tap cost can only tap untapped permanents you
-     * control, so the words restate the cost's own rules and the filter holds only what is left.
-     * Slotting them would print a filter the atom cannot hold.
-     */
-    private val tapPermanents: Phrase<AbilityCost> =
-        bothCases("tap", "tap several permanents") { verb ->
-            phrase("$verb {n} untapped {filter} you control", name = "tap several permanents") {
-                slot("n", Cardinals.word)
-                slot("filter", Filters.plural)
-                build { SdkCosts.TapPermanents(it.int("n"), it.value("filter")) }
-                match { cost ->
-                    val atom = (cost as? AbilityCost.Atom)?.atom as? CostAtom.TapPermanents ?: return@match null
-                    if (!Cardinals.spellable(atom.count)) return@match null
-                    if (cost != SdkCosts.TapPermanents(atom.count, atom.filter)) return@match null
-                    bind("n" to atom.count, "filter" to atom.filter)
-                }
-            }
-        }
-
-    /** "Pay 1 life" — Blood Celebrant. A numeral, per Oracle's convention for quantities of life. */
-    private val payLife: Phrase<AbilityCost> =
-        bothCases("pay", "pay life") { verb ->
-            phrase("$verb {n} life", name = "pay life") {
-                slot("n", Primitives.cardinal)
-                build { SdkCosts.PayLife(it.int("n")) }
-                match { cost ->
-                    val atom = (cost as? AbilityCost.Atom)?.atom as? CostAtom.PayLife ?: return@match null
-                    if (cost != SdkCosts.PayLife(atom.amount)) return@match null
-                    bind("n" to atom.amount)
-                }
-            }
-        }
-
-    /** One cost atom. */
-    private val atom: Phrase<AbilityCost> = oneOf(
-        "a cost",
+    /** The costs only a permanent can pay, plus the two that are symbols rather than sentences. */
+    private val abilityOnly: Phrase<AbilityCost> = oneOf(
+        "a permanent's own cost",
         tap,
+        untap,
         mana,
         sacrificeSelf,
         exileSelf,
-        sacrificeFiltered,
-        sacrificeSeveral,
-        tapPermanents,
-        payLife,
+        exertSelf,
     )
+
+    /** One cost atom, wrapped for the context that asks an activated ability's payer. */
+    private val liftedAtom: Phrase<AbilityCost> = phrase("{atom}", name = "a shared cost") {
+        slot("atom", atoms)
+        build { AbilityCost.Atom(it.value("atom")) }
+        match { cost -> (cost as? AbilityCost.Atom)?.let { bind("atom" to it.atom) } }
+    }
+
+    /** One cost. */
+    private val atom: Phrase<AbilityCost> = oneOf("a cost", abilityOnly, liftedAtom)
 
     /** "{2}{B}, {T}, Sacrifice a Goblin" — two or more atoms, in the order the card prints them. */
     private val composite: Phrase<AbilityCost> = phrase("{atoms}", name = "several costs") {
@@ -189,9 +533,24 @@ object Costs {
 
     val cost: Phrase<AbilityCost> = oneOf("an activation cost", atom, composite)
 
+    // -------------------------------------------------------------------------------------------
+    // Lifted into a spell's additional cost
+    // -------------------------------------------------------------------------------------------
+
+    /**
+     * One additional cost, mid-sentence — the payload of
+     * [Restrictions.additionalCostLine].
+     *
+     * Only the lowercase vocabulary, and only the atoms: the sentence puts the clause after a comma,
+     * so the capital would be a misprint, and a spell has no source permanent for [abilityOnly]'s
+     * rows to name.
+     */
+    val additional: Phrase<AdditionalCost> = phrase("{atom}", name = "an additional cost") {
+        slot("atom", lowercased)
+        build { AdditionalCost.Atom(it.value("atom")) }
+        match { cost -> (cost as? AdditionalCost.Atom)?.let { bind("atom" to it.atom) } }
+    }
+
     private fun manaCostOf(cost: AbilityCost): ManaCost? =
         ((cost as? AbilityCost.Atom)?.atom as? CostAtom.Mana)?.cost
-
-    private fun sacrificeAtom(cost: AbilityCost): CostAtom.Sacrifice? =
-        (cost as? AbilityCost.Atom)?.atom as? CostAtom.Sacrifice
 }

--- a/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Restrictions.kt
+++ b/oracle-assay/src/main/kotlin/com/wingedsheep/assay/grammar/Restrictions.kt
@@ -7,12 +7,9 @@ import com.wingedsheep.assay.syntax.oneOf
 import com.wingedsheep.assay.syntax.phrase
 import com.wingedsheep.assay.syntax.separated
 import com.wingedsheep.sdk.core.Step
-import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.scripting.ActivationRestriction
 import com.wingedsheep.sdk.scripting.AdditionalCost
 import com.wingedsheep.sdk.scripting.CastRestriction
-import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.costs.CostAtom
 
 /**
  * When a spell may be cast and when an ability may be activated — the two restriction vocabularies,
@@ -78,26 +75,26 @@ object Restrictions {
      * "As an additional cost to cast this spell, sacrifice a creature." — the line that adds to what
      * a spell costs rather than to what it does.
      *
-     * The noun phrase goes through [Filters.indefinite], so "a creature" and "a green creature" are
-     * the same rule; the cost is reconstructed from the filter for the comparison, the same
-     * fail-closed shape [SelfSteps.sacrificeUnless] uses on the pay-cost side.
+     * ### The clause after the comma is [Costs.additional], not a second cost vocabulary
+     *
+     * It used to be one rule that read "sacrifice {filter}" and nothing else, while the activation
+     * side of the grammar read a longer list of the *same English* — two vocabularies for the one
+     * thing `CostAtom`'s own KDoc calls "the one cost language". So this slots the shared atom
+     * vocabulary, lifted into `AdditionalCost`, and every row [Costs] gains reaches this line for
+     * free: "discard a card", "exile two creature cards from your graveyard", "pay 3 life",
+     * "return a permanent you control to its owner's hand".
+     *
+     * A *list* of one, because `CardScript.additionalCosts` is a list and the sentence spells one
+     * cost. The joined forms Oracle also prints — "sacrifice a creature **or pay** {3}{B}",
+     * "you may exile any number of …" — are `AdditionalCost.Choice` and the optional rail rather
+     * than a run over this, and they decline until they have rules of their own.
      */
-    val additionalCostLine: Phrase<List<AdditionalCost>> = run {
-        fun costFor(filter: GameObjectFilter) = listOf(Costs.additional.SacrificePermanent(filter))
-        phrase(
-            "as an additional cost to cast this spell, sacrifice {filter}.",
-            name = "an additional cost line",
-        ) {
-            slot("filter", Filters.indefinite)
-            build { costFor(it.value("filter")) }
-            match { costs ->
-                val atom = (costs.singleOrNull() as? AdditionalCost.Atom)?.atom as? CostAtom.Sacrifice
-                    ?: return@match null
-                if (costs != costFor(atom.filter)) return@match null
-                bind("filter" to atom.filter)
-            }
+    val additionalCostLine: Phrase<List<AdditionalCost>> =
+        phrase("as an additional cost to cast this spell, {cost}.", name = "an additional cost line") {
+            slot("cost", Costs.additional)
+            build { listOf(it.value<AdditionalCost>("cost")) }
+            match { costs -> costs.singleOrNull()?.let { bind("cost" to it) } }
         }
-    }
 
     // ---------------------------------------------------------------------------------------
     // Activation

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/CostsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/CostsTest.kt
@@ -60,4 +60,54 @@ class CostsTest : StringSpec({
     "paying life is a numeral, per Oracle's convention for quantities of life" {
         roundTrips("{B}, Pay 1 life: Draw a card.")
     }
+
+    // "card" is not a permanent type and [Filters] has no noun for `Any`, which is what keeps the
+    // unqualified row and the filtered one from being two spellings of one model.
+    "discarding takes the unqualified noun as a row of its own, not as the filter's empty case" {
+        roundTrips("Discard a card: Draw a card.")
+        roundTrips("Discard a creature card: Draw a card.")
+        roundTrips("Discard two cards: Draw a card.")
+        roundTrips("Discard a card at random: Draw a card.")
+    }
+
+    "the graveyard is a literal in the exile cost, because it is the only zone a cost names" {
+        roundTrips("{1}, Exile a creature card from your graveyard: Draw a card.")
+        roundTrips("Exile a card from your graveyard: Draw a card.")
+        roundTrips("Exile two creature cards from your graveyard: Draw a card.")
+    }
+
+    // "Another" is a determiner, so the noun phrase after it carries no article — the difference
+    // from the plain sacrifice, whose article comes from the filter's own spelling.
+    "excluding the source is the word \"another\", in both the sacrifice and the tap cost" {
+        roundTrips("Sacrifice another creature: Draw a card.")
+        roundTrips("Tap another untapped Rogue creature you control: Draw a card.")
+    }
+
+    "the singular tap cost is a row of its own, because the plural one refuses a count of one" {
+        roundTrips("Tap an untapped Cleric creature you control: Draw a card.")
+    }
+
+    "returning a permanent you control spells the controller as a literal, like the tap cost" {
+        roundTrips("Return a land you control to its owner's hand: Draw a card.")
+    }
+
+    // `self = true` is the whole distinction between removing counters from the source and
+    // distributing the removal across permanents you control, and "from ~" is how Oracle prints it.
+    "counters come off the source, in all three of the quantities Oracle spells" {
+        roundTrips("Remove a spore counter from ~: Draw a card.")
+        roundTrips("Remove three spore counters from ~: Draw a card.")
+        roundTrips("Remove X charge counters from ~: Draw a card.")
+    }
+
+    "milling as a cost counts cards and names no filter, because the top of the library is not chosen" {
+        roundTrips("{T}, Mill a card: Draw a card.")
+        roundTrips("Mill two cards: Draw a card.")
+    }
+
+    // The atom vocabulary is shared with the additional-cost line, so a row written for one context
+    // has to work in the other. This is the activation side of that pair; RestrictionsTest is the
+    // spell side, and between them they are the argument for the shape.
+    "a new atom reaches a composite without the run rule knowing about it" {
+        roundTrips("{2}, Discard a card, Sacrifice another creature: Draw a card.")
+    }
 })

--- a/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/RestrictionsTest.kt
+++ b/oracle-assay/src/test/kotlin/com/wingedsheep/assay/grammar/RestrictionsTest.kt
@@ -59,6 +59,28 @@ class RestrictionsTest : StringSpec({
         roundTrips("As an additional cost to cast this spell, sacrifice a green creature.")
     }
 
+    // The spell side of the shared atom vocabulary. None of these has a rule of its own here: they
+    // are rows written for an activated ability's cost, and this line reaches them because both
+    // contexts slot the same `Phrase<CostAtom>` — which is the whole argument for that shape.
+    "every cost atom reaches the additional-cost line, lowercased, without a rule of its own" {
+        fragment("As an additional cost to cast this spell, discard a card.") shouldBe CardFragment(
+            script = CardScript(additionalCosts = listOf(Costs.additional.DiscardCards()))
+        )
+        roundTrips("As an additional cost to cast this spell, discard a card.")
+        roundTrips("As an additional cost to cast this spell, discard two cards.")
+        roundTrips("As an additional cost to cast this spell, pay 3 life.")
+        roundTrips("As an additional cost to cast this spell, exile a creature card from your graveyard.")
+        roundTrips("As an additional cost to cast this spell, return a land you control to its owner's hand.")
+        roundTrips("As an additional cost to cast this spell, tap an untapped Vampire creature you control.")
+    }
+
+    // The other half of the split: a spell being cast has no source permanent, so the costs that
+    // *are* the source stay on the activation side and this line cannot spell them.
+    "the costs only a permanent can pay are unreachable from the additional-cost line" {
+        Grammar.abilityLine.parseLine("As an additional cost to cast this spell, sacrifice ~.")
+            .shouldBeInstanceOf<ParseOutcome.Declined>()
+    }
+
     // The activation restriction is a *sentence* after the ability's own, joined by a comma rather
     // than by "and" — a printed-shape difference from the casting line, so each has its separator.
     "an activated ability carries its restrictions in a trailing sentence" {


### PR DESCRIPTION
## The band

**What you pay, everywhere you pay it.** Whole-corpus coverage **7,177 → 7,451 cards** (+274),
byte-exact lines 24,993 → 25,377, the differential's compared population 2,698 → **2,747**.

It needed **no new SDK type**: every atom it reads was already in `CostAtom`, waiting for a sentence.

## Why this band

The tail ranking doesn't surface it as a row — a cost is *the text before a colon*, and the tail keys
on what came after. Ranking the colon lines directly (substitute `{T}: ` for every unreadable cost,
re-parse) says **465 whole cards are blocked on nothing but the cost clause**, against 104 for the
modal band and 111 for cost reduction. A second, greedy probe ranked the individual atoms —
"Discard a card" alone finishes 86 cards, counter removal 49, the singular tap 35, "Sacrifice another" 35.

Delivered **274**, which is the sum of exactly the rows written. The residue is named in the README
and every piece of it is a different band, not a missing row.

## The shape

`CostAtom`'s own KDoc calls itself *"the one cost language"* — one payable thing declared once, carried
into each context by that context's `Atom` wrapper. The grammar had it the other way round: `Costs`
read a list of cost sentences for an activated ability, and `Restrictions.additionalCostLine` read one
of them again, separately. Two vocabularies over one English.

So `Costs.atoms` is a `Phrase<CostAtom>` and the two contexts are two **lifts** of it. Adding
"discard a card" to the activation side gave `As an additional cost to cast this spell, discard a card.`
for free; there's one assertion for that property in each of the two test files.

**What stays outside the shared part is a rule, not a gap.** `Sacrifice ~`, `Exile ~`, `{T}`, `{Q}`,
`Exert ~` remain `AbilityCost` cases and are unreachable from the spell side — for the reason `CostAtom`
gives for keeping `excludeSelf` off it: *a spell being cast has no source permanent.* `RestrictionsTest`
asserts the decline.

**Capitalization stopped being an `alternate` and became a parameter.** While costs lived in one
position the lowercase spelling could be parseable-and-never-printed. In
"As an additional cost to cast this spell, **sacrifice** a creature." it is *canonical*. The vocabulary
is now a function of its leading word's spelling, instantiated twice — which is also what stops a row
existing in one capitalization only.

**Rows added:** discard (unqualified / filtered / counted / at random), remove counters from the source
(a / N / X), sacrifice another, the singular and "another" tap costs, exile from your graveyard
(a / unqualified / counted), return to hand, mill, and `{Q}` / `Exert ~`.

## Three card bugs, all invisible in play

The differential went 0 → 3 the first time the gate could read a cost's noun phrase. Every one of them
was a hand-written card:

- **Wirewood Symbiote** and **Fungal Plots** spell "an Elf you control" and "two Saprolings" as
  `GameObjectFilter.Creature.withSubtype(…)`. A bare tribal noun means any *permanent* of that tribe —
  the same correction the 103-card migration made everywhere the grammar could already see. These two
  survived it because their nouns sat inside a **cost**, which nothing read until now. Unobservable
  today: every printed Elf and Saproling is a creature.
- **Gene Pollinator** writes `Costs.TapAnotherPermanent()` for "Tap an untapped permanent you control" —
  a text with no "another" in it, and a filter left at the facade's unqualified default where the noun
  is "permanent". The `excludeSelf` restated what the co-paid `{T}` already guarantees.

Card snapshots re-blessed; the diff is three one-line changes and nothing else moved.

## Where this points next

- **Self costs activated from another zone** — "Discard ~" (25 cards), "Exile ~ from your graveyard"
  (22). The cost clause *determines* `activateFromZone`, which makes the cost rule's result a
  (cost, zone) pair — a change to `Costs.cost`'s type and `Activated`'s four call sites. A band, not a row.
- **Keyword-labelled costs** — Exhaust / Power-up / Boast / Max speed / Renew / Forecast / Waterbend.
  One shape, seven rows.
- **Filter gaps, not cost gaps** — "Sacrifice a Food" (14) declines in `Filters`, not here.
- **`{S}`** (20 cards) is an **SDK gap**: `ManaCost` cannot express snow mana, so `Primitives.manaCost`
  declines rather than inventing a symbol. `add-feature` work.

## Verification

- `just assay-gate` — ambiguity **0**, print mismatch **0**, normalization invertible.
- `just assay-differential` — **2,747 / 2,747**, zero divergences (rebased on #1846, which closed the
  standing `ManaColorSet.Specific` one).
- `:oracle-assay:test` — green, with new round-trip cases for every row added and both halves of the lift.
- `just build` — green, snapshots re-blessed. Re-run green after merging `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
