### PR TITLE
Check CR 608.2a's intervening-"if" before CR 608.2b's targets

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3923,6 +3923,11 @@ no shared field to fall back on.
 | `interveningIf` | CR 603.4 | an `if` **immediately after the trigger event**: "When/Whenever/At [event], **if** [condition], [effect]" | when the trigger would fire **and again on resolution** — a false condition removes the ability from the stack with an `AbilityFizzledEvent` and it does nothing |
 | `triggerRestriction` | CR 603.2 | a **"while"** clause ("…attacks **while** you control a Dinosaur", "…**while saddled**"), a **"during"** narrowing ("…**during your turn**"), or a mechanic's own gate with no printed word (an Offspring cost paid, a chosen mode, a Station threshold, a max-speed grant) | when the trigger would fire, and **never again** |
 
+The second check is **CR 608.2a**, and it runs *before* CR 608.2b's target legality check — an
+ability whose intervening-"if" has gone false is removed from the stack whether or not its targets
+are still legal, and the `AbilityFizzledEvent` reads `"Intervening-if condition is no longer true"`
+rather than `"All targets are invalid"`.
+
 CR 603.4's own parenthetical draws the line: the rule *"only applies to an 'if' that immediately
 follows a trigger condition"*. So an `if` printed **after** the effect — "Whenever this creature
 attacks, create a token **if** you control a creature with power 4 or greater" — is neither field.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TriggeredAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TriggeredAbility.kt
@@ -67,7 +67,9 @@ data class TriggeredAbility(
      * if it is true then; and again as the ability resolves, where a false condition removes the
      * ability from the stack and it does nothing. CR 603.4 calls the second check a mirror of the
      * check for legal targets, and [com.wingedsheep.engine.mechanics.stack.StackResolver] performs
-     * it in the same place, emitting an `AbilityFizzledEvent`.
+     * it in the same place, emitting an `AbilityFizzledEvent`. The two are ordered: CR 608.2a runs
+     * this check **before** CR 608.2b's target legality, so an ability whose condition has gone
+     * false is removed from the stack whether or not its targets are still legal.
      *
      * The rule's own parenthetical is the boundary: *"the word 'if' has only its normal English
      * meaning anywhere else in the text of a card; this rule only applies to an 'if' that

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2640,7 +2640,48 @@ class StackResolver(
         val abilityComponent = container.get<TriggeredAbilityOnStackComponent>()!!
         val targetsComponent = container.get<TargetsComponent>()
 
-        // Validate targets (including protection check - Rule 702.16)
+        // The resolution-time context the two checks below and the effect itself all read: trigger
+        // payload, last-known info, captured batch and all. Built up front because CR 608.2a's
+        // intervening-"if" is evaluated against it *before* CR 608.2b touches the targets. The
+        // targets it carries are the stored ones — legality is 608.2b's business, not the context's.
+        val resolvedTargets2 = targetsComponent?.targets ?: emptyList()
+        val targetReqs = targetsComponent?.targetRequirements ?: emptyList()
+        val context = EffectContext.forTriggeredAbility(
+            abilityComponent,
+            targets = resolvedTargets2,
+            targetRequirements = targetReqs
+        )
+
+        // CR 608.2a, then CR 608.2b — in that lettered order. 608.2a: "If a triggered ability has
+        // an intervening 'if' clause, it checks whether the clause's condition is true. If it
+        // isn't, the ability is removed from the stack and does nothing. Otherwise, it continues to
+        // resolve." Only a *continuing* resolution reaches 608.2b's target-legality check, so when
+        // both have gone false the intervening-"if" is what ends the resolution and what the fizzle
+        // reports.
+
+        // CR 608.2a / CR 603.4's second check. Fizzles through the same event as an illegal-target
+        // fizzle rather than silently doing nothing.
+        //
+        // Only [TriggeredAbilityOnStackComponent.interveningIf] reaches here. A
+        // `triggerRestriction` ("...attacks *while* you control a Dinosaur") is a CR 603.2
+        // restriction on the trigger event and was already spent when the ability triggered;
+        // re-checking it would fizzle abilities that must resolve.
+        abilityComponent.interveningIf?.let { condition ->
+            if (!conditionEvaluator.evaluate(state, condition, context)) {
+                return ExecutionResult.success(
+                    state.removeEntity(abilityId),
+                    listOf(
+                        AbilityFizzledEvent(
+                            abilityComponent.sourceId,
+                            abilityComponent.description,
+                            "Intervening-if condition is no longer true"
+                        )
+                    )
+                )
+            }
+        }
+
+        // CR 608.2b — validate targets (including protection check, CR 702.16)
         val sourceCard = state.getEntity(abilityComponent.sourceId)?.get<CardComponent>()
         val sourceColors = sourceCard?.colors ?: emptySet()
         val sourceSubtypes = sourceCard?.typeLine?.subtypes?.map { it.value }?.toSet() ?: emptySet()
@@ -2673,40 +2714,6 @@ class StackResolver(
         }
 
         // Execute the effect
-        val resolvedTargets2 = targetsComponent?.targets ?: emptyList()
-        val targetReqs = targetsComponent?.targetRequirements ?: emptyList()
-        val context = EffectContext.forTriggeredAbility(
-            abilityComponent,
-            targets = resolvedTargets2,
-            targetRequirements = targetReqs
-        )
-
-        // CR 603.4's second check. "If the ability triggers, it checks the stated condition again
-        // as it resolves. If the condition isn't true at that time, the ability is removed from the
-        // stack and does nothing. Note that this mirrors the check for legal targets." So it sits
-        // right after the target check above, reads the same resolution-time context the effect is
-        // about to run in — trigger payload, last-known info, captured batch and all — and fizzles
-        // through the same event rather than silently doing nothing.
-        //
-        // Only [TriggeredAbilityOnStackComponent.interveningIf] reaches here. A
-        // `triggerRestriction` ("...attacks *while* you control a Dinosaur") is a CR 603.2
-        // restriction on the trigger event and was already spent when the ability triggered;
-        // re-checking it would fizzle abilities that must resolve.
-        abilityComponent.interveningIf?.let { condition ->
-            if (!conditionEvaluator.evaluate(state, condition, context)) {
-                return ExecutionResult.success(
-                    state.removeEntity(abilityId),
-                    listOf(
-                        AbilityFizzledEvent(
-                            abilityComponent.sourceId,
-                            abilityComponent.description,
-                            "Intervening-if condition is no longer true"
-                        )
-                    )
-                )
-            }
-        }
-
         val effectResult = effectHandler.execute(state, abilityComponent.effect, context)
 
         // If effect is paused awaiting a decision, return paused state

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/InterveningIfBeforeTargetLegalityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/triggers/InterveningIfBeforeTargetLegalityTest.kt
@@ -1,0 +1,135 @@
+package com.wingedsheep.engine.triggers
+
+import com.wingedsheep.engine.event.GlobalGrantedTriggeredAbility
+import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.conditions.CreatureDiedThisTurnCondition
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.engine.core.AbilityFizzledEvent
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 608.2a runs before CR 608.2b.
+ *
+ * A resolving triggered ability checks its intervening-"if" clause *first* — "if it isn't [true],
+ * the ability is removed from the stack and does nothing" — and only then checks whether its
+ * targets are still legal. The distinction is invisible until both fail at once, which is exactly
+ * what the first test below sets up: it is the intervening-"if" that ends the resolution, so it is
+ * the intervening-"if" that the fizzle reports.
+ *
+ * The two controls pin the other corners: an ability whose condition still holds but whose target
+ * is gone must still fizzle on targets, and one where neither has changed must resolve.
+ */
+class InterveningIfBeforeTargetLegalityTest : FunSpec({
+
+    /**
+     * A trigger at your end step that deals 2 damage to target creature, gated by an
+     * intervening-"if" ("… if a creature died this turn"). Both halves are independently
+     * falsifiable at resolution: drop [CreaturesDiedThisTurnComponent] to break the condition,
+     * move the target off the battlefield to break its legality.
+     */
+    fun setUp(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.player1
+        val source = driver.putPermanentOnBattlefield(you, "Test Enchantment")
+        val victim = driver.putCreatureOnBattlefield(driver.player2, "Centaur Courser")
+
+        val ability = TriggeredAbility.create(
+            trigger = EventPattern.StepEvent(Step.END, Player.You),
+            effect = DealDamageEffect(2, EffectTarget.ContextTarget(0)),
+            targetRequirement = TargetCreature(),
+            interveningIf = CreatureDiedThisTurnCondition
+        )
+        driver.replaceState(
+            driver.state.copy(
+                globalGrantedTriggeredAbilities = listOf(
+                    GlobalGrantedTriggeredAbility(
+                        ability = ability,
+                        controllerId = you,
+                        sourceId = source,
+                        sourceName = "Test Intervening-If Ability",
+                        duration = Duration.Permanent
+                    )
+                )
+            )
+        )
+
+        // Make the intervening-"if" true so the ability triggers at all (CR 603.4's first check).
+        driver.replaceState(
+            driver.state.updateEntity(you) { container ->
+                container.with(CreaturesDiedThisTurnComponent(count = 1))
+            }
+        )
+
+        // Trigger it and choose the still-legal target.
+        driver.passPriorityUntil(Step.END)
+        driver.submitTargetSelection(you, listOf(victim))
+        driver.stackSize shouldBe 1
+
+        return Triple(driver, source, victim)
+    }
+
+    fun breakCondition(driver: GameTestDriver) {
+        driver.replaceState(
+            driver.state.updateEntity(driver.player1) { container ->
+                container.without<CreaturesDiedThisTurnComponent>()
+            }
+        )
+    }
+
+    test("both checks fail: CR 608.2a's intervening-if ends the resolution, not CR 608.2b's targets") {
+        val (driver, _, victim) = setUp()
+
+        breakCondition(driver)
+        driver.moveToGraveyard(victim)
+
+        val result = driver.bothPass()
+
+        val fizzles = result.events.filterIsInstance<AbilityFizzledEvent>()
+        fizzles.map { it.reason } shouldContain "Intervening-if condition is no longer true"
+        // CR 608.2b never got to speak.
+        fizzles.map { it.reason }.contains("All targets are invalid") shouldBe false
+        driver.stackSize shouldBe 0
+    }
+
+    test("control: condition still true, target gone — CR 608.2b fizzles on targets as before") {
+        val (driver, _, victim) = setUp()
+
+        driver.moveToGraveyard(victim)
+
+        val result = driver.bothPass()
+
+        val fizzles = result.events.filterIsInstance<AbilityFizzledEvent>()
+        fizzles.map { it.reason } shouldContain "All targets are invalid"
+        driver.stackSize shouldBe 0
+    }
+
+    test("control: condition true and target legal — the ability resolves and deals its damage") {
+        val (driver, _, victim) = setUp()
+
+        val result = driver.bothPass()
+
+        result.events.filterIsInstance<AbilityFizzledEvent>() shouldBe emptyList()
+        driver.stackSize shouldBe 0
+        // Centaur Courser is a 3/3; 2 damage leaves it on the battlefield with damage marked.
+        driver.state.getEntity(victim)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.DamageComponent>()
+            ?.amount shouldBe 2
+    }
+})


### PR DESCRIPTION
Fixes #1840.

## The bug

`StackResolver.resolveTriggeredAbility` validated targets before rechecking the
intervening-"if". CR 608.2 runs 608.2a **then** 608.2b:

> **608.2a** If a triggered ability has an intervening "if" clause, it checks whether the
> clause's condition is true. If it isn't, the ability is removed from the stack and does
> nothing. **Otherwise, it continues to resolve.**

Only a resolution that *continues* past 608.2a ever reaches 608.2b's target check. Ours
reached the target check first, so an ability that had lost **both** its condition and all
its targets fizzled as `"All targets are invalid"` — 608.2b speaking where 608.2a should
have.

## The fix

The ordering, not the CR 603.4 model from #1838. The resolution context is built up front
(it already carried the *stored* targets — legality is 608.2b's business, not the
context's), the intervening-"if" reads it, and the target validation follows. No SDK
model, serialization, Assay, or card-corpus change, exactly as the issue predicted.

## Tests

`InterveningIfBeforeTargetLegalityTest` — a global-granted end-step trigger with an
intervening-"if" (`CreatureDiedThisTurnCondition`) and a `TargetCreature`, so each half is
independently falsifiable at resolution:

| Case | Expected |
|---|---|
| condition false **and** target gone | `AbilityFizzledEvent(reason = "Intervening-if condition is no longer true")`, and *no* `"All targets are invalid"` |
| condition true, target gone | `"All targets are invalid"` — normal 608.2b fizzle, unchanged |
| both intact | resolves; 2 damage marked on the target |

Verified red before the reorder (case 1 only) and green after.

## Verification

- `just test-rules` — full engine suite + every card scenario, BUILD SUCCESSFUL.
- CR wording checked against `MagicCompRules 20260808.txt` (608.2, 608.2a, 608.2b, 603.4).

Docs: the `interveningIf` KDoc and the "`interveningIf` vs `triggerRestriction`" section in
`card-sdk-language-reference.md` now state the 608.2a-before-608.2b ordering and which
fizzle reason wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
