### PR TITLE
Document Argentum Assay in the help guide

### DIFF
--- a/web-client/src/components/setCompletion/SetCompletionPage.module.css
+++ b/web-client/src/components/setCompletion/SetCompletionPage.module.css
@@ -418,6 +418,14 @@
   color: var(--color-warning, #f2b134);
   white-space: nowrap;
 }
+/* The `?` rides inside the note rather than after it, so the two read as one thing. Wrapped instead
+   of styling `HelpTip` directly (it takes no class), and nudged off the baseline because the button
+   is a 14px box sitting in a smaller line of running text. */
+.assayNoteTip {
+  display: inline-flex;
+  vertical-align: -2px;
+  margin-left: 5px;
+}
 /* Top-LEFT, opposite the implementation badge: the two answer different questions and a reader
    scanning for one shouldn't have to disambiguate them by colour alone. */
 .assayBadge {

--- a/web-client/src/components/setCompletion/SetCompletionPage.tsx
+++ b/web-client/src/components/setCompletion/SetCompletionPage.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { SetIcon } from '../ui/SetIcon'
+import { HelpTip } from '../help/HelpTip'
 import { HoverCardPreview } from '../ui/HoverCardPreview'
 import { ProgressChartOverlay } from './ProgressChartOverlay'
 import { getScryfallFallbackUrl } from '@/utils/cardImages'
@@ -27,7 +28,13 @@ const SORT_LABELS: Record<SortKey, string> = {
   name: 'A–Z',
 }
 
-/** Where game-server mounts the live Argentum Assay explorer. Dev servers only — see `/api/config`. */
+/**
+ * Where game-server mounts the live Argentum Assay explorer.
+ *
+ * Mounted on *every* server, not just dev ones: the tool is a read over public card text and holds
+ * no state a request can mutate. See `AssayExploreController` for what that costs and why it is
+ * still worth it — and {@link ExplorerPane} for why there is consequently no flag to fetch.
+ */
 const EXPLORER_URL = '/api/assay/explorer'
 
 /**
@@ -187,11 +194,14 @@ export function SetCompletionPage() {
             aria-selected={tab === 'explorer'}
             className={tab === 'explorer' ? styles.segmentActive : styles.segment}
             onClick={() => setTab('explorer')}
-            title="Argentum Assay — the Oracle-text grammar and both its gates, against the live parser"
           >
             Assay Explorer
           </button>
         </div>
+        {/* Sibling of the tablist, never inside it: `HelpTip` is a button, and one nested in a
+            `role="tab"` would be both invalid markup and a click that switches tabs. The explanation
+            lives in `topics.ts` rather than in a `title=` so the popover and `/help` can't disagree. */}
+        <HelpTip topicId="assay-explorer" label="What is the Assay Explorer?" />
         <div className={styles.topbarSpacer} />
       </header>
 
@@ -659,11 +669,11 @@ function SetDetailOverlay({ code, onClose }: { code: string; onClose: () => void
                 )}
                 {notPlannedCount > 0 && <> · {notPlannedCount} not planned</>}
                 {detail.assayReady != null && detail.assayReady > 0 && (
-                  <span
-                    className={styles.assayNote}
-                    title="Argentum Assay reads these missing cards end to end — they need no new SDK vocabulary"
-                  >
+                  <span className={styles.assayNote}>
                     {' · '}⚡ {detail.assayReady} Assay-ready
+                    <span className={styles.assayNoteTip}>
+                      <HelpTip topicId="assay-ready" size="sm" />
+                    </span>
                   </span>
                 )}
               </span>

--- a/web-client/src/help/topics.ts
+++ b/web-client/src/help/topics.ts
@@ -74,7 +74,7 @@ export const HELP_SECTIONS: readonly { id: HelpSection; title: string; blurb: st
   {
     id: 'advanced',
     title: 'Advanced',
-    blurb: 'Shortcuts, replays, spectating, the multiplayer camera and the Lab tools.',
+    blurb: 'Shortcuts, replays, spectating, the multiplayer camera, Argentum Assay and the Lab tools.',
   },
 ]
 
@@ -629,8 +629,28 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
       'Set Completion, on the home screen under Build & Browse, lists every set and how much of it the engine can actually play. Useful before committing to a deck or picking a set to draft.',
     body: [
       { kind: 'p', text: 'The deckbuilder only ever offers implemented cards, so a deck you build there always works. This page is the other direction: it tells you what is missing from a set you had in mind.' },
+      { kind: 'p', text: 'Open a set to get its full card list, each card marked implemented or missing. A handful come back “not planned” — cards needing something the engine will never carry, like ante or physical dexterity — and those are left out of every total, so the percentage measures what there is any intention of building.' },
+      { kind: 'p', text: 'The second tab, Assay Explorer, is a different question about the same corpus: not which cards are written, but how much of Magic’s printed text the engine can read at all.' },
     ],
-    related: ['deckbuilder'],
+    related: ['deckbuilder', 'assay-ready', 'assay-explorer'],
+  },
+  {
+    id: 'assay-ready',
+    section: 'decks',
+    title: '⚡ Assay-ready cards',
+    summary:
+      'On Set Completion, ⚡ Assay-ready counts the cards a set is still missing that Argentum Assay already reads end to end — the ones the engine could express today, with nothing new built for them.',
+    body: [
+      { kind: 'p', text: 'It measures how much of what is left is cheap, which is a different question from how much is done. A set sitting at 40% with two hundred Assay-ready cards is closer to finished than its percentage suggests; one at 95% with none left is down to the cards that need new engine work first.' },
+      { kind: 'ul', items: [
+        'Set tiles carry a “⚡ 34 Assay-ready” tag in the footer — shown only above zero, because a row of “0 Assay-ready” across nine hundred sets would bury the sets where the number is the reason to look.',
+        'Sorting the grid by “Most Assay-ready” puts the sets holding the most of that work first.',
+        'Inside a set, the ⚡ Assay-ready filter lists exactly those cards, and each one wears a ⚡ on its tile.',
+      ] },
+      { kind: 'p', text: 'Hovering any card in a set gives you Assay’s reading of it: that it reads the card whole, or which line it declined and what stopped it. A card the reading does not cover stays silent rather than showing a negative — “Assay can’t read this” and “nobody asked Assay” are different statements, and only the first is worth a badge.' },
+      { kind: 'p', text: 'The counts come from a ledger baked from a full run of the parser rather than being recomputed per request, so they move when the grammar does rather than continuously.' },
+    ],
+    related: ['set-completion', 'assay', 'assay-explorer'],
   },
 
   // ── Advanced ───────────────────────────────────────────────────────────
@@ -680,7 +700,58 @@ export const HELP_TOPICS: readonly HelpTopic[] = [
     title: 'Lab tools',
     summary:
       'Debugging and content tools, not part of normal play: the Scenario Builder (start a game from a hand-authored board state), the LLM Tournament runner, and the AI Sandbox (a table of bots playing each other, so you can watch the built-in AI and spot where it goes wrong). They only appear in dev builds, because they all need server endpoints a production deployment does not expose.',
-    related: ['replays', 'set-completion'],
+    related: ['replays', 'set-completion', 'assay-custom-cards'],
+  },
+  {
+    id: 'assay',
+    section: 'advanced',
+    title: 'Argentum Assay',
+    summary:
+      'Argentum’s own reader for printed Magic text. It parses a card’s Oracle text into the engine’s model of that card — and because every grammar rule is written to run backwards too, it can print that model back out and check the two match word for word.',
+    body: [
+      { kind: 'p', text: 'Cards here are written by hand and each one carries its own test, and that is not changing. Assay answers the question that comes before writing one: does the engine already have the vocabulary this card needs? A line it reads is a line the engine can already express. A line it cannot is declined — and a decline names the exact word it stopped at instead of quietly approximating the rest.' },
+      { kind: 'p', text: 'Running the grammar backwards is what makes that reading worth trusting, because it can be checked at the scale of the whole corpus without anyone reading the output:' },
+      { kind: 'ul', items: [
+        'The touchstone parses every distinct piece of Oracle text Scryfall publishes and prints it back. A rule that quietly drops an “other”, or flattens “up to three” into “three”, fails on the next card that uses it.',
+        'The differential sets Assay’s reading of an already-implemented card against the definition someone hand-wrote for it. A disagreement is a bug in one of the two — and it has turned up both kinds.',
+      ] },
+      { kind: 'p', text: 'Coverage is reported as fineness, in parts per thousand, after the assay a metallurgist runs on ore — the name is the promise that it reports a number rather than “looks fine”. Text it cannot read is counted, never dropped.' },
+      { kind: 'p', text: 'Two things in this app are built on it: the ⚡ Assay-ready counts on Set Completion, and the Assay Explorer tab beside them.' },
+    ],
+    related: ['assay-ready', 'assay-explorer', 'assay-custom-cards', 'set-completion'],
+  },
+  {
+    id: 'assay-explorer',
+    section: 'advanced',
+    title: 'The Assay Explorer',
+    summary:
+      'The second tab on Set Completion. It runs against the live parser and answers three things: how much of Magic’s printed text the grammar reads today, what is blocking the rest, and what any text you paste into it parses to.',
+    body: [
+      { kind: 'p', text: 'What each of its views is for:' },
+      { kind: 'ul', items: [
+        'Overview — the fineness numbers: how much of the corpus round-trips, how much is declined, and how many cards are read whole rather than only in part.',
+        'Cards — the sweep, browsable by set or across the whole corpus, each card showing the lines that read and the ones that did not.',
+        'Declines — the ranked gap report: which missing piece of grammar blocks the most real cards. This is the backlog putting itself in order.',
+        'Grammar — every rule reachable from an ability line, with how many cards actually use each one.',
+        'Differential — Assay’s reading of an implemented card set against the hand-written definition, and every place the two disagree.',
+        'Parse — paste any Oracle text and read what it becomes, with a caret on the word a decline stopped at.',
+      ] },
+      { kind: 'p', text: 'The explorer only ever reads public card text — no game, no account, no deck — so it is mounted on every server rather than being a dev-build tool. The first time anyone opens it the server fetches Scryfall’s bulk Oracle data and sweeps it, so the numbers arrive shortly after the page does; the parser and the grammar tree work straight away either way.' },
+      { kind: 'p', text: 'Differential is the exception. It compares against the project’s own test fixtures, which a deployed server does not ship, so here it reports that it has nothing to compare against. It fills in when the explorer is run from a checkout of the repository.' },
+    ],
+    related: ['assay', 'assay-ready', 'set-completion'],
+  },
+  {
+    id: 'assay-custom-cards',
+    section: 'advanced',
+    title: 'Custom cards',
+    summary:
+      'The Scenario Builder can play a card that does not exist: paste a Scryfall-shaped card object, Assay reads it, and once it reads every line you can drop the compiled card into any zone and play with it. A dev-build tool — it needs endpoints a production deployment does not expose.',
+    body: [
+      { kind: 'p', text: 'Each printed line comes back with a verdict of its own — read, read (respelled), not read — and a caret on the word a decline stopped at. The card only becomes addable once every line reads: a half-read card would sit on the board looking correct and be quietly missing an ability, which is worse than being refused outright.' },
+      { kind: 'p', text: 'None of this touches the card corpus. The compiled card is scoped to that one scenario session, and cards that actually ship are still written by hand and still carry their own test — Assay makes a draft quick to trust, it does not make the review optional.' },
+    ],
+    related: ['lab-tools', 'assay'],
   },
 ]
 


### PR DESCRIPTION
`/help` had nothing on Argentum Assay. The two places it surfaces in the app — the ⚡ Assay-ready counts on Set Completion and the Assay Explorer tab beside them — were explained only by `title=` attributes, which is exactly the drift the topic registry was built to end.

## Four new topics

Written in the register the guide already uses (*knows Magic, new to Argentum*; explain what **this app** does, and why), as data in `web-client/src/help/topics.ts`.

| Topic | Section | Answers |
|---|---|---|
| `assay` | Advanced | What it is: a reader for printed card text, and the fact that every grammar rule runs backwards — which is what lets the touchstone and the differential check it without a human reading the output. |
| `assay-ready` | Decks | What ⚡ means on a set tile, a sort, a filter and a card — and that it measures how much of what's left is *cheap*, not how much is done. Also why a card with no reading shows nothing rather than a negative badge. |
| `assay-explorer` | Advanced | The six views and what each answers. |
| `assay-custom-cards` | Advanced | The Scenario Builder sandbox, and why a partially-read card is refused rather than approximated. |

`set-completion` and `lab-tools` gain bodies and cross-links into these; the Advanced section blurb now names Assay.

**One thing the copy is deliberately honest about:** the Explorer's *Differential* view is empty in production. It compares against the project's own test fixtures, which a deployed server doesn't ship — `GET /api/assay/explorer/status` on magic.wingedsheep.com reports `goldens: 0`, matching what `AssayExploreController`'s KDoc predicts. The topic says so rather than describing a view that reads as broken.

No hard numbers anywhere in the copy — the UI shows live counts, and a figure baked into help prose would be wrong by the next band.

## Two tooltips, replacing their `title=`

Both point at a topic id, so the popover and `/help` can't disagree.

- **Beside the Assay Explorer tab** — a *sibling* of the tablist, never inside it: `HelpTip` renders a `<button>`, and one nested in a `role="tab"` would be invalid markup *and* would switch tabs on click.
- **On the ⚡ N Assay-ready note** in the set-detail header.

The per-card and per-tile `title`s stay as they are: those render a card's individual verdict, which is data, not an explanation.

## Drive-by correction

`EXPLORER_URL`'s comment claimed the explorer was dev-servers-only and gated by `/api/config`. It isn't — `ExplorerPane`'s own KDoc three lines below already said "always available, so there is no flag to fetch", and production serves it. The stale line is the one thing that would have made this documentation wrong.

## Screenshots

The `?` beside the Assay Explorer tab:

![Assay Explorer tooltip](https://raw.githubusercontent.com/wingedsheep/argentum-engine/help-assay-docs-screenshots/01-explorer-tip.png)

The `?` on the ⚡ N Assay-ready note, in Portal Three Kingdoms (101 ready):

![Assay-ready tooltip](https://raw.githubusercontent.com/wingedsheep/argentum-engine/help-assay-docs-screenshots/02-assay-ready-tip.png)

The new Advanced topics on `/help`:

![Help page](https://raw.githubusercontent.com/wingedsheep/argentum-engine/help-assay-docs-screenshots/03-help-assay.png)

The ⚡ Assay-ready filter the copy describes:

![Assay-ready filter](https://raw.githubusercontent.com/wingedsheep/argentum-engine/help-assay-docs-screenshots/04-assay-ready-filter.png)

> Images live on `help-assay-docs-screenshots`, a throwaway branch — delete it once this merges.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `topics.test.ts` + `help-topic-claims.test.ts` — 17 passed. The registry test is the load-bearing one here: it proves every new `topicId` referenced from `SetCompletionPage` resolves, and that every `related` cross-reference does too. A typo there silently deletes the `?` button rather than failing.
- Screenshots captured against the **real production API** (`GAME_SERVER_URL=https://magic.wingedsheep.com npm run dev`), so the counts shown are live rather than seeded.

No engine, SDK, or server code is touched — client-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
