### PR TITLE
Add all 262 Assay-ready Jumpstart 2022 cards

### DIFF
--- a/backlog/sets/bloomburrow-commander/cards.md
+++ b/backlog/sets/bloomburrow-commander/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 312 cards
 **Release Date:** August 2, 2024
-**Implemented:** 114 / 312
+**Implemented:** 118 / 312
 | Color      | Total | Done |
 |------------|-------|------|
 | White      | 37    | 0    |
@@ -69,7 +69,7 @@
 - [ ] Chittering Witch
 - [ ] Chitterspitter
 - [x] Cinder Glade
-- [ ] Circuit Mender
+- [x] Circuit Mender
 - [x] Clifftop Retreat
 - [ ] Cloudblazer
 - [ ] Coiling Oracle
@@ -145,7 +145,7 @@
 - [ ] Inferno Titan
 - [ ] Ink-Eyes, Servant of Oni
 - [ ] Insatiable Frugivore
-- [ ] Inspiring Overseer
+- [x] Inspiring Overseer
 - [ ] Intellectual Offering
 - [ ] Ishai, Ojutai Dragonspeaker
 - [ ] Izzet Signet
@@ -241,7 +241,7 @@
 - [ ] Seaside Citadel
 - [ ] Second Harvest
 - [ ] Secret Rendezvous
-- [ ] Selfless Spirit
+- [x] Selfless Spirit
 - [ ] Selvala, Explorer Returned
 - [ ] Shamanic Revelation
 - [x] Sheltered Thicket
@@ -257,7 +257,7 @@
 - [ ] Solemn Simulacrum
 - [ ] Sphinx of Enlightenment
 - [x] Spine of Ish Sah
-- [ ] Spirited Companion
+- [x] Spirited Companion
 - [ ] Spore Frog
 - [ ] Squirrel Mob
 - [ ] Squirrel Nest

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fem/cards/GoblinGrenade.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fem/cards/GoblinGrenade.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.fem.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+
+/**
+ * Goblin Grenade
+ * {R}
+ * Sorcery
+ * As an additional cost to cast this spell, sacrifice a Goblin.
+ * Goblin Grenade deals 5 damage to any target.
+ *
+ * The sacrifice filter is *permanent* with the Goblin subtype, not creature — per the ruling, a
+ * kindred enchantment such as Boggart Shenanigans is a legal sacrifice.
+ */
+val GoblinGrenade = card("Goblin Grenade") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "As an additional cost to cast this spell, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to any target."
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Permanent.withSubtype("Goblin")))
+
+    spell {
+        val t = target("any target", AnyTarget())
+        effect = Effects.DealDamage(5, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56a"
+        artist = "Ron Spencer"
+        flavorText = "\"According to accepted theory, the Grenade held some kind of flammable mixture and was carried to its target by a hapless Goblin.\" —*Sarpadian Empires, vol. IV*"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/8837eaba-9602-4f63-9897-85583fcdcf51.jpg?1783947894"
+        ruling("2011-09-22", "Players can only respond once Goblin Grenade has been cast and all its costs have been paid. No one can try and destroy the Goblin to prevent you from casting Goblin Grenade.")
+        ruling("2011-09-22", "The Goblin you sacrifice to cast Goblin Grenade doesn't have to be a creature. For example, you could sacrifice Boggart Shenanigans (a kindred enchantment with the subtype Goblin).")
+        ruling("2004-10-04", "You can't sacrifice more than one Goblin to get a greater effect.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredIsland.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ice/cards/SnowCoveredIsland.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.ice.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Snow-Covered Island
+ * Basic Snow Land — Island
+ * ({T}: Add {U}.)
+ *
+ * Written with the plain [card] DSL rather than the `basicLand` helper: that helper hardcodes the
+ * "Basic Land — <type>" type line and cannot carry the Snow supertype. The intrinsic mana ability is
+ * spelled out here to match what `basicLand` would have generated.
+ */
+val SnowCoveredIsland = card("Snow-Covered Island") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Basic Snow Land — Island"
+    oracleText = "({T}: Add {U}.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "371"
+        artist = "Anson Maddocks"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad8b77cf-b53e-4da3-9c27-3851b7b25a98.jpg?1783947448"
+        ruling("2021-02-05", "Snow is a supertype, not a card type. It has no rules meaning or function by itself, but spells and abilities may refer to it.")
+        ruling("2021-02-05", "The {S} symbol is a generic mana symbol. It represents a cost that can be paid by one mana that was produced by a snow source. That mana can be any color or colorless.")
+        ruling("2021-02-05", "Snow isn't a type of mana. If an effect says you may spend mana as though it were any type, you can't pay for {S} using mana that wasn't produced by a snow source.")
+        ruling("2021-02-05", "Some cards have additional effects for each {S} spent to cast them. You can cast these spells even if you don't spend any snow mana to cast them; their additional effects simply won't do anything.")
+        ruling("2021-02-05", "The Kaldheim set doesn't have any cards with mana costs that include {S}, but some previous sets do. If an effect says such a spell costs {1} less to cast, that reduction doesn't apply to any {S} costs. This is also true for activated abilities that include {S} in their activation costs and effects that reduce those costs.")
+        ruling("2021-02-05", "In a Limited event (usually Booster Draft or Sealed Deck), you can't add basic snow lands to your card pool as you would other basic lands. You can play with basic snow lands only if you open them in your sealed deck or draft them.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ArmsDealer.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mmq/cards/ArmsDealer.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.mmq.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Arms Dealer
+ * {2}{R}
+ * Creature — Goblin Rogue
+ * 1/1
+ * {1}{R}, Sacrifice a Goblin: This creature deals 4 damage to target creature.
+ *
+ * "Sacrifice a Goblin" is [Costs.Sacrifice] over any *permanent* with the Goblin subtype — not
+ * `SacrificeAnother` — so Arms Dealer itself is a legal sacrifice for its own ability.
+ */
+val ArmsDealer = card("Arms Dealer") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{R}, Sacrifice a Goblin: This creature deals 4 damage to target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{R}"),
+            Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype("Goblin"))
+        )
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(4, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "172"
+        artist = "Luca Zontini"
+        flavorText = "He has the weapons, he has the connections, and he knows the hangar's dark secret."
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/dafea45d-be00-428d-a127-70e6a14efe3f.jpg?1783945943"
+        ruling("2012-07-01", "You can sacrifice Arms Dealer to activate its own ability.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/Manakin.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/Manakin.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.tmp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Manakin
+ * {2}
+ * Artifact Creature — Construct
+ * 1/1
+ * {T}: Add {C}.
+ */
+val Manakin = card("Manakin") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Add {C}."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "296"
+        artist = "Scott Kirschner"
+        flavorText = "Hanna regarded Squee sternly. \"Because it's *not* a toy, no matter how much it may look like one,\" she said, taking the manakin from him."
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d33ce7f-f318-4161-843a-f5bb6d6e3d29.jpg?1783946602"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/InfantryVeteran.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/InfantryVeteran.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.vis.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Infantry Veteran
+ * {W}
+ * Creature — Human Soldier
+ * 1/1
+ * {T}: Target attacking creature gets +1/+1 until end of turn.
+ */
+val InfantryVeteran = card("Infantry Veteran") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Target attacking creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target attacking creature", TargetCreature(filter = TargetFilter.AttackingCreature))
+        effect = Effects.ModifyStats(1, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Christopher Rush"
+        flavorText = "\"The true dishonor for a soldier is surviving the war.\" —Telim'Tor"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/0350470b-feea-4e15-bdf0-850b71dbeea6.jpg?1783947006"
+        ruling("2010-08-15", "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/MiraculousRecovery.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/MiraculousRecovery.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.vis.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Miraculous Recovery
+ * {4}{W}
+ * Instant
+ * Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.
+ *
+ * The reanimated permanent keeps its entity id across the graveyard→battlefield move, so the
+ * follow-up counter lands on the same object: [Effects.Move] then [Effects.AddCounters] on the same
+ * target reference. That ordering is also what the rulings describe — the creature enters *without*
+ * the counter and receives it afterwards, with no priority window in between.
+ */
+val MiraculousRecovery = card("Miraculous Recovery") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it."
+
+    spell {
+        val creatureCard = target(
+            "target creature card from your graveyard",
+            Targets.CreatureCardInYourGraveyard
+        )
+        effect = Effects.Move(creatureCard, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+            .then(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creatureCard))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "13"
+        artist = "Brian Horton"
+        flavorText = "\"You stop breathing for just a few minutes and everyone jumps to conclusions.\" —Zarkuu, necrosavant"
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76fecb31-790a-4454-918e-5aeb253021f0.jpg?1783947006"
+        ruling("2018-12-07", "The creature returns to the battlefield without a +1/+1 counter on it. Any abilities that trigger when a creature enters the battlefield will trigger or not as appropriate before it receives the +1/+1 counter and resolve after it has received that counter.")
+        ruling("2018-12-07", "No player may take actions between the time the creature returns to the battlefield and the time you put a +1/+1 counter on it.")
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/UktabiOrangutan.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vis/cards/UktabiOrangutan.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.vis.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Uktabi Orangutan
+ * {2}{G}
+ * Creature — Ape
+ * 2/2
+ * When this creature enters, destroy target artifact.
+ */
+val UktabiOrangutan = card("Uktabi Orangutan") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ape"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, destroy target artifact."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target artifact", TargetPermanent(filter = TargetFilter.Artifact))
+        effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "123"
+        artist = "Una Fricker"
+        flavorText = "\"Is it true that the apes wear furs of gold when they marry?\" —Rana, Suq'Ata market fool"
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/101c7d58-43cc-4ebd-87f1-2016fbff56dd.jpg?1783946979"
+    }
+}

--- a/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wth/cards/FesteringEvil.kt
+++ b/mtg-sets/1993-1999/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wth/cards/FesteringEvil.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.wth.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Festering Evil
+ * {3}{B}{B}
+ * Enchantment
+ * At the beginning of your upkeep, this enchantment deals 1 damage to each creature and each player.
+ * {B}{B}, Sacrifice this enchantment: It deals 3 damage to each creature and each player.
+ *
+ * "each creature and each player" is the standard two-part sweep: [Effects.ForEachInGroup] over
+ * [GroupFilter.AllCreatures] then [Effects.ForEachPlayer] over [Player.Each].
+ */
+val FesteringEvil = card("Festering Evil") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, this enchantment deals 1 damage to each creature and each player.\n{B}{B}, Sacrifice this enchantment: It deals 3 damage to each creature and each player."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.ForEachInGroup(GroupFilter.AllCreatures, DealDamageEffect(1, EffectTarget.Self)) then
+            Effects.ForEachPlayer(Player.Each, listOf(Effects.DealDamage(1, EffectTarget.Controller)))
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{B}{B}"), Costs.SacrificeSelf)
+        effect = Effects.ForEachInGroup(GroupFilter.AllCreatures, DealDamageEffect(3, EffectTarget.Self)) then
+            Effects.ForEachPlayer(Player.Each, listOf(Effects.DealDamage(3, EffectTarget.Controller)))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "68"
+        artist = "John Matson"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d688bda-fee2-496d-9793-794c2568b54e.jpg?1783946734"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SimianBrawler.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/csp/cards/SimianBrawler.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.csp.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Simian Brawler
+ * {3}{G}
+ * Creature — Ape Warrior
+ * 3/3
+ * Discard a land card: This creature gets +1/+1 until end of turn.
+ */
+val SimianBrawler = card("Simian Brawler") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ape Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Discard a land card: This creature gets +1/+1 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Discard(GameObjectFilter.Land)
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Warren Mahy"
+        flavorText = "\"It's odd to see the apes rip down trees to arm themselves in defense of their forests.\" —Taaveti of Kelsinko, elvish hunter"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df2ed9f3-50b1-493b-9c14-0f8ddb4d8c57.jpg?1783943326"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MudbuttonTorchrunner.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/MudbuttonTorchrunner.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mudbutton Torchrunner
+ * {2}{R}
+ * Creature — Goblin Warrior
+ * 1/1
+ * When this creature dies, it deals 3 damage to any target.
+ */
+val MudbuttonTorchrunner = card("Mudbutton Torchrunner") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature dies, it deals 3 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val damaged = target("any target", Targets.Any)
+        effect = Effects.DealDamage(3, damaged)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Steve Ellis"
+        flavorText = "The oil sloshes against his skull as he nears his destination: the Frogtosser Games and the lighting of the Flaming Boggart."
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50575eab-6c23-4f63-9667-458416c5caa5.jpg?1783942871"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SentinelsOfGlenElendra.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lrw/cards/SentinelsOfGlenElendra.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.lrw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sentinels of Glen Elendra
+ * {3}{U}
+ * Creature — Faerie Soldier
+ * 2/3
+ * Flash
+ * Flying
+ */
+val SentinelsOfGlenElendra = card("Sentinels of Glen Elendra") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "Flash\nFlying"
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Howard Lyon"
+        flavorText = "Some say the valley of Glen Elendra is mythical, and that rumors of its existence are nothing but a faerie prank. Others say it is the fae's most fiercely guarded secret."
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f48daf7e-2f8e-4179-a145-a6b36dd11d44.jpg?1783942897"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DevouringLight.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DevouringLight.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Devouring Light
+ * {1}{W}{W}
+ * Instant
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Exile target attacking or blocking creature.
+ */
+val DevouringLight = card("Devouring Light") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile target attacking or blocking creature."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        val creature = target(
+            "target attacking or blocking creature",
+            TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature)
+        )
+        effect = Effects.Exile(creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "13"
+        artist = "Pete Venters"
+        flavorText = "Into the light the good are welcomed, and with the light the evil are banished."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53fcc46c-682c-4482-8422-811b951d96cf.jpg?1783943702"
+
+        ruling("2024-01-12", "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value.")
+        ruling("2024-01-12", "You can tap any untapped creature you control to convoke a spell, even one you haven't controlled continuously since the beginning of your most recent turn.")
+        ruling("2024-01-12", "Tapping an untapped creature that's attacking or blocking to convoke a spell won't cause that creature to stop attacking or blocking.")
+        ruling("2024-01-12", "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors.")
+        ruling("2024-01-12", "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped before you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke.")
+        ruling("2024-01-12", "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs.")
+        ruling("2014-07-18", "The declare blockers step is the last chance to cast Devouring Light before creatures deal their combat damage. However, a creature remains an attacking or blocking creature during the combat damage step and end of combat step. Devouring Light may be cast targeting such a creature during those steps, after the creature has dealt combat damage.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HourOfReckoning.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/HourOfReckoning.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Hour of Reckoning
+ * {4}{W}{W}{W}
+ * Sorcery
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Destroy all nontoken creatures.
+ */
+val HourOfReckoning = card("Hour of Reckoning") {
+    manaCost = "{4}{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy all nontoken creatures."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        effect = Effects.DestroyAll(GameObjectFilter.Creature.nontoken())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "21"
+        artist = "Randy Gallegos"
+        flavorText = "\"Ravnica, like a hedge, must be pruned, leaving only leaves of verdant uniformity.\" —Niszka, Selesnya evangel"
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/bec7a987-1ef2-40aa-a744-92d90b246df4.jpg?1783943699"
+
+        ruling("2024-01-12", "You can tap any untapped creature you control to convoke a spell, even one you haven't controlled continuously since the beginning of your most recent turn.")
+        ruling("2024-01-12", "Tapping an untapped creature that's attacking or blocking to convoke a spell won't cause that creature to stop attacking or blocking.")
+        ruling("2024-01-12", "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value.")
+        ruling("2024-01-12", "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped before you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke.")
+        ruling("2024-01-12", "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs.")
+        ruling("2024-01-12", "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors.")
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/HavenwoodWurm.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/HavenwoodWurm.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Havenwood Wurm
+ * {6}{G}
+ * Creature — Wurm
+ * 5/6
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Trample
+ */
+val HavenwoodWurm = card("Havenwood Wurm") {
+    manaCost = "{6}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wurm"
+    power = 5
+    toughness = 6
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\nTrample"
+
+    keywords(Keyword.FLASH, Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "199"
+        artist = "Stuart Griffin"
+        flavorText = "Time rifts bring tunneling beasts of old into the hard, dry earth of the present. Most die there, trapped, but the mightiest burst through the surface."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/561a4bb5-285a-4d52-b372-d165e442cff3.jpg?1783943212"
+    }
+}

--- a/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TolarianSentinel.kt
+++ b/mtg-sets/2003-2007/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tsp/cards/TolarianSentinel.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tsp.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tolarian Sentinel
+ * {3}{U}
+ * Creature — Human Spellshaper
+ * 1/3
+ * Flying
+ * {U}, {T}, Discard a card: Return target permanent you control to its owner's hand.
+ */
+val TolarianSentinel = card("Tolarian Sentinel") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Spellshaper"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\n{U}, {T}, Discard a card: Return target permanent you control to its owner's hand."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.Tap, Costs.DiscardCard)
+        val permanent = target("target permanent you control", Targets.PermanentYouControl)
+        effect = Effects.ReturnToHand(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Thomas M. Baxa"
+        flavorText = "\"It is not just our people I try to rescue. It is our culture, and our hope that we can return to greatness.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e97ec8b-6163-41ff-9e6f-af091a7c529e.jpg?1783943238"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SanctumGargoyle.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/SanctumGargoyle.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sanctum Gargoyle
+ * {3}{W}
+ * Artifact Creature — Gargoyle
+ * 2/3
+ * Flying
+ * When this creature enters, you may return target artifact card from your graveyard to your hand.
+ */
+val SanctumGargoyle = card("Sanctum Gargoyle") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Gargoyle"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\nWhen this creature enters, you may return target artifact card from your graveyard to your hand."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Artifact.ownedByYou(), zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.Move(t, Zone.HAND)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Shelly Wan"
+        flavorText = "As their supplies of etherium dwindled, mechanists sent gargoyles farther and farther afield in search of salvage."
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1da1a2d5-d1fe-4aa2-aa83-64d6c269f7bc.jpg?1783942579"
+
+        ruling("2008-10-01", "The only difference between a colored artifact and a colorless artifact is, obviously, its color. Unlike most artifacts, a colored artifact requires colored mana to cast. Also unlike most artifacts, a colored artifact has a color in all zones. It will interact with cards that care about color. Other than that, a colored artifact behaves just like any other artifact. It will interact as normal with any card that cares about artifacts, such as Shatter or Arcbound Ravager.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GoldnightCommander.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/avr/cards/GoldnightCommander.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.avr.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Goldnight Commander
+ * {3}{W}
+ * Creature — Human Cleric Soldier
+ * 2/2
+ * Whenever another creature you control enters, creatures you control get +1/+1 until end of turn.
+ *
+ * The group is gathered when the ability *resolves*, so the creature that entered is pumped too
+ * if it is still on the battlefield then — but the trigger itself is [TriggerBinding.OTHER], so
+ * Goldnight Commander's own arrival doesn't trigger it.
+ */
+val GoldnightCommander = card("Goldnight Commander") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever another creature you control enters, creatures you control get +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.OTHER
+        )
+        effect = Patterns.Group.modifyStatsForAll(1, 1, GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "22"
+        artist = "Chris Rahn"
+        flavorText = "\"One faith, but many hands in victory.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c6ebec82-9d4a-4e78-b923-37c3a52133e7.jpg?1783940736"
+        ruling("2012-05-01", "The creature that entered will also get +1/+1 until end of turn if it's still on the battlefield when the ability resolves.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DemonsGrasp.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/DemonsGrasp.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Demon's Grasp
+ * {4}{B}
+ * Sorcery
+ * Target creature gets -5/-5 until end of turn.
+ */
+val DemonsGrasp = card("Demon's Grasp") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target creature gets -5/-5 until end of turn."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(-5, -5, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "108"
+        artist = "David Gaillet"
+        flavorText = "\"Take what solace you can in the knowledge that you will not be here to witness Zendikar's demise.\" —Ob Nixilis"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff953948-db26-43af-9905-7d387769b4a9.jpg?1783938202"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/LavastepRaider.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/LavastepRaider.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lavastep Raider
+ * {R}
+ * Creature — Goblin Warrior
+ * 1/2
+ * {2}{R}: This creature gets +2/+0 until end of turn.
+ */
+val LavastepRaider = card("Lavastep Raider") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 1
+    toughness = 2
+    oracleText = "{2}{R}: This creature gets +2/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{R}")
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Matt Stewart"
+        flavorText = "Goblins were first to see the potential of hedrons in the fight against the Eldrazi, for the magical stones came ready-made with pointy bits."
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/2428f13f-c445-4eb4-bab1-309f27cab208.jpg?1783938194"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/Outnumber.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/Outnumber.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Outnumber
+ * {R}
+ * Instant
+ * Outnumber deals damage to target creature equal to the number of creatures you control.
+ *
+ * [DynamicAmounts.creaturesYouControl] is counted on resolution, per the BFZ ruling.
+ */
+val Outnumber = card("Outnumber") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Outnumber deals damage to target creature equal to the number of creatures you control."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(DynamicAmounts.creaturesYouControl(), creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Tyler Jacobson"
+        flavorText = "Everyone who could still lift a weapon had a part in retaking Sea Gate."
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3373281-7319-4320-8afb-4546fb55ab4c.jpg?1783938193"
+
+        ruling(
+            "2015-08-25",
+            "Count the number of creatures you control as Outnumber resolves to determine how much " +
+                "damage Outnumber deals."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SandstoneBridge.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SandstoneBridge.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Sandstone Bridge
+ * Land
+ * This land enters tapped.
+ * When this land enters, target creature gets +1/+1 and gains vigilance until end of turn.
+ * {T}: Add {W}.
+ */
+val SandstoneBridge = card("Sandstone Bridge") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\nWhen this land enters, target creature gets +1/+1 and gains vigilance until end of turn.\n{T}: Add {W}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(power = 1, toughness = 1, target = t),
+            Effects.GrantKeyword(Keyword.VIGILANCE, target = t)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "243"
+        artist = "Cliff Childs"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c781e932-4605-47aa-add1-4ee62f4e7ead.jpg?1783938173"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SnappingGnarlid.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/SnappingGnarlid.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Snapping Gnarlid
+ * {1}{G}
+ * Creature — Beast
+ * 2/2
+ * Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn.
+ */
+val SnappingGnarlid = card("Snapping Gnarlid") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 2
+    oracleText = "Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn."
+
+    // Landfall — +1/+1 until end of turn whenever a land you control enters.
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "190"
+        artist = "Kev Walker"
+        flavorText = "All of Zendikar's beings sense the upheaval that accompanies the Eldrazi."
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/834409e3-134e-4a34-89cb-53e2a039e980.jpg?1783938185"
+        ruling(
+            "2024-11-08",
+            "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control.",
+        )
+        ruling(
+            "2024-11-08",
+            "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land.",
+        )
+        ruling(
+            "2024-11-08",
+            "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.).",
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/WindriderPatrol.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bfz/cards/WindriderPatrol.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.bfz.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Windrider Patrol
+ * {3}{U}{U}
+ * Creature — Merfolk Wizard
+ * 4/3
+ * Flying
+ * Whenever this creature deals combat damage to a player, scry 2.
+ *
+ * Printed flying plus the Jeskai Elder trigger shape — [Triggers.DealsCombatDamageToPlayer] feeding
+ * [Effects.Scry]`(2)`.
+ */
+val WindriderPatrol = card("Windrider Patrol") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 4
+    toughness = 3
+    oracleText = "Flying\nWhenever this creature deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Scry(2)
+        description = "Scry 2."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "89"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4ac7b904-7658-4248-a75c-b3a862bde196.jpg?1783938206"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/Commander2016Set.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/Commander2016Set.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.c16
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Commander 2016
+ *
+ * Scaffolded to hold the cards whose earliest real printing is Commander 2016. Intentionally
+ * incomplete relative to the official set.
+ *
+ * Set Code: C16
+ * Release Date: 2016-11-11
+ */
+object Commander2016Set : MtgSet {
+
+    override val code = "C16"
+    override val displayName = "Commander 2016"
+    override val releaseDate = "2016-11-11"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.c16.cards"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/AshBarrens.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c16/cards/AshBarrens.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.c16.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Ash Barrens
+ * Land
+ * {T}: Add {C}.
+ * Basic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)
+ *
+ * A plain colorless mana ability plus the [KeywordAbility.basicLandcycling] alternative-play
+ * ability — the engine owns the search/reveal/shuffle pipeline.
+ */
+val AshBarrens = card("Ash Barrens") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    keywordAbility(KeywordAbility.basicLandcycling(ManaCost.parse("{1}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d7ac112-bb20-4ea4-b797-5d21f6b7c121.jpg?1783937080"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SigilOfTheEmptyThrone.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/conflux/cards/SigilOfTheEmptyThrone.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.conflux.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigil of the Empty Throne
+ * {3}{W}{W}
+ * Enchantment
+ * Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.
+ */
+val SigilOfTheEmptyThrone = card("Sigil of the Empty Throne") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastEnchantment
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Angel"),
+            keywords = setOf(Keyword.FLYING),
+        )
+        description = "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "18"
+        artist = "Cyril Van Der Haegen"
+        flavorText = "When Asha left Bant, she ensured that the world would have protection and order in her absence."
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c451f63-2827-49fe-9d1d-87c87f7f5f8d.jpg?1783942490"
+        ruling(
+            "2021-03-19",
+            "An ability that triggers when a player casts a spell resolves before the spell that caused it to trigger, but after targets have been chosen for that spell. It resolves even if that spell is countered.",
+        )
+        ruling(
+            "2021-03-19",
+            "Because it's not on the battlefield yet, casting Sigil of the Empty Throne won't cause its own ability to trigger.",
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/KraulWarrior.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dgm/cards/KraulWarrior.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.dgm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kraul Warrior
+ * {1}{G}
+ * Creature — Insect Warrior
+ * 2/2
+ * {5}{G}: This creature gets +3/+3 until end of turn.
+ */
+val KraulWarrior = card("Kraul Warrior") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "{5}{G}: This creature gets +3/+3 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}")
+        effect = Effects.ModifyStats(3, 3, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "42"
+        artist = "David Rapoza"
+        flavorText = "The insectile kraul lurk in the tunnels below street level. Many are loyal to the Golgari Swarm, but others follow their own esoteric caste system."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f71da8cc-8773-4dcb-aca8-50a000142218.jpg?1783940036"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/BlackCat.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/BlackCat.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Black Cat
+ * {1}{B}
+ * Creature — Zombie Cat
+ * 1/1
+ * When this creature dies, target opponent discards a card at random.
+ */
+val BlackCat = card("Black Cat") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Cat"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature dies, target opponent discards a card at random."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Patterns.Hand.discardRandom(1, opponent)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "David Palumbo"
+        flavorText = "Its last life is spent tormenting your dreams."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bb1c6379-69d5-48aa-8d06-257c0592794e.jpg?1783940835"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/BriarpackAlpha.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/BriarpackAlpha.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Briarpack Alpha
+ * {3}{G}
+ * Creature — Wolf
+ * 3/3
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * When this creature enters, target creature gets +2/+2 until end of turn.
+ */
+val BriarpackAlpha = card("Briarpack Alpha") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 3
+    toughness = 3
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, target creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 2, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "108"
+        artist = "Daarken"
+        flavorText = "\"The wolves turned on us and a chill swept over me. The pack had a new leader.\" —Alena, trapper of Kessig"
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a052e945-7535-4b0a-b580-cf76377633f3.jpg?1783940811"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/MidnightGuard.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/MidnightGuard.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Midnight Guard
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/3
+ * Whenever another creature enters, untap this creature.
+ *
+ * "Another creature" is any creature, any controller — [TriggerBinding.OTHER] over an unscoped
+ * [GameObjectFilter.Creature], the same shape as Soul Warden.
+ */
+val MidnightGuard = card("Midnight Guard") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever another creature enters, untap this creature."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature,
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.Untap(EffectTarget.Self)
+        description = "Whenever another creature enters, untap this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Jason A. Engle"
+        flavorText = "\"When you're on watch, no noise is harmless and no shadow can be ignored.\" —Olgard of the Skiltfolk"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/2264b760-c527-470d-bad0-d8baaf543631.jpg?1783940853"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/VialOfDragonfire.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dtk/cards/VialOfDragonfire.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.dtk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vial of Dragonfire
+ * {2}
+ * Artifact
+ * {2}, {T}, Sacrifice this artifact: It deals 2 damage to target creature.
+ *
+ * A single activated ability whose cost composes [Costs.Mana], [Costs.Tap] and [Costs.SacrificeSelf];
+ * the effect is a plain [Effects.DealDamage] attributed to the artifact itself.
+ */
+val VialOfDragonfire = card("Vial of Dragonfire") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{2}, {T}, Sacrifice this artifact: It deals 2 damage to target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(2, creature)
+        description = "It deals 2 damage to target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "247"
+        artist = "Franz Vohwinkel"
+        flavorText = "Designed by an ancient artificer, the vials are strong enough to hold the very breath of a dragon—until it's needed."
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e50e88fe-307a-4944-9233-14df4e0bb775.jpg?1783938567"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BrazenWolves.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/BrazenWolves.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Brazen Wolves
+ * {2}{R}
+ * Creature — Wolf
+ * 2/3
+ * Whenever this creature attacks, it gets +2/+0 until end of turn.
+ */
+val BrazenWolves = card("Brazen Wolves") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wolf"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever this creature attacks, it gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Nils Hamm"
+        flavorText = "With fewer patrols about, Kessig's roads have become prime hunting grounds."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab8e2ece-3c66-4f34-9042-fc02639c6a79.jpg?1783937466"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GrafHarvest.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/GrafHarvest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Graf Harvest
+ * {B}
+ * Enchantment
+ * Zombies you control have menace. (They can't be blocked except by two or more creatures.)
+ * {3}{B}, Exile a creature card from your graveyard: Create a 2/2 black Zombie creature token.
+ *
+ * "Zombies you control" is a bare tribal noun — every Zombie *permanent* you control, not only
+ * the creature ones.
+ */
+val GrafHarvest = card("Graf Harvest") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Zombies you control have menace. (They can't be blocked except by two or more creatures.)\n{3}{B}, Exile a creature card from your graveyard: Create a 2/2 black Zombie creature token."
+
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.MENACE,
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.ZOMBIE).youControl())
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}{B}"),
+            Costs.ExileFromGraveyard(1, GameObjectFilter.Creature)
+        )
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Lake Hurwitz"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbc17697-9db9-41d4-aacf-b2f2e6ff80cf.jpg?1783937482"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/SelflessSpirit.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/SelflessSpirit.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Selfless Spirit
+ * {1}{W}
+ * Creature — Spirit Cleric
+ * 2/1
+ * Flying
+ * Sacrifice this creature: Creatures you control gain indestructible until end of turn.
+ */
+val SelflessSpirit = card("Selfless Spirit") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Cleric"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\nSacrifice this creature: Creatures you control gain indestructible until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "40"
+        artist = "Seb McKinnon"
+        flavorText = "\"There is always more to give.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4624976-3773-4a1e-b725-5f6efce147a5.jpg?1783937510"
+
+        ruling("2016-07-13", "The set of creatures affected by Selfless Spirit's last ability is determined as the ability resolves. Creatures you begin to control later in the turn won't gain indestructible.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/WolfkinBond.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/WolfkinBond.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Wolfkin Bond
+ * {4}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * When this Aura enters, create a 2/2 green Wolf creature token.
+ * Enchanted creature gets +2/+2.
+ *
+ * The Lunarch Mantle shape: [ModifyStats]`(2, 2)` with no filter is the Aura's static buff on its
+ * attached creature, and the one-shot token is a plain self-ETB trigger, so the Wolf's controller is
+ * the Aura's caster. The token's art comes from Eldritch Moon's synced token set, so no explicit
+ * `imageUri` is needed.
+ */
+val WolfkinBond = card("Wolfkin Bond") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nWhen this Aura enters, create a 2/2 green Wolf creature token.\nEnchanted creature gets +2/+2."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Wolf"),
+        )
+        description = "Create a 2/2 green Wolf creature token."
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "178"
+        artist = "Lindsey Look"
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/748f263e-efef-4033-8950-c58fd024a87f.jpg?1783937435"
+        ruling(
+            "2019-07-12",
+            "You need a creature for Wolfkin Bond to target as you cast it. It can't enter the " +
+                "battlefield attached to the Wolf token it will create."
+        )
+        ruling(
+            "2019-07-12",
+            "If the target creature is an illegal target by the time Wolfkin Bond tries to resolve, " +
+                "the spell doesn't resolve. It won't enter the battlefield, so its ability won't trigger."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eve/EventideSet.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eve/EventideSet.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.eve
+
+import com.wingedsheep.mtg.sets.discovery.CardDiscovery
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
+
+/**
+ * Eventide (2008)
+ *
+ * Scaffolded to hold the cards whose earliest real printing is Eventide. Intentionally
+ * incomplete relative to the official set.
+ *
+ * Set Code: EVE
+ * Release Date: 2008-07-25
+ */
+object EventideSet : MtgSet {
+
+    override val code = "EVE"
+    override val displayName = "Eventide"
+    override val releaseDate = "2008-07-25"
+    override val block = "Shadowmoor"
+    override val sealedSupported = false
+    override val incomplete = true
+
+    override val cards: List<CardDefinition> by lazy {
+        CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
+    }
+
+    private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.eve.cards"
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eve/cards/ArchonOfJustice.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eve/cards/ArchonOfJustice.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.eve.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Archon of Justice
+ * {3}{W}{W}
+ * Creature — Archon
+ * 4/4
+ * Flying
+ * When this creature dies, exile target permanent.
+ *
+ * [Triggers.Dies] plus a mandatory [Effects.Exile] on a [Targets.Permanent] — any permanent,
+ * including one you control and including lands.
+ */
+val ArchonOfJustice = card("Archon of Justice") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Archon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\nWhen this creature dies, exile target permanent."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val t = target("target permanent", Targets.Permanent)
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "1"
+        artist = "Jason Chan"
+        flavorText = "In dark times, Truth bears a blade."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab707e7f-8ab5-43f1-9428-6a17c1b672fa.jpg?1783942696"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/TritonShorestalker.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/TritonShorestalker.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Triton Shorestalker
+ * {U}
+ * Creature — Merfolk Rogue
+ * 1/1
+ * This creature can't be blocked.
+ */
+val TritonShorestalker = card("Triton Shorestalker") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "This creature can't be blocked."
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "56"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Who will miss you, drywalker? A wife? A child? Perhaps they will blame the sea for your fate, and teach future generations to stay far away from it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/881c554e-2324-41e2-89f1-db9f4017bc31.jpg?1783939440"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/AradaraExpress.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/AradaraExpress.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Aradara Express
+ * {5}
+ * Artifact — Vehicle
+ * 8/6
+ * Menace
+ * Crew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)
+ *
+ * Both halves are printed keywords: [Keyword.MENACE] and the [KeywordAbility.crew] activated
+ * ability — the engine owns the crew tap-for-total-power pipeline, so nothing card-specific is
+ * needed. Menace only matters once the Vehicle is crewed and attacking.
+ */
+val AradaraExpress = card("Aradara Express") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact — Vehicle"
+    power = 8
+    toughness = 6
+    oracleText = "Menace\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)"
+
+    keywords(Keyword.MENACE)
+
+    keywordAbility(KeywordAbility.crew(4))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Adam Paquette"
+        flavorText = "It glides around the city, a sublime combination of elegance and utility."
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5fc0d1f7-c81c-4329-92b7-c4df227cc56c.jpg?1783937163"
+        ruling("2017-09-29", "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability), it will have that power and toughness.")
+        ruling("2017-09-29", "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness.")
+        ruling("2017-09-29", "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't normally have any creature type.")
+        ruling("2017-09-29", "Once a player announces that they are activating a crew ability, no player may take other actions until the ability has been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature.")
+        ruling("2017-09-29", "Any untapped creature you control can be tapped to pay a crew cost, even one that just came under your control.")
+        ruling("2017-09-29", "You may tap more creatures than necessary to activate a crew ability.")
+        ruling("2017-09-29", "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it.")
+        ruling("2017-09-29", "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/ImpeccableTiming.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/ImpeccableTiming.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Impeccable Timing
+ * {1}{W}
+ * Instant
+ * Impeccable Timing deals 3 damage to target attacking or blocking creature.
+ */
+val ImpeccableTiming = card("Impeccable Timing") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Impeccable Timing deals 3 damage to target attacking or blocking creature."
+
+    spell {
+        val t = target("target", TargetPermanent(filter = TargetFilter.AttackingOrBlockingCreature))
+        effect = Effects.DealDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Chris Rallis"
+        flavorText = "When Baral constructed his trap for Chandra, he did not account for the arrival of an enormous leonin wielding a twin-headed axe."
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/2921c95e-bf2f-409b-a41d-86d873690562.jpg?1783937231"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/KujarSeedsculptor.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/KujarSeedsculptor.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Kujar Seedsculptor
+ * {1}{G}
+ * Creature — Elf Druid
+ * 1/2
+ * When this creature enters, put a +1/+1 counter on target creature you control.
+ *
+ * The trigger's target is a plain "creature you control" — Kujar Seedsculptor is already on the
+ * battlefield when the ability goes on the stack, so it is itself a legal target (per the KLD
+ * ruling); no `.other()` narrowing.
+ */
+val KujarSeedsculptor = card("Kujar Seedsculptor") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elf Druid"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature enters, put a +1/+1 counter on target creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "159"
+        artist = "Anna Steinbauer"
+        flavorText = "Every leaf, tree, and building in Kujar has been placed to achieve maximum harmony, in accordance with the elvish philosophy known as the Great Conduit."
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a8664c65-77ca-4881-959a-e1923e1a6b98.jpg?1783937178"
+
+        ruling(
+            "2016-09-20",
+            "Kujar Seedsculptor can be the target of its own triggered ability."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/SelfAssembler.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/SelfAssembler.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Self-Assembler
+ * {5}
+ * Artifact Creature — Assembly-Worker
+ * 4/4
+ * When this creature enters, you may search your library for an Assembly-Worker creature card,
+ * reveal it, put it into your hand, then shuffle.
+ */
+val SelfAssembler = card("Self-Assembler") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Assembly-Worker"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Creature.withSubtype("Assembly-Worker"),
+                count = 1,
+                destination = SearchDestination.HAND,
+                reveal = true,
+                shuffleAfter = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "232"
+        artist = "Noah Bradley"
+        flavorText = "It sees itself in all of its creations."
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d05c6c2-4bb3-468a-b23c-b0425a9982f1.jpg?1783937148"
+
+        ruling("2018-03-16", "Self-Assembler's ability can find any creature card with the Assembly-Worker subtype, not only creature cards named Assembly-Worker. Notably, it can't find Mishra's Factory.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/WeldfastWingsmith.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/WeldfastWingsmith.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Weldfast Wingsmith
+ * {3}{U}
+ * Creature — Human Artificer
+ * 3/3
+ * Whenever an artifact you control enters, this creature gains flying until end of turn.
+ *
+ * The Tidus, Blitzball Star trigger shape — [Triggers.entersBattlefield] over
+ * `Artifact.youControl()` with [TriggerBinding.ANY] — feeding a self-targeted
+ * [Effects.GrantKeyword] (default `Duration.EndOfTurn`).
+ */
+val WeldfastWingsmith = card("Weldfast Wingsmith") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Artificer"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever an artifact you control enters, this creature gains flying until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        description = "This creature gains flying until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"Airships are too confining. If I'm in the sky, I want to feel the wind in my hair and taste the aether.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b115a65-e273-4264-9db7-317e1855f492.jpg?1783937211"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/WilyBandar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/WilyBandar.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wily Bandar
+ * {G}
+ * Creature — Cat Monkey
+ * 1/1
+ * {2}{G}: This creature gains indestructible until end of turn.
+ *
+ * A mana-only activated ability granting [Keyword.INDESTRUCTIBLE] to [EffectTarget.Self] for the
+ * default `Duration.EndOfTurn`.
+ */
+val WilyBandar = card("Wily Bandar") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Monkey"
+    power = 1
+    toughness = 1
+    oracleText = "{2}{G}: This creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+        description = "This creature gains indestructible until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "175"
+        artist = "Yeong-Hao Han"
+        flavorText = "Part feline, part primate, all trouble."
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/cac6ece3-9889-47fa-9140-420b4f31dd1b.jpg?1783937171"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DivineVerdict.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/DivineVerdict.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Divine Verdict
+ * {3}{W}
+ * Instant
+ * Destroy target attacking or blocking creature.
+ */
+val DivineVerdict = card("Divine Verdict") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target attacking or blocking creature."
+
+    spell {
+        val creature = target("creature", TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature))
+        effect = Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Kev Walker"
+        flavorText = "Giants and pit spawn attempted to topple the cathedral's pillars. The fine grit of their remains still swirls in the breeze outside."
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48444e14-c73b-47d1-9c55-0ff4dc3c6034.jpg?1783942404"
+        ruling("2012-07-01", "Destroying a blocking creature won't cause any of the creatures it was blocking to become unblocked. They won't deal combat damage to the defending player or planeswalker (unless they have trample).")
+        ruling("2009-10-01", "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat.")
+        ruling("2009-10-01", "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/MerfolkSovereign.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/MerfolkSovereign.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Merfolk Sovereign
+ * {1}{U}{U}
+ * Creature — Merfolk Noble
+ * 2/2
+ *
+ * Other Merfolk creatures you control get +1/+1.
+ * {T}: Target Merfolk creature can't be blocked this turn.
+ *
+ * The lord clause is the usual `GroupFilter(..., excludeSelf = true)` — "other" Merfolk you
+ * control. The activated ability targets *any* Merfolk creature (no "you control" clause), and
+ * grants [AbilityFlag.CANT_BE_BLOCKED] for the turn.
+ */
+val MerfolkSovereign = card("Merfolk Sovereign") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Noble"
+    power = 2
+    toughness = 2
+    oracleText = "Other Merfolk creatures you control get +1/+1.\n{T}: Target Merfolk creature can't be blocked this turn."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.MERFOLK).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.withSubtype(Subtype.MERFOLK)))
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+        description = "Target Merfolk creature can't be blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "62"
+        artist = "Jesper Ejsing"
+        flavorText = "\"The sharks envy our ferocity. The eels envy our cunning.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9826a2e-361e-4701-9177-0907c0c6dc9f.jpg?1783942390"
+
+        ruling(
+            "2009-10-01",
+            "To have any effect, Merfolk Sovereign's activated ability must be activated before the " +
+                "declare blockers step begins. Once a Merfolk has become blocked, activating Merfolk " +
+                "Sovereign's ability won't change that."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/AuguryOwl.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/AuguryOwl.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Augury Owl
+ * {1}{U}
+ * Creature — Bird
+ * 1/1
+ * Flying
+ * When this creature enters, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+ *
+ * [Triggers.EntersBattlefield] plus the compact [Effects.Scry] macro — the engine expands it to the
+ * look/bottom/top pipeline.
+ */
+val AuguryOwl = card("Augury Owl") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\nWhen this creature enters, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Jim Nelson"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42b8b752-086c-4d7c-a0a2-e359819c550e.jpg?1783941827"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/Preordain.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/Preordain.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Preordain
+ * {U}
+ * Sorcery
+ * Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+ */
+val Preordain = card("Preordain") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+
+    spell {
+        effect = Effects.Composite(
+            Effects.Scry(2),
+            Effects.DrawCards(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3868c3d-4fcd-444b-866f-0f8e50ce7b67.jpg?1783941822"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/DevouringSwarm.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/DevouringSwarm.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Devouring Swarm
+ * {1}{B}{B}
+ * Creature — Insect
+ * 2/1
+ * Flying
+ * Sacrifice a creature: This creature gets +1/+1 until end of turn.
+ *
+ * "Sacrifice a creature" accepts any creature you control, including this one, so the cost is
+ * [Costs.Sacrifice] over [Filters.Creature] — not `SacrificeAnother`.
+ */
+val DevouringSwarm = card("Devouring Swarm") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\nSacrifice a creature: This creature gets +1/+1 until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Sacrifice(Filters.Creature)
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "91"
+        artist = "Wayne England"
+        flavorText = "Their arrival is heralded by the deafening hum of ten thousand wings. Their departure is marked by the silence of the dead."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/735c2c79-9b4f-4f86-9dec-0749237fe9ce.jpg?1783941082"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GideonsLawkeeper.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/GideonsLawkeeper.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gideon's Lawkeeper
+ * {W}
+ * Creature — Human Soldier
+ * 1/1
+ * {W}, {T}: Tap target creature.
+ */
+val GideonsLawkeeper = card("Gideon's Lawkeeper") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "{W}, {T}: Tap target creature."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Tap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "18"
+        artist = "Steve Prescott"
+        flavorText = "\"The essence of a lawful society is swift deterrence.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c71eb81-a077-4c85-a4ce-4ad664486bee.jpg?1783941103"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/RummagingGoblin.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/RummagingGoblin.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rummaging Goblin
+ * {2}{R}
+ * Creature — Goblin Rogue
+ * 1/1
+ * {T}, Discard a card: Draw a card.
+ *
+ * The discard is part of the activation cost ([Costs.DiscardCard]), not an effect — with an empty
+ * hand the ability can't be activated at all.
+ */
+val RummagingGoblin = card("Rummaging Goblin") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    power = 1
+    toughness = 1
+    oracleText = "{T}, Discard a card: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.DiscardCard)
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Karl Kopinski"
+        flavorText = "To a goblin, value is based on the four S's: shiny, stabby, smelly, and super smelly."
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc5b622c-83a4-477e-a99c-2674e2bd6bb9.jpg?1783940480"
+
+        ruling(
+            "2012-07-01",
+            "Discarding a card is part of the cost to activate Rummaging Goblin's ability. If you " +
+                "don't have a card in your hand, you can't pay this part of the cost and you can't " +
+                "activate the ability."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/SearingSpear.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/SearingSpear.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Searing Spear
+ * {1}{R}
+ * Instant
+ * Searing Spear deals 3 damage to any target.
+ */
+val SearingSpear = card("Searing Spear") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Searing Spear deals 3 damage to any target."
+
+    spell {
+        val t = target("target", Targets.Any)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Chris Rahn"
+        flavorText = "Sometimes you die a glorious death with your sword held high. Sometimes you're just target practice."
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11a94b7c-0216-473c-87a6-71e5a64d7799.jpg?1783940479"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GnawingZombie.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/GnawingZombie.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Gnawing Zombie
+ * {1}{B}
+ * Creature — Zombie
+ * 1/3
+ * {1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life.
+ */
+val GnawingZombie = card("Gnawing Zombie") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 3
+    oracleText = "{1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        val player = target("player", Targets.Player)
+        effect = Effects.Composite(
+            Effects.LoseLife(1, player),
+            Effects.GainLife(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Greg Staples"
+        flavorText = "On still nights you can hear its rotted teeth grinding tirelessly on scavenged bones."
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56653d9e-0c29-440b-8724-cae746abb1a9.jpg?1783939924"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/WoodbornBehemoth.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/WoodbornBehemoth.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Woodborn Behemoth
+ * {3}{G}{G}
+ * Creature — Elemental
+ * 4/4
+ * As long as you control eight or more lands, this creature gets +4/+4 and has trample.
+ *
+ * The Earth Rumble Wrestlers shape: one "as long as" condition
+ * ([Conditions.ControlLandsAtLeast]`(8)`) shared by two continuous statics — [ModifyStats] in Layer
+ * 7c and [GrantKeyword]`(TRAMPLE)` in Layer 6 — both scoped to the source permanent.
+ */
+val WoodbornBehemoth = card("Woodborn Behemoth") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Elemental"
+    power = 4
+    toughness = 4
+    oracleText = "As long as you control eight or more lands, this creature gets +4/+4 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    val eightLands = Conditions.ControlLandsAtLeast(8)
+
+    staticAbility {
+        ability = ModifyStats(4, 4, Filters.Self)
+        condition = eightLands
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE, GroupFilter.source())
+        condition = eightLands
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c73dbf3-e68e-4f21-b6ca-94302bf5574c.jpg?1783939898"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/YoungPyromancer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/YoungPyromancer.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Young Pyromancer
+ * {1}{R}
+ * Creature — Human Shaman
+ * 2/1
+ * Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.
+ */
+val YoungPyromancer = card("Young Pyromancer") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Elemental")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Cynthia Sheppard"
+        flavorText = "Immolation is the sincerest form of flattery."
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e349c204-3a93-4bf7-b79a-5f5f261ea2d3.jpg?1783939908"
+        ruling(
+            "2021-03-19",
+            "An ability that triggers when a player casts a spell resolves before the spell that caused " +
+                "it to trigger, but after targets have been chosen for that spell. It resolves even if " +
+                "that spell is countered."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/AeronautTinkerer.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/AeronautTinkerer.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Aeronaut Tinkerer
+ * {2}{U}
+ * Creature — Human Artificer
+ * 2/3
+ * This creature has flying as long as you control an artifact. (It can't be blocked except by creatures with flying or reach.)
+ *
+ * A [ConditionalStaticAbility] wrapping [GrantKeyword](FLYING) over [GroupFilter.source()], gated by
+ * an [Exists] check for an artifact you control — re-evaluated continuously in Layer 6, so flying
+ * comes and goes with the artifact.
+ */
+val AeronautTinkerer = card("Aeronaut Tinkerer") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Artificer"
+    power = 2
+    toughness = 3
+    oracleText = "This creature has flying as long as you control an artifact. (It can't be blocked except by creatures with flying or reach.)"
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FLYING, GroupFilter.source()),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Artifact)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Willian Murai"
+        flavorText = "\"All tinkerers have their heads in the clouds. I don't intend to stop there.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/1/e145e85d-1eaa-4ec6-9208-ca6491577302.jpg?1783939196"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/BorderlandMarauder.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/BorderlandMarauder.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Borderland Marauder
+ * {1}{R}
+ * Creature — Human Warrior
+ * 1/2
+ * Whenever this creature attacks, it gets +2/+0 until end of turn.
+ */
+val BorderlandMarauder = card("Borderland Marauder") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 1
+    toughness = 2
+    oracleText = "Whenever this creature attacks, it gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Scott M. Fischer"
+        flavorText = "Though she is rightly feared, there are relatively few tales of her deeds in battle, for few survive her raids."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/12e29b2b-5fe3-4dee-b247-10cd139fe2d0.jpg?1783939177"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/TriplicateSpirits.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/TriplicateSpirits.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Triplicate Spirits
+ * {4}{W}{W}
+ * Sorcery
+ * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)
+ * Create three 1/1 white Spirit creature tokens with flying.
+ */
+val TriplicateSpirits = card("Triplicate Spirits") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 1/1 white Spirit creature tokens with flying."
+
+    keywords(Keyword.CONVOKE)
+
+    spell {
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            count = 3,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d6498d3-bf1f-4bf1-a602-7c21fb44c106.jpg?1783939196"
+        ruling(
+            "2024-01-12",
+            "You can tap any untapped creature you control to convoke a spell, even one you haven't controlled continuously since the beginning of your most recent turn.",
+        )
+        ruling(
+            "2024-01-12",
+            "Tapping an untapped creature that's attacking or blocking to convoke a spell won't cause that creature to stop attacking or blocking.",
+        )
+        ruling(
+            "2024-01-12",
+            "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value.",
+        )
+        ruling(
+            "2024-01-12",
+            "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped before you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke.",
+        )
+        ruling(
+            "2024-01-12",
+            "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs.",
+        )
+        ruling(
+            "2024-01-12",
+            "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors.",
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/Ulcerate.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/Ulcerate.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ulcerate
+ * {B}
+ * Instant
+ * Target creature gets -3/-3 until end of turn. You lose 3 life.
+ */
+val Ulcerate = card("Ulcerate") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -3/-3 until end of turn. You lose 3 life."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        // The life loss isn't a cost — it only happens if the spell resolves.
+        effect = Effects.ModifyStats(-3, -3, t)
+            .then(Effects.LoseLife(3, EffectTarget.Controller))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Johann Bodin"
+        flavorText = "\"If it were merely lethal, that would be sufficient. The art, however, is in maximizing the suffering it causes.\" —Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e06e6c8-05c0-4d87-9961-605b888bc794.jpg?1783939179"
+        ruling(
+            "2017-11-17",
+            "The loss of life isn't a cost. If the target creature is an illegal target when Ulcerate tries to resolve, it won't resolve and none of its effects will happen. You won't lose any life.",
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/OrderOfTheGoldenCricket.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/OrderOfTheGoldenCricket.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mor.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Order of the Golden Cricket
+ * {1}{W}
+ * Creature — Kithkin Knight
+ * 2/2
+ * Whenever this creature attacks, you may pay {W}. If you do, it gains flying until end of turn.
+ *
+ * The "you may pay {W}" gate is an [OptionalCostEffect] (same shape as Descendant of Storms);
+ * "it" is the attacker itself, so the granted keyword lands on [EffectTarget.Self].
+ */
+val OrderOfTheGoldenCricket = card("Order of the Golden Cricket") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature attacks, you may pay {W}. If you do, it gains flying until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = OptionalCostEffect(
+            cost = PayManaCostEffect(ManaCost.parse("{W}")),
+            ifPaid = Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self),
+        )
+        description = "Whenever this creature attacks, you may pay {W}. If you do, it gains flying until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Mark Zug"
+        flavorText = "\"Should you take it in mind to ride a springjack, remember: there are easier ways to fly, and harder ways to break your skull.\" —Lann of Cloverdell"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d1c2f16-5661-4c17-8265-f4b88ff1e833.jpg?1783942804"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/WardenOfGeometries.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ogw/cards/WardenOfGeometries.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.ogw.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Warden of Geometries
+ * {4}
+ * Creature — Eldrazi Drone
+ * 2/3
+ * Vigilance
+ * {T}: Add {C}.
+ *
+ * Vigilance is a printed keyword; the mana ability is the standard [Effects.AddColorlessMana]`(1)`
+ * tap ability flagged `manaAbility = true` with [TimingRule.ManaAbility] so it never uses the stack.
+ */
+val WardenOfGeometries = card("Warden of Geometries") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Creature — Eldrazi Drone"
+    power = 2
+    toughness = 3
+    oracleText = "Vigilance\n{T}: Add {C}. ({C} represents colorless mana.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {C}."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Jason Felix"
+        flavorText = "The wastelands disorient even the most experienced scouts, making them easy prey for Kozilek's drones."
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7f517b9-ac10-4710-8ef1-ced1253d5ecf.jpg?1783937928"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AnchorToTheAether.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/AnchorToTheAether.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Anchor to the Aether
+ * {2}{U}
+ * Sorcery
+ * Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)
+ *
+ * A [Effects.Composite] of the atomic [Effects.PutOnTopOfLibrary] on the chosen creature followed by
+ * [Effects.Scry] 1. The scry is unconditional — it happens even if the creature has already left the
+ * battlefield.
+ */
+val AnchorToTheAether = card("Anchor to the Aether") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.PutOnTopOfLibrary(t),
+            Effects.Scry(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "44"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/15058f91-d266-4804-96af-fc050b6c8436.jpg?1783938355"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BlessedSpirits.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/BlessedSpirits.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Blessed Spirits
+ * {2}{W}
+ * Creature — Spirit
+ * 2/2
+ * Flying
+ * Whenever you cast an enchantment spell, put a +1/+1 counter on this creature.
+ */
+val BlessedSpirits = card("Blessed Spirits") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\nWhenever you cast an enchantment spell, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastEnchantment
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Anna Steinbauer"
+        flavorText = "Not all heroes die in armor."
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/150dd602-5f61-4f1e-a422-e64c079de141.jpg?1783938364"
+
+        ruling("2015-06-22", "Blessed Spirits's ability will resolve before the enchantment spell that caused it to trigger.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CausticCaterpillar.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/CausticCaterpillar.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Caustic Caterpillar
+ * {G}
+ * Creature — Insect
+ * 1/1
+ * {1}{G}, Sacrifice this creature: Destroy target artifact or enchantment.
+ */
+val CausticCaterpillar = card("Caustic Caterpillar") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{G}, Sacrifice this creature: Destroy target artifact or enchantment."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.SacrificeSelf)
+        val t = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+        effect = Effects.Destroy(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Jack Wang"
+        flavorText = "\"The rare and beautiful butterflies inspire the design of our thopters. The larvae, however, are a different story entirely.\" —Kiran Nalaar, Ghirapur inventor"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f03d4e0d-bddd-4835-91b8-11c2f15e54c3.jpg?1783938324"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/FetidImp.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/FetidImp.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Fetid Imp
+ * {1}{B}
+ * Creature — Imp
+ * 1/2
+ * Flying
+ * {B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)
+ */
+val FetidImp = card("Fetid Imp") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Imp"
+    power = 1
+    toughness = 2
+    oracleText = "Flying\n{B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)"
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{B}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "97"
+        artist = "Nils Hamm"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/891718e9-bef3-470a-80c5-514f7f43abe8.jpg?1783938342"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PriestOfTheBloodRite.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/PriestOfTheBloodRite.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Priest of the Blood Rite
+ * {3}{B}{B}
+ * Creature — Human Cleric
+ * 2/2
+ * When this creature enters, create a 5/5 black Demon creature token with flying.
+ * At the beginning of your upkeep, you lose 2 life.
+ *
+ * The Demon token is the same 5/5 black flier Skirsdag High Priest mints, so it reuses that
+ * token's art. The upkeep drawback is unconditional — no "unless", no sacrifice.
+ */
+val PriestOfTheBloodRite = card("Priest of the Blood Rite") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, create a 5/5 black Demon creature token with flying.\nAt the beginning of your upkeep, you lose 2 life." +
+        "At the beginning of your upkeep, you lose 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 5,
+            toughness = 5,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Demon"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg?1783940883"
+        )
+        description = "When this creature enters, create a 5/5 black Demon creature token with flying."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.LoseLife(2, EffectTarget.Controller)
+        description = "At the beginning of your upkeep, you lose 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "112"
+        artist = "David Palumbo"
+        flavorText = "Some will sacrifice everything for but a taste of power."
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/118ba6f2-a2f0-4554-ad87-a932c951cdd4.jpg?1783938338"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ReaveSoul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ReaveSoul.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reave Soul
+ * {1}{B}
+ * Sorcery
+ * Destroy target creature with power 3 or less.
+ */
+val ReaveSoul = card("Reave Soul") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature with power 3 or less."
+
+    spell {
+        val creature = target("target creature with power 3 or less", Targets.CreatureWithPowerAtMost(3))
+        effect = Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "David Palumbo"
+        flavorText = "\"I was not convinced you had a soul until I saw it for myself.\" —Liliana Vess"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db3d5e9d-07e8-43e1-aaf0-1f9e4ed2834a.jpg?1783938337"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ShamblingGhoul.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ShamblingGhoul.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Shambling Ghoul
+ * {1}{B}
+ * Creature — Zombie
+ * 2/3
+ * This creature enters tapped.
+ */
+val ShamblingGhoul = card("Shambling Ghoul") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 3
+    oracleText = "This creature enters tapped."
+
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "119"
+        artist = "Joseph Meehan"
+        flavorText = "Once he gets up and going, he will forever shamble on."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fd8061d2-84ce-4e4a-9911-ffc9833749da.jpg?1783938337"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SubterraneanScout.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/SubterraneanScout.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Subterranean Scout
+ * {1}{R}
+ * Creature — Goblin Scout
+ * 2/1
+ * When this creature enters, target creature with power 2 or less can't be blocked this turn.
+ */
+val SubterraneanScout = card("Subterranean Scout") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Scout"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, target creature with power 2 or less can't be blocked this turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature with power 2 or less", Targets.CreatureWithPowerAtMost(2))
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+        description = "When this creature enters, target creature with power 2 or less can't be blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Lucas Graciano"
+        flavorText = "When things get ugly above ground, goblins resort to alternate routes of passage."
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c9289dd-f1a3-4be5-8ed1-4b4dd4e97743.jpg?1783938325"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ValorInAkros.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ValorInAkros.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Valor in Akros
+ * {3}{W}
+ * Enchantment
+ * Whenever a creature you control enters, creatures you control get +1/+1 until end of turn.
+ *
+ * A plain "another permanent entered" trigger ([Triggers.entersBattlefield] over
+ * `Creature.youControl()` with [TriggerBinding.ANY], since the watcher is the enchantment rather
+ * than the entering creature) feeding [Patterns.Group.modifyStatsForAll] over
+ * [GroupFilter.AllCreaturesYouControl]. The group is snapshotted when the ability resolves, so the
+ * creature that caused the trigger is included and later arrivals are not (printed ruling).
+ */
+val ValorInAkros = card("Valor in Akros") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a creature you control enters, creatures you control get +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Patterns.Group.modifyStatsForAll(1, 1, GroupFilter.AllCreaturesYouControl)
+        description = "Creatures you control get +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Igor Kieryluk"
+        flavorText = "They became a single entity, a phalanx in the Temple of Triumph standing against a host of enemies."
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/22fa0acd-84c3-492e-adf7-e7438db47e0a.jpg?1783938356"
+        ruling(
+            "2020-08-07",
+            "Valor in Akros's ability affects only creatures you control at the time the ability " +
+                "resolves, including the creature that caused it to trigger. Creatures you begin " +
+                "to control later in the turn won't get +1/+1."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ZendikarsRoil.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ori/cards/ZendikarsRoil.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.ori.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zendikar's Roil
+ * {3}{G}{G}
+ * Enchantment
+ * Landfall — Whenever a land you control enters, create a 2/2 green Elemental creature token.
+ */
+val ZendikarsRoil = card("Zendikar's Roil") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Landfall — Whenever a land you control enters, create a 2/2 green Elemental creature token."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Elemental")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "209"
+        artist = "Sam Burley"
+        flavorText = "\"I was wrong. Zendikar isn't after me. It isn't after any of us. It's not evil or vengeful. It's magnificent . . . but it's in pain.\" —Nissa Revane"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f75c0783-936d-4fa2-bdcb-01dae7a67fdb.jpg?1783938315"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/GoblinRally.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/GoblinRally.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Rally
+ * {3}{R}{R}
+ * Sorcery
+ * Create four 1/1 red Goblin creature tokens.
+ */
+val GoblinRally = card("Goblin Rally") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create four 1/1 red Goblin creature tokens."
+
+    spell {
+        effect = Effects.CreateToken(
+            count = 4,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+            imageUri = "https://cards.scryfall.io/normal/front/e/d/ed418a8b-f158-492d-a323-6265b3175292.jpg?1562640121"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "95"
+        artist = "Nic Klein"
+        flavorText = "You don't so much hire goblins as put ideas in their heads."
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e4ec8ada-09a6-449a-ac4a-7d3acbd08014.jpg?1783940356"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SellerOfSongbirds.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/SellerOfSongbirds.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seller of Songbirds
+ * {2}{W}
+ * Creature — Human
+ * 1/2
+ * When this creature enters, create a 1/1 white Bird creature token with flying.
+ */
+val SellerOfSongbirds = card("Seller of Songbirds") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature enters, create a 1/1 white Bird creature token with flying."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Bird"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/4/b/4b0c59f8-b407-47e7-8885-8c968f4ceecf.jpg?1783914993"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "22"
+        artist = "Christopher Moeller"
+        flavorText = "\"Lady Wren is the one merchant in Keyhole Downs who isn't running a scam.\" —Mirela, Azorius hussar"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2a41edbe-4c5a-4535-a082-235dc3ffe60a.jpg?1783940373"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/TrainedCaracal.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/TrainedCaracal.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trained Caracal
+ * {W}
+ * Creature — Cat
+ * 1/1
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ */
+val TrainedCaracal = card("Trained Caracal") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 1
+    toughness = 1
+    oracleText = "Lifelink (Damage dealt by this creature also causes you to gain that much life.)"
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "27"
+        artist = "James Ryman"
+        flavorText = "Some Ravnicans consider carrying a sword to be beneath them, preferring instead a tooth-and-claw escort."
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/797e45d1-d17d-40c0-bfdf-ec533784e676.jpg?1783940372"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/GrotesqueMutation.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/GrotesqueMutation.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Grotesque Mutation
+ * {1}{B}
+ * Instant
+ * Target creature gets +3/+1 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)
+ */
+val GrotesqueMutation = card("Grotesque Mutation") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+1 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)"
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 1, t),
+            Effects.GrantKeyword(Keyword.LIFELINK, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "115"
+        artist = "Dan Murayama Scott"
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce84d54c-ef63-4b90-a2b6-99a4aa21c02d.jpg?1783937773"
+
+        ruling(
+            "2016-04-08",
+            "Multiple instances of lifelink on the same creature are redundant."
+        )
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/RushOfAdrenaline.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/soi/cards/RushOfAdrenaline.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.soi.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rush of Adrenaline
+ * {R}
+ * Instant
+ * Target creature gets +2/+1 and gains trample until end of turn.
+ */
+val RushOfAdrenaline = card("Rush of Adrenaline") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+1 and gains trample until end of turn."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.ModifyStats(power = 2, toughness = 1, target = t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, target = t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "177"
+        artist = "Chris Rallis"
+        flavorText = "Scarecrows only go so far in sending the message to stay away."
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0def54b-9f0a-4ab1-9df9-25506a06350c.jpg?1783937744"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BarrageOgre.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/som/cards/BarrageOgre.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.som.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Barrage Ogre
+ * {3}{R}{R}
+ * Creature — Ogre Warrior
+ * 3/3
+ * {T}, Sacrifice an artifact: This creature deals 2 damage to any target.
+ *
+ * The same shape as Orcish Vandal: a [Costs.Composite] of [Costs.Tap] and
+ * [Costs.Sacrifice](Artifact), dealing 2 damage to [Targets.Any].
+ */
+val BarrageOgre = card("Barrage Ogre") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Ogre Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "{T}, Sacrifice an artifact: This creature deals 2 damage to any target."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.Sacrifice(GameObjectFilter.Artifact))
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "David Rapoza"
+        flavorText = "The elves had devised countless strategies to combat Memnarch's war machines, but they had no idea what to do when one was *thrown* at them."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e02c6f71-2448-47e1-9133-7af6a4d4577a.jpg?1783941726"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LeoninSnarecaster.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LeoninSnarecaster.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Leonin Snarecaster
+ * {1}{W}
+ * Creature — Cat Soldier
+ * 2/1
+ * When this creature enters, you may tap target creature.
+ */
+val LeoninSnarecaster = card("Leonin Snarecaster") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, you may tap target creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Tap(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "23"
+        artist = "Kev Walker"
+        flavorText = "Formerly oppressed by the polis of Meletis, leonin occasionally \"mistake\" their old enemies for game."
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ade9b739-122c-4659-b1b2-ea0510d96dbc.jpg?1783939812"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/Kitesail.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/Kitesail.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.wwk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Kitesail
+ * {2}
+ * Artifact — Equipment
+ * Equipped creature gets +1/+0 and has flying.
+ * Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ */
+val Kitesail = card("Kitesail") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = ModifyStats(1, 0)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Cyril Van Der Haegen"
+        flavorText = "Kitesailing is a way of life—and without practice, the end of it."
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/217a05a7-557f-4879-8fd1-d6c003f1751e.jpg?1783942039"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/BalothWoodcrasher.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/BalothWoodcrasher.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Baloth Woodcrasher
+ * {4}{G}{G}
+ * Creature — Beast
+ * 4/4
+ * Landfall — Whenever a land you control enters, this creature gets +4/+4 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)
+ *
+ * Landfall is the standard [Triggers.entersBattlefield] over `GameObjectFilter.Land.youControl()`
+ * with [TriggerBinding.ANY]; the effect is a [Effects.Composite] of an until-end-of-turn
+ * [Effects.ModifyStats] and [Effects.GrantKeyword](TRAMPLE), both on [EffectTarget.Self].
+ */
+val BalothWoodcrasher = card("Baloth Woodcrasher") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 4
+    oracleText = "Landfall — Whenever a land you control enters, this creature gets +4/+4 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Land.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Composite(
+            Effects.ModifyStats(4, 4, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "157"
+        artist = "Zoltan Boros & Gabor Szikszai"
+        flavorText = "Its insatiable hunger quickly depletes a region of prey. It must migrate from place to place to feed its massive bulk."
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/8223dc6a-2bee-4be9-86d5-f0a17a24c33e.jpg?1783942137"
+        ruling("2024-11-08", "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control.")
+        ruling("2024-11-08", "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land.")
+        ruling("2024-11-08", "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.).")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/FeastOfBlood.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/FeastOfBlood.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Feast of Blood
+ * {1}{B}
+ * Sorcery
+ * Cast this spell only if you control two or more Vampires.
+ * Destroy target creature. You gain 4 life.
+ *
+ * "two or more Vampires" is a bare tribal noun, so it counts every Vampire *permanent* you
+ * control, not only the creature ones. The restriction is a cast-time check
+ * ([castOnlyIf]); it is not rechecked on resolution.
+ */
+val FeastOfBlood = card("Feast of Blood") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Cast this spell only if you control two or more Vampires.\nDestroy target creature. You gain 4 life."
+
+    spell {
+        castOnlyIf(Conditions.YouControlAtLeast(2, GameObjectFilter.Permanent.withSubtype(Subtype.VAMPIRE)))
+
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Destroy(creature),
+            Effects.GainLife(4)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "88"
+        artist = "Jason Felix"
+        flavorText = "\"The vampires of this world don't know the pleasures of hunger. They gorge themselves without savoring the kill.\" —Sorin Markov"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a7dd5e2-b2a5-46ab-a67c-499451706505.jpg?1783942154"
+        ruling("2009-10-01", "Whether you control two or more Vampires is checked only as you try to move Feast of Blood to the stack as the first step of casting it. It doesn’t matter whether you still control two or more Vampires as you finish casting Feast of Blood (in case you somehow sacrifice one to produce mana) or as Feast of Blood resolves.")
+        ruling("2009-10-01", "If the targeted creature is an illegal target by the time Feast of Blood resolves, the entire spell doesn’t resolve. You don’t gain life.")
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/PiranhaMarsh.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/PiranhaMarsh.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Piranha Marsh
+ * Land
+ * This land enters tapped.
+ * When this land enters, target player loses 1 life.
+ * {T}: Add {B}.
+ */
+val PiranhaMarsh = card("Piranha Marsh") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Land"
+    oracleText = "This land enters tapped.\nWhen this land enters, target player loses 1 life.\n{T}: Add {B}."
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val player = target("target player", Targets.Player)
+        effect = Effects.LoseLife(1, player)
+        description = "When this land enters, target player loses 1 life."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "222"
+        artist = "Nic Klein"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea077cff-b5c9-4a40-8e66-8810c37be5cb.jpg?1783942122"
+    }
+}

--- a/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/SteppeLynx.kt
+++ b/mtg-sets/2008-2016/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/SteppeLynx.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Steppe Lynx
+ * {W}
+ * Creature — Cat
+ * 0/1
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ */
+val SteppeLynx = card("Steppe Lynx") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 0
+    toughness = 1
+    oracleText = "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+
+    // Landfall — +2/+2 until end of turn whenever a land you control enters.
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "36"
+        artist = "Nic Klein"
+        flavorText = "Nothing quickens the predator's blood like the unfamiliar scents of new hunting grounds and the mewling cries of new prey."
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0aaec1c-8084-4468-82e7-2e4cc5ebe244.jpg?1783942167"
+        ruling(
+            "2024-11-08",
+            "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control.",
+        )
+        ruling(
+            "2024-11-08",
+            "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land.",
+        )
+        ruling(
+            "2024-11-08",
+            "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.).",
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/AlleyStrangler.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/aer/cards/AlleyStrangler.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.aer.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alley Strangler
+ * {2}{B}
+ * Creature — Aetherborn Rogue
+ * 2/3
+ * Menace
+ */
+val AlleyStrangler = card("Alley Strangler") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Aetherborn Rogue"
+    power = 2
+    toughness = 3
+    oracleText = "Menace"
+
+    keywords(Keyword.MENACE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Enora Mercier"
+        flavorText = "\"You never know what day might be your last.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a131d558-5f6b-448b-a378-1882e2d02bd2.jpg?1783936767"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/afr/cards/ImprovisedWeaponry.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/afr/cards/ImprovisedWeaponry.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.afr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Improvised Weaponry
+ * {2}{R}
+ * Sorcery
+ * Improvised Weaponry deals 2 damage to any target. Create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ */
+val ImprovisedWeaponry = card("Improvised Weaponry") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Improvised Weaponry deals 2 damage to any target. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    spell {
+        val t = target("any target", Targets.Any)
+        effect = Effects.Composite(
+            Effects.DealDamage(2, t),
+            Effects.CreateTreasure(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "150"
+        artist = "Alix Branwyn"
+        flavorText = "Anything can be a weapon if you swing it hard enough."
+        imageUri = "https://cards.scryfall.io/normal/front/2/9/29d5fd00-c616-4079-a91e-4da0bcaf9120.jpg?1783926476"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/Electrify.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/Electrify.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Electrify
+ * {3}{R}
+ * Instant
+ * Electrify deals 4 damage to target creature.
+ */
+val Electrify = card("Electrify") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Electrify deals 4 damage to target creature."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.DealDamage(4, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Craig J Spearing"
+        flavorText = "\"Some hid from the storm. I embraced it and learned its name.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/1/21c67128-2e5a-4c97-b265-6f3c73b4997a.jpg?1783936490"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HieroglyphicIllumination.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/HieroglyphicIllumination.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Hieroglyphic Illumination
+ * {3}{U}
+ * Instant
+ * Draw two cards.
+ * Cycling {U} ({U}, Discard this card: Draw a card.)
+ */
+val HieroglyphicIllumination = card("Hieroglyphic Illumination") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Draw two cards.\nCycling {U} ({U}, Discard this card: Draw a card.)"
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Raoul Vitale"
+        flavorText = "\"The answers are here. This is the way through the trial.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/6/c60a0e75-53bb-43e4-890f-0e1972a7e0b9.jpg?1783936520"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/LilianasMastery.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/LilianasMastery.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Liliana's Mastery
+ * {3}{B}{B}
+ * Enchantment
+ * Zombies you control get +1/+1.
+ * When this enchantment enters, create two 2/2 black Zombie creature tokens.
+ *
+ * The anthem is not "other" — Liliana's Mastery is an Enchantment, never a Zombie, so the group has
+ * no self to exclude and the two tokens it makes are pumped by it.
+ */
+val LilianasMastery = card("Liliana's Mastery") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Zombies you control get +1/+1.\nWhen this enchantment enters, create two 2/2 black Zombie creature tokens."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.ZOMBIE).youControl()
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie"),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+        )
+        description = "When this enchantment enters, create two 2/2 black Zombie creature tokens."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "98"
+        artist = "Kieran Yanner"
+        flavorText = "\"There are so many of them. It seems they've just been waiting for someone to serve.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c57b3b8-71f1-479c-b7f7-508fee2b5b0f.jpg?1783936503"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/LordOfTheAccursed.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/LordOfTheAccursed.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lord of the Accursed
+ * {2}{B}
+ * Creature — Zombie
+ * 2/3
+ * Other Zombies you control get +1/+1.
+ * {1}{B}, {T}: All Zombies gain menace until end of turn.
+ *
+ * The lord clause is a static [ModifyStats] over Zombies you control with
+ * `excludeSelf = true` ("other"). The activated ability is deliberately *not*
+ * controller-scoped — "All Zombies" reaches every Zombie on the battlefield,
+ * including opponents', so its [GroupFilter] carries no `youControl()`.
+ */
+val LordOfTheAccursed = card("Lord of the Accursed") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 3
+    oracleText = "Other Zombies you control get +1/+1.\n{1}{B}, {T}: All Zombies gain menace until end of turn."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.ZOMBIE).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{B}"), Costs.Tap)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.ZOMBIE)),
+            Effects.GrantKeyword(Keyword.MENACE, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99"
+        artist = "Grzegorz Rutkowski"
+        flavorText = "The Curse of Wandering leaves only hatred."
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/3941562d-3e39-4746-9a18-d3aa6d3468b0.jpg?1783936503"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/FaerieFormation.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/FaerieFormation.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faerie Formation
+ * {4}{U}
+ * Creature — Faerie
+ * 5/4
+ * Flying
+ * {3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card.
+ */
+val FaerieFormation = card("Faerie Formation") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie"
+    power = 5
+    toughness = 4
+    oracleText = "Flying\n{3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{U}")
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Faerie"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg?1782727481",
+        ).then(Effects.DrawCards(1))
+        description = "{3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "316"
+        artist = "Ryan Yee"
+        flavorText = "The throng flitted from castle to castle, leaving a trail of star-crossed love, damaging rumors, and missing heirlooms in their wake."
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/15709316-7382-46b9-9b70-53a5147e7051.jpg?1783932552"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/FierceWitchstalker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/FierceWitchstalker.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fierce Witchstalker
+ * {2}{G}{G}
+ * Creature — Wolf
+ * 4/4
+ * Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)
+ * When this creature enters, create a Food token. (It's an artifact with "{2}, {T}, Sacrifice this token: You gain 3 life.")
+ */
+val FierceWitchstalker = card("Fierce Witchstalker") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 4
+    toughness = 4
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "154"
+        artist = "Nicholas Gregory"
+        flavorText = "While the realm has laws, in the wilds there are other ways of balancing power."
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d63a6be2-ae9a-4758-9d5c-0297ef9af57c.jpg?1783932611"
+        ruling("2024-11-08", "Food is an artifact type. Even though it appears on some creatures, it's never a creature type.")
+        ruling("2024-11-08", "You can't sacrifice a Food to pay multiple costs. For example, you can't sacrifice a Food token to activate its own ability and also to activate Maraleaf Rider's ability.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/LocthwainGargoyle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/LocthwainGargoyle.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Locthwain Gargoyle
+ * {1}
+ * Artifact Creature — Gargoyle
+ * 0/3
+ * {4}: This creature gets +2/+0 and gains flying until end of turn.
+ *
+ * A repeatable self-pump: one activated ability whose effect composes the stat
+ * modification with the flying grant, both on [EffectTarget.Self] and both with the
+ * default end-of-turn duration. Re-activating while it already has flying is legal
+ * and simply stacks another +2/+0.
+ */
+val LocthwainGargoyle = card("Locthwain Gargoyle") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Gargoyle"
+    power = 0
+    toughness = 3
+    oracleText = "{4}: This creature gets +2/+0 and gains flying until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{4}")
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 0, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "225"
+        artist = "Nils Hamm"
+        flavorText = "\"As the traitor hurried across the courtyard, its eyes snapped open. It was time to pay the queen a visit.\" —*Beyond the Great Henge*"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02551bee-335c-4bf7-b38e-67dd71d1d567.jpg?1783932583"
+        ruling("2019-10-04", "You can activate Locthwain Gargoyle's ability multiple times during one turn, even if it already has flying.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/ShimmerDragon.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/ShimmerDragon.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Shimmer Dragon
+ * {4}{U}{U}
+ * Creature — Dragon
+ * 5/6
+ * Flying
+ * As long as you control four or more artifacts, this creature has hexproof.
+ * Tap two untapped artifacts you control: Draw a card.
+ *
+ * The conditional hexproof is a [ConditionalStaticAbility] wrapping a source-scoped
+ * [GrantKeyword] gated on [Conditions.YouControlAtLeast]`(4, Artifact)`. The draw ability's only
+ * cost is [Costs.TapPermanents]`(2, Artifact)` — no mana, no tapping the Dragon itself.
+ */
+val ShimmerDragon = card("Shimmer Dragon") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Dragon"
+    power = 5
+    toughness = 6
+    oracleText = "Flying\nAs long as you control four or more artifacts, this creature has hexproof. (It can't be the target of spells or abilities your opponents control.)\nTap two untapped artifacts you control: Draw a card."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.HEXPROOF, GroupFilter.source()),
+            condition = Conditions.YouControlAtLeast(4, GameObjectFilter.Artifact),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.TapPermanents(2, GameObjectFilter.Artifact)
+        effect = Effects.DrawCards(1)
+        description = "Tap two untapped artifacts you control: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "317"
+        artist = "Lie Setiawan"
+        flavorText = "The indigo dragon gladly traded a bit of its hoard for everlasting moonlight."
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5beffa4c-4188-48c1-8374-3ac3e8ea1900.jpg?1783932551"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/TheCircleOfLoyalty.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/TheCircleOfLoyalty.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * The Circle of Loyalty
+ * {4}{W}{W}
+ * Legendary Artifact
+ * Affinity for Knights (This spell costs {1} less to cast for each Knight you control.)
+ * Creatures you control get +1/+1.
+ * Whenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.
+ * {3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.
+ *
+ * Four existing primitives: [KeywordAbility.AffinityForSubtype] (Riders of the Mark), a static
+ * [ModifyStats] anthem over `Creature.youControl()` (Glorious Anthem), `Triggers.youCastSpell`
+ * with a legendary spell filter (Venat, Heart of Hydaelyn), and Aryel's token-making activated
+ * ability.
+ */
+val TheCircleOfLoyalty = card("The Circle of Loyalty") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Artifact"
+    oracleText = "Affinity for Knights (This spell costs {1} less to cast for each Knight you control.)\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance."
+
+    // Affinity for Knights
+    keywordAbility(KeywordAbility.AffinityForSubtype(Subtype.KNIGHT))
+
+    // Creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+        )
+    }
+
+    // Whenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.legendary())
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Knight"),
+            keywords = setOf(Keyword.VIGILANCE),
+        )
+    }
+
+    // {3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{W}"), Costs.Tap)
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Knight"),
+            keywords = setOf(Keyword.VIGILANCE),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "9"
+        artist = "Bastien L. Deharme"
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/79093d00-362d-4d07-8a0a-cf5e1ccf9c0f.jpg?1783932677"
+        ruling("2019-10-04", "The Circle of Loyalty's triggered ability resolves before the spell that caused it to trigger. It resolves even if that spell is countered.")
+        ruling("2019-10-04", "The Circle of Loyalty's triggered ability won't trigger when you cast it because it's not on the battlefield yet.")
+        ruling("2019-10-04", "To determine the total cost of a spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions. The mana value of the spell remains unchanged, no matter what the total cost to cast it was.")
+        ruling("2019-10-04", "The cost reduction ability reduces only the generic mana in the relic's cost. The colored mana must still be paid.")
+        ruling("2019-10-04", "Once you announce that you're casting a spell, no player may take actions until the spell has been paid for. Notably, opponents can't try to change by how much a relic's cost is reduced.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/WeaselbackRedcap.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/WeaselbackRedcap.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Weaselback Redcap
+ * {R}
+ * Creature — Goblin Knight
+ * 1/1
+ * {1}{R}: This creature gets +2/+0 until end of turn.
+ */
+val WeaselbackRedcap = card("Weaselback Redcap") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Knight"
+    power = 1
+    toughness = 1
+    oracleText = "{1}{R}: This creature gets +2/+0 until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "148"
+        artist = "Grzegorz Rutkowski"
+        flavorText = "\"I would rather cast myself into the abyss than let my blood stain the cap of those monsters.\" —Syr Alin, the Lion's Claw"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33a78207-fd76-4112-a257-54a25da6f818.jpg?1783932614"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/DesertOfTheMindful.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/DesertOfTheMindful.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Desert of the Mindful
+ * Land — Desert
+ * This land enters tapped.
+ * {T}: Add {U}.
+ * Cycling {1}{U} ({1}{U}, Discard this card: Draw a card.)
+ */
+val DesertOfTheMindful = card("Desert of the Mindful") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Land — Desert"
+    oracleText = "This land enters tapped.\n{T}: Add {U}.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)"
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    keywordAbility(KeywordAbility.cycling("{1}{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "173"
+        artist = "Christine Choi"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/91b92d87-776c-490f-9ff1-234e47145df8.jpg?1783935997"
+        ruling(
+            "2017-04-18",
+            "Desert is a land subtype with no special meaning. It doesn't grant the land an " +
+                "intrinsic mana ability. Other cards may care about which lands are Deserts."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/Overcome.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/Overcome.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Overcome
+ * {3}{G}{G}
+ * Sorcery
+ * Creatures you control get +2/+2 and gain trample until end of turn. (Each of those creatures can deal excess combat damage to the player or planeswalker it's attacking.)
+ *
+ * Overrun's shape at one less power: one group named once, two things said about it, so it is
+ * [Patterns.Group.pumpAndGrantToAll] rather than a pump composed with a keyword grant — the group is
+ * gathered a single time, on resolution, which is exactly the "only creatures you control at the time
+ * it resolves" ruling.
+ */
+val Overcome = card("Overcome") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Creatures you control get +2/+2 and gain trample until end of turn. (Each of those creatures can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    spell {
+        effect = Patterns.Group.pumpAndGrantToAll(
+            power = 2,
+            toughness = 2,
+            keyword = Keyword.TRAMPLE,
+            filter = Filters.Group.creaturesYouControl,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Craig J Spearing"
+        flavorText = "\"Forward! Until the horizon is ours!\" —Khemses, charioteer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1dc2427-685a-4739-8b92-e60f134d4adb.jpg?1783936018"
+
+        ruling(
+            "2019-07-12",
+            "Overcome affects only creatures you control at the time it resolves. Creatures you " +
+                "begin to control later in the turn won't get +2/+2 or gain trample."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/QuarryBeetle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/hou/cards/QuarryBeetle.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.hou.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Quarry Beetle
+ * {4}{G}
+ * Creature — Insect
+ * 4/5
+ * When this creature enters, you may return target land card from your graveyard to the battlefield.
+ *
+ * The return is [Effects.PutOntoBattlefieldFromGraveyard], the guarded move: if the land has left
+ * the graveyard by the time the trigger resolves, nothing happens. It is not a land drop, so it
+ * ignores the one-land-per-turn limit.
+ */
+val QuarryBeetle = card("Quarry Beetle") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 4
+    toughness = 5
+    oracleText = "When this creature enters, you may return target land card from your graveyard to the battlefield."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        val t = target(
+            "target",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Land.ownedByYou(), zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.PutOntoBattlefieldFromGraveyard(t)
+        description = "When this creature enters, you may return target land card from your graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Mike Burns"
+        flavorText = "\"The ruin of the past is the topsoil of the future.\" —Sokar, former Nef-crop initiate"
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/69e11478-bfc7-4bcc-b65c-dc2d4449e99f.jpg?1783936016"
+
+        ruling(
+            "2017-07-14",
+            "Quarry Beetle's ability doesn't count as playing a land. It can return a land card to " +
+                "the battlefield even if you've already played as many lands as able this turn."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/LavaSerpent.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/LavaSerpent.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Lava Serpent
+ * {5}{R}
+ * Creature — Elemental Serpent
+ * 5/5
+ * Haste
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val LavaSerpent = card("Lava Serpent") {
+    manaCost = "{5}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Serpent"
+    power = 5
+    toughness = 5
+    oracleText = "Haste\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    keywords(Keyword.HASTE)
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "124"
+        artist = "Jason A. Engle"
+        flavorText = "Lavabrink's boiling moat is a deterrent for most, and a relaxing bath for one."
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/00ebd57f-7f7c-41b0-aa56-511c1816bc14.jpg?1783931047"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/LightOfHope.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/LightOfHope.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Light of Hope
+ * {W}
+ * Instant
+ * Choose one —
+ * • You gain 4 life.
+ * • Destroy target enchantment.
+ * • Put a +1/+1 counter on target creature.
+ */
+val LightOfHope = card("Light of Hope") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• You gain 4 life.\n• Destroy target enchantment.\n• Put a +1/+1 counter on target creature."
+
+    spell {
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                effect = Effects.GainLife(4),
+                description = "You gain 4 life."
+            ),
+            Mode.withTarget(
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                target = Targets.Enchantment,
+                description = "Destroy target enchantment."
+            ),
+            Mode.withTarget(
+                effect = Effects.AddCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    1,
+                    EffectTarget.ContextTarget(0)
+                ),
+                target = Targets.Creature,
+                description = "Put a +1/+1 counter on target creature."
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Kimonas Theodossiou"
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bcb00599-e082-49b0-88f3-ef91b75595e4.jpg?1783931088"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Neutralize.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/Neutralize.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Neutralize
+ * {1}{U}{U}
+ * Instant
+ * Counter target spell.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val Neutralize = card("Neutralize") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell()
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "59"
+        artist = "Yongjae Choi"
+        flavorText = "On Ikoria, reactive magic can make the difference between barely grazed and really dead."
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/0430da3c-9460-4b62-ae28-2e7e6f4d06a4.jpg?1783931073"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RakingClaws.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/RakingClaws.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Raking Claws
+ * {1}{R}
+ * Instant
+ * Target creature gains double strike until end of turn.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val RakingClaws = card("Raking Claws") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gains double strike until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, t)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "131"
+        artist = "Slawomir Maniak"
+        flavorText = "\"How many claws does a monster have? Exactly one more than you've accounted for.\" —Alux, Skysail defender"
+        imageUri = "https://cards.scryfall.io/normal/front/6/e/6eb0d9a2-f9bb-4d8e-a1ca-896c42f8ad56.jpg?1783931044"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ShreddedSails.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/iko/cards/ShreddedSails.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.iko.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Shredded Sails
+ * {1}{R}
+ * Instant
+ * Choose one —
+ * • Destroy target artifact.
+ * • Shredded Sails deals 4 damage to target creature with flying.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ */
+val ShreddedSails = card("Shredded Sails") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Destroy target artifact.\n• Shredded Sails deals 4 damage to target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Destroy target artifact") {
+                val t = target("target artifact", Targets.Artifact)
+                effect = Effects.Destroy(t)
+            }
+            mode("Shredded Sails deals 4 damage to target creature with flying") {
+                val t = target("target creature with flying", Targets.CreatureWithKeyword(Keyword.FLYING))
+                effect = Effects.DealDamage(4, t)
+            }
+        }
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Titus Lunter"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b10219a-aa72-4431-9a6a-984109a605c8.jpg?1783931044"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/Jumpstart2022Set.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/Jumpstart2022Set.kt
@@ -23,6 +23,10 @@ object Jumpstart2022Set : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AcademyJourneymageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AcademyJourneymageReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Academy Journeymage reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.AcademyJourneymage`.
+ */
+val AcademyJourneymageReprint = Printing(
+    oracleId = "b400700c-1d82-4721-a166-56f88ba6ad19",
+    name = "Academy Journeymage",
+    setCode = "J22",
+    collectorNumber = "267",
+    scryfallId = "6a88507f-8089-42a6-a722-d07d04a59295",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a88507f-8089-42a6-a722-d07d04a59295.jpg?1783919075",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AeronautTinkererReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AeronautTinkererReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aeronaut Tinkerer reprint in J22. Canonical CardDefinition lives in Magic 2015 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m15.cards.AeronautTinkerer`.
+ */
+val AeronautTinkererReprint = Printing(
+    oracleId = "a15bb807-ea31-4bff-b573-c249c4c78dd6",
+    name = "Aeronaut Tinkerer",
+    setCode = "J22",
+    collectorNumber = "268",
+    scryfallId = "86920134-b45d-4690-af61-c9c1488d70e0",
+    artist = "Willian Murai",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/86920134-b45d-4690-af61-c9c1488d70e0.jpg?1783919075",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AetherSpellbombReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AetherSpellbombReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aether Spellbomb reprint in J22. Canonical CardDefinition lives in Mirrodin (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mrd.cards.AetherSpellbomb`.
+ */
+val AetherSpellbombReprint = Printing(
+    oracleId = "4b033a0a-c1ae-44d7-9662-72cbbfda024b",
+    name = "Aether Spellbomb",
+    setCode = "J22",
+    collectorNumber = "752",
+    scryfallId = "ee539bda-62b4-40fb-95d3-c7d1fc0a7e09",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee539bda-62b4-40fb-95d3-c7d1fc0a7e09.jpg?1783918819",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AethershieldArtificerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AethershieldArtificerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aethershield Artificer reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.AethershieldArtificer`.
+ */
+val AethershieldArtificerReprint = Printing(
+    oracleId = "d2575513-72fa-49c7-be6b-9f6f85950f88",
+    name = "Aethershield Artificer",
+    setCode = "J22",
+    collectorNumber = "140",
+    scryfallId = "0fd33b41-e8f4-46e2-9a44-9cba5758a6fb",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/0/f/0fd33b41-e8f4-46e2-9a44-9cba5758a6fb.jpg?1783919135",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AlleyStranglerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AlleyStranglerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Alley Strangler reprint in J22. Canonical CardDefinition lives in Aether Revolt (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.aer.cards.AlleyStrangler`.
+ */
+val AlleyStranglerReprint = Printing(
+    oracleId = "fb9af562-7384-4575-93bb-34f1ada23735",
+    name = "Alley Strangler",
+    setCode = "J22",
+    collectorNumber = "375",
+    scryfallId = "35b168d5-b111-4a1c-a4b8-d3cd376bfa3b",
+    artist = "Enora Mercier",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/35b168d5-b111-4a1c-a4b8-d3cd376bfa3b.jpg?1783919025",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AnchorToTheAetherReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AnchorToTheAetherReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Anchor to the Aether reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.AnchorToTheAether`.
+ */
+val AnchorToTheAetherReprint = Printing(
+    oracleId = "3e00326d-2bf4-4731-a6cd-1c015f94f553",
+    name = "Anchor to the Aether",
+    setCode = "J22",
+    collectorNumber = "270",
+    scryfallId = "57976884-2a67-41c6-bf06-c10b6c3afb4b",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/57976884-2a67-41c6-bf06-c10b6c3afb4b.jpg?1783919075",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AngelOfFlightAlabasterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AngelOfFlightAlabasterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel of Flight Alabaster reprint in J22. Canonical CardDefinition lives in Innistrad (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.isd.cards.AngelOfFlightAlabaster`.
+ */
+val AngelOfFlightAlabasterReprint = Printing(
+    oracleId = "9b6a74fb-c48f-4d85-b4b3-96eb80b9efc7",
+    name = "Angel of Flight Alabaster",
+    setCode = "J22",
+    collectorNumber = "144",
+    scryfallId = "dd39a1e1-9784-4cb0-b8ed-98e659b32edd",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd39a1e1-9784-4cb0-b8ed-98e659b32edd.jpg?1783919134",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AngelicEdictReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AngelicEdictReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angelic Edict reprint in J22. Canonical CardDefinition lives in Gatecrash (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.gtc.cards.AngelicEdict`.
+ */
+val AngelicEdictReprint = Printing(
+    oracleId = "36de8401-ee4e-413f-91ad-06924e39c857",
+    name = "Angelic Edict",
+    setCode = "J22",
+    collectorNumber = "145",
+    scryfallId = "baef1f8f-42bc-4e0a-96d3-4904fbdcc923",
+    artist = "Trevor Claxton",
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/baef1f8f-42bc-4e0a-96d3-4904fbdcc923.jpg?1783919133",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AngelicPageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AngelicPageReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angelic Page reprint in J22. Canonical CardDefinition lives in Urza's Saga (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.usg.cards.AngelicPage`.
+ */
+val AngelicPageReprint = Printing(
+    oracleId = "f7f76abc-8656-4e97-9b7f-7f89ca3e6d93",
+    name = "Angelic Page",
+    setCode = "J22",
+    collectorNumber = "146",
+    scryfallId = "623d9e1d-4154-4d77-bd0e-e6204117dc83",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/623d9e1d-4154-4d77-bd0e-e6204117dc83.jpg?1783919132",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AquaticIncursionReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AquaticIncursionReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aquatic Incursion reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.AquaticIncursion`.
+ */
+val AquaticIncursionReprint = Printing(
+    oracleId = "e4212b05-d397-49fb-af8b-9e52a60e6d1e",
+    name = "Aquatic Incursion",
+    setCode = "J22",
+    collectorNumber = "271",
+    scryfallId = "4e7566ac-e9b3-4220-9b25-84d5b33f5842",
+    artist = "Jason Rainville",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e7566ac-e9b3-4220-9b25-84d5b33f5842.jpg?1783919073",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AradaraExpressReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AradaraExpressReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aradara Express reprint in J22. Canonical CardDefinition lives in Kaladesh (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.kld.cards.AradaraExpress`.
+ */
+val AradaraExpressReprint = Printing(
+    oracleId = "be96b9e1-10ef-4955-8d23-c39384def86d",
+    name = "Aradara Express",
+    setCode = "J22",
+    collectorNumber = "754",
+    scryfallId = "7d28fa0c-5c88-40cd-8295-8d56c76a7938",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/7/d/7d28fa0c-5c88-40cd-8295-8d56c76a7938.jpg?1783918819",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ArchonOfJusticeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ArchonOfJusticeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Archon of Justice reprint in J22. Canonical CardDefinition lives in Eventide (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.eve.cards.ArchonOfJustice`.
+ */
+val ArchonOfJusticeReprint = Printing(
+    oracleId = "d551931d-4ebe-4acc-9e87-6c628897071a",
+    name = "Archon of Justice",
+    setCode = "J22",
+    collectorNumber = "150",
+    scryfallId = "d17c4f01-78c4-4635-86e0-46596e6e6ec6",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d17c4f01-78c4-4635-86e0-46596e6e6ec6.jpg?1783919129",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ArchonOfSunsGraceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ArchonOfSunsGraceReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Archon of Sun's Grace reprint in J22. Canonical CardDefinition lives in Theros Beyond Death (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.thb.cards.ArchonOfSunsGrace`.
+ */
+val ArchonOfSunsGraceReprint = Printing(
+    oracleId = "48a99dce-0aa9-4aac-81df-cec5f94c639d",
+    name = "Archon of Sun's Grace",
+    setCode = "J22",
+    collectorNumber = "151",
+    scryfallId = "895da74d-26ce-4e0c-baef-6eabc40bf0de",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/895da74d-26ce-4e0c-baef-6eabc40bf0de.jpg?1783919130",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ArmsDealerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ArmsDealerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Arms Dealer reprint in J22. Canonical CardDefinition lives in Mercadian Masques (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mmq.cards.ArmsDealer`.
+ */
+val ArmsDealerReprint = Printing(
+    oracleId = "8ebc4198-7317-4ffb-b8b8-14733c2077ff",
+    name = "Arms Dealer",
+    setCode = "J22",
+    collectorNumber = "493",
+    scryfallId = "aa460a11-afd1-4997-89ac-6a64af63db55",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa460a11-afd1-4997-89ac-6a64af63db55.jpg?1783918965",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AshBarrensReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AshBarrensReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ash Barrens reprint in J22. Canonical CardDefinition lives in Commander 2016 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.c16.cards.AshBarrens`.
+ */
+val AshBarrensReprint = Printing(
+    oracleId = "58257464-278e-45fa-8e0b-bcd9a7500bc1",
+    name = "Ash Barrens",
+    setCode = "J22",
+    collectorNumber = "809",
+    scryfallId = "5b20e63c-f9fa-46c0-a3f8-30ea70e07fc6",
+    artist = "Jonas De Ro",
+    imageUri = "https://cards.scryfall.io/normal/front/5/b/5b20e63c-f9fa-46c0-a3f8-30ea70e07fc6.jpg?1783918793",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AuguryOwlReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AuguryOwlReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Augury Owl reprint in J22. Canonical CardDefinition lives in Magic 2011 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m11.cards.AuguryOwl`.
+ */
+val AuguryOwlReprint = Printing(
+    oracleId = "44c5f8e1-d9b8-4067-a60a-1ecc8bd11145",
+    name = "Augury Owl",
+    setCode = "J22",
+    collectorNumber = "273",
+    scryfallId = "e25dd284-ccc5-423c-830d-d3d331212293",
+    artist = "Jim Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e25dd284-ccc5-423c-830d-d3d331212293.jpg?1783919072",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AuramancerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AuramancerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Auramancer reprint in J22. Canonical CardDefinition lives in Odyssey (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ody.cards.Auramancer`.
+ */
+val AuramancerReprint = Printing(
+    oracleId = "bd5eb181-6a69-4dc2-93a0-fa000291bc3d",
+    name = "Auramancer",
+    setCode = "J22",
+    collectorNumber = "153",
+    scryfallId = "d6e3b21e-a05c-4603-b4d1-68353273d4a9",
+    artist = "Rebecca Guay",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d6e3b21e-a05c-4603-b4d1-68353273d4a9.jpg?1783919130",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AxgardCavalryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AxgardCavalryReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Axgard Cavalry reprint in J22. Canonical CardDefinition lives in Kaldheim (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.khm.cards.AxgardCavalry`.
+ */
+val AxgardCavalryReprint = Printing(
+    oracleId = "6a92b011-fd01-4b6a-a17c-73ac1967ff98",
+    name = "Axgard Cavalry",
+    setCode = "J22",
+    collectorNumber = "494",
+    scryfallId = "5e16bc35-5237-4a13-9179-aaa0347ceffe",
+    artist = "Evyn Fong",
+    imageUri = "https://cards.scryfall.io/normal/front/5/e/5e16bc35-5237-4a13-9179-aaa0347ceffe.jpg?1783918968",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BalothWoodcrasherReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BalothWoodcrasherReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Baloth Woodcrasher reprint in J22. Canonical CardDefinition lives in Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.zen.cards.BalothWoodcrasher`.
+ */
+val BalothWoodcrasherReprint = Printing(
+    oracleId = "faaf9975-74df-4e9d-be0c-19a446cd507c",
+    name = "Baloth Woodcrasher",
+    setCode = "J22",
+    collectorNumber = "630",
+    scryfallId = "a65ce531-48cb-4a52-a0ea-9cba5dcb4060",
+    artist = "Zoltan Boros & Gabor Szikszai",
+    imageUri = "https://cards.scryfall.io/normal/front/a/6/a65ce531-48cb-4a52-a0ea-9cba5dcb4060.jpg?1783918892",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BarrageOgreReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BarrageOgreReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Barrage Ogre reprint in J22. Canonical CardDefinition lives in Scars of Mirrodin (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.som.cards.BarrageOgre`.
+ */
+val BarrageOgreReprint = Printing(
+    oracleId = "d556c71e-ce16-4229-880b-744790f93797",
+    name = "Barrage Ogre",
+    setCode = "J22",
+    collectorNumber = "496",
+    scryfallId = "68a335cb-e437-4957-9675-6eaa0316abd2",
+    artist = "David Rapoza",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/68a335cb-e437-4957-9675-6eaa0316abd2.jpg?1783918969",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BigScoreReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BigScoreReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Big Score reprint in J22. Canonical CardDefinition lives in Streets of New Capenna (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.snc.cards.BigScore`.
+ */
+val BigScoreReprint = Printing(
+    oracleId = "a5cbd257-c836-493e-bb1a-76242619dea2",
+    name = "Big Score",
+    setCode = "J22",
+    collectorNumber = "498",
+    scryfallId = "5fbb7413-af44-4038-a56c-8cc3ca645a58",
+    artist = "Gaboleps",
+    imageUri = "https://cards.scryfall.io/normal/front/5/f/5fbb7413-af44-4038-a56c-8cc3ca645a58.jpg?1783918965",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BlackCatReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BlackCatReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Black Cat reprint in J22. Canonical CardDefinition lives in Dark Ascension (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dka.cards.BlackCat`.
+ */
+val BlackCatReprint = Printing(
+    oracleId = "10edf7e0-d6be-4510-819f-8834bedfba41",
+    name = "Black Cat",
+    setCode = "J22",
+    collectorNumber = "377",
+    scryfallId = "84ede129-83fc-42b7-8941-fa649d3329e5",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/84ede129-83fc-42b7-8941-fa649d3329e5.jpg?1783919024",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BlazeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BlazeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blaze reprint in J22. Canonical CardDefinition lives in Portal (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.por.cards.Blaze`.
+ */
+val BlazeReprint = Printing(
+    oracleId = "0596920f-9946-42f4-a03b-24aab67f9f1b",
+    name = "Blaze",
+    setCode = "J22",
+    collectorNumber = "499",
+    scryfallId = "10e27dd9-5b6a-4dab-9ee6-ad083b5c0911",
+    artist = "Alex Horley-Orlandelli",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/10e27dd9-5b6a-4dab-9ee6-ad083b5c0911.jpg?1783918963",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BlessedSpiritsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BlessedSpiritsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blessed Spirits reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.BlessedSpirits`.
+ */
+val BlessedSpiritsReprint = Printing(
+    oracleId = "5fb899c1-3a2f-4b5e-a82d-fece51bdf786",
+    name = "Blessed Spirits",
+    setCode = "J22",
+    collectorNumber = "158",
+    scryfallId = "41adcf82-1cb2-4b38-8607-c6229e9948cb",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/4/1/41adcf82-1cb2-4b38-8607-c6229e9948cb.jpg?1783919128",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BloodArtistReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BloodArtistReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blood Artist reprint in J22. Canonical CardDefinition lives in Avacyn Restored (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.avr.cards.BloodArtist`.
+ */
+val BloodArtistReprint = Printing(
+    oracleId = "310f141c-7f37-4729-aed6-dd9c09db448d",
+    name = "Blood Artist",
+    setCode = "J22",
+    collectorNumber = "117",
+    scryfallId = "c4c1641d-c4ea-4657-a0ae-db09bba83a0f",
+    artist = "Julie Dillon",
+    imageUri = "https://cards.scryfall.io/normal/front/c/4/c4c1641d-c4ea-4657-a0ae-db09bba83a0f.jpg?1783919145",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BorderlandMarauderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BorderlandMarauderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Borderland Marauder reprint in J22. Canonical CardDefinition lives in Magic 2015 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m15.cards.BorderlandMarauder`.
+ */
+val BorderlandMarauderReprint = Printing(
+    oracleId = "11fd2650-2150-4e62-8b64-e820d734a231",
+    name = "Borderland Marauder",
+    setCode = "J22",
+    collectorNumber = "505",
+    scryfallId = "f7eef6f1-318b-4f0b-b269-94b09a039c97",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/f/7/f7eef6f1-318b-4f0b-b269-94b09a039c97.jpg?1783918961",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BoundingWolfReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BoundingWolfReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bounding Wolf reprint in J22. Canonical CardDefinition lives in Innistrad: Midnight Hunt (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mid.cards.BoundingWolf`.
+ */
+val BoundingWolfReprint = Printing(
+    oracleId = "257f7c29-8857-429e-a421-9262982804e0",
+    name = "Bounding Wolf",
+    setCode = "J22",
+    collectorNumber = "633",
+    scryfallId = "515d4a0a-61db-4be0-b9a3-cfd4c163f31b",
+    artist = "Andrea Radeck",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/515d4a0a-61db-4be0-b9a3-cfd4c163f31b.jpg?1783918891",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BrazenFreebooterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BrazenFreebooterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brazen Freebooter reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.BrazenFreebooter`.
+ */
+val BrazenFreebooterReprint = Printing(
+    oracleId = "13e8d063-eece-4f38-83f6-02403130defa",
+    name = "Brazen Freebooter",
+    setCode = "J22",
+    collectorNumber = "506",
+    scryfallId = "60a1e6e9-5e5f-4431-9732-fd313df843df",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60a1e6e9-5e5f-4431-9732-fd313df843df.jpg?1783918962",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BrazenWolvesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BrazenWolvesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brazen Wolves reprint in J22. Canonical CardDefinition lives in Eldritch Moon (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.emn.cards.BrazenWolves`.
+ */
+val BrazenWolvesReprint = Printing(
+    oracleId = "0b5a3d7b-6b2c-4e91-8218-2b957277855c",
+    name = "Brazen Wolves",
+    setCode = "J22",
+    collectorNumber = "507",
+    scryfallId = "15f94348-6c9a-4d0e-975c-618b4a540ad4",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/1/5/15f94348-6c9a-4d0e-975c-618b4a540ad4.jpg?1783918959",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BriarpackAlphaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BriarpackAlphaReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Briarpack Alpha reprint in J22. Canonical CardDefinition lives in Dark Ascension (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dka.cards.BriarpackAlpha`.
+ */
+val BriarpackAlphaReprint = Printing(
+    oracleId = "5604c475-6e01-4e9d-b4e6-8e8d72874581",
+    name = "Briarpack Alpha",
+    setCode = "J22",
+    collectorNumber = "634",
+    scryfallId = "e3c2c145-3ddf-45d8-a5f0-f757dbd94ad1",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3c2c145-3ddf-45d8-a5f0-f757dbd94ad1.jpg?1783918888",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BringToTrialReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BringToTrialReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bring to Trial reprint in J22. Canonical CardDefinition lives in Ravnica Allegiance (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rna.cards.BringToTrial`.
+ */
+val BringToTrialReprint = Printing(
+    oracleId = "968b6277-584c-4947-98ac-4d6e5f8d6754",
+    name = "Bring to Trial",
+    setCode = "J22",
+    collectorNumber = "160",
+    scryfallId = "444d7e10-0d5b-47f4-b29c-730d1d08a59a",
+    artist = "Victor Adame Minguez",
+    imageUri = "https://cards.scryfall.io/normal/front/4/4/444d7e10-0d5b-47f4-b29c-730d1d08a59a.jpg?1783919125",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BristlingBoarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BristlingBoarReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bristling Boar reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.BristlingBoar`.
+ */
+val BristlingBoarReprint = Printing(
+    oracleId = "f4aed3d2-04f5-49a4-a6be-d3cf097903f8",
+    name = "Bristling Boar",
+    setCode = "J22",
+    collectorNumber = "635",
+    scryfallId = "27591452-2750-4eed-bded-832bdee79e00",
+    artist = "Zezhou Chen",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27591452-2750-4eed-bded-832bdee79e00.jpg?1783918887",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BurglarRatReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BurglarRatReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Burglar Rat reprint in J22. Canonical CardDefinition lives in Guilds of Ravnica (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.grn.cards.BurglarRat`.
+ */
+val BurglarRatReprint = Printing(
+    oracleId = "2f807301-37df-4724-871a-08e3512b07b3",
+    name = "Burglar Rat",
+    setCode = "J22",
+    collectorNumber = "384",
+    scryfallId = "8e8bb46d-acc2-4631-89c7-b92f927a5940",
+    artist = "Tyler Walpole",
+    imageUri = "https://cards.scryfall.io/normal/front/8/e/8e8bb46d-acc2-4631-89c7-b92f927a5940.jpg?1783919020",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BurnBrightReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BurnBrightReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Burn Bright reprint in J22. Canonical CardDefinition lives in Ravnica Allegiance (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rna.cards.BurnBright`.
+ */
+val BurnBrightReprint = Printing(
+    oracleId = "ed14c7fa-632c-47ee-9db0-8c492771121a",
+    name = "Burn Bright",
+    setCode = "J22",
+    collectorNumber = "508",
+    scryfallId = "8836ea09-9136-4f97-9b38-1aeb9c155d03",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/8836ea09-9136-4f97-9b38-1aeb9c155d03.jpg?1783918958",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CampusGuideReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CampusGuideReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Campus Guide reprint in J22. Canonical CardDefinition lives in Strixhaven: School of Mages (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.stx.cards.CampusGuide`.
+ */
+val CampusGuideReprint = Printing(
+    oracleId = "5b8e0913-47e9-4d56-971d-abd91b0f7587",
+    name = "Campus Guide",
+    setCode = "J22",
+    collectorNumber = "758",
+    scryfallId = "c7655790-d091-47d6-8387-08bfa4333f19",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/c/7/c7655790-d091-47d6-8387-08bfa4333f19.jpg?1783918816",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CanopyBalothReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CanopyBalothReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Canopy Baloth reprint in J22. Canonical CardDefinition lives in Zendikar Rising (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.znr.cards.CanopyBaloth`.
+ */
+val CanopyBalothReprint = Printing(
+    oracleId = "4493828f-144f-49cf-9fd2-61de86e632ec",
+    name = "Canopy Baloth",
+    setCode = "J22",
+    collectorNumber = "638",
+    scryfallId = "f20920ff-ccfe-46a2-9b2e-0dc342f2e057",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/f/2/f20920ff-ccfe-46a2-9b2e-0dc342f2e057.jpg?1783918888",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CaptivatingUnicornReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CaptivatingUnicornReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Captivating Unicorn reprint in J22. Canonical CardDefinition lives in Theros Beyond Death (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.thb.cards.CaptivatingUnicorn`.
+ */
+val CaptivatingUnicornReprint = Printing(
+    oracleId = "22005b01-84b1-4d4b-9193-3c561bd422ce",
+    name = "Captivating Unicorn",
+    setCode = "J22",
+    collectorNumber = "163",
+    scryfallId = "4e5364ee-cfa3-48b0-93e9-c14c55ecc8ba",
+    artist = "Emrah Elmasli",
+    imageUri = "https://cards.scryfall.io/normal/front/4/e/4e5364ee-cfa3-48b0-93e9-c14c55ecc8ba.jpg?1783919124",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CatalystElementalReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CatalystElementalReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Catalyst Elemental reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.CatalystElemental`.
+ */
+val CatalystElementalReprint = Printing(
+    oracleId = "7779525d-080d-4669-bb65-af532bf0983e",
+    name = "Catalyst Elemental",
+    setCode = "J22",
+    collectorNumber = "510",
+    scryfallId = "cdd9b5c4-0911-4d0a-92bf-2d0107329671",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/c/d/cdd9b5c4-0911-4d0a-92bf-2d0107329671.jpg?1783918957",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CausticCaterpillarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CausticCaterpillarReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Caustic Caterpillar reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.CausticCaterpillar`.
+ */
+val CausticCaterpillarReprint = Printing(
+    oracleId = "45d35128-76e6-43f9-8d23-41f7506c3a71",
+    name = "Caustic Caterpillar",
+    setCode = "J22",
+    collectorNumber = "86",
+    scryfallId = "c5c0e3e1-a578-4c3d-95d1-f1c6c243779d",
+    artist = "Ai Nanahira",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5c0e3e1-a578-4c3d-95d1-f1c6c243779d.jpg?1783919158",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CavalryDrillmasterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CavalryDrillmasterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cavalry Drillmaster reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.CavalryDrillmaster`.
+ */
+val CavalryDrillmasterReprint = Printing(
+    oracleId = "d89bbfe7-e7ef-4f1c-a6b5-6d8ef4079daa",
+    name = "Cavalry Drillmaster",
+    setCode = "J22",
+    collectorNumber = "165",
+    scryfallId = "27db546a-f117-41ad-a917-69e6086a43dd",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27db546a-f117-41ad-a917-69e6086a43dd.jpg?1783919123",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ChandrasMagmuttReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ChandrasMagmuttReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chandra's Magmutt reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.ChandrasMagmutt`.
+ */
+val ChandrasMagmuttReprint = Printing(
+    oracleId = "a2c4537e-70a6-416d-9e8b-f549ad535147",
+    name = "Chandra's Magmutt",
+    setCode = "J22",
+    collectorNumber = "512",
+    scryfallId = "b40d6eb9-dd25-4a1d-ae0a-ad5d235073c3",
+    artist = "Kimonas Theodossiou",
+    imageUri = "https://cards.scryfall.io/normal/front/b/4/b40d6eb9-dd25-4a1d-ae0a-ad5d235073c3.jpg?1783918957",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ChillingTrapReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ChillingTrapReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chilling Trap reprint in J22. Canonical CardDefinition lives in Zendikar Rising (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.znr.cards.ChillingTrap`.
+ */
+val ChillingTrapReprint = Printing(
+    oracleId = "7ac49129-7da2-4729-b48c-b6da279c212e",
+    name = "Chilling Trap",
+    setCode = "J22",
+    collectorNumber = "281",
+    scryfallId = "d97f33bb-4796-4890-a209-d9d4b3afa601",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d97f33bb-4796-4890-a209-d9d4b3afa601.jpg?1783919069",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CircuitMenderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CircuitMenderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Circuit Mender reprint in J22. Canonical CardDefinition lives in Kamigawa: Neon Dynasty (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.neo.cards.CircuitMender`.
+ */
+val CircuitMenderReprint = Printing(
+    oracleId = "1665ca9f-176d-40f1-a4e9-42da4f1236e9",
+    name = "Circuit Mender",
+    setCode = "J22",
+    collectorNumber = "760",
+    scryfallId = "6c6fc201-9365-40be-bc59-f3715fd3d15d",
+    artist = "Hector Ortiz",
+    imageUri = "https://cards.scryfall.io/normal/front/6/c/6c6fc201-9365-40be-bc59-f3715fd3d15d.jpg?1783918817",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ColossalDreadmawReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ColossalDreadmawReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Colossal Dreadmaw reprint in J22. Canonical CardDefinition lives in Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.xln.cards.ColossalDreadmaw`.
+ */
+val ColossalDreadmawReprint = Printing(
+    oracleId = "08c7db90-c0cf-4482-b7ee-bb033e5996d2",
+    name = "Colossal Dreadmaw",
+    setCode = "J22",
+    collectorNumber = "640",
+    scryfallId = "b35fd2a8-cccd-4b35-b791-d70e74e203bc",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/b/3/b35fd2a8-cccd-4b35-b791-d70e74e203bc.jpg?1783918884",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ColossalMajestyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ColossalMajestyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Colossal Majesty reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.ColossalMajesty`.
+ */
+val ColossalMajestyReprint = Printing(
+    oracleId = "cac95494-0db0-4bec-8665-998431a6f76b",
+    name = "Colossal Majesty",
+    setCode = "J22",
+    collectorNumber = "87",
+    scryfallId = "4fd1764f-9b62-4977-9fee-1266f0ea01aa",
+    artist = "Tetsu Kurosawa",
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4fd1764f-9b62-4977-9fee-1266f0ea01aa.jpg?1783919157",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CombatProfessorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CombatProfessorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Combat Professor reprint in J22. Canonical CardDefinition lives in Strixhaven: School of Mages (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.stx.cards.CombatProfessor`.
+ */
+val CombatProfessorReprint = Printing(
+    oracleId = "1b59665f-23c7-4df9-8e71-f9b1a419063b",
+    name = "Combat Professor",
+    setCode = "J22",
+    collectorNumber = "167",
+    scryfallId = "24d8e9d2-8c5b-4f75-ac03-df23435f3404",
+    artist = "Andrey Kuzinskiy",
+    imageUri = "https://cards.scryfall.io/normal/front/2/4/24d8e9d2-8c5b-4f75-ac03-df23435f3404.jpg?1783919123",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DawningAngelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DawningAngelReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dawning Angel reprint in J22. Canonical CardDefinition lives in Core Set 2020 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m20.cards.DawningAngel`.
+ */
+val DawningAngelReprint = Printing(
+    oracleId = "a7d88510-d2ce-4dd6-938c-964cc74ff7d7",
+    name = "Dawning Angel",
+    setCode = "J22",
+    collectorNumber = "170",
+    scryfallId = "326e1569-3394-468d-addd-c0a5346f7031",
+    artist = "Yongjae Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/326e1569-3394-468d-addd-c0a5346f7031.jpg?1783919122",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DaybreakChaplainReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DaybreakChaplainReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Daybreak Chaplain reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.DaybreakChaplain`.
+ */
+val DaybreakChaplainReprint = Printing(
+    oracleId = "ebd33f4c-2cc8-46e3-b367-ce5b37c2719b",
+    name = "Daybreak Chaplain",
+    setCode = "J22",
+    collectorNumber = "171",
+    scryfallId = "0877c7da-e606-4c24-822a-2af987527361",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/0877c7da-e606-4c24-822a-2af987527361.jpg?1783919123",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DaybreakChargerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DaybreakChargerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Daybreak Charger reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.DaybreakCharger`.
+ */
+val DaybreakChargerReprint = Printing(
+    oracleId = "d3de6b36-c631-4b52-b16b-0749a347d73d",
+    name = "Daybreak Charger",
+    setCode = "J22",
+    collectorNumber = "172",
+    scryfallId = "309ea7a5-c096-4216-b6bd-a848f2540c31",
+    artist = "Forrest Imel",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/309ea7a5-c096-4216-b6bd-a848f2540c31.jpg?1783919121",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DeadWeightReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DeadWeightReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dead Weight reprint in J22. Canonical CardDefinition lives in Innistrad (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.isd.cards.DeadWeight`.
+ */
+val DeadWeightReprint = Printing(
+    oracleId = "b1804304-fac1-4b19-a48d-6ade9407972a",
+    name = "Dead Weight",
+    setCode = "J22",
+    collectorNumber = "393",
+    scryfallId = "7776aa09-158a-4286-a6db-8c94cea22855",
+    artist = "Lake Hurwitz",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/7776aa09-158a-4286-a6db-8c94cea22855.jpg?1783919016",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DeathbloomThallidReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DeathbloomThallidReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Deathbloom Thallid reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.DeathbloomThallid`.
+ */
+val DeathbloomThallidReprint = Printing(
+    oracleId = "ce873790-de4d-4ba3-8023-c44306ba3ff8",
+    name = "Deathbloom Thallid",
+    setCode = "J22",
+    collectorNumber = "395",
+    scryfallId = "bbe74b50-a2a9-4ace-95ed-4ad5d12e3f2e",
+    artist = "Mike Burns",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bbe74b50-a2a9-4ace-95ed-4ad5d12e3f2e.jpg?1783919019",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DecreeOfJusticeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DecreeOfJusticeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Decree of Justice reprint in J22. Canonical CardDefinition lives in Scourge (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.scg.cards.DecreeOfJustice`.
+ */
+val DecreeOfJusticeReprint = Printing(
+    oracleId = "67a98359-6f02-4556-ad47-c01b643686d6",
+    name = "Decree of Justice",
+    setCode = "J22",
+    collectorNumber = "173",
+    scryfallId = "c2cecbd0-87a7-45e5-bf10-e97b298803fd",
+    artist = "Lius Lasahido",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c2cecbd0-87a7-45e5-bf10-e97b298803fd.jpg?1783919121",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DemonOfCatastrophesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DemonOfCatastrophesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Demon of Catastrophes reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.DemonOfCatastrophes`.
+ */
+val DemonOfCatastrophesReprint = Printing(
+    oracleId = "2e0b838d-c858-4aa5-999e-c4ef9d29571b",
+    name = "Demon of Catastrophes",
+    setCode = "J22",
+    collectorNumber = "397",
+    scryfallId = "861100dd-376a-4a8b-862a-76ad4edda725",
+    artist = "Sidharth Chaturvedi",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/861100dd-376a-4a8b-862a-76ad4edda725.jpg?1783919015",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DemonsGraspReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DemonsGraspReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Demon's Grasp reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.DemonsGrasp`.
+ */
+val DemonsGraspReprint = Printing(
+    oracleId = "13228a22-d63a-4952-a482-4f84da696e88",
+    name = "Demon's Grasp",
+    setCode = "J22",
+    collectorNumber = "400",
+    scryfallId = "c305f55c-6bcf-464b-aa80-e227bf30c9ea",
+    artist = "David Gaillet",
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c305f55c-6bcf-464b-aa80-e227bf30c9ea.jpg?1783919013",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DesertOfTheMindfulReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DesertOfTheMindfulReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Desert of the Mindful reprint in J22. Canonical CardDefinition lives in Hour of Devastation (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.hou.cards.DesertOfTheMindful`.
+ */
+val DesertOfTheMindfulReprint = Printing(
+    oracleId = "508f9e7e-2ff7-4593-b0a9-0612d7b5d646",
+    name = "Desert of the Mindful",
+    setCode = "J22",
+    collectorNumber = "812",
+    scryfallId = "6bf14f8a-373b-4244-9427-a5a3224bf21f",
+    artist = "Christine Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6bf14f8a-373b-4244-9427-a5a3224bf21f.jpg?1783918790",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DevouringLightReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DevouringLightReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Devouring Light reprint in J22. Canonical CardDefinition lives in Ravnica: City of Guilds (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rav.cards.DevouringLight`.
+ */
+val DevouringLightReprint = Printing(
+    oracleId = "5334dc24-040e-4094-80f4-8d1b9de01230",
+    name = "Devouring Light",
+    setCode = "J22",
+    collectorNumber = "175",
+    scryfallId = "61ef2107-1d92-482c-a7ea-6847e6c50aed",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/61ef2107-1d92-482c-a7ea-6847e6c50aed.jpg?1783919119",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DevouringSwarmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DevouringSwarmReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Devouring Swarm reprint in J22. Canonical CardDefinition lives in Magic 2012 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m12.cards.DevouringSwarm`.
+ */
+val DevouringSwarmReprint = Printing(
+    oracleId = "11656b2a-b459-4b1c-b505-8547c3507856",
+    name = "Devouring Swarm",
+    setCode = "J22",
+    collectorNumber = "401",
+    scryfallId = "1065b467-f24b-4add-bced-1d4709df1adb",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/1/0/1065b467-f24b-4add-bced-1d4709df1adb.jpg?1783919012",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DivineArrowReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DivineArrowReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divine Arrow reprint in J22. Canonical CardDefinition lives in War of the Spark (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.war.cards.DivineArrow`.
+ */
+val DivineArrowReprint = Printing(
+    oracleId = "6add505a-9c0f-42e6-898d-be3194c3df33",
+    name = "Divine Arrow",
+    setCode = "J22",
+    collectorNumber = "176",
+    scryfallId = "80b54945-444f-45db-bffa-0d844291f579",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80b54945-444f-45db-bffa-0d844291f579.jpg?1783919118",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DivineVerdictReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DivineVerdictReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Divine Verdict reprint in J22. Canonical CardDefinition lives in Magic 2010 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m10.cards.DivineVerdict`.
+ */
+val DivineVerdictReprint = Printing(
+    oracleId = "3070f997-24f2-471d-af96-a2f3b588198e",
+    name = "Divine Verdict",
+    setCode = "J22",
+    collectorNumber = "177",
+    scryfallId = "9bb9d872-3ea5-4f8a-891e-00707c4ff5c0",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9bb9d872-3ea5-4f8a-891e-00707c4ff5c0.jpg?1783919117",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DoomedDissenterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DoomedDissenterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Doomed Dissenter reprint in J22. Canonical CardDefinition lives in Amonkhet (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.akh.cards.DoomedDissenter`.
+ */
+val DoomedDissenterReprint = Printing(
+    oracleId = "11cb509d-21af-48f1-b355-135ebd3e4bd1",
+    name = "Doomed Dissenter",
+    setCode = "J22",
+    collectorNumber = "402",
+    scryfallId = "a53d3ce5-3e71-44f1-ab0e-98d399287722",
+    artist = "Tony Foti",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a53d3ce5-3e71-44f1-ab0e-98d399287722.jpg?1783919012",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonFodderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonFodderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon Fodder reprint in J22. Canonical CardDefinition lives in Shards of Alara (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ala.cards.DragonFodder`.
+ */
+val DragonFodderReprint = Printing(
+    oracleId = "d0d2c45b-b6e3-4999-bdab-976e8f0d6617",
+    name = "Dragon Fodder",
+    setCode = "J22",
+    collectorNumber = "76",
+    scryfallId = "686d43eb-ea91-4ae1-bdc4-dcd885688acd",
+    artist = "Yoshiya",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/686d43eb-ea91-4ae1-bdc4-dcd885688acd.jpg?1783919164",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonlordsServantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonlordsServantReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonlord's Servant reprint in J22. Canonical CardDefinition lives in Dragons of Tarkir (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dtk.cards.DragonlordsServant`.
+ */
+val DragonlordsServantReprint = Printing(
+    oracleId = "faf81ae0-0b35-45ef-a50d-6cecf0c0eeeb",
+    name = "Dragonlord's Servant",
+    setCode = "J22",
+    collectorNumber = "524",
+    scryfallId = "41ac2c18-a26b-4683-b326-97f0e75b4f2a",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/4/1/41ac2c18-a26b-4683-b326-97f0e75b4f2a.jpg?1783918950",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonsHoardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonsHoardReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragon's Hoard reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.DragonsHoard`.
+ */
+val DragonsHoardReprint = Printing(
+    oracleId = "8cf77dc4-763b-41b7-a5da-0ef2734f08e6",
+    name = "Dragon's Hoard",
+    setCode = "J22",
+    collectorNumber = "763",
+    scryfallId = "e48e23fe-f0ed-4c5a-b90b-30cf096a9d02",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/e/4/e48e23fe-f0ed-4c5a-b90b-30cf096a9d02.jpg?1783918814",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonspeakerShamanReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/DragonspeakerShamanReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dragonspeaker Shaman reprint in J22. Canonical CardDefinition lives in Scourge (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.scg.cards.DragonspeakerShaman`.
+ */
+val DragonspeakerShamanReprint = Printing(
+    oracleId = "6a29f36b-7911-4d84-a3ae-546b131d5159",
+    name = "Dragonspeaker Shaman",
+    setCode = "J22",
+    collectorNumber = "525",
+    scryfallId = "d7098bac-9e43-41e7-a891-780fe4232940",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d7098bac-9e43-41e7-a891-780fe4232940.jpg?1783918955",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ElectricRevelationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ElectricRevelationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Electric Revelation reprint in J22. Canonical CardDefinition lives in Innistrad: Midnight Hunt (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mid.cards.ElectricRevelation`.
+ */
+val ElectricRevelationReprint = Printing(
+    oracleId = "c92af0f4-e5f1-4731-a781-b2ca360867a7",
+    name = "Electric Revelation",
+    setCode = "J22",
+    collectorNumber = "526",
+    scryfallId = "9622e628-3a8f-44ea-aec2-60c8fbd1baae",
+    artist = "Liiga Smilshkalne",
+    imageUri = "https://cards.scryfall.io/normal/front/9/6/9622e628-3a8f-44ea-aec2-60c8fbd1baae.jpg?1783918948",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ElectrifyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ElectrifyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Electrify reprint in J22. Canonical CardDefinition lives in Amonkhet (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.akh.cards.Electrify`.
+ */
+val ElectrifyReprint = Printing(
+    oracleId = "da952213-9a3c-4e13-bc5a-55d1e5dbaa5b",
+    name = "Electrify",
+    setCode = "J22",
+    collectorNumber = "527",
+    scryfallId = "0538bd14-fc75-4e1b-8183-8e852b78fa9d",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/0/5/0538bd14-fc75-4e1b-8183-8e852b78fa9d.jpg?1783918949",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/EliteInstructorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/EliteInstructorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elite Instructor reprint in J22. Canonical CardDefinition lives in Theros Beyond Death (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.thb.cards.EliteInstructor`.
+ */
+val EliteInstructorReprint = Printing(
+    oracleId = "6536f72e-ff4e-4cda-bc7d-909145adf829",
+    name = "Elite Instructor",
+    setCode = "J22",
+    collectorNumber = "290",
+    scryfallId = "d64fa3b1-fbaa-4b35-bd09-007b95fb54a4",
+    artist = "Mike Sass",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d64fa3b1-fbaa-4b35-bd09-007b95fb54a4.jpg?1783919064",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/EviscerateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/EviscerateReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eviscerate reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.Eviscerate`.
+ */
+val EviscerateReprint = Printing(
+    oracleId = "c3a89c67-1931-4d42-98c8-94a40cfd046e",
+    name = "Eviscerate",
+    setCode = "J22",
+    collectorNumber = "412",
+    scryfallId = "6e215786-5c2a-4f08-afab-78342ad8fa17",
+    artist = "Min Yum",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e215786-5c2a-4f08-afab-78342ad8fa17.jpg?1783919010",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ExpeditionMapReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ExpeditionMapReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Expedition Map reprint in J22. Canonical CardDefinition lives in Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.zen.cards.ExpeditionMap`.
+ */
+val ExpeditionMapReprint = Printing(
+    oracleId = "8fcf50cd-e6d0-4516-850f-d42ee75dcc3a",
+    name = "Expedition Map",
+    setCode = "J22",
+    collectorNumber = "765",
+    scryfallId = "ff02f3e9-7bee-486c-9f19-9fac52c93418",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/ff02f3e9-7bee-486c-9f19-9fac52c93418.jpg?1783918812",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FaerieFormationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FaerieFormationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faerie Formation reprint in J22. Canonical CardDefinition lives in Throne of Eldraine (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.eld.cards.FaerieFormation`.
+ */
+val FaerieFormationReprint = Printing(
+    oracleId = "0366c2f6-6e78-4526-808c-fa7bace6006e",
+    name = "Faerie Formation",
+    setCode = "J22",
+    collectorNumber = "294",
+    scryfallId = "86682959-6720-44e0-8fe3-982f0b3e94ce",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/86682959-6720-44e0-8fe3-982f0b3e94ce.jpg?1783919062",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FaerieSeerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FaerieSeerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faerie Seer reprint in J22. Canonical CardDefinition lives in Modern Horizons (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mh1.cards.FaerieSeer`.
+ */
+val FaerieSeerReprint = Printing(
+    oracleId = "b2e65e8b-5f08-4cc2-ab1d-00f8903dbea2",
+    name = "Faerie Seer",
+    setCode = "J22",
+    collectorNumber = "295",
+    scryfallId = "d05949b2-abb4-4431-b047-f4381a2a920e",
+    artist = "Colin Boyer",
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d05949b2-abb4-4431-b047-f4381a2a920e.jpg?1783919062",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FanaticalFirebrandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FanaticalFirebrandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fanatical Firebrand reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.FanaticalFirebrand`.
+ */
+val FanaticalFirebrandReprint = Printing(
+    oracleId = "d36e11f1-6ab3-4273-8114-a8fbbe21c1c3",
+    name = "Fanatical Firebrand",
+    setCode = "J22",
+    collectorNumber = "528",
+    scryfallId = "ff16d927-c8ed-4bb3-abfe-ae4f12571377",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/ff16d927-c8ed-4bb3-abfe-ae4f12571377.jpg?1783918949",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FavoredOfIroasReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FavoredOfIroasReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Favored of Iroas reprint in J22. Canonical CardDefinition lives in Theros Beyond Death (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.thb.cards.FavoredOfIroas`.
+ */
+val FavoredOfIroasReprint = Printing(
+    oracleId = "5df784c0-3adc-4613-ba30-905ec8cf66f9",
+    name = "Favored of Iroas",
+    setCode = "J22",
+    collectorNumber = "182",
+    scryfallId = "888a511d-218e-49a9-a57a-ee0e9e4ddc5d",
+    artist = "John Severin Brassell",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/888a511d-218e-49a9-a57a-ee0e9e4ddc5d.jpg?1783919115",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FeastOfBloodReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FeastOfBloodReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Feast of Blood reprint in J22. Canonical CardDefinition lives in Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.zen.cards.FeastOfBlood`.
+ */
+val FeastOfBloodReprint = Printing(
+    oracleId = "fed05740-01b2-4c7a-8b97-55e64837c07f",
+    name = "Feast of Blood",
+    setCode = "J22",
+    collectorNumber = "118",
+    scryfallId = "f576f3b6-59c5-4710-b238-7fb2bbcf563e",
+    artist = "Irina Nordsol",
+    imageUri = "https://cards.scryfall.io/normal/front/f/5/f576f3b6-59c5-4710-b238-7fb2bbcf563e.jpg?1783919145",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FelidarCubReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FelidarCubReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Felidar Cub reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.FelidarCub`.
+ */
+val FelidarCubReprint = Printing(
+    oracleId = "cae60cf8-cd64-4595-a4dd-946694cf2bb1",
+    name = "Felidar Cub",
+    setCode = "J22",
+    collectorNumber = "183",
+    scryfallId = "b096d925-a76d-494e-8f72-ebb14263748b",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b096d925-a76d-494e-8f72-ebb14263748b.jpg?1783919115",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FerociousPupReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FerociousPupReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ferocious Pup reprint in J22. Canonical CardDefinition lives in Core Set 2020 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m20.cards.FerociousPup`.
+ */
+val FerociousPupReprint = Printing(
+    oracleId = "a1112750-8d38-49e0-ab1c-77110b2bbc4d",
+    name = "Ferocious Pup",
+    setCode = "J22",
+    collectorNumber = "659",
+    scryfallId = "eee53763-7344-4627-93c3-b4a5b26b1f16",
+    artist = "Rudy Siswanto",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/eee53763-7344-4627-93c3-b4a5b26b1f16.jpg?1783918874",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FerventStrikeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FerventStrikeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fervent Strike reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.FerventStrike`.
+ */
+val FerventStrikeReprint = Printing(
+    oracleId = "35efb1e6-6be2-4a38-969a-199524d48e02",
+    name = "Fervent Strike",
+    setCode = "J22",
+    collectorNumber = "529",
+    scryfallId = "f9555482-f0b8-4b1d-8557-4138e9d20126",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/f/9/f9555482-f0b8-4b1d-8557-4138e9d20126.jpg?1783918952",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FesteringEvilReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FesteringEvilReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Festering Evil reprint in J22. Canonical CardDefinition lives in Weatherlight (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.wth.cards.FesteringEvil`.
+ */
+val FesteringEvilReprint = Printing(
+    oracleId = "0581b047-ffa1-42cc-a175-b7bf928e279e",
+    name = "Festering Evil",
+    setCode = "J22",
+    collectorNumber = "119",
+    scryfallId = "bc58d8cd-f1f8-4a3e-9052-12e319802cb5",
+    artist = "Samuel Araya",
+    imageUri = "https://cards.scryfall.io/normal/front/b/c/bc58d8cd-f1f8-4a3e-9052-12e319802cb5.jpg?1783919145",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FetidImpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FetidImpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fetid Imp reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.FetidImp`.
+ */
+val FetidImpReprint = Printing(
+    oracleId = "cdb68656-633d-436e-ad56-0fdb4814bd19",
+    name = "Fetid Imp",
+    setCode = "J22",
+    collectorNumber = "415",
+    scryfallId = "9a3353a2-b443-4084-b43f-0ff3a22b26c1",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/9/a/9a3353a2-b443-4084-b43f-0ff3a22b26c1.jpg?1783919005",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FierceWitchstalkerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FierceWitchstalkerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fierce Witchstalker reprint in J22. Canonical CardDefinition lives in Throne of Eldraine (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.eld.cards.FierceWitchstalker`.
+ */
+val FierceWitchstalkerReprint = Printing(
+    oracleId = "ad69f48e-c387-4376-a04f-37d3992c7946",
+    name = "Fierce Witchstalker",
+    setCode = "J22",
+    collectorNumber = "661",
+    scryfallId = "797744c0-cfcc-43cb-baeb-bc2be3f7523d",
+    artist = "Nicholas Gregory",
+    imageUri = "https://cards.scryfall.io/normal/front/7/9/797744c0-cfcc-43cb-baeb-bc2be3f7523d.jpg?1783918874",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FieryConclusionReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FieryConclusionReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fiery Conclusion reprint in J22. Canonical CardDefinition lives in Ravnica: City of Guilds (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rav.cards.FieryConclusion`.
+ */
+val FieryConclusionReprint = Printing(
+    oracleId = "91af3c81-615a-4b89-acf2-34c72001ebbd",
+    name = "Fiery Conclusion",
+    setCode = "J22",
+    collectorNumber = "530",
+    scryfallId = "32aef50c-2d73-49a9-8458-0d7c2dc3e658",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32aef50c-2d73-49a9-8458-0d7c2dc3e658.jpg?1783918948",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FieryInterventionReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FieryInterventionReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fiery Intervention reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.FieryIntervention`.
+ */
+val FieryInterventionReprint = Printing(
+    oracleId = "a8cd3a52-1056-4664-ae55-eb0ba3a43a15",
+    name = "Fiery Intervention",
+    setCode = "J22",
+    collectorNumber = "531",
+    scryfallId = "e85cfa83-27bd-4bd5-92e3-65aab37e2ae6",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e85cfa83-27bd-4bd5-92e3-65aab37e2ae6.jpg?1783918948",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FireboltReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FireboltReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Firebolt reprint in J22. Canonical CardDefinition lives in Odyssey (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ody.cards.Firebolt`.
+ */
+val FireboltReprint = Printing(
+    oracleId = "7aa31280-12c3-479d-a6dd-f1c669043083",
+    name = "Firebolt",
+    setCode = "J22",
+    collectorNumber = "532",
+    scryfallId = "e5bbf30c-795c-4580-a0e6-5e2665e6b6fc",
+    artist = "Chris Rallis",
+    imageUri = "https://cards.scryfall.io/normal/front/e/5/e5bbf30c-795c-4580-a0e6-5e2665e6b6fc.jpg?1783918946",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FlameLashReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FlameLashReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Flame Lash reprint in J22. Canonical CardDefinition lives in Kaladesh (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.kld.cards.FlameLash`.
+ */
+val FlameLashReprint = Printing(
+    oracleId = "c65e804b-9222-4fa8-88d1-df06a3279f22",
+    name = "Flame Lash",
+    setCode = "J22",
+    collectorNumber = "534",
+    scryfallId = "ce1a0053-f9a3-43f4-a317-07eb801dbb9b",
+    artist = "Viktor Titov",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/ce1a0053-f9a3-43f4-a317-07eb801dbb9b.jpg?1783918944",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ForgottenCaveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ForgottenCaveReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Forgotten Cave reprint in J22. Canonical CardDefinition lives in Onslaught (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ons.cards.ForgottenCave`.
+ */
+val ForgottenCaveReprint = Printing(
+    oracleId = "394c6de5-7957-4a0b-a6b9-ee0c707cd022",
+    name = "Forgotten Cave",
+    setCode = "J22",
+    collectorNumber = "814",
+    scryfallId = "a1501d59-b253-4449-966f-8922803d84a0",
+    artist = "Tony Szczudlo",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1501d59-b253-4449-966f-8922803d84a0.jpg?1783918790",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FungalInfectionReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FungalInfectionReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fungal Infection reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.FungalInfection`.
+ */
+val FungalInfectionReprint = Printing(
+    oracleId = "04a8858e-9033-403e-9346-5a2ad1bdf680",
+    name = "Fungal Infection",
+    setCode = "J22",
+    collectorNumber = "416",
+    scryfallId = "727a589a-2248-478f-825f-932bfb456675",
+    artist = "Filip Burburan",
+    imageUri = "https://cards.scryfall.io/normal/front/7/2/727a589a-2248-478f-825f-932bfb456675.jpg?1783919005",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FurnaceWhelpReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FurnaceWhelpReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Furnace Whelp reprint in J22. Canonical CardDefinition lives in Fifth Dawn (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.5dn.cards.FurnaceWhelp`.
+ */
+val FurnaceWhelpReprint = Printing(
+    oracleId = "8422f1e0-00ca-4ffb-a6b2-e2c9f96d7f23",
+    name = "Furnace Whelp",
+    setCode = "J22",
+    collectorNumber = "537",
+    scryfallId = "ac7ba3f5-3ad5-47e7-86c9-31954f015b91",
+    artist = "Shreya Shetty",
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac7ba3f5-3ad5-47e7-86c9-31954f015b91.jpg?1783918946",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GallantCavalryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GallantCavalryReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gallant Cavalry reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.GallantCavalry`.
+ */
+val GallantCavalryReprint = Printing(
+    oracleId = "b500c460-2814-47a4-b307-17ca519f3565",
+    name = "Gallant Cavalry",
+    setCode = "J22",
+    collectorNumber = "186",
+    scryfallId = "38f370a9-1401-4018-bbd3-0a8737f9fbea",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/38f370a9-1401-4018-bbd3-0a8737f9fbea.jpg?1783919114",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GallowsWardenReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GallowsWardenReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gallows Warden reprint in J22. Canonical CardDefinition lives in Innistrad (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.isd.cards.GallowsWarden`.
+ */
+val GallowsWardenReprint = Printing(
+    oracleId = "06157e34-dbe1-4936-a718-3b1d70726794",
+    name = "Gallows Warden",
+    setCode = "J22",
+    collectorNumber = "187",
+    scryfallId = "6fa9a592-9495-41ea-918e-09f81bd10309",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6fa9a592-9495-41ea-918e-09f81bd10309.jpg?1783919114",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GearsmithGuardianReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GearsmithGuardianReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gearsmith Guardian reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.GearsmithGuardian`.
+ */
+val GearsmithGuardianReprint = Printing(
+    oracleId = "0c0f7092-3fe6-4a6e-8b4e-803810b43e50",
+    name = "Gearsmith Guardian",
+    setCode = "J22",
+    collectorNumber = "767",
+    scryfallId = "06a89661-47a3-4827-8c60-532c3934aa45",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/06a89661-47a3-4827-8c60-532c3934aa45.jpg?1783918812",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GearsmithProdigyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GearsmithProdigyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gearsmith Prodigy reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.GearsmithProdigy`.
+ */
+val GearsmithProdigyReprint = Printing(
+    oracleId = "589d6b67-17ad-4ca7-9b0c-1b919bf03a27",
+    name = "Gearsmith Prodigy",
+    setCode = "J22",
+    collectorNumber = "303",
+    scryfallId = "554c0b9b-3c92-44b3-90b4-a725c7b68a73",
+    artist = "Deruchenko Alexander",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/554c0b9b-3c92-44b3-90b4-a725c7b68a73.jpg?1783919057",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GiantLadybug.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GiantLadybug.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Giant Ladybug
+ * {2}{G}
+ * Creature — Insect
+ * 4/1
+ * Reach
+ * When this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.
+ */
+val GiantLadybug = card("Giant Ladybug") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Insect"
+    power = 4
+    toughness = 1
+    oracleText = "Reach\nWhen this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            destination = SearchDestination.TOP_OF_LIBRARY,
+            reveal = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Marta Nael"
+        flavorText = "It's bad luck to step on one, but worse luck to have one step on you."
+        imageUri = "https://cards.scryfall.io/normal/front/6/7/67f55ef7-8479-4d56-9801-cb4fd5526e73.jpg?1783919180"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GiantLadybugReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GiantLadybugReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Giant Ladybug reprint in J22. Canonical CardDefinition lives in Jumpstart 2022 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.j22.cards.GiantLadybug`.
+ */
+val GiantLadybugReprint = Printing(
+    oracleId = "abfe31f1-7c6d-4a7a-9f44-7f3e4166d9f1",
+    name = "Giant Ladybug",
+    setCode = "J22",
+    collectorNumber = "39",
+    scryfallId = "67f55ef7-8479-4d56-9801-cb4fd5526e73",
+    artist = "Marta Nael",
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67f55ef7-8479-4d56-9801-cb4fd5526e73.jpg?1783919180",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GideonsLawkeeperReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GideonsLawkeeperReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gideon's Lawkeeper reprint in J22. Canonical CardDefinition lives in Magic 2012 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m12.cards.GideonsLawkeeper`.
+ */
+val GideonsLawkeeperReprint = Printing(
+    oracleId = "bae86bb0-5a97-4f6a-8a3f-4e6848bfacc0",
+    name = "Gideon's Lawkeeper",
+    setCode = "J22",
+    collectorNumber = "190",
+    scryfallId = "9e9e4e1a-9c21-4296-9bfc-ba1c007c1cdd",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9e9e4e1a-9c21-4296-9bfc-ba1c007c1cdd.jpg?1783919112",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GleamingBarrierReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GleamingBarrierReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gleaming Barrier reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.GleamingBarrier`.
+ */
+val GleamingBarrierReprint = Printing(
+    oracleId = "1eb9e401-8975-447b-839d-f7cd23897465",
+    name = "Gleaming Barrier",
+    setCode = "J22",
+    collectorNumber = "768",
+    scryfallId = "bf4ba8a3-77b0-4da8-9bdd-0950d0fe8401",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bf4ba8a3-77b0-4da8-9bdd-0950d0fe8401.jpg?1783918810",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GnawingZombieReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GnawingZombieReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gnawing Zombie reprint in J22. Canonical CardDefinition lives in Magic 2014 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m14.cards.GnawingZombie`.
+ */
+val GnawingZombieReprint = Printing(
+    oracleId = "7979c1e6-6bc5-4b8c-82b0-2770e67ba898",
+    name = "Gnawing Zombie",
+    setCode = "J22",
+    collectorNumber = "419",
+    scryfallId = "d5d82703-20a5-4e81-a396-c5e22655b8ba",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5d82703-20a5-4e81-a396-c5e22655b8ba.jpg?1783919007",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinGrenadeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinGrenadeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Grenade reprint in J22. Canonical CardDefinition lives in Fallen Empires (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.fem.cards.GoblinGrenade`.
+ */
+val GoblinGrenadeReprint = Printing(
+    oracleId = "20aecb7b-7e37-4efe-ac27-f9f9042203f4",
+    name = "Goblin Grenade",
+    setCode = "J22",
+    collectorNumber = "542",
+    scryfallId = "c5dacb5a-68d7-4eb0-b3ba-b1b96a100d3c",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5dacb5a-68d7-4eb0-b3ba-b1b96a100d3c.jpg?1783918940",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinOriflammeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinOriflammeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Oriflamme reprint in J22. Canonical CardDefinition lives in Modern Horizons (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mh1.cards.GoblinOriflamme`.
+ */
+val GoblinOriflammeReprint = Printing(
+    oracleId = "836bd011-2da5-443a-a814-19a664b98a1a",
+    name = "Goblin Oriflamme",
+    setCode = "J22",
+    collectorNumber = "543",
+    scryfallId = "2e00348c-bfa7-4254-9a13-8f7e3d38f6f0",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2e00348c-bfa7-4254-9a13-8f7e3d38f6f0.jpg?1783918942",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinRallyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinRallyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Rally reprint in J22. Canonical CardDefinition lives in Return to Ravnica (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rtr.cards.GoblinRally`.
+ */
+val GoblinRallyReprint = Printing(
+    oracleId = "9ccb6ce8-ccb6-4809-a1cc-cebd38744815",
+    name = "Goblin Rally",
+    setCode = "J22",
+    collectorNumber = "546",
+    scryfallId = "60b0a697-e901-42d9-9833-fedfcb6db9b3",
+    artist = "Nic Klein",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60b0a697-e901-42d9-9833-fedfcb6db9b3.jpg?1783918938",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinTrailblazerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinTrailblazerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Trailblazer reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.GoblinTrailblazer`.
+ */
+val GoblinTrailblazerReprint = Printing(
+    oracleId = "38f66ef9-6afc-478b-a1d4-a9d42c31dfc9",
+    name = "Goblin Trailblazer",
+    setCode = "J22",
+    collectorNumber = "547",
+    scryfallId = "32b16412-3e91-415a-9444-3ca4d30bd8d6",
+    artist = "Josh Hass",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32b16412-3e91-415a-9444-3ca4d30bd8d6.jpg?1783918940",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinWarchiefReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoblinWarchiefReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Warchief reprint in J22. Canonical CardDefinition lives in Scourge (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.scg.cards.GoblinWarchief`.
+ */
+val GoblinWarchiefReprint = Printing(
+    oracleId = "39882df0-c20f-469d-94ba-1617224e71a1",
+    name = "Goblin Warchief",
+    setCode = "J22",
+    collectorNumber = "548",
+    scryfallId = "8567a329-9e3a-4c3d-b74d-2a2d2d4c8c41",
+    artist = "Karl Kopinski",
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/8567a329-9e3a-4c3d-b74d-2a2d2d4c8c41.jpg?1783918937",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoldhoundReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoldhoundReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goldhound reprint in J22. Canonical CardDefinition lives in Streets of New Capenna (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.snc.cards.Goldhound`.
+ */
+val GoldhoundReprint = Printing(
+    oracleId = "b5eb72bb-897f-4911-a797-3153c31df3e0",
+    name = "Goldhound",
+    setCode = "J22",
+    collectorNumber = "549",
+    scryfallId = "f8ed08f2-b251-43ea-818a-7ad833151284",
+    artist = "Donato Giancola",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f8ed08f2-b251-43ea-818a-7ad833151284.jpg?1783918940",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoldnightCommanderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GoldnightCommanderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goldnight Commander reprint in J22. Canonical CardDefinition lives in Avacyn Restored (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.avr.cards.GoldnightCommander`.
+ */
+val GoldnightCommanderReprint = Printing(
+    oracleId = "3dc51dfc-7a60-41bf-b944-6afad6b06c22",
+    name = "Goldnight Commander",
+    setCode = "J22",
+    collectorNumber = "192",
+    scryfallId = "889f5a07-3b5c-494b-834a-3a5e444e38cc",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/889f5a07-3b5c-494b-834a-3a5e444e38cc.jpg?1783919111",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GrafHarvestReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GrafHarvestReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Graf Harvest reprint in J22. Canonical CardDefinition lives in Eldritch Moon (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.emn.cards.GrafHarvest`.
+ */
+val GrafHarvestReprint = Printing(
+    oracleId = "d3ba6922-c2f7-45ab-87a3-d4bbd770d1ba",
+    name = "Graf Harvest",
+    setCode = "J22",
+    collectorNumber = "421",
+    scryfallId = "83f2413f-987f-4eab-96c1-f662821546a5",
+    artist = "Lake Hurwitz",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/83f2413f-987f-4eab-96c1-f662821546a5.jpg?1783919002",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GravediggerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GravediggerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gravedigger reprint in J22. Canonical CardDefinition lives in Portal (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.por.cards.Gravedigger`.
+ */
+val GravediggerReprint = Printing(
+    oracleId = "1a2030cc-d7ee-4059-b2d7-fb95ea8e267b",
+    name = "Gravedigger",
+    setCode = "J22",
+    collectorNumber = "424",
+    scryfallId = "80467e94-81b3-4b2f-865d-69e3d531e845",
+    artist = "Dermot Power",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80467e94-81b3-4b2f-865d-69e3d531e845.jpg?1783919001",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GrotesqueMutationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/GrotesqueMutationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grotesque Mutation reprint in J22. Canonical CardDefinition lives in Shadows over Innistrad (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.soi.cards.GrotesqueMutation`.
+ */
+val GrotesqueMutationReprint = Printing(
+    oracleId = "058a8475-649f-433a-b258-42bc03bf40ba",
+    name = "Grotesque Mutation",
+    setCode = "J22",
+    collectorNumber = "425",
+    scryfallId = "9db61b56-6bfb-448f-ae6d-932d96760917",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9db61b56-6bfb-448f-ae6d-932d96760917.jpg?1783919000",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HavenwoodWurmReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HavenwoodWurmReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Havenwood Wurm reprint in J22. Canonical CardDefinition lives in Time Spiral (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.tsp.cards.HavenwoodWurm`.
+ */
+val HavenwoodWurmReprint = Printing(
+    oracleId = "a4ddff34-d0ae-481f-870b-b911b249250f",
+    name = "Havenwood Wurm",
+    setCode = "J22",
+    collectorNumber = "670",
+    scryfallId = "d3577918-58a0-4bcb-a037-f3932c1cdc8a",
+    artist = "Stuart Griffin",
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d3577918-58a0-4bcb-a037-f3932c1cdc8a.jpg?1783918867",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HedronArchiveReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HedronArchiveReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hedron Archive reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.HedronArchive`.
+ */
+val HedronArchiveReprint = Printing(
+    oracleId = "32263baa-d3f0-463f-92b3-4e9938476add",
+    name = "Hedron Archive",
+    setCode = "J22",
+    collectorNumber = "774",
+    scryfallId = "857d324d-3576-4f1a-9025-db84703ef10f",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/8/5/857d324d-3576-4f1a-9025-db84703ef10f.jpg?1783918810",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HieroglyphicIlluminationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HieroglyphicIlluminationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hieroglyphic Illumination reprint in J22. Canonical CardDefinition lives in Amonkhet (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.akh.cards.HieroglyphicIllumination`.
+ */
+val HieroglyphicIlluminationReprint = Printing(
+    oracleId = "60e358ec-eb11-4a16-a0ae-b7c064a8ea6c",
+    name = "Hieroglyphic Illumination",
+    setCode = "J22",
+    collectorNumber = "307",
+    scryfallId = "8cbaf939-e475-4fb6-b5cd-440632bba505",
+    artist = "Raoul Vitale",
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8cbaf939-e475-4fb6-b5cd-440632bba505.jpg?1783919056",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HootingMandrillsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HootingMandrillsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hooting Mandrills reprint in J22. Canonical CardDefinition lives in Khans of Tarkir (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ktk.cards.HootingMandrills`.
+ */
+val HootingMandrillsReprint = Printing(
+    oracleId = "70e35385-6129-4bd1-861c-df04469566b7",
+    name = "Hooting Mandrills",
+    setCode = "J22",
+    collectorNumber = "671",
+    scryfallId = "7829f217-4d59-442a-8a03-21bd93d84103",
+    artist = "Mike Bierek",
+    imageUri = "https://cards.scryfall.io/normal/front/7/8/7829f217-4d59-442a-8a03-21bd93d84103.jpg?1783918865",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HordelingOutburstReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HordelingOutburstReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hordeling Outburst reprint in J22. Canonical CardDefinition lives in Khans of Tarkir (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ktk.cards.HordelingOutburst`.
+ */
+val HordelingOutburstReprint = Printing(
+    oracleId = "a6450b8e-eb18-431c-9eb7-7daf107978b2",
+    name = "Hordeling Outburst",
+    setCode = "J22",
+    collectorNumber = "552",
+    scryfallId = "81b98d04-937e-47ee-8f97-775c77e33de9",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/8/1/81b98d04-937e-47ee-8f97-775c77e33de9.jpg?1783918938",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HourOfReckoningReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/HourOfReckoningReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hour of Reckoning reprint in J22. Canonical CardDefinition lives in Ravnica: City of Guilds (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rav.cards.HourOfReckoning`.
+ */
+val HourOfReckoningReprint = Printing(
+    oracleId = "3bc13640-03f8-4b19-b0a4-7e7cb5271c0c",
+    name = "Hour of Reckoning",
+    setCode = "J22",
+    collectorNumber = "194",
+    scryfallId = "a4c50249-4039-4442-bc6c-a9318f8ffe9d",
+    artist = "Joseph Meehan",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a4c50249-4039-4442-bc6c-a9318f8ffe9d.jpg?1783919110",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ImpeccableTimingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ImpeccableTimingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Impeccable Timing reprint in J22. Canonical CardDefinition lives in Kaladesh (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.kld.cards.ImpeccableTiming`.
+ */
+val ImpeccableTimingReprint = Printing(
+    oracleId = "102bbedf-9f84-433a-bd01-e1a4c05fbedb",
+    name = "Impeccable Timing",
+    setCode = "J22",
+    collectorNumber = "195",
+    scryfallId = "f4202dc3-3299-4bf3-a37e-78588e07bb1e",
+    artist = "Chris Rallis",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f4202dc3-3299-4bf3-a37e-78588e07bb1e.jpg?1783919109",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ImprovisedWeaponryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ImprovisedWeaponryReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Improvised Weaponry reprint in J22. Canonical CardDefinition lives in Adventures in the Forgotten Realms (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.afr.cards.ImprovisedWeaponry`.
+ */
+val ImprovisedWeaponryReprint = Printing(
+    oracleId = "fa5dad0b-8e23-4b88-b383-849f7318e01f",
+    name = "Improvised Weaponry",
+    setCode = "J22",
+    collectorNumber = "558",
+    scryfallId = "828a5005-0b19-49a2-bc9a-5b32c719c74c",
+    artist = "Alix Branwyn",
+    imageUri = "https://cards.scryfall.io/normal/front/8/2/828a5005-0b19-49a2-bc9a-5b32c719c74c.jpg?1783918932",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/InfantryVeteranReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/InfantryVeteranReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Infantry Veteran reprint in J22. Canonical CardDefinition lives in Visions (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.vis.cards.InfantryVeteran`.
+ */
+val InfantryVeteranReprint = Printing(
+    oracleId = "42798e2b-9a5c-4f93-8f77-b7bb7a916d07",
+    name = "Infantry Veteran",
+    setCode = "J22",
+    collectorNumber = "198",
+    scryfallId = "0d42086a-74b3-4700-b070-95e1357ae527",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0d42086a-74b3-4700-b070-95e1357ae527.jpg?1783919109",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/InspiringClericReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/InspiringClericReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspiring Cleric reprint in J22. Canonical CardDefinition lives in Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.xln.cards.InspiringCleric`.
+ */
+val InspiringClericReprint = Printing(
+    oracleId = "65e19aec-e8ea-412f-a239-bd8d1b78249c",
+    name = "Inspiring Cleric",
+    setCode = "J22",
+    collectorNumber = "199",
+    scryfallId = "adc56f47-ae0a-498b-8730-2096937887e5",
+    artist = "Randy Gallegos",
+    imageUri = "https://cards.scryfall.io/normal/front/a/d/adc56f47-ae0a-498b-8730-2096937887e5.jpg?1783919108",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/InspiringOverseerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/InspiringOverseerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspiring Overseer reprint in J22. Canonical CardDefinition lives in Streets of New Capenna (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.snc.cards.InspiringOverseer`.
+ */
+val InspiringOverseerReprint = Printing(
+    oracleId = "d646e42b-5635-4798-b633-29c093b66a55",
+    name = "Inspiring Overseer",
+    setCode = "J22",
+    collectorNumber = "200",
+    scryfallId = "fa372561-4c23-4aea-8186-9fcf8b230ce2",
+    artist = "Irina Nordsol",
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/fa372561-4c23-4aea-8186-9fcf8b230ce2.jpg?1783919107",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IronBullyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IronBullyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Iron Bully reprint in J22. Canonical CardDefinition lives in War of the Spark (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.war.cards.IronBully`.
+ */
+val IronBullyReprint = Printing(
+    oracleId = "7d78155c-c63f-48a3-86e5-12b80400d8de",
+    name = "Iron Bully",
+    setCode = "J22",
+    collectorNumber = "778",
+    scryfallId = "a3fd4e1d-359c-46b3-ae99-50a4b90b3032",
+    artist = "Aaron Miller",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a3fd4e1d-359c-46b3-ae99-50a4b90b3032.jpg?1783918808",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IronshellBeetleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IronshellBeetleReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ironshell Beetle reprint in J22. Canonical CardDefinition lives in Judgment (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.jud.cards.IronshellBeetle`.
+ */
+val IronshellBeetleReprint = Printing(
+    oracleId = "693ca077-2b91-4de1-8136-8fe45f8ea5a7",
+    name = "Ironshell Beetle",
+    setCode = "J22",
+    collectorNumber = "679",
+    scryfallId = "99ffe5ca-9b60-4882-ad17-5657bff0ae20",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/99ffe5ca-9b60-4882-ad17-5657bff0ae20.jpg?1783918863",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IrreverentRevelersReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IrreverentRevelersReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Irreverent Revelers reprint in J22. Canonical CardDefinition lives in Theros Beyond Death (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.thb.cards.IrreverentRevelers`.
+ */
+val IrreverentRevelersReprint = Printing(
+    oracleId = "05abc57a-839d-4376-986c-8e3855e34239",
+    name = "Irreverent Revelers",
+    setCode = "J22",
+    collectorNumber = "560",
+    scryfallId = "55c5690c-7c11-4b04-9a50-9d3dc6aa8d49",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/55c5690c-7c11-4b04-9a50-9d3dc6aa8d49.jpg?1783918929",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IsamaruHoundOfKondaReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IsamaruHoundOfKondaReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Isamaru, Hound of Konda reprint in J22. Canonical CardDefinition lives in Champions of Kamigawa (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.chk.cards.IsamaruHoundOfKonda`.
+ */
+val IsamaruHoundOfKondaReprint = Printing(
+    oracleId = "cfb756dd-6fe1-430a-8f04-8b10cac62a86",
+    name = "Isamaru, Hound of Konda",
+    setCode = "J22",
+    collectorNumber = "201",
+    scryfallId = "9e66b0f2-262e-4feb-8ae5-ad1f60b6611c",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9e66b0f2-262e-4feb-8ae5-ad1f60b6611c.jpg?1783919108",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IvyLaneDenizenReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IvyLaneDenizenReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ivy Lane Denizen reprint in J22. Canonical CardDefinition lives in Gatecrash (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.gtc.cards.IvyLaneDenizen`.
+ */
+val IvyLaneDenizenReprint = Printing(
+    oracleId = "a5da5ad6-4ed2-4041-a983-76a8c87fa109",
+    name = "Ivy Lane Denizen",
+    setCode = "J22",
+    collectorNumber = "680",
+    scryfallId = "90202611-961d-48b5-87b6-58486b572216",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/90202611-961d-48b5-87b6-58486b572216.jpg?1783918862",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/Jumpstart2022BasicLands.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/Jumpstart2022BasicLands.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Jumpstart 2022 Basic Lands
+ *
+ * One art variant per basic land type. `CardDiscovery.findBasicLandsIn` picks these up from
+ * the set object and stamps them with the J22 set code.
+ */
+
+val Jumpstart2022Plains98 = basicLand("Plains") {
+    collectorNumber = "98"
+    artist = "John Avon"
+    imageUri = "https://cards.scryfall.io/normal/front/0/a/0a479838-b6b1-4d83-9104-0a79f3b934c7.jpg?1783919156"
+}
+
+val Jumpstart2022Plains99 = basicLand("Plains") {
+    collectorNumber = "99"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/464fa166-82be-4f28-8fd8-0c9cc4393012.jpg?1783919154"
+}
+
+val Jumpstart2022Plains100 = basicLand("Plains") {
+    collectorNumber = "100"
+    artist = "Daniel Ljunggren"
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9d4b8bde-412b-4d12-b296-7364c95e0510.jpg?1783919153"
+}
+
+val Jumpstart2022Island101 = basicLand("Island") {
+    collectorNumber = "101"
+    artist = "Cliff Childs"
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b0559d67-e151-4c6b-b8eb-5e9b5603f487.jpg?1783919151"
+}
+
+val Jumpstart2022Island102 = basicLand("Island") {
+    collectorNumber = "102"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/49050cb4-1d8b-4f2f-ba48-206a107eb09c.jpg?1783919152"
+}
+
+val Jumpstart2022Island103 = basicLand("Island") {
+    collectorNumber = "103"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/4237eaa8-1169-47b2-9009-ac529831a36e.jpg?1783919151"
+}
+
+val Jumpstart2022Swamp104 = basicLand("Swamp") {
+    collectorNumber = "104"
+    artist = "Mike Bierek"
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/42fec83d-8260-478e-a20f-94d265036e31.jpg?1783919151"
+}
+
+val Jumpstart2022Swamp105 = basicLand("Swamp") {
+    collectorNumber = "105"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b7a442a-16a0-459a-8c24-cd0c72edee03.jpg?1783919150"
+}
+
+val Jumpstart2022Swamp106 = basicLand("Swamp") {
+    collectorNumber = "106"
+    artist = "Alexander Forssberg"
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c802ec1c-4d12-45d0-930b-6b4ca77487e8.jpg?1783919149"
+}
+
+val Jumpstart2022Mountain107 = basicLand("Mountain") {
+    collectorNumber = "107"
+    artist = "Sam Burley"
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/577aff75-67f7-42c8-b31f-50026c5ba5c6.jpg?1783919149"
+}
+
+val Jumpstart2022Mountain108 = basicLand("Mountain") {
+    collectorNumber = "108"
+    artist = "Piotr Dura"
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/52c79d57-a8eb-427d-86ac-b203c0bb7cda.jpg?1783919149"
+}
+
+val Jumpstart2022Mountain109 = basicLand("Mountain") {
+    collectorNumber = "109"
+    artist = "Andreas Rocha"
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a1cfd796-50a5-404f-acc1-21dbf543ccc1.jpg?1783919149"
+}
+
+val Jumpstart2022Forest110 = basicLand("Forest") {
+    collectorNumber = "110"
+    artist = "Volkan Baǵa"
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/cee97ab6-8e81-4396-a788-db0ed0da62d2.jpg?1783919150"
+}
+
+val Jumpstart2022Forest111 = basicLand("Forest") {
+    collectorNumber = "111"
+    artist = "Steven Belledin"
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee56689a-da7b-4cd7-8767-e3f514b6db9e.jpg?1783919148"
+}
+
+val Jumpstart2022Forest112 = basicLand("Forest") {
+    collectorNumber = "112"
+    artist = "Jim Nelson"
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/900eedf8-71b0-4b82-9709-019018bc29fe.jpg?1783919147"
+}
+
+val Jumpstart2022Wastes834 = basicLand("Wastes") {
+    collectorNumber = "834"
+    artist = "Jason Felix"
+    imageUri = "https://cards.scryfall.io/normal/front/5/6/56ef693d-7c48-46cb-8f52-abc660a2736e.jpg?1783918782"
+}
+
+/**
+ * All Jumpstart 2022 basic land variants.
+ */
+val Jumpstart2022BasicLands = listOf(
+    Jumpstart2022Plains98,
+    Jumpstart2022Plains99,
+    Jumpstart2022Plains100,
+    Jumpstart2022Island101,
+    Jumpstart2022Island102,
+    Jumpstart2022Island103,
+    Jumpstart2022Swamp104,
+    Jumpstart2022Swamp105,
+    Jumpstart2022Swamp106,
+    Jumpstart2022Mountain107,
+    Jumpstart2022Mountain108,
+    Jumpstart2022Mountain109,
+    Jumpstart2022Forest110,
+    Jumpstart2022Forest111,
+    Jumpstart2022Forest112,
+    Jumpstart2022Wastes834,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KamiOfAncientLawReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KamiOfAncientLawReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kami of Ancient Law reprint in J22. Canonical CardDefinition lives in Champions of Kamigawa (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.chk.cards.KamiOfAncientLaw`.
+ */
+val KamiOfAncientLawReprint = Printing(
+    oracleId = "e937e0f5-ca35-4dce-9f05-8f2075731628",
+    name = "Kami of Ancient Law",
+    setCode = "J22",
+    collectorNumber = "203",
+    scryfallId = "4d39bae5-780c-489c-87b6-4a60336afe31",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/4/d/4d39bae5-780c-489c-87b6-4a60336afe31.jpg?1783919106",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KarganDragonriderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KarganDragonriderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kargan Dragonrider reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.KarganDragonrider`.
+ */
+val KarganDragonriderReprint = Printing(
+    oracleId = "df366871-8ed7-4183-8b0c-414ca361a711",
+    name = "Kargan Dragonrider",
+    setCode = "J22",
+    collectorNumber = "561",
+    scryfallId = "069b3c69-ee4c-4fc9-981e-62db77f9821d",
+    artist = "Greg Opalinski",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/069b3c69-ee4c-4fc9-981e-62db77f9821d.jpg?1783918930",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KingOfThePrideReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KingOfThePrideReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * King of the Pride reprint in J22. Canonical CardDefinition lives in Modern Horizons (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mh1.cards.KingOfThePride`.
+ */
+val KingOfThePrideReprint = Printing(
+    oracleId = "96d0e4dd-6cc2-4349-ac44-785b50f8dd90",
+    name = "King of the Pride",
+    setCode = "J22",
+    collectorNumber = "57",
+    scryfallId = "56b8343f-0554-42b1-9e32-431dcc4b0346",
+    artist = "Inuchiyo Meimaru",
+    imageUri = "https://cards.scryfall.io/normal/front/5/6/56b8343f-0554-42b1-9e32-431dcc4b0346.jpg?1783919174",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KitesailReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KitesailReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kitesail reprint in J22. Canonical CardDefinition lives in Worldwake (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.wwk.cards.Kitesail`.
+ */
+val KitesailReprint = Printing(
+    oracleId = "b079f9db-974d-4525-a894-57b754ba9dcc",
+    name = "Kitesail",
+    setCode = "J22",
+    collectorNumber = "781",
+    scryfallId = "557dc342-b265-4370-969e-ecb9de5bc01d",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/5/5/557dc342-b265-4370-969e-ecb9de5bc01d.jpg?1783918805",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KraulWarriorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KraulWarriorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kraul Warrior reprint in J22. Canonical CardDefinition lives in Dragon's Maze (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dgm.cards.KraulWarrior`.
+ */
+val KraulWarriorReprint = Printing(
+    oracleId = "b05d000d-39b4-4db5-bd32-9c77a7434127",
+    name = "Kraul Warrior",
+    setCode = "J22",
+    collectorNumber = "684",
+    scryfallId = "6fd7b87d-cd5c-45de-a7bd-e834337f3400",
+    artist = "David Rapoza",
+    imageUri = "https://cards.scryfall.io/normal/front/6/f/6fd7b87d-cd5c-45de-a7bd-e834337f3400.jpg?1783918862",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KujarSeedsculptorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/KujarSeedsculptorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kujar Seedsculptor reprint in J22. Canonical CardDefinition lives in Kaladesh (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.kld.cards.KujarSeedsculptor`.
+ */
+val KujarSeedsculptorReprint = Printing(
+    oracleId = "93f817c7-2a3d-4346-94c1-3ba8bafb485d",
+    name = "Kujar Seedsculptor",
+    setCode = "J22",
+    collectorNumber = "685",
+    scryfallId = "aa8d81bf-a573-441f-9593-41af41d927d2",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa8d81bf-a573-441f-9593-41af41d927d2.jpg?1783918859",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LathlissDragonQueenReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LathlissDragonQueenReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lathliss, Dragon Queen reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.LathlissDragonQueen`.
+ */
+val LathlissDragonQueenReprint = Printing(
+    oracleId = "15fef45d-f1a9-49b2-abaa-fe77bb9d1afd",
+    name = "Lathliss, Dragon Queen",
+    setCode = "J22",
+    collectorNumber = "566",
+    scryfallId = "8435c03c-b9a2-40fa-a979-879bd120a011",
+    artist = "Alex Konstad",
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/8435c03c-b9a2-40fa-a979-879bd120a011.jpg?1783918928",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LavaSerpentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LavaSerpentReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lava Serpent reprint in J22. Canonical CardDefinition lives in Ikoria: Lair of Behemoths (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.iko.cards.LavaSerpent`.
+ */
+val LavaSerpentReprint = Printing(
+    oracleId = "4d94d807-97d9-4cdf-a63c-d8b82c2acc6e",
+    name = "Lava Serpent",
+    setCode = "J22",
+    collectorNumber = "567",
+    scryfallId = "772df6a2-315b-4516-93e1-623a90b802c7",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/772df6a2-315b-4516-93e1-623a90b802c7.jpg?1783918927",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LavastepRaiderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LavastepRaiderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lavastep Raider reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.LavastepRaider`.
+ */
+val LavastepRaiderReprint = Printing(
+    oracleId = "3a96782b-e9c8-4bc5-845d-45f6bf7b8dc4",
+    name = "Lavastep Raider",
+    setCode = "J22",
+    collectorNumber = "568",
+    scryfallId = "761a6b01-1a0e-46bb-8576-80eaf2490f21",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/761a6b01-1a0e-46bb-8576-80eaf2490f21.jpg?1783918930",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LeoninScimitarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LeoninScimitarReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leonin Scimitar reprint in J22. Canonical CardDefinition lives in Mirrodin (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mrd.cards.LeoninScimitar`.
+ */
+val LeoninScimitarReprint = Printing(
+    oracleId = "cde26d69-f3e7-4dd0-a53b-cd0ec812d717",
+    name = "Leonin Scimitar",
+    setCode = "J22",
+    collectorNumber = "782",
+    scryfallId = "7f30adfa-2581-47ca-946f-d1a193523be3",
+    artist = "Doug Chaffee",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7f30adfa-2581-47ca-946f-d1a193523be3.jpg?1783918803",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LeoninSnarecasterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LeoninSnarecasterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Leonin Snarecaster reprint in J22. Canonical CardDefinition lives in Theros (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ths.cards.LeoninSnarecaster`.
+ */
+val LeoninSnarecasterReprint = Printing(
+    oracleId = "75f269df-ee49-44db-b256-4d005e3022fb",
+    name = "Leonin Snarecaster",
+    setCode = "J22",
+    collectorNumber = "207",
+    scryfallId = "708124d5-8447-4c22-a3c9-268ccece7854",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/708124d5-8447-4c22-a3c9-268ccece7854.jpg?1783919103",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LibraryLarcenistReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LibraryLarcenistReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Library Larcenist reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.LibraryLarcenist`.
+ */
+val LibraryLarcenistReprint = Printing(
+    oracleId = "eb0e6f63-2861-4392-ac0e-64380fbbd8ae",
+    name = "Library Larcenist",
+    setCode = "J22",
+    collectorNumber = "314",
+    scryfallId = "fa3287f1-aaef-4db2-bed6-63fc7dfa39c7",
+    artist = "Mila Pesic",
+    imageUri = "https://cards.scryfall.io/normal/front/f/a/fa3287f1-aaef-4db2-bed6-63fc7dfa39c7.jpg?1783919052",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LightOfHopeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LightOfHopeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Light of Hope reprint in J22. Canonical CardDefinition lives in Ikoria: Lair of Behemoths (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.iko.cards.LightOfHope`.
+ */
+val LightOfHopeReprint = Printing(
+    oracleId = "5b6f655b-1518-4ab1-8765-3f549819ef3b",
+    name = "Light of Hope",
+    setCode = "J22",
+    collectorNumber = "209",
+    scryfallId = "83fcdd23-7535-4995-b5db-c004bfc40566",
+    artist = "Kimonas Theodossiou",
+    imageUri = "https://cards.scryfall.io/normal/front/8/3/83fcdd23-7535-4995-b5db-c004bfc40566.jpg?1783919103",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LilianasMasteryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LilianasMasteryReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Liliana's Mastery reprint in J22. Canonical CardDefinition lives in Amonkhet (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.akh.cards.LilianasMastery`.
+ */
+val LilianasMasteryReprint = Printing(
+    oracleId = "bd104c7e-311e-4b03-98d3-5f20f3a99d26",
+    name = "Liliana's Mastery",
+    setCode = "J22",
+    collectorNumber = "435",
+    scryfallId = "e28b5fce-ac73-44ec-be2c-c95d8d3579fe",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e28b5fce-ac73-44ec-be2c-c95d8d3579fe.jpg?1783918995",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LocthwainGargoyleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LocthwainGargoyleReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Locthwain Gargoyle reprint in J22. Canonical CardDefinition lives in Throne of Eldraine (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.eld.cards.LocthwainGargoyle`.
+ */
+val LocthwainGargoyleReprint = Printing(
+    oracleId = "d8a04142-1d28-4c2e-b2d5-da88b2199678",
+    name = "Locthwain Gargoyle",
+    setCode = "J22",
+    collectorNumber = "783",
+    scryfallId = "372b3c3a-ed78-43a1-b117-9e2793d77bbc",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/372b3c3a-ed78-43a1-b117-9e2793d77bbc.jpg?1783918805",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LordOfTheAccursedReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LordOfTheAccursedReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lord of the Accursed reprint in J22. Canonical CardDefinition lives in Amonkhet (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.akh.cards.LordOfTheAccursed`.
+ */
+val LordOfTheAccursedReprint = Printing(
+    oracleId = "3f372107-6c52-4f1f-8bf0-7b3fa21b2cae",
+    name = "Lord of the Accursed",
+    setCode = "J22",
+    collectorNumber = "69",
+    scryfallId = "d67c2c4c-f593-4e46-910c-616d3135a8b1",
+    artist = "Yuichi Murakami",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d67c2c4c-f593-4e46-910c-616d3135a8b1.jpg?1783919167",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LoxodonWarhammerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LoxodonWarhammerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Loxodon Warhammer reprint in J22. Canonical CardDefinition lives in Mirrodin (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mrd.cards.LoxodonWarhammer`.
+ */
+val LoxodonWarhammerReprint = Printing(
+    oracleId = "dba35ac5-7ad3-488a-a006-6b9a1d54eea5",
+    name = "Loxodon Warhammer",
+    setCode = "J22",
+    collectorNumber = "784",
+    scryfallId = "ebca896a-6f1e-4235-a725-aa5d57c06181",
+    artist = "Jeremy Jarvis",
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/ebca896a-6f1e-4235-a725-aa5d57c06181.jpg?1783918803",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LumengridSentinelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/LumengridSentinelReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lumengrid Sentinel reprint in J22. Canonical CardDefinition lives in Mirrodin (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mrd.cards.LumengridSentinel`.
+ */
+val LumengridSentinelReprint = Printing(
+    oracleId = "ede92fb6-dfd6-40b4-b58f-af1f7a155efc",
+    name = "Lumengrid Sentinel",
+    setCode = "J22",
+    collectorNumber = "317",
+    scryfallId = "f8763fe5-ae09-48c9-ada6-0b05f3c0adc3",
+    artist = "Scott M. Fischer",
+    imageUri = "https://cards.scryfall.io/normal/front/f/8/f8763fe5-ae09-48c9-ada6-0b05f3c0adc3.jpg?1783919050",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MaalfeldTwinsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MaalfeldTwinsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Maalfeld Twins reprint in J22. Canonical CardDefinition lives in Avacyn Restored (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.avr.cards.MaalfeldTwins`.
+ */
+val MaalfeldTwinsReprint = Printing(
+    oracleId = "dda4b515-49c0-43fe-9f6a-36defa326bb1",
+    name = "Maalfeld Twins",
+    setCode = "J22",
+    collectorNumber = "438",
+    scryfallId = "7c8cce8a-43b4-42aa-abbd-0835583e74bd",
+    artist = "Mike Sass",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c8cce8a-43b4-42aa-abbd-0835583e74bd.jpg?1783918995",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MakeAStandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MakeAStandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Make a Stand reprint in J22. Canonical CardDefinition lives in Oath of the Gatewatch (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ogw.cards.MakeAStand`.
+ */
+val MakeAStandReprint = Printing(
+    oracleId = "531f78d5-5004-4b02-99c7-b390cb342fd9",
+    name = "Make a Stand",
+    setCode = "J22",
+    collectorNumber = "211",
+    scryfallId = "38d0d4a3-7ce9-4881-a94b-bac5cbbf4dc0",
+    artist = "Magali Villeneuve",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/38d0d4a3-7ce9-4881-a94b-bac5cbbf4dc0.jpg?1783919101",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MammothSpiderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MammothSpiderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mammoth Spider reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.MammothSpider`.
+ */
+val MammothSpiderReprint = Printing(
+    oracleId = "df77cb98-e3c6-4927-99d5-c3380641f356",
+    name = "Mammoth Spider",
+    setCode = "J22",
+    collectorNumber = "687",
+    scryfallId = "aac46277-1980-40aa-8356-dd283bda297b",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aac46277-1980-40aa-8356-dd283bda297b.jpg?1783918859",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ManakinReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ManakinReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Manakin reprint in J22. Canonical CardDefinition lives in Tempest (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.tmp.cards.Manakin`.
+ */
+val ManakinReprint = Printing(
+    oracleId = "d2343af0-468b-42bc-8a0c-347c10f7e2f3",
+    name = "Manakin",
+    setCode = "J22",
+    collectorNumber = "785",
+    scryfallId = "9990b3d4-50cd-4c54-9068-5403796ab394",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/9990b3d4-50cd-4c54-9068-5403796ab394.jpg?1783918804",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MausoleumGuardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MausoleumGuardReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mausoleum Guard reprint in J22. Canonical CardDefinition lives in Innistrad (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.isd.cards.MausoleumGuard`.
+ */
+val MausoleumGuardReprint = Printing(
+    oracleId = "64f3af46-f8ab-4ba4-9dff-7412cefb4eea",
+    name = "Mausoleum Guard",
+    setCode = "J22",
+    collectorNumber = "213",
+    scryfallId = "43227caf-f902-46b4-936f-125d879eb54a",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/4/3/43227caf-f902-46b4-936f-125d879eb54a.jpg?1783919102",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MemorialToGeniusReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MemorialToGeniusReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Memorial to Genius reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.MemorialToGenius`.
+ */
+val MemorialToGeniusReprint = Printing(
+    oracleId = "81763d7d-3897-4be9-bbf6-f6f5dee366ff",
+    name = "Memorial to Genius",
+    setCode = "J22",
+    collectorNumber = "815",
+    scryfallId = "238a5103-6688-4fe5-ab93-b949afd0c2ca",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/238a5103-6688-4fe5-ab93-b949afd0c2ca.jpg?1783918789",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MerfolkSovereignReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MerfolkSovereignReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Merfolk Sovereign reprint in J22. Canonical CardDefinition lives in Magic 2010 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m10.cards.MerfolkSovereign`.
+ */
+val MerfolkSovereignReprint = Printing(
+    oracleId = "16aba9af-7a12-4c3d-87eb-06278921cb7c",
+    name = "Merfolk Sovereign",
+    setCode = "J22",
+    collectorNumber = "321",
+    scryfallId = "7a6436ac-e129-461c-a40d-9388ec7a0d27",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/7/a/7a6436ac-e129-461c-a40d-9388ec7a0d27.jpg?1783919050",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MeteorGolemReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MeteorGolemReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meteor Golem reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.MeteorGolem`.
+ */
+val MeteorGolemReprint = Printing(
+    oracleId = "d9f11aa1-9219-42a8-85a9-a8f204160706",
+    name = "Meteor Golem",
+    setCode = "J22",
+    collectorNumber = "786",
+    scryfallId = "64cda05e-a1c8-451f-9d1f-b47b4e2b1e95",
+    artist = "Lake Hurwitz",
+    imageUri = "https://cards.scryfall.io/normal/front/6/4/64cda05e-a1c8-451f-9d1f-b47b4e2b1e95.jpg?1783918802",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MidnightGuardReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MidnightGuardReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Midnight Guard reprint in J22. Canonical CardDefinition lives in Dark Ascension (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dka.cards.MidnightGuard`.
+ */
+val MidnightGuardReprint = Printing(
+    oracleId = "f5430b0e-e77f-47b8-ae6d-30bcff4d7e35",
+    name = "Midnight Guard",
+    setCode = "J22",
+    collectorNumber = "216",
+    scryfallId = "9185d2cc-5380-4be1-ab67-a755b2e02016",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/9185d2cc-5380-4be1-ab67-a755b2e02016.jpg?1783919099",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MiraculousRecoveryReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MiraculousRecoveryReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Miraculous Recovery reprint in J22. Canonical CardDefinition lives in Visions (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.vis.cards.MiraculousRecovery`.
+ */
+val MiraculousRecoveryReprint = Printing(
+    oracleId = "cea73a4b-e10a-4517-a92b-24a08321009f",
+    name = "Miraculous Recovery",
+    setCode = "J22",
+    collectorNumber = "217",
+    scryfallId = "a193b7b6-0ec6-4225-9f23-67294a957f06",
+    artist = "Mark Winters",
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a193b7b6-0ec6-4225-9f23-67294a957f06.jpg?1783919100",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MistwalkerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MistwalkerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mistwalker reprint in J22. Canonical CardDefinition lives in Kaldheim (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.khm.cards.Mistwalker`.
+ */
+val MistwalkerReprint = Printing(
+    oracleId = "ceb302df-d67e-4e5d-aca0-f53bcdea658d",
+    name = "Mistwalker",
+    setCode = "J22",
+    collectorNumber = "323",
+    scryfallId = "a397551c-5609-4353-aa43-504af1b27f5a",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a397551c-5609-4353-aa43-504af1b27f5a.jpg?1783919049",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MomentOfCravingReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MomentOfCravingReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moment of Craving reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.MomentOfCraving`.
+ */
+val MomentOfCravingReprint = Printing(
+    oracleId = "1489551f-5714-471b-a0e6-f40bc3085afc",
+    name = "Moment of Craving",
+    setCode = "J22",
+    collectorNumber = "444",
+    scryfallId = "a506f54f-b25b-4b15-99b9-cdf0af9df79a",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a506f54f-b25b-4b15-99b9-cdf0af9df79a.jpg?1783918991",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MomentOfTriumphReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MomentOfTriumphReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moment of Triumph reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.MomentOfTriumph`.
+ */
+val MomentOfTriumphReprint = Printing(
+    oracleId = "57579799-2582-417f-9864-4560cac39ac3",
+    name = "Moment of Triumph",
+    setCode = "J22",
+    collectorNumber = "218",
+    scryfallId = "3ffffb3e-253e-4e93-9ed1-9c2455220dac",
+    artist = "Steven Belledin",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3ffffb3e-253e-4e93-9ed1-9c2455220dac.jpg?1783919100",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MudbuttonTorchrunnerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MudbuttonTorchrunnerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mudbutton Torchrunner reprint in J22. Canonical CardDefinition lives in Lorwyn (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.lrw.cards.MudbuttonTorchrunner`.
+ */
+val MudbuttonTorchrunnerReprint = Printing(
+    oracleId = "045b2b84-96bd-46fb-8aae-a33968e741c7",
+    name = "Mudbutton Torchrunner",
+    setCode = "J22",
+    collectorNumber = "574",
+    scryfallId = "d696b42b-02c7-4389-bc37-15fa1fa4f01b",
+    artist = "Steve Ellis",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d696b42b-02c7-4389-bc37-15fa1fa4f01b.jpg?1783918923",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NestRobberReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NestRobberReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nest Robber reprint in J22. Canonical CardDefinition lives in Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.xln.cards.NestRobber`.
+ */
+val NestRobberReprint = Printing(
+    oracleId = "b909ff27-423f-4e84-887b-7840149a85be",
+    name = "Nest Robber",
+    setCode = "J22",
+    collectorNumber = "576",
+    scryfallId = "3135dfde-ad52-4b93-9356-107d0efad93c",
+    artist = "Jonathan Kuo",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/3135dfde-ad52-4b93-9356-107d0efad93c.jpg?1783918921",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NeutralizeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NeutralizeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Neutralize reprint in J22. Canonical CardDefinition lives in Ikoria: Lair of Behemoths (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.iko.cards.Neutralize`.
+ */
+val NeutralizeReprint = Printing(
+    oracleId = "c2c60973-b4d5-43fa-a0c4-b5688b28df05",
+    name = "Neutralize",
+    setCode = "J22",
+    collectorNumber = "327",
+    scryfallId = "3a897be4-95e2-4fab-bd08-565afe19533b",
+    artist = "Yongjae Choi",
+    imageUri = "https://cards.scryfall.io/normal/front/3/a/3a897be4-95e2-4fab-bd08-565afe19533b.jpg?1783919048",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NezumiBoneReaderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NezumiBoneReaderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nezumi Bone-Reader reprint in J22. Canonical CardDefinition lives in Champions of Kamigawa (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.chk.cards.NezumiBoneReader`.
+ */
+val NezumiBoneReaderReprint = Printing(
+    oracleId = "c77f8fee-8d2d-4cec-948f-2ca3e5b64070",
+    name = "Nezumi Bone-Reader",
+    setCode = "J22",
+    collectorNumber = "122",
+    scryfallId = "8987aa13-8d61-4db7-9680-63421e729325",
+    artist = "Leonardo Santanna",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/8987aa13-8d61-4db7-9680-63421e729325.jpg?1783919143",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NightguardPatrolReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/NightguardPatrolReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nightguard Patrol reprint in J22. Canonical CardDefinition lives in Ravnica: City of Guilds (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rav.cards.NightguardPatrol`.
+ */
+val NightguardPatrolReprint = Printing(
+    oracleId = "bb482f90-5624-4e2c-9916-85fb09a3639a",
+    name = "Nightguard Patrol",
+    setCode = "J22",
+    collectorNumber = "220",
+    scryfallId = "eb360f53-0013-4c0e-b7db-d2fc8029473a",
+    artist = "Dany Orizio",
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/eb360f53-0013-4c0e-b7db-d2fc8029473a.jpg?1783919097",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OctoprophetReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OctoprophetReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Octoprophet reprint in J22. Canonical CardDefinition lives in Core Set 2020 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m20.cards.Octoprophet`.
+ */
+val OctoprophetReprint = Printing(
+    oracleId = "af6cfc23-b64b-4c8a-94b4-69d2b01cb3b9",
+    name = "Octoprophet",
+    setCode = "J22",
+    collectorNumber = "329",
+    scryfallId = "84622757-064b-4323-b4ea-0a87084f57cd",
+    artist = "Grzegorz Rutkowski",
+    imageUri = "https://cards.scryfall.io/normal/front/8/4/84622757-064b-4323-b4ea-0a87084f57cd.jpg?1783919045",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OneWithTheWindReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OneWithTheWindReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * One With the Wind reprint in J22. Canonical CardDefinition lives in Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.xln.cards.OneWithTheWind`.
+ */
+val OneWithTheWindReprint = Printing(
+    oracleId = "9203bee0-718a-4ede-9556-5521417c4080",
+    name = "One With the Wind",
+    setCode = "J22",
+    collectorNumber = "330",
+    scryfallId = "2a897196-85d0-4e49-a617-b30fb33b145a",
+    artist = "Naomi Baker",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2a897196-85d0-4e49-a617-b30fb33b145a.jpg?1783919045",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OrderOfTheGoldenCricketReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OrderOfTheGoldenCricketReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Order of the Golden Cricket reprint in J22. Canonical CardDefinition lives in Morningtide (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mor.cards.OrderOfTheGoldenCricket`.
+ */
+val OrderOfTheGoldenCricketReprint = Printing(
+    oracleId = "02abe85a-c603-4963-aba4-524cc80847ea",
+    name = "Order of the Golden Cricket",
+    setCode = "J22",
+    collectorNumber = "223",
+    scryfallId = "bfcf25b6-b4a6-4077-b827-3d44a6f5d744",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bfcf25b6-b4a6-4077-b827-3d44a6f5d744.jpg?1783919097",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OrneryDilophosaurReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OrneryDilophosaurReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ornery Dilophosaur reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.OrneryDilophosaur`.
+ */
+val OrneryDilophosaurReprint = Printing(
+    oracleId = "8291bc2e-ef58-4bd4-b261-b587142bbb1c",
+    name = "Ornery Dilophosaur",
+    setCode = "J22",
+    collectorNumber = "700",
+    scryfallId = "2ac24ccd-8db0-4c93-9542-0eac3b369d61",
+    artist = "Jonathan Kuo",
+    imageUri = "https://cards.scryfall.io/normal/front/2/a/2ac24ccd-8db0-4c93-9542-0eac3b369d61.jpg?1783918851",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OutnumberReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OutnumberReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Outnumber reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.Outnumber`.
+ */
+val OutnumberReprint = Printing(
+    oracleId = "b72efd67-a234-44af-8296-3e182292c7e6",
+    name = "Outnumber",
+    setCode = "J22",
+    collectorNumber = "578",
+    scryfallId = "cf73acce-3159-458b-a0d3-28a02959b7f5",
+    artist = "Tyler Jacobson",
+    imageUri = "https://cards.scryfall.io/normal/front/c/f/cf73acce-3159-458b-a0d3-28a02959b7f5.jpg?1783918921",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OvercomeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/OvercomeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Overcome reprint in J22. Canonical CardDefinition lives in Hour of Devastation (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.hou.cards.Overcome`.
+ */
+val OvercomeReprint = Printing(
+    oracleId = "15353e27-96ca-48c7-83d7-efd57c094643",
+    name = "Overcome",
+    setCode = "J22",
+    collectorNumber = "701",
+    scryfallId = "012f1dab-24c5-4bcd-bcc0-d282f28c8689",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/012f1dab-24c5-4bcd-bcc0-d282f28c8689.jpg?1783918851",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PestilentWolfReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PestilentWolfReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pestilent Wolf reprint in J22. Canonical CardDefinition lives in Innistrad: Midnight Hunt (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mid.cards.PestilentWolf`.
+ */
+val PestilentWolfReprint = Printing(
+    oracleId = "39940633-ef64-408e-ae8f-ade201fe7f06",
+    name = "Pestilent Wolf",
+    setCode = "J22",
+    collectorNumber = "705",
+    scryfallId = "ed46aa9c-bcf1-4853-abbe-8bae3499aa2d",
+    artist = "Oriana Menendez",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed46aa9c-bcf1-4853-abbe-8bae3499aa2d.jpg?1783918846",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PhyrexianDebaserReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PhyrexianDebaserReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Debaser reprint in J22. Canonical CardDefinition lives in Urza's Legacy (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ulg.cards.PhyrexianDebaser`.
+ */
+val PhyrexianDebaserReprint = Printing(
+    oracleId = "554de904-086c-428c-9f32-b0b2498a6fd5",
+    name = "Phyrexian Debaser",
+    setCode = "J22",
+    collectorNumber = "454",
+    scryfallId = "80f3efc2-2b36-4e69-8bcc-54385b78519a",
+    artist = "Mark Tedin",
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80f3efc2-2b36-4e69-8bcc-54385b78519a.jpg?1783918986",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PhyrexianPlaguelordReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PhyrexianPlaguelordReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Plaguelord reprint in J22. Canonical CardDefinition lives in Urza's Legacy (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ulg.cards.PhyrexianPlaguelord`.
+ */
+val PhyrexianPlaguelordReprint = Printing(
+    oracleId = "aff9e844-9e03-490b-b44f-10d385738cc6",
+    name = "Phyrexian Plaguelord",
+    setCode = "J22",
+    collectorNumber = "123",
+    scryfallId = "9e537802-164f-4ba2-8f3a-9ebc845e05fd",
+    artist = "Raf Kayupov",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9e537802-164f-4ba2-8f3a-9ebc845e05fd.jpg?1783919143",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PhyrexianReclamationReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PhyrexianReclamationReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Phyrexian Reclamation reprint in J22. Canonical CardDefinition lives in Urza's Legacy (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ulg.cards.PhyrexianReclamation`.
+ */
+val PhyrexianReclamationReprint = Printing(
+    oracleId = "647ca69e-cc01-4b2b-b376-bee2a98331e8",
+    name = "Phyrexian Reclamation",
+    setCode = "J22",
+    collectorNumber = "124",
+    scryfallId = "b27a82ea-6d35-4121-84bb-93adff381f99",
+    artist = "Irina Nordsol",
+    imageUri = "https://cards.scryfall.io/normal/front/b/2/b27a82ea-6d35-4121-84bb-93adff381f99.jpg?1783919142",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PilgrimsEyeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PilgrimsEyeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pilgrim's Eye reprint in J22. Canonical CardDefinition lives in Worldwake (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.wwk.cards.PilgrimsEye`.
+ */
+val PilgrimsEyeReprint = Printing(
+    oracleId = "66155010-cc2c-449a-85d5-92c95aade514",
+    name = "Pilgrim's Eye",
+    setCode = "J22",
+    collectorNumber = "791",
+    scryfallId = "c8ec1dd3-cc5c-4bd1-b9a8-b3035e67a290",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/c/8/c8ec1dd3-cc5c-4bd1-b9a8-b3035e67a290.jpg?1783918801",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PiousWayfarerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PiousWayfarerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pious Wayfarer reprint in J22. Canonical CardDefinition lives in Theros Beyond Death (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.thb.cards.PiousWayfarer`.
+ */
+val PiousWayfarerReprint = Printing(
+    oracleId = "8790c7be-c14a-4293-bc4a-3d0efe42ed79",
+    name = "Pious Wayfarer",
+    setCode = "J22",
+    collectorNumber = "227",
+    scryfallId = "52429695-4146-4b68-98b7-72b31c854070",
+    artist = "Mark Zug",
+    imageUri = "https://cards.scryfall.io/normal/front/5/2/52429695-4146-4b68-98b7-72b31c854070.jpg?1783919094",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PiranhaMarshReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PiranhaMarshReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Piranha Marsh reprint in J22. Canonical CardDefinition lives in Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.zen.cards.PiranhaMarsh`.
+ */
+val PiranhaMarshReprint = Printing(
+    oracleId = "6bc8fd7e-7616-484a-ac23-04d37c93733b",
+    name = "Piranha Marsh",
+    setCode = "J22",
+    collectorNumber = "818",
+    scryfallId = "9332ac39-1a34-42e2-9c84-645cbf1721cf",
+    artist = "Nic Klein",
+    imageUri = "https://cards.scryfall.io/normal/front/9/3/9332ac39-1a34-42e2-9c84-645cbf1721cf.jpg?1783918789",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PlagueSpitterReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PlagueSpitterReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Plague Spitter reprint in J22. Canonical CardDefinition lives in Invasion (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.inv.cards.PlagueSpitter`.
+ */
+val PlagueSpitterReprint = Printing(
+    oracleId = "5feedfb0-30e6-400d-9e28-d541ea1aa14e",
+    name = "Plague Spitter",
+    setCode = "J22",
+    collectorNumber = "456",
+    scryfallId = "ae7c8cfe-79b1-463e-a0bd-5bc003ce26cd",
+    artist = "Chippy",
+    imageUri = "https://cards.scryfall.io/normal/front/a/e/ae7c8cfe-79b1-463e-a0bd-5bc003ce26cd.jpg?1783918985",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PreordainReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PreordainReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Preordain reprint in J22. Canonical CardDefinition lives in Magic 2011 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m11.cards.Preordain`.
+ */
+val PreordainReprint = Printing(
+    oracleId = "ac641490-ca14-48d7-8cc4-b69ce984befa",
+    name = "Preordain",
+    setCode = "J22",
+    collectorNumber = "63",
+    scryfallId = "c95460ec-153d-4fe0-a261-f9840a174308",
+    artist = "Ayuko",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c95460ec-153d-4fe0-a261-f9840a174308.jpg?1783919170",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PriestOfTheBloodRiteReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/PriestOfTheBloodRiteReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Priest of the Blood Rite reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.PriestOfTheBloodRite`.
+ */
+val PriestOfTheBloodRiteReprint = Printing(
+    oracleId = "441cdd7d-6c4c-4a91-a118-7eaa35276660",
+    name = "Priest of the Blood Rite",
+    setCode = "J22",
+    collectorNumber = "457",
+    scryfallId = "87f77674-dd03-4f19-bd87-aec2359b620e",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/8/7/87f77674-dd03-4f19-bd87-aec2359b620e.jpg?1783918985",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ProwlingFelidarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ProwlingFelidarReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prowling Felidar reprint in J22. Canonical CardDefinition lives in Zendikar Rising (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.znr.cards.ProwlingFelidar`.
+ */
+val ProwlingFelidarReprint = Printing(
+    oracleId = "ed26f6bf-fcd6-4cf4-9b65-a492cb79f2df",
+    name = "Prowling Felidar",
+    setCode = "J22",
+    collectorNumber = "229",
+    scryfallId = "94bb131e-b659-4caa-98c5-505b72ac26ac",
+    artist = "Ilse Gort",
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/94bb131e-b659-4caa-98c5-505b72ac26ac.jpg?1783919094",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/QuarryBeetleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/QuarryBeetleReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Quarry Beetle reprint in J22. Canonical CardDefinition lives in Hour of Devastation (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.hou.cards.QuarryBeetle`.
+ */
+val QuarryBeetleReprint = Printing(
+    oracleId = "fff66029-24bb-4354-a650-99a205fd168f",
+    name = "Quarry Beetle",
+    setCode = "J22",
+    collectorNumber = "714",
+    scryfallId = "0614fe56-aafb-4e7b-96b9-a940735da560",
+    artist = "Mike Burns",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/0614fe56-aafb-4e7b-96b9-a940735da560.jpg?1783918844",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RadiantsJudgmentReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RadiantsJudgmentReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Radiant's Judgment reprint in J22. Canonical CardDefinition lives in Urza's Legacy (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ulg.cards.RadiantsJudgment`.
+ */
+val RadiantsJudgmentReprint = Printing(
+    oracleId = "85fd04e9-b39c-4ce0-97a1-58f9670a298f",
+    name = "Radiant's Judgment",
+    setCode = "J22",
+    collectorNumber = "230",
+    scryfallId = "23f8f288-69da-438d-967b-167060fdcbb9",
+    artist = "Greg Staples",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/23f8f288-69da-438d-967b-167060fdcbb9.jpg?1783919093",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RakingClawsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RakingClawsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raking Claws reprint in J22. Canonical CardDefinition lives in Ikoria: Lair of Behemoths (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.iko.cards.RakingClaws`.
+ */
+val RakingClawsReprint = Printing(
+    oracleId = "c2248d3d-3157-4610-868d-2b3fae2b1ec8",
+    name = "Raking Claws",
+    setCode = "J22",
+    collectorNumber = "584",
+    scryfallId = "c018be5c-0357-47cc-ac8c-2929f90c4097",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/c/0/c018be5c-0357-47cc-ac8c-2929f90c4097.jpg?1783918917",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RambunctiousMuttReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RambunctiousMuttReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rambunctious Mutt reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.RambunctiousMutt`.
+ */
+val RambunctiousMuttReprint = Printing(
+    oracleId = "48a53d6e-0320-4b9c-b692-6d0fc00e46cc",
+    name = "Rambunctious Mutt",
+    setCode = "J22",
+    collectorNumber = "231",
+    scryfallId = "2cc371de-3e82-4d66-8636-f9c03579ba10",
+    artist = "Campbell White",
+    imageUri = "https://cards.scryfall.io/normal/front/2/c/2cc371de-3e82-4d66-8636-f9c03579ba10.jpg?1783919092",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RampagingBalothsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RampagingBalothsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rampaging Baloths reprint in J22. Canonical CardDefinition lives in Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.zen.cards.RampagingBaloths`.
+ */
+val RampagingBalothsReprint = Printing(
+    oracleId = "2d3e6549-6cc6-434f-a189-ba3b55e64c34",
+    name = "Rampaging Baloths",
+    setCode = "J22",
+    collectorNumber = "715",
+    scryfallId = "455f4de4-c6f5-43f5-b9f0-f1e9414b7748",
+    artist = "Steve Prescott",
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/455f4de4-c6f5-43f5-b9f0-f1e9414b7748.jpg?1783918844",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RapaciousDragonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RapaciousDragonReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rapacious Dragon reprint in J22. Canonical CardDefinition lives in Core Set 2020 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m20.cards.RapaciousDragon`.
+ */
+val RapaciousDragonReprint = Printing(
+    oracleId = "0944ec2e-1dd9-459f-8f1d-667242cf52fe",
+    name = "Rapacious Dragon",
+    setCode = "J22",
+    collectorNumber = "80",
+    scryfallId = "6d5d5f0b-7574-43d9-b9ab-b4d0fa419212",
+    artist = "Yumi Ozuno",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d5d5f0b-7574-43d9-b9ab-b4d0fa419212.jpg?1783919162",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RazeTheEffigyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RazeTheEffigyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Raze the Effigy reprint in J22. Canonical CardDefinition lives in Innistrad: Midnight Hunt (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mid.cards.RazeTheEffigy`.
+ */
+val RazeTheEffigyReprint = Printing(
+    oracleId = "9286ddc5-8151-4129-aaf6-2a2abe7047e5",
+    name = "Raze the Effigy",
+    setCode = "J22",
+    collectorNumber = "586",
+    scryfallId = "a4277a7f-13c3-4e7b-a489-3116ae9d21bc",
+    artist = "Cristi Balanescu",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a4277a7f-13c3-4e7b-a489-3116ae9d21bc.jpg?1783918918",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ReaveSoulReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ReaveSoulReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reave Soul reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.ReaveSoul`.
+ */
+val ReaveSoulReprint = Printing(
+    oracleId = "8eb328e6-332e-435c-9733-4c5336f17824",
+    name = "Reave Soul",
+    setCode = "J22",
+    collectorNumber = "459",
+    scryfallId = "90f1f7a6-d7ef-462c-9e6c-980c35bb81ed",
+    artist = "David Palumbo",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/90f1f7a6-d7ef-462c-9e6c-980c35bb81ed.jpg?1783918984",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ReclamationSageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ReclamationSageReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Reclamation Sage reprint in J22. Canonical CardDefinition lives in Magic 2015 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m15.cards.ReclamationSage`.
+ */
+val ReclamationSageReprint = Printing(
+    oracleId = "032ec6e2-6cc3-4a97-9cc7-3233f5e11904",
+    name = "Reclamation Sage",
+    setCode = "J22",
+    collectorNumber = "717",
+    scryfallId = "c67127e1-accb-49a5-99c6-4508d5dd81da",
+    artist = "Clint Cearley",
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c67127e1-accb-49a5-99c6-4508d5dd81da.jpg?1783918837",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RighteousnessReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RighteousnessReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Righteousness reprint in J22. Canonical CardDefinition lives in Limited Edition Alpha (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.lea.cards.Righteousness`.
+ */
+val RighteousnessReprint = Printing(
+    oracleId = "3f6b2f76-0364-415e-a6a2-e9e5bf31b745",
+    name = "Righteousness",
+    setCode = "J22",
+    collectorNumber = "235",
+    scryfallId = "ed7ee36d-fdaa-4520-a86a-0feb93a7f9b4",
+    artist = "Wayne England",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed7ee36d-fdaa-4520-a86a-0feb93a7f9b4.jpg?1783919091",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RipscalePredatorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RipscalePredatorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ripscale Predator reprint in J22. Canonical CardDefinition lives in Gatecrash (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.gtc.cards.RipscalePredator`.
+ */
+val RipscalePredatorReprint = Printing(
+    oracleId = "4c297085-5ec1-4d29-9a8e-1785c016ce09",
+    name = "Ripscale Predator",
+    setCode = "J22",
+    collectorNumber = "589",
+    scryfallId = "27bf7caa-cf00-4b94-8cc8-40b31c7cb3a5",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27bf7caa-cf00-4b94-8cc8-40b31c7cb3a5.jpg?1783918918",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RiverSneakReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RiverSneakReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * River Sneak reprint in J22. Canonical CardDefinition lives in Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.xln.cards.RiverSneak`.
+ */
+val RiverSneakReprint = Printing(
+    oracleId = "678095cc-ec8f-471a-b675-e59905d65c33",
+    name = "River Sneak",
+    setCode = "J22",
+    collectorNumber = "339",
+    scryfallId = "cac32ebc-c7c6-49fd-a2e3-1ace1bc979ae",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/c/a/cac32ebc-c7c6-49fd-a2e3-1ace1bc979ae.jpg?1783919042",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RummagingGoblinReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RummagingGoblinReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rummaging Goblin reprint in J22. Canonical CardDefinition lives in Magic 2013 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m13.cards.RummagingGoblin`.
+ */
+val RummagingGoblinReprint = Printing(
+    oracleId = "2055eb91-ee36-4752-a6dc-581eaef335c8",
+    name = "Rummaging Goblin",
+    setCode = "J22",
+    collectorNumber = "591",
+    scryfallId = "d300a9e8-4611-4728-b54d-bb73005091d1",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/d/3/d300a9e8-4611-4728-b54d-bb73005091d1.jpg?1783918914",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RushOfAdrenalineReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/RushOfAdrenalineReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Rush of Adrenaline reprint in J22. Canonical CardDefinition lives in Shadows over Innistrad (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.soi.cards.RushOfAdrenaline`.
+ */
+val RushOfAdrenalineReprint = Printing(
+    oracleId = "ec9975f4-dfff-4b72-9da8-8f2025f0524a",
+    name = "Rush of Adrenaline",
+    setCode = "J22",
+    collectorNumber = "592",
+    scryfallId = "6d8b5383-f4cf-45e7-aefc-7f3a42748a8e",
+    artist = "Chris Rallis",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d8b5383-f4cf-45e7-aefc-7f3a42748a8e.jpg?1783918913",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SagesRowSavantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SagesRowSavantReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sage's Row Savant reprint in J22. Canonical CardDefinition lives in Ravnica Allegiance (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rna.cards.SagesRowSavant`.
+ */
+val SagesRowSavantReprint = Printing(
+    oracleId = "6eaf5cdc-2843-4167-bd18-df4c2ac73ac0",
+    name = "Sage's Row Savant",
+    setCode = "J22",
+    collectorNumber = "341",
+    scryfallId = "fb5c9852-bd90-42fd-bf8f-87e131c96461",
+    artist = "Bastien L. Deharme",
+    imageUri = "https://cards.scryfall.io/normal/front/f/b/fb5c9852-bd90-42fd-bf8f-87e131c96461.jpg?1783919040",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SanctumGargoyleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SanctumGargoyleReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sanctum Gargoyle reprint in J22. Canonical CardDefinition lives in Shards of Alara (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ala.cards.SanctumGargoyle`.
+ */
+val SanctumGargoyleReprint = Printing(
+    oracleId = "6ee9802a-7a44-49c7-93d9-f75c4d42e71e",
+    name = "Sanctum Gargoyle",
+    setCode = "J22",
+    collectorNumber = "236",
+    scryfallId = "b53e6ab8-d778-4cf6-ab21-1352618d093b",
+    artist = "Shelly Wan",
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b53e6ab8-d778-4cf6-ab21-1352618d093b.jpg?1783919089",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SandstoneBridgeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SandstoneBridgeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sandstone Bridge reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.SandstoneBridge`.
+ */
+val SandstoneBridgeReprint = Printing(
+    oracleId = "08911e8e-cd67-4960-a927-958c33632469",
+    name = "Sandstone Bridge",
+    setCode = "J22",
+    collectorNumber = "819",
+    scryfallId = "ffb3d37e-5118-405a-906d-529ec1d90dce",
+    artist = "Cliff Childs",
+    imageUri = "https://cards.scryfall.io/normal/front/f/f/ffb3d37e-5118-405a-906d-529ec1d90dce.jpg?1783918788",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SavannahLionsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SavannahLionsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savannah Lions reprint in J22. Canonical CardDefinition lives in Limited Edition Alpha (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.lea.cards.SavannahLions`.
+ */
+val SavannahLionsReprint = Printing(
+    oracleId = "60ba93eb-39e6-4af2-9c66-cd38f72daff2",
+    name = "Savannah Lions",
+    setCode = "J22",
+    collectorNumber = "237",
+    scryfallId = "89b77ad5-1585-49dc-b635-780143e1e1c8",
+    artist = "Winona Nelson",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/89b77ad5-1585-49dc-b635-780143e1e1c8.jpg?1783919087",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SavannahSageReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SavannahSageReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savannah Sage reprint in J22. Canonical CardDefinition lives in Core Set 2020 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m20.cards.SavannahSage`.
+ */
+val SavannahSageReprint = Printing(
+    oracleId = "7e6cfec7-3b54-43db-853a-27c164776a5f",
+    name = "Savannah Sage",
+    setCode = "J22",
+    collectorNumber = "238",
+    scryfallId = "a9edf976-bf2e-4528-9001-0c70bdc94762",
+    artist = "Bayard Wu",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a9edf976-bf2e-4528-9001-0c70bdc94762.jpg?1783919089",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SeafloorOracleReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SeafloorOracleReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seafloor Oracle reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.SeafloorOracle`.
+ */
+val SeafloorOracleReprint = Printing(
+    oracleId = "f9f719cb-7778-4109-bbd3-4504ee1b5f49",
+    name = "Seafloor Oracle",
+    setCode = "J22",
+    collectorNumber = "343",
+    scryfallId = "479aff39-d9b0-411d-bcc5-a4d1d495f11c",
+    artist = "Simon Dominic",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/479aff39-d9b0-411d-bcc5-a4d1d495f11c.jpg?1783919040",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SearingSpearReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SearingSpearReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Searing Spear reprint in J22. Canonical CardDefinition lives in Magic 2013 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m13.cards.SearingSpear`.
+ */
+val SearingSpearReprint = Printing(
+    oracleId = "aafd44c1-74a9-4aa7-a4a2-67eb39a07478",
+    name = "Searing Spear",
+    setCode = "J22",
+    collectorNumber = "597",
+    scryfallId = "9154f49f-229f-4362-a8e1-616666a81bee",
+    artist = "Chris Rahn",
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/9154f49f-229f-4362-a8e1-616666a81bee.jpg?1783918908",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SeatOfTheSynodReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SeatOfTheSynodReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seat of the Synod reprint in J22. Canonical CardDefinition lives in Mirrodin (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mrd.cards.SeatOfTheSynod`.
+ */
+val SeatOfTheSynodReprint = Printing(
+    oracleId = "39451b4d-cd7a-40da-b457-cb51b609173f",
+    name = "Seat of the Synod",
+    setCode = "J22",
+    collectorNumber = "820",
+    scryfallId = "0633d38e-de0b-4f14-abbb-ac9260887c4d",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/0/6/0633d38e-de0b-4f14-abbb-ac9260887c4d.jpg?1783918790",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SelfAssemblerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SelfAssemblerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Self-Assembler reprint in J22. Canonical CardDefinition lives in Kaladesh (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.kld.cards.SelfAssembler`.
+ */
+val SelfAssemblerReprint = Printing(
+    oracleId = "8f36e058-e5fa-48f9-9996-09b77fc193b3",
+    name = "Self-Assembler",
+    setCode = "J22",
+    collectorNumber = "795",
+    scryfallId = "02e77f29-8ce1-4a18-871c-d69853bfd9db",
+    artist = "Toraji",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/02e77f29-8ce1-4a18-871c-d69853bfd9db.jpg?1783918799",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SelflessSpiritReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SelflessSpiritReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Selfless Spirit reprint in J22. Canonical CardDefinition lives in Eldritch Moon (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.emn.cards.SelflessSpirit`.
+ */
+val SelflessSpiritReprint = Printing(
+    oracleId = "71d785a9-ddc8-472e-a778-a551b444a4bd",
+    name = "Selfless Spirit",
+    setCode = "J22",
+    collectorNumber = "239",
+    scryfallId = "efc30cb5-e845-472c-8bdb-659ce7ece6de",
+    artist = "Seb McKinnon",
+    imageUri = "https://cards.scryfall.io/normal/front/e/f/efc30cb5-e845-472c-8bdb-659ce7ece6de.jpg?1783919090",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SellerOfSongbirdsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SellerOfSongbirdsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Seller of Songbirds reprint in J22. Canonical CardDefinition lives in Return to Ravnica (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rtr.cards.SellerOfSongbirds`.
+ */
+val SellerOfSongbirdsReprint = Printing(
+    oracleId = "87e4c6ff-f83f-412b-9d23-aac7a57ef6db",
+    name = "Seller of Songbirds",
+    setCode = "J22",
+    collectorNumber = "240",
+    scryfallId = "4f3b2176-958a-42e0-b88e-5b3416b40150",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/4/f/4f3b2176-958a-42e0-b88e-5b3416b40150.jpg?1783919088",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SentinelsOfGlenElendraReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SentinelsOfGlenElendraReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sentinels of Glen Elendra reprint in J22. Canonical CardDefinition lives in Lorwyn (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.lrw.cards.SentinelsOfGlenElendra`.
+ */
+val SentinelsOfGlenElendraReprint = Printing(
+    oracleId = "a93779c5-603e-4a91-aef8-a0cd8fd1b3e9",
+    name = "Sentinels of Glen Elendra",
+    setCode = "J22",
+    collectorNumber = "344",
+    scryfallId = "dccd614d-f57b-413f-9177-830964a65150",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/d/c/dccd614d-f57b-413f-9177-830964a65150.jpg?1783919038",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SerumVisionsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SerumVisionsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Serum Visions reprint in J22. Canonical CardDefinition lives in Fifth Dawn (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.5dn.cards.SerumVisions`.
+ */
+val SerumVisionsReprint = Printing(
+    oracleId = "56956afd-db53-4542-816b-490c8b0bbcf7",
+    name = "Serum Visions",
+    setCode = "J22",
+    collectorNumber = "345",
+    scryfallId = "a44d8329-fe4c-4102-a5ee-3c058b84e315",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/a/4/a44d8329-fe4c-4102-a5ee-3c058b84e315.jpg?1783919045",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ShamblingGhoulReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ShamblingGhoulReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shambling Ghoul reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.ShamblingGhoul`.
+ */
+val ShamblingGhoulReprint = Printing(
+    oracleId = "2acc1657-d716-41d7-aedf-9b080a58ec83",
+    name = "Shambling Ghoul",
+    setCode = "J22",
+    collectorNumber = "465",
+    scryfallId = "1258c7d4-cc4f-47c2-b346-27274bfee151",
+    artist = "Joseph Meehan",
+    imageUri = "https://cards.scryfall.io/normal/front/1/2/1258c7d4-cc4f-47c2-b346-27274bfee151.jpg?1783918983",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ShimmerDragonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ShimmerDragonReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shimmer Dragon reprint in J22. Canonical CardDefinition lives in Throne of Eldraine (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.eld.cards.ShimmerDragon`.
+ */
+val ShimmerDragonReprint = Printing(
+    oracleId = "de1316f2-1cca-4ac4-aead-0fd8b4036d88",
+    name = "Shimmer Dragon",
+    setCode = "J22",
+    collectorNumber = "347",
+    scryfallId = "ed4de1a9-18c2-4dcd-9377-e8dc6ac6190c",
+    artist = "Lie Setiawan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/d/ed4de1a9-18c2-4dcd-9377-e8dc6ac6190c.jpg?1783919038",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ShreddedSailsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ShreddedSailsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shredded Sails reprint in J22. Canonical CardDefinition lives in Ikoria: Lair of Behemoths (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.iko.cards.ShreddedSails`.
+ */
+val ShreddedSailsReprint = Printing(
+    oracleId = "ea908d2d-d443-4385-a71a-ebb00938cd57",
+    name = "Shredded Sails",
+    setCode = "J22",
+    collectorNumber = "599",
+    scryfallId = "769e9434-5db8-4497-9dc9-a42f3675a1cc",
+    artist = "Titus Lunter",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/769e9434-5db8-4497-9dc9-a42f3675a1cc.jpg?1783918910",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SigilOfTheEmptyThroneReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SigilOfTheEmptyThroneReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sigil of the Empty Throne reprint in J22. Canonical CardDefinition lives in Conflux (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.conflux.cards.SigilOfTheEmptyThrone`.
+ */
+val SigilOfTheEmptyThroneReprint = Printing(
+    oracleId = "3b9b5b22-5a7d-4e37-a870-ca0f0efa4f36",
+    name = "Sigil of the Empty Throne",
+    setCode = "J22",
+    collectorNumber = "244",
+    scryfallId = "733e1156-39a3-49a2-af5d-75c978107b2a",
+    artist = "Cyril Van Der Haegen",
+    imageUri = "https://cards.scryfall.io/normal/front/7/3/733e1156-39a3-49a2-af5d-75c978107b2a.jpg?1783919086",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SilverbackShamanReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SilverbackShamanReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Silverback Shaman reprint in J22. Canonical CardDefinition lives in Core Set 2020 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m20.cards.SilverbackShaman`.
+ */
+val SilverbackShamanReprint = Printing(
+    oracleId = "fc011947-b496-400e-99b8-b368068ba79b",
+    name = "Silverback Shaman",
+    setCode = "J22",
+    collectorNumber = "728",
+    scryfallId = "49463346-99b6-422f-9577-34873dd13d36",
+    artist = "Mathias Kollros",
+    imageUri = "https://cards.scryfall.io/normal/front/4/9/49463346-99b6-422f-9577-34873dd13d36.jpg?1783918835",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SimianBrawlerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SimianBrawlerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Simian Brawler reprint in J22. Canonical CardDefinition lives in Coldsnap (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.csp.cards.SimianBrawler`.
+ */
+val SimianBrawlerReprint = Printing(
+    oracleId = "2497cfe2-a85c-47ea-af7a-9a745d84f8b4",
+    name = "Simian Brawler",
+    setCode = "J22",
+    collectorNumber = "729",
+    scryfallId = "c20f5455-70ac-416c-8cf4-021b41e51a7e",
+    artist = "Warren Mahy",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c20f5455-70ac-416c-8cf4-021b41e51a7e.jpg?1783918833",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SkyhunterPatrolReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SkyhunterPatrolReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skyhunter Patrol reprint in J22. Canonical CardDefinition lives in Mirrodin (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mrd.cards.SkyhunterPatrol`.
+ */
+val SkyhunterPatrolReprint = Printing(
+    oracleId = "aadcff6f-9207-4d90-a12d-4913c96867e2",
+    name = "Skyhunter Patrol",
+    setCode = "J22",
+    collectorNumber = "245",
+    scryfallId = "028bd68c-24bf-4808-80d7-051012ff90e1",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/0/2/028bd68c-24bf-4808-80d7-051012ff90e1.jpg?1783919085",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SkyhunterProwlerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SkyhunterProwlerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Skyhunter Prowler reprint in J22. Canonical CardDefinition lives in Fifth Dawn (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.5dn.cards.SkyhunterProwler`.
+ */
+val SkyhunterProwlerReprint = Printing(
+    oracleId = "5e0d13b0-d5d0-4c5f-945e-5cda7d980670",
+    name = "Skyhunter Prowler",
+    setCode = "J22",
+    collectorNumber = "246",
+    scryfallId = "2014229c-11cd-4289-bf06-1b55d1f2939a",
+    artist = "Vance Kovacs",
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/2014229c-11cd-4289-bf06-1b55d1f2939a.jpg?1783919086",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SlingGangLieutenantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SlingGangLieutenantReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sling-Gang Lieutenant reprint in J22. Canonical CardDefinition lives in Modern Horizons (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mh1.cards.SlingGangLieutenant`.
+ */
+val SlingGangLieutenantReprint = Printing(
+    oracleId = "4e93b23c-a7f7-4bdd-bbca-0dc48bb5c223",
+    name = "Sling-Gang Lieutenant",
+    setCode = "J22",
+    collectorNumber = "469",
+    scryfallId = "8d8d27af-e4cf-4e18-825e-8f6c972e64ba",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/8/d/8d8d27af-e4cf-4e18-825e-8f6c972e64ba.jpg?1783918979",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SnappingGnarlidReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SnappingGnarlidReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snapping Gnarlid reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.SnappingGnarlid`.
+ */
+val SnappingGnarlidReprint = Printing(
+    oracleId = "eeba70f5-336c-46e6-90db-50818f88e8a5",
+    name = "Snapping Gnarlid",
+    setCode = "J22",
+    collectorNumber = "730",
+    scryfallId = "7062c430-c8a4-4f35-83b5-21519b6c0edc",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/7062c430-c8a4-4f35-83b5-21519b6c0edc.jpg?1783918835",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SnowCoveredIslandReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SnowCoveredIslandReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Snow-Covered Island reprint in J22. Canonical CardDefinition lives in Ice Age (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ice.cards.SnowCoveredIsland`.
+ */
+val SnowCoveredIslandReprint = Printing(
+    oracleId = "5b2460a5-6ae5-4cad-ba94-1a9e98e6e4c0",
+    name = "Snow-Covered Island",
+    setCode = "J22",
+    collectorNumber = "833",
+    scryfallId = "fe6b4706-5452-4c50-872d-2d04f96407a8",
+    artist = "Piotr Dura",
+    imageUri = "https://cards.scryfall.io/normal/front/f/e/fe6b4706-5452-4c50-872d-2d04f96407a8.jpg?1783918783",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SparkReaperReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SparkReaperReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spark Reaper reprint in J22. Canonical CardDefinition lives in War of the Spark (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.war.cards.SparkReaper`.
+ */
+val SparkReaperReprint = Printing(
+    oracleId = "894176e3-af9c-41ef-9f35-59dfdda3c17f",
+    name = "Spark Reaper",
+    setCode = "J22",
+    collectorNumber = "471",
+    scryfallId = "bf6f8cfe-20b1-430a-8aa8-dcaebc94ca2a",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/b/f/bf6f8cfe-20b1-430a-8aa8-dcaebc94ca2a.jpg?1783918977",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SparkmageApprenticeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SparkmageApprenticeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sparkmage Apprentice reprint in J22. Canonical CardDefinition lives in Ravnica: City of Guilds (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rav.cards.SparkmageApprentice`.
+ */
+val SparkmageApprenticeReprint = Printing(
+    oracleId = "69003cbc-8e5a-41dc-ac53-18f6e776217b",
+    name = "Sparkmage Apprentice",
+    setCode = "J22",
+    collectorNumber = "603",
+    scryfallId = "2227b652-f429-4b2a-ab43-ce551eb0a59d",
+    artist = "Jaime Jones",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/2227b652-f429-4b2a-ab43-ce551eb0a59d.jpg?1783918906",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpectralHuntCaller.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpectralHuntCaller.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Spectral Hunt-Caller
+ * {4}{G}
+ * Creature — Wolf Spirit
+ * 4/4
+ * {5}{G}: Creatures you control get +1/+1 and gain trample until end of turn.
+ *
+ * The overrun shape: `Patterns.Group.pumpAndGrantToAll` fans a +1/+1 [ModifyStatsEffect] and a
+ * trample [GrantKeywordEffect] — both `Duration.EndOfTurn` — over every creature you control at
+ * resolution (same pattern as Glorious Sunrise's first mode).
+ */
+val SpectralHuntCaller = card("Spectral Hunt-Caller") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf Spirit"
+    power = 4
+    toughness = 4
+    oracleText = "{5}{G}: Creatures you control get +1/+1 and gain trample until end of turn."
+
+    // {5}{G}: Creatures you control get +1/+1 and gain trample until end of turn.
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}")
+        effect = Patterns.Group.pumpAndGrantToAll(
+            power = 1,
+            toughness = 1,
+            keyword = Keyword.TRAMPLE,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Uriah Voth"
+        flavorText = "The nightsong begins with a lone howl, but soon swells to a deafening chorus."
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/358fc99b-b2e5-4967-ba5a-ab2caee1751c.jpg?1783919178"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpectralHuntCallerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpectralHuntCallerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spectral Hunt-Caller reprint in J22. Canonical CardDefinition lives in Jumpstart 2022 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.j22.cards.SpectralHuntCaller`.
+ */
+val SpectralHuntCallerReprint = Printing(
+    oracleId = "d03ef35b-0609-46b5-ab8a-64d8007eab26",
+    name = "Spectral Hunt-Caller",
+    setCode = "J22",
+    collectorNumber = "45",
+    scryfallId = "358fc99b-b2e5-4967-ba5a-ab2caee1751c",
+    artist = "Uriah Voth",
+    imageUri = "https://cards.scryfall.io/normal/front/3/5/358fc99b-b2e5-4967-ba5a-ab2caee1751c.jpg?1783919178",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpectralSailorReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpectralSailorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spectral Sailor reprint in J22. Canonical CardDefinition lives in Core Set 2020 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m20.cards.SpectralSailor`.
+ */
+val SpectralSailorReprint = Printing(
+    oracleId = "a8fdbcdf-479d-4582-9ad5-9fbd4c740c29",
+    name = "Spectral Sailor",
+    setCode = "J22",
+    collectorNumber = "64",
+    scryfallId = "7743b587-e498-4761-9173-e803c9eed86b",
+    artist = "Fuzichoco",
+    imageUri = "https://cards.scryfall.io/normal/front/7/7/7743b587-e498-4761-9173-e803c9eed86b.jpg?1783919171",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpellgorgerWeirdReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpellgorgerWeirdReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spellgorger Weird reprint in J22. Canonical CardDefinition lives in War of the Spark (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.war.cards.SpellgorgerWeird`.
+ */
+val SpellgorgerWeirdReprint = Printing(
+    oracleId = "550811ca-0995-4886-aa8c-5cee118aa54f",
+    name = "Spellgorger Weird",
+    setCode = "J22",
+    collectorNumber = "605",
+    scryfallId = "312069a7-bbe2-44a2-b00c-5f3b827f21ae",
+    artist = "James Paick",
+    imageUri = "https://cards.scryfall.io/normal/front/3/1/312069a7-bbe2-44a2-b00c-5f3b827f21ae.jpg?1783918907",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpiritedCompanionReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SpiritedCompanionReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spirited Companion reprint in J22. Canonical CardDefinition lives in Kamigawa: Neon Dynasty (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.neo.cards.SpiritedCompanion`.
+ */
+val SpiritedCompanionReprint = Printing(
+    oracleId = "9c5f0d91-9d86-4e66-94fd-4af93ad01838",
+    name = "Spirited Companion",
+    setCode = "J22",
+    collectorNumber = "248",
+    scryfallId = "f2d28a16-e119-456d-ad8b-c37cec069ab0",
+    artist = "Ilse Gort",
+    imageUri = "https://cards.scryfall.io/normal/front/f/2/f2d28a16-e119-456d-ad8b-c37cec069ab0.jpg?1783919087",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/StarnheimAspirantReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/StarnheimAspirantReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Starnheim Aspirant reprint in J22. Canonical CardDefinition lives in Kaldheim (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.khm.cards.StarnheimAspirant`.
+ */
+val StarnheimAspirantReprint = Printing(
+    oracleId = "e7b92789-47a9-430a-ad57-be7b6c3d63cb",
+    name = "Starnheim Aspirant",
+    setCode = "J22",
+    collectorNumber = "250",
+    scryfallId = "170914cc-3c3d-4929-a45d-836a5b8a4090",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/170914cc-3c3d-4929-a45d-836a5b8a4090.jpg?1783919082",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SteppeLynxReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SteppeLynxReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Steppe Lynx reprint in J22. Canonical CardDefinition lives in Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.zen.cards.SteppeLynx`.
+ */
+val SteppeLynxReprint = Printing(
+    oracleId = "b16cef02-dcf8-4866-ac42-6ee929ddbea2",
+    name = "Steppe Lynx",
+    setCode = "J22",
+    collectorNumber = "251",
+    scryfallId = "6dff6978-a794-4f4c-9039-594b15e7dbfe",
+    artist = "Nic Klein",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6dff6978-a794-4f4c-9039-594b15e7dbfe.jpg?1783919085",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/StranglingSporesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/StranglingSporesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Strangling Spores reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.StranglingSpores`.
+ */
+val StranglingSporesReprint = Printing(
+    oracleId = "444493a6-0f90-4847-9619-4ea8fbf7cf6f",
+    name = "Strangling Spores",
+    setCode = "J22",
+    collectorNumber = "473",
+    scryfallId = "30c87f47-419f-4551-9e74-29f1df81dfbe",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/30c87f47-419f-4551-9e74-29f1df81dfbe.jpg?1783918977",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SubterraneanScoutReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/SubterraneanScoutReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Subterranean Scout reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.SubterraneanScout`.
+ */
+val SubterraneanScoutReprint = Printing(
+    oracleId = "19f66bfa-bdfc-430a-ae39-4535f0b28324",
+    name = "Subterranean Scout",
+    setCode = "J22",
+    collectorNumber = "609",
+    scryfallId = "c502f2f7-e12b-4a3b-85ae-c0e69f210e8b",
+    artist = "Lucas Graciano",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c502f2f7-e12b-4a3b-85ae-c0e69f210e8b.jpg?1783918905",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TeferisProtegeReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TeferisProtegeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Teferi's Protege reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.TeferisProtege`.
+ */
+val TeferisProtegeReprint = Printing(
+    oracleId = "e84f1727-ce01-44be-aebf-8a0c4e032c9a",
+    name = "Teferi's Protege",
+    setCode = "J22",
+    collectorNumber = "359",
+    scryfallId = "662ccce8-c49a-4890-a725-fe01733d07f3",
+    artist = "Bram Sels",
+    imageUri = "https://cards.scryfall.io/normal/front/6/6/662ccce8-c49a-4890-a725-fe01733d07f3.jpg?1783919032",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ThaumaturgesFamiliarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ThaumaturgesFamiliarReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thaumaturge's Familiar reprint in J22. Canonical CardDefinition lives in Theros Beyond Death (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.thb.cards.ThaumaturgesFamiliar`.
+ */
+val ThaumaturgesFamiliarReprint = Printing(
+    oracleId = "74a1a484-7c35-466a-b097-9aaf6fc2073b",
+    name = "Thaumaturge's Familiar",
+    setCode = "J22",
+    collectorNumber = "802",
+    scryfallId = "6a1858f5-16b8-4a58-8f31-b60f926fdbf8",
+    artist = "Andrea Radeck",
+    imageUri = "https://cards.scryfall.io/normal/front/6/a/6a1858f5-16b8-4a58-8f31-b60f926fdbf8.jpg?1783918796",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TheCircleOfLoyaltyReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TheCircleOfLoyaltyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * The Circle of Loyalty reprint in J22. Canonical CardDefinition lives in Throne of Eldraine (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.eld.cards.TheCircleOfLoyalty`.
+ */
+val TheCircleOfLoyaltyReprint = Printing(
+    oracleId = "fd1b4523-2399-4771-89bf-1d65f5d67056",
+    name = "The Circle of Loyalty",
+    setCode = "J22",
+    collectorNumber = "166",
+    scryfallId = "29a37ed7-223e-4e19-b318-83cac54f6b16",
+    artist = "Bastien L. Deharme",
+    imageUri = "https://cards.scryfall.io/normal/front/2/9/29a37ed7-223e-4e19-b318-83cac54f6b16.jpg?1783919122",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ThrashingBrontodonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ThrashingBrontodonReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrashing Brontodon reprint in J22. Canonical CardDefinition lives in Rivals of Ixalan (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rix.cards.ThrashingBrontodon`.
+ */
+val ThrashingBrontodonReprint = Printing(
+    oracleId = "60bc63dc-ac9f-4a2f-aef5-c90d0aa31553",
+    name = "Thrashing Brontodon",
+    setCode = "J22",
+    collectorNumber = "92",
+    scryfallId = "d5a65e7c-3f2e-44d1-8f85-4acf5f147c17",
+    artist = "Kemonomichi",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5a65e7c-3f2e-44d1-8f85-4acf5f147c17.jpg?1783919157",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TolarianSentinelReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TolarianSentinelReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tolarian Sentinel reprint in J22. Canonical CardDefinition lives in Time Spiral (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.tsp.cards.TolarianSentinel`.
+ */
+val TolarianSentinelReprint = Printing(
+    oracleId = "bef15918-c0e7-4f6d-a589-f91f3fa11ef1",
+    name = "Tolarian Sentinel",
+    setCode = "J22",
+    collectorNumber = "363",
+    scryfallId = "92867aa1-698d-47cf-bed7-b758a2cc0e5d",
+    artist = "Thomas M. Baxa",
+    imageUri = "https://cards.scryfall.io/normal/front/9/2/92867aa1-698d-47cf-bed7-b758a2cc0e5d.jpg?1783919029",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TormentingVoiceReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TormentingVoiceReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tormenting Voice reprint in J22. Canonical CardDefinition lives in Khans of Tarkir (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ktk.cards.TormentingVoice`.
+ */
+val TormentingVoiceReprint = Printing(
+    oracleId = "f307b5b4-e949-4f69-8dc7-856e33a45a16",
+    name = "Tormenting Voice",
+    setCode = "J22",
+    collectorNumber = "615",
+    scryfallId = "7c337af5-35bf-4a80-8cc0-bb9af20305b3",
+    artist = "Volkan Baǵa",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c337af5-35bf-4a80-8cc0-bb9af20305b3.jpg?1783918900",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TrainedCaracalReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TrainedCaracalReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Trained Caracal reprint in J22. Canonical CardDefinition lives in Return to Ravnica (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.rtr.cards.TrainedCaracal`.
+ */
+val TrainedCaracalReprint = Printing(
+    oracleId = "a939f01b-afce-4d92-a897-1a6dc3d788c6",
+    name = "Trained Caracal",
+    setCode = "J22",
+    collectorNumber = "256",
+    scryfallId = "c299243b-5ccf-44e8-82f7-fce496f237d1",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c299243b-5ccf-44e8-82f7-fce496f237d1.jpg?1783919080",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TriplicateSpiritsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TriplicateSpiritsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Triplicate Spirits reprint in J22. Canonical CardDefinition lives in Magic 2015 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m15.cards.TriplicateSpirits`.
+ */
+val TriplicateSpiritsReprint = Printing(
+    oracleId = "48090c64-f41a-447b-ad7a-54e3194f759b",
+    name = "Triplicate Spirits",
+    setCode = "J22",
+    collectorNumber = "258",
+    scryfallId = "d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d7cf5453-f8b8-4f86-a2f0-fdc79f7c977f.jpg?1783919080",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TritonShorestalkerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TritonShorestalkerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Triton Shorestalker reprint in J22. Canonical CardDefinition lives in Journey into Nyx (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.jou.cards.TritonShorestalker`.
+ */
+val TritonShorestalkerReprint = Printing(
+    oracleId = "71a60247-17e5-44bd-9fed-f7d550b09ef3",
+    name = "Triton Shorestalker",
+    setCode = "J22",
+    collectorNumber = "365",
+    scryfallId = "ac5213d8-2848-4cb3-b05e-226e08676b18",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/ac5213d8-2848-4cb3-b05e-226e08676b18.jpg?1783919028",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TyphoidRatsReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/TyphoidRatsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Typhoid Rats reprint in J22. Canonical CardDefinition lives in Innistrad (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.isd.cards.TyphoidRats`.
+ */
+val TyphoidRatsReprint = Printing(
+    oracleId = "d6ee6cc1-902d-4f56-afa5-6fa4813bfbbc",
+    name = "Typhoid Rats",
+    setCode = "J22",
+    collectorNumber = "480",
+    scryfallId = "dec112cf-aa50-4246-9730-e034a3656c3d",
+    artist = "Kev Walker",
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/dec112cf-aa50-4246-9730-e034a3656c3d.jpg?1783918974",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UktabiOrangutanReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UktabiOrangutanReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Uktabi Orangutan reprint in J22. Canonical CardDefinition lives in Visions (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.vis.cards.UktabiOrangutan`.
+ */
+val UktabiOrangutanReprint = Printing(
+    oracleId = "6cc07a7e-e70c-45c5-83c5-a2704e57dbc5",
+    name = "Uktabi Orangutan",
+    setCode = "J22",
+    collectorNumber = "133",
+    scryfallId = "347cff91-9f18-4ebc-8deb-3d4bf617fdb9",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/347cff91-9f18-4ebc-8deb-3d4bf617fdb9.jpg?1783919138",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UlcerateReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UlcerateReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ulcerate reprint in J22. Canonical CardDefinition lives in Magic 2015 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m15.cards.Ulcerate`.
+ */
+val UlcerateReprint = Printing(
+    oracleId = "4a9e73b7-8c8b-4489-b670-ce49c2c8a46a",
+    name = "Ulcerate",
+    setCode = "J22",
+    collectorNumber = "481",
+    scryfallId = "f6b01b24-67a7-44a5-80ab-b058d8b0f593",
+    artist = "Johann Bodin",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f6b01b24-67a7-44a5-80ab-b058d8b0f593.jpg?1783918972",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UnderseaInvaderReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UnderseaInvaderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Undersea Invader reprint in J22. Canonical CardDefinition lives in Kaldheim (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.khm.cards.UnderseaInvader`.
+ */
+val UnderseaInvaderReprint = Printing(
+    oracleId = "ff12dfee-7140-44bd-a62e-5f8ab98e93c6",
+    name = "Undersea Invader",
+    setCode = "J22",
+    collectorNumber = "366",
+    scryfallId = "68eb319b-e455-4803-8884-3b28d207ead0",
+    artist = "Lorenzo Mastroianni",
+    imageUri = "https://cards.scryfall.io/normal/front/6/8/68eb319b-e455-4803-8884-3b28d207ead0.jpg?1783919028",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UniversalAutomatonReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UniversalAutomatonReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Universal Automaton reprint in J22. Canonical CardDefinition lives in Modern Horizons (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.mh1.cards.UniversalAutomaton`.
+ */
+val UniversalAutomatonReprint = Printing(
+    oracleId = "d50b1d2e-1825-432a-ab73-068fdc356f50",
+    name = "Universal Automaton",
+    setCode = "J22",
+    collectorNumber = "803",
+    scryfallId = "b16ddbcb-b28d-4a67-857b-5c30ccf055f0",
+    artist = "Ben Maier",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b16ddbcb-b28d-4a67-857b-5c30ccf055f0.jpg?1783918796",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UniversalSolventReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/UniversalSolventReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Universal Solvent reprint in J22. Canonical CardDefinition lives in Aether Revolt (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.aer.cards.UniversalSolvent`.
+ */
+val UniversalSolventReprint = Printing(
+    oracleId = "f34ba913-cf9a-48fe-b5fe-68bf504693b2",
+    name = "Universal Solvent",
+    setCode = "J22",
+    collectorNumber = "804",
+    scryfallId = "db05aef5-07b4-46d3-bad7-6568c00b2aef",
+    artist = "Christopher Moeller",
+    imageUri = "https://cards.scryfall.io/normal/front/d/b/db05aef5-07b4-46d3-bad7-6568c00b2aef.jpg?1783918795",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ValorInAkrosReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ValorInAkrosReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Valor in Akros reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.ValorInAkros`.
+ */
+val ValorInAkrosReprint = Printing(
+    oracleId = "56a60fcb-f9b7-438f-9221-eaca8fb2649b",
+    name = "Valor in Akros",
+    setCode = "J22",
+    collectorNumber = "262",
+    scryfallId = "6e20c0de-c9fa-463c-965a-2e868f7965b1",
+    artist = "Chris Rallis",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e20c0de-c9fa-463c-965a-2e868f7965b1.jpg?1783919081",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ValorousSteedReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ValorousSteedReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Valorous Steed reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.ValorousSteed`.
+ */
+val ValorousSteedReprint = Printing(
+    oracleId = "4b5f30a6-b0fb-4dcb-85d5-1db1bba73737",
+    name = "Valorous Steed",
+    setCode = "J22",
+    collectorNumber = "264",
+    scryfallId = "637c80b7-6cbb-4f3f-b279-55048b90ad1c",
+    artist = "Donato Giancola",
+    imageUri = "https://cards.scryfall.io/normal/front/6/3/637c80b7-6cbb-4f3f-b279-55048b90ad1c.jpg?1783919077",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VampiricRitesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VampiricRitesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vampiric Rites reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.VampiricRites`.
+ */
+val VampiricRitesReprint = Printing(
+    oracleId = "660de988-b6fb-4f36-8006-42af3e7f908d",
+    name = "Vampiric Rites",
+    setCode = "J22",
+    collectorNumber = "484",
+    scryfallId = "f4afbfbc-55d3-4cea-be37-9c6c015d121d",
+    artist = "Anastasia Ovchinnikova",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f4afbfbc-55d3-4cea-be37-9c6c015d121d.jpg?1783918973",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VaultRobberReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VaultRobberReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vault Robber reprint in J22. Canonical CardDefinition lives in Kaldheim (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.khm.cards.VaultRobber`.
+ */
+val VaultRobberReprint = Printing(
+    oracleId = "68c90a32-d6ee-4595-8517-5f4cb0e4062d",
+    name = "Vault Robber",
+    setCode = "J22",
+    collectorNumber = "617",
+    scryfallId = "e1f67518-b5ea-4b9b-96b5-e01de054b348",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1f67518-b5ea-4b9b-96b5-e01de054b348.jpg?1783918897",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VialOfDragonfireReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VialOfDragonfireReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vial of Dragonfire reprint in J22. Canonical CardDefinition lives in Dragons of Tarkir (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dtk.cards.VialOfDragonfire`.
+ */
+val VialOfDragonfireReprint = Printing(
+    oracleId = "17be934e-1e33-4b95-a984-242fa018e280",
+    name = "Vial of Dragonfire",
+    setCode = "J22",
+    collectorNumber = "805",
+    scryfallId = "9eca56b1-0e1f-4473-a427-fba3f8200b2e",
+    artist = "Franz Vohwinkel",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9eca56b1-0e1f-4473-a427-fba3f8200b2e.jpg?1783918795",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ViashinoPyromancerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ViashinoPyromancerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Viashino Pyromancer reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.ViashinoPyromancer`.
+ */
+val ViashinoPyromancerReprint = Printing(
+    oracleId = "5e78e6e0-60f0-4c3c-b8dd-bd673f5152b8",
+    name = "Viashino Pyromancer",
+    setCode = "J22",
+    collectorNumber = "618",
+    scryfallId = "379a456f-ebc7-4e15-8750-b710dd1edcec",
+    artist = "Jesper Ejsing",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/379a456f-ebc7-4e15-8750-b710dd1edcec.jpg?1783918899",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VillageRitesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VillageRitesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Village Rites reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.VillageRites`.
+ */
+val VillageRitesReprint = Printing(
+    oracleId = "365548fb-5acc-4a8a-b20b-26d28b7d029f",
+    name = "Village Rites",
+    setCode = "J22",
+    collectorNumber = "486",
+    scryfallId = "40a27914-5e4f-48d4-ba2a-9d3187a39606",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40a27914-5e4f-48d4-ba2a-9d3187a39606.jpg?1783918971",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VolleyVeteranReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/VolleyVeteranReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Volley Veteran reprint in J22. Canonical CardDefinition lives in Core Set 2019 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m19.cards.VolleyVeteran`.
+ */
+val VolleyVeteranReprint = Printing(
+    oracleId = "bf4268e6-170a-445b-b215-718f7494ae28",
+    name = "Volley Veteran",
+    setCode = "J22",
+    collectorNumber = "619",
+    scryfallId = "dd2e618a-eec3-4077-841e-4503b6a06963",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd2e618a-eec3-4077-841e-4503b6a06963.jpg?1783918899",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WardenOfGeometriesReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WardenOfGeometriesReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Warden of Geometries reprint in J22. Canonical CardDefinition lives in Oath of the Gatewatch (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ogw.cards.WardenOfGeometries`.
+ */
+val WardenOfGeometriesReprint = Printing(
+    oracleId = "448da389-81db-4931-9cf7-3fde0ce9392f",
+    name = "Warden of Geometries",
+    setCode = "J22",
+    collectorNumber = "750",
+    scryfallId = "a7c06a62-ae48-4732-94d8-659917201726",
+    artist = "Jason Felix",
+    imageUri = "https://cards.scryfall.io/normal/front/a/7/a7c06a62-ae48-4732-94d8-659917201726.jpg?1783918820",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WeaselbackRedcapReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WeaselbackRedcapReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Weaselback Redcap reprint in J22. Canonical CardDefinition lives in Throne of Eldraine (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.eld.cards.WeaselbackRedcap`.
+ */
+val WeaselbackRedcapReprint = Printing(
+    oracleId = "b14bd895-1d4e-4bd5-9ac1-fed56afb6c90",
+    name = "Weaselback Redcap",
+    setCode = "J22",
+    collectorNumber = "622",
+    scryfallId = "ce6e6945-ce52-4e50-a558-9c974b08e781",
+    artist = "Grzegorz Rutkowski",
+    imageUri = "https://cards.scryfall.io/normal/front/c/e/ce6e6945-ce52-4e50-a558-9c974b08e781.jpg?1783918898",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WeldfastWingsmithReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WeldfastWingsmithReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Weldfast Wingsmith reprint in J22. Canonical CardDefinition lives in Kaladesh (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.kld.cards.WeldfastWingsmith`.
+ */
+val WeldfastWingsmithReprint = Printing(
+    oracleId = "a05bcc3e-25d5-4111-820e-a097189afb7e",
+    name = "Weldfast Wingsmith",
+    setCode = "J22",
+    collectorNumber = "372",
+    scryfallId = "a2494e2a-847a-4605-80dd-a5a6ce80abf5",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/a/2/a2494e2a-847a-4605-80dd-a5a6ce80abf5.jpg?1783919030",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WilyBandarReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WilyBandarReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wily Bandar reprint in J22. Canonical CardDefinition lives in Kaladesh (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.kld.cards.WilyBandar`.
+ */
+val WilyBandarReprint = Printing(
+    oracleId = "2b0ba5a5-649a-4d7a-8136-6bcf692337f5",
+    name = "Wily Bandar",
+    setCode = "J22",
+    collectorNumber = "739",
+    scryfallId = "eb4fe963-5bf3-473a-afbd-0b93f5791279",
+    artist = "Yeong-Hao Han",
+    imageUri = "https://cards.scryfall.io/normal/front/e/b/eb4fe963-5bf3-473a-afbd-0b93f5791279.jpg?1783918827",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WindriderPatrolReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WindriderPatrolReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Windrider Patrol reprint in J22. Canonical CardDefinition lives in Battle for Zendikar (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.bfz.cards.WindriderPatrol`.
+ */
+val WindriderPatrolReprint = Printing(
+    oracleId = "dea0f359-19a5-4aef-8c96-574eaa748a31",
+    name = "Windrider Patrol",
+    setCode = "J22",
+    collectorNumber = "373",
+    scryfallId = "9978703f-30bc-4126-a8e5-e7fcb654956c",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/9/9/9978703f-30bc-4126-a8e5-e7fcb654956c.jpg?1783919026",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WitchsCauldronReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WitchsCauldronReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Witch's Cauldron reprint in J22. Canonical CardDefinition lives in Core Set 2021 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m21.cards.WitchsCauldron`.
+ */
+val WitchsCauldronReprint = Printing(
+    oracleId = "cb65ee08-bfdb-4c18-8967-8bcf31fcabfa",
+    name = "Witch's Cauldron",
+    setCode = "J22",
+    collectorNumber = "490",
+    scryfallId = "27d11924-23c5-485e-9c56-9efcaf6cd9d2",
+    artist = "Jason A. Engle",
+    imageUri = "https://cards.scryfall.io/normal/front/2/7/27d11924-23c5-485e-9c56-9efcaf6cd9d2.jpg?1783918967",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WolfkinBondReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WolfkinBondReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Wolfkin Bond reprint in J22. Canonical CardDefinition lives in Eldritch Moon (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.emn.cards.WolfkinBond`.
+ */
+val WolfkinBondReprint = Printing(
+    oracleId = "49e22e88-d4d9-4781-81e3-bf77b76b132b",
+    name = "Wolfkin Bond",
+    setCode = "J22",
+    collectorNumber = "741",
+    scryfallId = "40101dc6-4354-4f0a-aa90-946ed78d731e",
+    artist = "Lindsey Look",
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40101dc6-4354-4f0a-aa90-946ed78d731e.jpg?1783918825",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WoodbornBehemothReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/WoodbornBehemothReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Woodborn Behemoth reprint in J22. Canonical CardDefinition lives in Magic 2014 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m14.cards.WoodbornBehemoth`.
+ */
+val WoodbornBehemothReprint = Printing(
+    oracleId = "9bc458ac-5566-4978-aeaa-73b600d4ec29",
+    name = "Woodborn Behemoth",
+    setCode = "J22",
+    collectorNumber = "744",
+    scryfallId = "7f887474-760c-4f33-8051-35b9d2e65307",
+    artist = "Matt Stewart",
+    imageUri = "https://cards.scryfall.io/normal/front/7/f/7f887474-760c-4f33-8051-35b9d2e65307.jpg?1783918825",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/YargleGluttonOfUrborgReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/YargleGluttonOfUrborgReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Yargle, Glutton of Urborg reprint in J22. Canonical CardDefinition lives in Dominaria (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.dom.cards.YargleGluttonOfUrborg`.
+ */
+val YargleGluttonOfUrborgReprint = Printing(
+    oracleId = "ed66cd31-958f-4b28-82a3-e04acc819afc",
+    name = "Yargle, Glutton of Urborg",
+    setCode = "J22",
+    collectorNumber = "491",
+    scryfallId = "51a4a591-92e0-4318-a71c-376fbfe2b14f",
+    artist = "Jehan Choo",
+    imageUri = "https://cards.scryfall.io/normal/front/5/1/51a4a591-92e0-4318-a71c-376fbfe2b14f.jpg?1783918966",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/YoungPyromancerReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/YoungPyromancerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Young Pyromancer reprint in J22. Canonical CardDefinition lives in Magic 2014 (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.m14.cards.YoungPyromancer`.
+ */
+val YoungPyromancerReprint = Printing(
+    oracleId = "5fac139a-07d3-4e6c-98e3-d98b199f7a6f",
+    name = "Young Pyromancer",
+    setCode = "J22",
+    collectorNumber = "626",
+    scryfallId = "9b53aa90-f8d6-4cbc-9836-9e4d95ea74f7",
+    artist = "Cynthia Sheppard",
+    imageUri = "https://cards.scryfall.io/normal/front/9/b/9b53aa90-f8d6-4cbc-9836-9e4d95ea74f7.jpg?1783918896",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ZendikarsRoilReprint.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ZendikarsRoilReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zendikar's Roil reprint in J22. Canonical CardDefinition lives in Magic Origins (its earliest real printing),
+ * `com.wingedsheep.mtg.sets.definitions.ori.cards.ZendikarsRoil`.
+ */
+val ZendikarsRoilReprint = Printing(
+    oracleId = "a842cc2b-52eb-4dc5-86c6-6575c2ed913d",
+    name = "Zendikar's Roil",
+    setCode = "J22",
+    collectorNumber = "747",
+    scryfallId = "3f0768ee-aa58-48ca-91e8-64332af5dcfe",
+    artist = "Sam Burley",
+    imageUri = "https://cards.scryfall.io/normal/front/3/f/3f0768ee-aa58-48ca-91e8-64332af5dcfe.jpg?1783918823",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/Mistwalker.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/Mistwalker.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mistwalker
+ * {2}{U}
+ * Creature — Shapeshifter
+ * 1/4
+ * Changeling (This card is every creature type.)
+ * Flying
+ * {1}{U}: This creature gets +1/-1 until end of turn.
+ */
+val Mistwalker = card("Mistwalker") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Shapeshifter"
+    power = 1
+    toughness = 4
+    oracleText = "Changeling (This card is every creature type.)\nFlying\n{1}{U}: This creature gets +1/-1 until end of turn."
+
+    keywords(Keyword.CHANGELING, Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Mana("{1}{U}")
+        effect = Effects.ModifyStats(1, -1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Steve Prescott"
+        flavorText = "\"To escape Littjara, follow a bird.\" —Tuskeri folklore"
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/92f64b49-327c-473b-a492-f020a322aed7.jpg?1783928259"
+        ruling("2021-02-05", "Changeling is a characteristic-defining ability. It functions in all zones, not only while a card that has it is on the battlefield.")
+        ruling("2021-02-05", "The subtype Shapeshifter that appears on the type line is mostly there to reinforce the flavor. A creature card with changeling is just as much an Elf, a Dwarf, a Sliver, a Goat, a Coward, and a Zombie as it is a Shapeshifter.")
+        ruling("2021-02-05", "If an effect causes a creature with changeling to become a new creature type, it will be only that new creature type. It will still have changeling; the effect making it all creature types will simply be overwritten.")
+        ruling("2021-02-05", "If an effect causes a creature with changeling to lose all abilities, it will remain all creature types, even though it will no longer have changeling. This is because changeling applies before the effect that removes it.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/StarnheimAspirant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/StarnheimAspirant.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Starnheim Aspirant
+ * {2}{W}
+ * Creature — Human Cleric
+ * 2/2
+ * Angel spells you cast cost {2} less to cast.
+ *
+ * Dragonspeaker Shaman's shape: a static [ModifySpellCost] over [SpellCostTarget.YouCast] with an
+ * Angel-subtype filter, reducing only the generic portion ([CostModification.ReduceGeneric]).
+ */
+val StarnheimAspirant = card("Starnheim Aspirant") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "Angel spells you cast cost {2} less to cast."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withSubtype("Angel")),
+            modification = CostModification.ReduceGeneric(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "380"
+        artist = "Kieran Yanner"
+        flavorText = "\"I do not fear death. I know my soul will rise to Starnheim, where I will feast forever among valkyries and heroes. Can you say the same?\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea007a18-b31a-4881-92c4-86120dc5729b.jpg?1783928123"
+        ruling("2021-02-05", "To determine the total cost of a spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions (such as that of Starnheim Aspirant). The mana value of the spell is determined only by its mana cost, no matter what the total cost to cast the spell was.")
+        ruling("2021-02-05", "The cost reduction applies only to generic mana in the costs of Angel spells you cast. It can't reduce requirements of specific colors of mana.")
+        ruling("2021-02-05", "An Angel spell is a creature spell with the creature type Angel. Instant, sorcery, and enchantment cards that may create Angel tokens are not Angel spells.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/UnderseaInvader.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/UnderseaInvader.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Undersea Invader
+ * {4}{U}{U}
+ * Creature — Giant Rogue
+ * 5/6
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * This creature enters tapped.
+ */
+val UnderseaInvader = card("Undersea Invader") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Giant Rogue"
+    power = 5
+    toughness = 6
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\nThis creature enters tapped."
+
+    keywords(Keyword.FLASH)
+
+    // This creature enters tapped.
+    replacementEffect(EntersTapped())
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "\"The currents are strange today, and the fish are fearful. Something's stirring in the depths.\" —Rathstaf, Kannah fisherman"
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/550c745b-64e8-4d20-9cf0-024248ddbd57.jpg?1783928254"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/VaultRobber.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/VaultRobber.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Vault Robber
+ * {1}{R}
+ * Creature — Dwarf Rogue
+ * 1/3
+ * {1}, {T}, Exile a creature card from your graveyard: Create a Treasure token. (It's an artifact with "{T}, Sacrifice this token: Add one mana of any color.")
+ */
+val VaultRobber = card("Vault Robber") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf Rogue"
+    power = 1
+    toughness = 3
+    oracleText = "{1}, {T}, Exile a creature card from your graveyard: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")"
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap,
+            Costs.ExileFromGraveyard(1, GameObjectFilter.Creature)
+        )
+        effect = Effects.CreateTreasure(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Slawomir Maniak"
+        flavorText = "The dwarves believe works of art should be passed down the generations, not buried with the dead."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74f68014-489d-4f51-a959-0f335541cb4e.jpg?1783928220"
+        ruling("2021-02-05", "Once you announce that you’re activating the activated ability, no player may take actions until the ability has been paid for. Notably, opponents can’t try to remove one of your creature cards to stop you from exiling it.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AethershieldArtificer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/AethershieldArtificer.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Aethershield Artificer
+ * {3}{W}
+ * Creature — Dwarf Artificer
+ * 3/3
+ * At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
+ */
+val AethershieldArtificer = card("Aethershield Artificer") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dwarf Artificer"
+    power = 3
+    toughness = 3
+    oracleText = "At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)"
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val creature = target(
+            "artifact creature you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.ArtifactCreature.youControl()))
+        )
+        effect = Effects.ModifyStats(2, 2, creature)
+            .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature, Duration.EndOfTurn))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "Izzy"
+        flavorText = "Most smiths shape metal, but some prefer more delicate materials."
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/226f7c45-db9f-4d48-b575-4d2f1904c963.jpg?1783934613"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/BristlingBoar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/BristlingBoar.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+
+/**
+ * Bristling Boar
+ * {3}{G}
+ * Creature — Boar
+ * 4/3
+ * This creature can't be blocked by more than one creature.
+ */
+val BristlingBoar = card("Bristling Boar") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar"
+    power = 4
+    toughness = 3
+    oracleText = "This creature can't be blocked by more than one creature."
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Nicol Bolas destroyed my world. I owe it to Skalla to celebrate all life, no matter how dangerous.\" —Vivien Reid"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/999030b2-2f91-4c45-981f-acdbbf9034af.jpg?1783934541"
+        ruling("2020-04-17", "If Bristling Boar gains menace, it can't be blocked at all.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CatalystElemental.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CatalystElemental.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Catalyst Elemental
+ * {2}{R}
+ * Creature — Elemental
+ * 2/2
+ * Sacrifice this creature: Add {R}{R}.
+ *
+ * A mana ability (no target, no stack) — cf. Blood Vassal, the same sacrifice-for-two-mana shape.
+ */
+val CatalystElemental = card("Catalyst Elemental") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 2
+    toughness = 2
+    oracleText = "Sacrifice this creature: Add {R}{R}."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.AddMana(Color.RED, 2)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "132"
+        artist = "Deruchenko Alexander"
+        flavorText = "As the hyperstormic generator crept past redline, a being emerged from the arc."
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e83a678b-19d4-47a5-aa1c-c2437e5009c0.jpg?1783934556"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CavalryDrillmaster.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/CavalryDrillmaster.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cavalry Drillmaster
+ * {1}{W}
+ * Creature — Human Knight
+ * 2/1
+ * When this creature enters, target creature gets +2/+0 and gains first strike until end of turn.
+ *
+ * One ETB trigger with one target: the pump and the keyword grant both land on the same chosen
+ * creature and both default to [com.wingedsheep.sdk.scripting.Duration.EndOfTurn]. Not restricted
+ * to creatures you control — any creature is a legal target.
+ */
+val CavalryDrillmaster = card("Cavalry Drillmaster") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 0, creature)
+            .then(Effects.GrantKeyword(Keyword.FIRST_STRIKE, creature))
+        description = "When this creature enters, target creature gets +2/+0 and gains first strike until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "8"
+        artist = "Slawomir Maniak"
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62d2e929-7ae3-4560-9cfa-53b89c8a6016.jpg?1783934610"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ColossalMajesty.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/ColossalMajesty.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Colossal Majesty
+ * {2}{G}
+ * Enchantment
+ * At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card.
+ */
+val ColossalMajesty = card("Colossal Majesty") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        interveningIf = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "173"
+        artist = "Randy Vargas"
+        flavorText = "\"Might doesn't just build empires. It protects them.\" —Inti, Sun Empire knight"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93f99796-ddc5-4ccd-b925-35622a8648b8.jpg?1783934541"
+        ruling(
+            "2018-07-13",
+            "If you don't control a creature with power 4 or greater as your upkeep begins, " +
+                "Colossal Majesty's ability won't trigger. You can't take any actions during your " +
+                "turn before your upkeep begins."
+        )
+        ruling(
+            "2018-07-13",
+            "If you don't control a creature with power 4 or greater as Colossal Majesty's ability " +
+                "resolves, you won't draw a card."
+        )
+        ruling(
+            "2018-07-13",
+            "The creature with power 4 or greater that you control as Colossal Majesty's ability " +
+                "resolves doesn't have to be the same creature with power 4 or greater that was " +
+                "under your control as the ability triggered."
+        )
+        ruling(
+            "2018-07-13",
+            "You draw only one card, no matter how many creatures with power 4 or greater you control."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DaybreakChaplain.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DaybreakChaplain.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Daybreak Chaplain
+ * {1}{W}
+ * Creature — Human Cleric
+ * 1/3
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ */
+val DaybreakChaplain = card("Daybreak Chaplain") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 1
+    toughness = 3
+    oracleText = "Lifelink (Damage dealt by this creature also causes you to gain that much life.)"
+
+    keywords(Keyword.LIFELINK)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Volkan Baǵa"
+        flavorText = "\"May the light shine through me to guide the lost.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2f461b1-c801-4f0c-8fd7-fe68b6078ac6.jpg?1783934608"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DemonOfCatastrophes.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DemonOfCatastrophes.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Demon of Catastrophes
+ * {2}{B}{B}
+ * Creature — Demon
+ * 6/6
+ * As an additional cost to cast this spell, sacrifice a creature.
+ * Flying, trample
+ */
+val DemonOfCatastrophes = card("Demon of Catastrophes") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 6
+    toughness = 6
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature.\nFlying, trample"
+
+    additionalCost(Costs.additional.SacrificePermanent(GameObjectFilter.Creature))
+
+    keywords(Keyword.FLYING, Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "91"
+        artist = "Sidharth Chaturvedi"
+        flavorText = "A pit yawned open, a column of oily smoke arose, and a towering form hissed, \"I accept this offering.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d50f9563-7bf8-4c3c-ac82-327221e56551.jpg?1783934573"
+        ruling(
+            "2018-07-13",
+            "You must sacrifice exactly one creature to cast Demon of Catastrophes; you can't cast " +
+                "it without sacrificing a creature, and you can't sacrifice additional creatures."
+        )
+        ruling(
+            "2018-07-13",
+            "Players can respond only after Demon of Catastrophes has been cast and all its costs " +
+                "have been paid. No one can try to destroy the creature you sacrificed to prevent " +
+                "you from casting this spell."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DragonsHoard.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DragonsHoard.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dragon's Hoard
+ * {3}
+ * Artifact
+ * Whenever a Dragon you control enters, put a gold counter on this artifact.
+ * {T}, Remove a gold counter from this artifact: Draw a card.
+ * {T}: Add one mana of any color.
+ *
+ * Same shape as Bandit's Haul: a counter-accruing trigger plus two activated abilities — a
+ * tap-and-spend draw and a plain any-color mana ability.
+ */
+val DragonsHoard = card("Dragon's Hoard") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "Whenever a Dragon you control enters, put a gold counter on this artifact.\n{T}, Remove a gold counter from this artifact: Draw a card.\n{T}: Add one mana of any color."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.youControl().withSubtype(Subtype.DRAGON),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.GOLD, 1, EffectTarget.Self)
+        description = "Whenever a Dragon you control enters, put a gold counter on this artifact."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.RemoveCounterFromSelf(Counters.GOLD, 1)
+        )
+        effect = Effects.DrawCards(1)
+        description = "{T}, Remove a gold counter from this artifact: Draw a card."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "232"
+        artist = "Adam Paquette"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b441fc8-bc89-47d4-8745-2525aeb6d98d.jpg?1783934514"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GallantCavalry.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GallantCavalry.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gallant Cavalry
+ * {3}{W}
+ * Creature — Human Knight
+ * 2/2
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * When this creature enters, create a 2/2 white Knight creature token with vigilance.
+ */
+val GallantCavalry = card("Gallant Cavalry") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, create a 2/2 white Knight creature token with vigilance."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Knight"),
+            keywords = setOf(Keyword.VIGILANCE)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Craig J Spearing"
+        flavorText = "\"Our duty does not stop at our borders.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e388c433-3a37-45f6-825a-d13d2223b6f7.jpg?1783934607"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GearsmithGuardian.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GearsmithGuardian.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Gearsmith Guardian
+ * {5}
+ * Artifact Creature — Construct
+ * 3/5
+ * This creature gets +2/+0 as long as you control a blue creature.
+ */
+val GearsmithGuardian = card("Gearsmith Guardian") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 3
+    toughness = 5
+    oracleText = "This creature gets +2/+0 as long as you control a blue creature."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(2, 0, Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature.withColor(Color.BLUE)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "237"
+        artist = "Deruchenko Alexander"
+        flavorText = "Made in its creator's image, though slightly more clangy."
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d532b01-8bf7-4a27-a438-db03bcd00694.jpg?1783934512"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GearsmithProdigy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/GearsmithProdigy.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Gearsmith Prodigy
+ * {U}
+ * Creature — Human Artificer
+ * 1/2
+ * This creature gets +1/+0 as long as you control an artifact.
+ */
+val GearsmithProdigy = card("Gearsmith Prodigy") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Artificer"
+    power = 1
+    toughness = 2
+    oracleText = "This creature gets +1/+0 as long as you control an artifact."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(1, 0, Filters.Self),
+            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Artifact),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "57"
+        artist = "Deruchenko Alexander"
+        flavorText = "Young artificers on Kaladesh let their imaginations run wild."
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/77d9e666-d9c9-4ccd-89a5-83de79677fa6.jpg?1783934589"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/StranglingSpores.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/StranglingSpores.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Strangling Spores
+ * {3}{B}
+ * Instant
+ * Target creature gets -3/-3 until end of turn.
+ */
+val StranglingSpores = card("Strangling Spores") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -3/-3 until end of turn."
+
+    spell {
+        val creature = target("target creature", TargetCreature())
+        effect = Effects.ModifyStats(power = -3, toughness = -3, target = creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Jason A. Engle"
+        flavorText = "Imagine a thousand tiny mushrooms cropping up within your lungs."
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/300468ab-fbae-42ae-97bc-b08f795efa5c.jpg?1783934561"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DawningAngel.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DawningAngel.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dawning Angel
+ * {4}{W}
+ * Creature — Angel
+ * 3/2
+ * Flying
+ * When this creature enters, you gain 4 life.
+ */
+val DawningAngel = card("Dawning Angel") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\nWhen this creature enters, you gain 4 life."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Yongjae Choi"
+        flavorText = "\"As the sun rose behind the Bone Spire, an angel appeared over the charnel fields, bringing a surge of new hope.\" —Krinnea, *Siege of the Bone Spire*"
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f3d90ef-6f70-4897-85c1-4e1beeb33363.jpg?1783933032"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/FerociousPup.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/FerociousPup.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ferocious Pup
+ * {2}{G}
+ * Creature — Wolf
+ * 0/1
+ * When this creature enters, create a 2/2 green Wolf creature token.
+ */
+val FerociousPup = card("Ferocious Pup") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 0
+    toughness = 1
+    oracleText = "When this creature enters, create a 2/2 green Wolf creature token."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Wolf"),
+            imageUri = "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1783924694",
+        )
+        description = "When this creature enters, create a 2/2 green Wolf creature token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Rudy Siswanto"
+        flavorText = "The strongest pack has the fiercest pups."
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/2354cb24-5c70-4aaa-8636-46866f0950c1.jpg?1783932968"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/Octoprophet.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/Octoprophet.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Octoprophet
+ * {3}{U}
+ * Creature — Octopus
+ * 3/3
+ * When this creature enters, scry 2. (Look at the top two cards of your library, then put any
+ * number of them on the bottom and the rest on top in any order.)
+ */
+val Octoprophet = card("Octoprophet") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Octopus"
+    power = 3
+    toughness = 3
+    oracleText = "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Grzegorz Rutkowski"
+        flavorText = "In every swirl of the tide, it sees the awakening of things yet to come."
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13becea1-e745-4c96-bfc2-6a277fb60ee1.jpg?1783933006"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/SavannahSage.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/SavannahSage.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Savannah Sage
+ * {1}{W}
+ * Creature — Cat Cleric
+ * 2/2
+ * When this creature enters, you gain 2 life.
+ */
+val SavannahSage = card("Savannah Sage") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, you gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+        description = "When this creature enters, you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "284"
+        artist = "Bayard Wu"
+        flavorText = "\"Now is not the time for your light to fade.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b5fa4bb-e061-456f-808e-8d98b2c8abf5.jpg?1783932921"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ChandrasMagmutt.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ChandrasMagmutt.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chandra's Magmutt
+ * {1}{R}
+ * Creature — Elemental Dog
+ * 2/2
+ * {T}: This creature deals 1 damage to target player or planeswalker.
+ *
+ * A tap-only activated ability. [Targets.PlayerOrPlaneswalker] is the narrower "any target"
+ * minus creatures/battles, so a creature can never be chosen.
+ */
+val ChandrasMagmutt = card("Chandra's Magmutt") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental Dog"
+    power = 2
+    toughness = 2
+    oracleText = "{T}: This creature deals 1 damage to target player or planeswalker."
+
+    activatedAbility {
+        cost = Costs.Tap
+        val victim = target("player or planeswalker", Targets.PlayerOrPlaneswalker)
+        effect = Effects.DealDamage(1, victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Kimonas Theodossiou"
+        flavorText = "\"Is it purebred? No, but it's pure fire.\" —Chandra Nalaar"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/91d3e366-4da5-42c8-bbd5-a0c178c0da28.jpg?1783930694"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/DaybreakCharger.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/DaybreakCharger.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Daybreak Charger
+ * {1}{W}
+ * Creature — Unicorn
+ * 3/1
+ * When this creature enters, target creature gets +2/+0 until end of turn.
+ */
+val DaybreakCharger = card("Daybreak Charger") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Unicorn"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature enters, target creature gets +2/+0 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.ModifyStats(2, 0, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "14"
+        artist = "Forrest Imel"
+        flavorText = "It's often mistaken for the coming dawn as it gallops across the horizon."
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff87a671-054f-4357-8a62-450d36559a1b.jpg?1783930743"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/LibraryLarcenist.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/LibraryLarcenist.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Library Larcenist
+ * {2}{U}
+ * Creature — Merfolk Rogue
+ * 1/2
+ * Whenever this creature attacks, draw a card.
+ */
+val LibraryLarcenist = card("Library Larcenist") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Rogue"
+    power = 1
+    toughness = 2
+    oracleText = "Whenever this creature attacks, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.DrawCards(1)
+        description = "Whenever this creature attacks, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Mila Pesic"
+        flavorText = "\"I specialize in missing manuscripts, pilfered poetry, and lifted letters.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/b/cb33529b-80bd-4f52-94cc-d8371c53ad75.jpg?1783930725"
+        ruling(
+            "2020-06-23",
+            "You may cast spells and activate abilities after the card has been drawn but before " +
+                "blockers are declared."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/OrneryDilophosaur.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/OrneryDilophosaur.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ornery Dilophosaur
+ * {3}{G}
+ * Creature — Dinosaur
+ * 2/2
+ * Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)
+ * Whenever this creature attacks, if you control a creature with power 4 or greater, this
+ * creature gets +2/+2 until end of turn.
+ *
+ * The "if" is printed straight after the trigger event, so it is a CR 603.4 intervening-if:
+ * checked both when the attack trigger would fire and again on resolution. It is a plain
+ * existence check — a single creature with power 4 or greater is enough, and it need not be
+ * the same one at both checks.
+ */
+val OrneryDilophosaur = card("Ornery Dilophosaur") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 2
+    toughness = 2
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever this creature attacks, if you control a creature with power 4 or greater, this creature gets +2/+2 until end of turn."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        interveningIf = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4))
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "194"
+        artist = "Jonathan Kuo"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2c4a0e7-9ca4-4291-94de-165cc2ded822.jpg?1783930671"
+        ruling("2020-06-23", "If you don't control a creature with power 4 or greater immediately after Ornery Dilophosaur attacks, its ability doesn't trigger. If you don't control one as the ability resolves, it has no effect. It doesn't have to be the same creature at both times, however.")
+        ruling("2020-06-23", "If Ornery Dilophosaur's power is raised to 4 or greater, its ability triggers when it attacks.")
+        ruling("2020-06-23", "Ornery Dilophosaur gets just +2/+2, no matter how many creatures you control with power 4 or greater.")
+        ruling("2020-06-23", "Once Ornery Dilophosaur's ability has resolved, it keeps +2/+2 for the rest of the turn even if you no longer control a creature with power 4 or greater.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/RambunctiousMutt.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/RambunctiousMutt.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Rambunctious Mutt
+ * {3}{W}{W}
+ * Creature — Dog
+ * 3/4
+ * When this creature enters, destroy target artifact or enchantment an opponent controls.
+ *
+ * Not optional and not "up to one" — the trigger needs a legal target to go on the stack at all.
+ */
+val RambunctiousMutt = card("Rambunctious Mutt") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dog"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, destroy target artifact or enchantment an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter.ArtifactOrEnchantment.opponentControls())
+        )
+        effect = Effects.Destroy(t)
+        description = "When this creature enters, destroy target artifact or enchantment an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Campbell White"
+        flavorText = "Emphatic words with powerful gestures. Clearly this was playtime."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f602ecc-c264-4f3e-adeb-d0186668653e.jpg?1783930737"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/TeferisProtege.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/TeferisProtege.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Teferi's Protege
+ * {2}{U}
+ * Creature — Human Wizard
+ * 2/3
+ * {1}{U}, {T}: Draw a card, then discard a card.
+ *
+ * The looter shape (Qiqirn Merchant): a single composite effect so the draw and the discard both
+ * happen while the ability resolves, with no player action between them.
+ */
+val TeferisProtege = card("Teferi's Protege") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "{1}{U}, {T}: Draw a card, then discard a card."
+
+    // {1}{U}, {T}: Draw a card, then discard a card.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{U}"), Costs.Tap)
+        effect = Effects.Composite(
+            Effects.DrawCards(1),
+            Patterns.Hand.discardCards(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "77"
+        artist = "Bram Sels"
+        flavorText = "Teferi's legacy lives on in Tolaria through the study of time magic and a tradition of irrepressible mischief."
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/5449d71c-5c1b-44c6-9407-0212aa3c3e3a.jpg?1783930718"
+        ruling("2020-06-23", "You draw a card and discard a card all while the ability is resolving. Nothing can happen between the two, and no player may choose to take actions.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ValorousSteed.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ValorousSteed.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Valorous Steed
+ * {4}{W}
+ * Creature — Unicorn
+ * 3/3
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * When this creature enters, create a 2/2 white Knight creature token with vigilance.
+ */
+val ValorousSteed = card("Valorous Steed") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Unicorn"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, create a 2/2 white Knight creature token with vigilance."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Knight"),
+            keywords = setOf(Keyword.VIGILANCE)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "42"
+        artist = "Donato Giancola"
+        flavorText = "A unicorn chooses only the most virtuous and noble of knights to be its companion."
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa01cb8c-f080-456b-a91a-f1d7943a70b2.jpg?1783930732"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/WitchsCauldron.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/WitchsCauldron.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Witch's Cauldron
+ * {B}
+ * Artifact
+ * {1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.
+ */
+val WitchsCauldron = card("Witch's Cauldron") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "{1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Creature)
+        )
+        effect = Effects.GainLife(1)
+            .then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "129"
+        artist = "Jason A. Engle"
+        flavorText = "The best recipes start with reliable cookware."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d43a3eb7-3daf-4667-b824-1f5d801c9341.jpg?1783930697"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FaerieSeer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/FaerieSeer.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Faerie Seer
+ * {U}
+ * Creature — Faerie Wizard
+ * 1/1
+ * Flying
+ * When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+ */
+val FaerieSeer = card("Faerie Seer") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\nWhen this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Scry(2)
+        description = "When this creature enters, scry 2."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Colin Boyer"
+        flavorText = "\"The patterns of crossing ripples reveal the future to those who know how to read them.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1fcfeb4-1818-4e08-be4c-27b8a9dc12e6.jpg?1783933144"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/KingOfThePride.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/KingOfThePride.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * King of the Pride
+ * {2}{W}
+ * Creature — Cat
+ * 2/1
+ * Other Cats you control get +2/+1.
+ *
+ * A plain lord: [ModifyStats] over every Cat you control, `excludeSelf = true` for "other".
+ */
+val KingOfThePride = card("King of the Pride") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat"
+    power = 2
+    toughness = 1
+    oracleText = "Other Cats you control get +2/+1."
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Permanent.withSubtype(Subtype.CAT).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "16"
+        artist = "Jonathan Kuo"
+        flavorText = "\"Glorious, to walk again across the savannah with my beloved.\" —\"Love Song of Night and Day\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/4/c4e83abd-6f15-491e-9253-90af9f6f1025.jpg?1783933160"
+        ruling(
+            "2024-11-08",
+            "Because damage remains marked on a creature until the damage is removed as the turn " +
+                "ends, nonlethal damage dealt to a Cat you control may become lethal if King of " +
+                "the Pride leaves the battlefield during that turn."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SlingGangLieutenant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/SlingGangLieutenant.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Sling-Gang Lieutenant
+ * {3}{B}
+ * Creature — Goblin
+ * 1/1
+ * When this creature enters, create two 1/1 red Goblin creature tokens.
+ * Sacrifice a Goblin: Target player loses 1 life and you gain 1 life.
+ *
+ * The bare tribal noun "Goblin" in the sacrifice cost names every *permanent* with the subtype,
+ * and [Costs.Sacrifice] doesn't exclude the source — so Sling-Gang Lieutenant can sacrifice
+ * itself, as the ruling notes.
+ */
+val SlingGangLieutenant = card("Sling-Gang Lieutenant") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, create two 1/1 red Goblin creature tokens.\nSacrifice a Goblin: Target player loses 1 life and you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Goblin"),
+            imageUri = "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1782727474",
+        )
+        description = "When this creature enters, create two 1/1 red Goblin creature tokens."
+    }
+
+    activatedAbility {
+        cost = Costs.Sacrifice(GameObjectFilter.Permanent.withSubtype("Goblin"))
+        val player = target("target player", Targets.Player)
+        effect = Effects.Composite(
+            Effects.LoseLife(1, player),
+            Effects.GainLife(1),
+        )
+        description = "Sacrifice a Goblin: Target player loses 1 life and you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "108"
+        artist = "Craig J Spearing"
+        flavorText = "Freshly promoted to \"first rock,\" Zaz was eager to make an impact."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f82aec21-441b-4fcd-b666-61723bd79531.jpg?1783933120"
+        ruling("2019-06-14", "You can sacrifice any Goblin you control to activate Sling-Gang Lieutenant's activated ability, not just the ones its triggered ability creates. You can even sacrifice Sling-Gang Lieutenant itself.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/UniversalAutomaton.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mh1/cards/UniversalAutomaton.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.mh1.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Universal Automaton
+ * {1}
+ * Artifact Creature — Shapeshifter
+ * 1/1
+ * Changeling (This card is every creature type.)
+ */
+val UniversalAutomaton = card("Universal Automaton") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Shapeshifter"
+    power = 1
+    toughness = 1
+    oracleText = "Changeling (This card is every creature type.)"
+
+    keywords(Keyword.CHANGELING)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "235"
+        artist = "Ben Maier"
+        flavorText = "\"Within minutes, the strange device was indistinguishable from the other upon my workbench.\" —Tocasia, journal entry"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53c682e2-c90f-4f4b-9010-00b099e85518.jpg?1783933069"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/BoundingWolf.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/BoundingWolf.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Bounding Wolf
+ * {2}{G}
+ * Creature — Wolf
+ * 3/2
+ * Flash
+ * Reach
+ */
+val BoundingWolf = card("Bounding Wolf") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 3
+    toughness = 2
+    oracleText = "Flash\nReach"
+
+    keywords(Keyword.FLASH, Keyword.REACH)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "170"
+        artist = "Andrea Radeck"
+        flavorText = "With their usual prey scared off by werewolves, the wolves of the Ulvenwald adopted inventive new hunting techniques."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/74e22ed6-9d39-4feb-8c64-64cdd8313816.jpg?1783925585"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/ElectricRevelation.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/ElectricRevelation.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Electric Revelation
+ * {2}{R}
+ * Instant
+ * As an additional cost to cast this spell, discard a card.
+ * Draw two cards.
+ * Flashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)
+ *
+ * Thrill of Possibility plus flashback: the additional discard is declared with
+ * [Costs.additional] so it is paid on both the normal cast and the flashback cast.
+ */
+val ElectricRevelation = card("Electric Revelation") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, discard a card.\nDraw two cards.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)"
+
+    additionalCost(Costs.additional.DiscardCards())
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    keywordAbility(KeywordAbility.flashback("{3}{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Liiga Smilshkalne"
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20ff3289-00fb-4e91-b34f-6255e9de8e9e.jpg?1783925602"
+        ruling(
+            "2021-09-24",
+            "If you cast Electric Revelation using flashback, you must still pay its additional cost of discarding a card."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/PestilentWolf.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/PestilentWolf.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pestilent Wolf
+ * {1}{G}
+ * Creature — Wolf
+ * 2/2
+ * {2}{G}: This creature gains deathtouch until end of turn.
+ */
+val PestilentWolf = card("Pestilent Wolf") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    power = 2
+    toughness = 2
+    oracleText = "{2}{G}: This creature gains deathtouch until end of turn."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Oriana Menendez"
+        flavorText = "Wolves that feast on zombie flesh and survive carry the foul diseases of the dead wherever they roam."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2686431-8d9c-4b9c-998f-38b5ae113d4a.jpg?1783925575"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/RazeTheEffigy.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mid/cards/RazeTheEffigy.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mid.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Raze the Effigy
+ * {R}
+ * Instant
+ * Choose one —
+ * • Destroy target artifact.
+ * • Target attacking creature gets +2/+2 until end of turn.
+ *
+ * Each mode carries its own target, so the mode chosen on announcement decides what is targeted —
+ * the +2/+2 mode is only castable while something is attacking.
+ */
+val RazeTheEffigy = card("Raze the Effigy") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n• Destroy target artifact.\n• Target attacking creature gets +2/+2 until end of turn."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Destroy target artifact") {
+                val t = target("target", Targets.Artifact)
+                effect = Effects.Destroy(t)
+            }
+            mode("Target attacking creature gets +2/+2 until end of turn") {
+                val t = target("target", TargetCreature(filter = TargetFilter.AttackingCreature))
+                effect = Effects.ModifyStats(2, 2, t)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "156"
+        artist = "Cristi Balanescu"
+        flavorText = "The folk of Kessig build up their courage by burning effigies of the things they fear."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0dd378c-5050-48c9-9a16-6d91afa62d21.jpg?1783925591"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/CircuitMender.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/CircuitMender.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Circuit Mender
+ * {3}
+ * Artifact Creature — Insect
+ * 2/3
+ * When this creature enters, you gain 2 life.
+ * When this creature leaves the battlefield, draw a card.
+ *
+ * Two independent SELF zone-change triggers. The second is [Triggers.LeavesBattlefield], not
+ * [Triggers.Dies] — bouncing, exiling, or milling it off the battlefield all draw the card.
+ */
+val CircuitMender = card("Circuit Mender") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Insect"
+    power = 2
+    toughness = 3
+    oracleText = "When this creature enters, you gain 2 life.\nWhen this creature leaves the battlefield, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(2)
+        description = "When this creature enters, you gain 2 life."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.DrawCards(1)
+        description = "When this creature leaves the battlefield, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "242"
+        artist = "Hector Ortiz"
+        flavorText = "Inspired by industrious silkworms, its maker crafted it to restore the broken pieces of the world."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/defaeb68-3f8a-4740-b13f-8c71c7e9c8b4.jpg?1783923827"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/SpiritedCompanion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/neo/cards/SpiritedCompanion.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.neo.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spirited Companion
+ * {1}{W}
+ * Enchantment Creature — Dog
+ * 1/1
+ * When this creature enters, draw a card.
+ */
+val SpiritedCompanion = card("Spirited Companion") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment Creature — Dog"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, draw a card."
+
+    // When this creature enters, draw a card.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Ilse Gort"
+        flavorText = "She formed a friendship with several playful spirits, and soon \"the pack\" was known as the source of much mischief in Eiganjo."
+        imageUri = "https://cards.scryfall.io/normal/front/5/a/5aa91a9e-2fe2-43bc-aa9c-cfb8a71829ff.jpg?1783923912"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/AquaticIncursion.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/AquaticIncursion.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Aquatic Incursion
+ * {3}{U}
+ * Enchantment
+ * When this enchantment enters, create two 1/1 blue Merfolk creature tokens with hexproof. (They can't be the targets of spells or abilities your opponents control.)
+ * {3}{U}: Target Merfolk can't be blocked this turn.
+ */
+val AquaticIncursion = card("Aquatic Incursion") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, create two 1/1 blue Merfolk creature tokens with hexproof. (They can't be the targets of spells or abilities your opponents control.)\n{3}{U}: Target Merfolk can't be blocked this turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Merfolk"),
+            keywords = setOf(Keyword.HEXPROOF),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/f/5/f5d353ad-7160-41fa-809c-d76b36478a2a.jpg?1783913608"
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{U}")
+        val merfolk = target(
+            "Merfolk",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK)))
+        )
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, merfolk)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "32"
+        artist = "Jason Rainville"
+        imageUri = "https://cards.scryfall.io/normal/front/5/6/56cb8fa2-337b-4596-9c31-01f0c0b171b7.jpg?1783935328"
+        ruling("2018-01-19", "Activating the last ability of Aquatic Incursion after a Merfolk has become blocked won't cause it to become unblocked.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/SeafloorOracle.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/SeafloorOracle.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Seafloor Oracle
+ * {2}{U}{U}
+ * Creature — Merfolk Wizard
+ * 2/3
+ * Whenever a Merfolk you control deals combat damage to a player, draw a card.
+ *
+ * The bare tribal noun "Merfolk" names every *permanent* with the subtype, so the source filter
+ * is [GameObjectFilter.Permanent]; [TriggerBinding.ANY] lets Seafloor Oracle's own combat damage
+ * trigger it too.
+ */
+val SeafloorOracle = card("Seafloor Oracle") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Wizard"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever a Merfolk you control deals combat damage to a player, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK).youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.DrawCards(1)
+        description = "Whenever a Merfolk you control deals combat damage to a player, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "51"
+        artist = "Simon Dominic"
+        flavorText = "Where the light falls dim and blue on broken ships, secrets lie unclaimed."
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/4316eacf-4b78-4b99-833c-53ecf49a0ae5.jpg?1783935319"
+        ruling("2018-01-19", "If Seafloor Oracle is dealt lethal damage at the same time a Merfolk you control deals combat damage to a player, you'll draw a card.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/BringToTrial.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/BringToTrial.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bring to Trial
+ * {2}{W}
+ * Sorcery
+ * Exile target creature with power 4 or greater.
+ */
+val BringToTrial = card("Bring to Trial") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Exile target creature with power 4 or greater."
+
+    spell {
+        val t = target(
+            "creature with power 4 or greater",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.powerAtLeast(4)))
+        )
+        effect = Effects.Exile(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Victor Adame Minguez"
+        flavorText = "\"In you go, big guy. Watch your head.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/63d566fc-0936-4035-96fd-f8b0c4eadbf5.jpg?1783933724"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/BurnBright.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/BurnBright.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Burn Bright
+ * {2}{R}
+ * Instant
+ * Creatures you control get +2/+0 until end of turn.
+ */
+val BurnBright = card("Burn Bright") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Creatures you control get +2/+0 until end of turn."
+
+    spell {
+        effect = Patterns.Group.modifyStatsForAll(2, 0, Filters.Group.creaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Scott Murphy"
+        flavorText = "\"From a great bonfire at the dawn of time, the first Gruul kindled their rage. The same flame burns in you.\" —Kroshkar, Gruul shaman"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8574ffd-3e72-41de-90bf-69363189f047.jpg?1783933685"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SagesRowSavant.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rna/cards/SagesRowSavant.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.rna.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sage's Row Savant
+ * {1}{U}
+ * Creature — Vedalken Wizard
+ * 2/1
+ * When this creature enters, scry 2.
+ */
+val SagesRowSavant = card("Sage's Row Savant") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Vedalken Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature enters, scry 2."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(2)
+        description = "When this creature enters, scry 2."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Bastien L. Deharme"
+        flavorText = "The streets of Ravnica are full of former guild members now using their institutional skills for personal gain."
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d573626b-e7fa-4c31-a3d4-b853adfe787e.jpg?1783933705"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Goldhound.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/Goldhound.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Goldhound
+ * {R}
+ * Artifact Creature — Treasure Dog
+ * 1/1
+ * First strike
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * {T}, Sacrifice this creature: Add one mana of any color.
+ */
+val Goldhound = card("Goldhound") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Treasure Dog"
+    power = 1
+    toughness = 1
+    oracleText = "First strike\nMenace (This creature can't be blocked except by two or more creatures.)\n{T}, Sacrifice this creature: Add one mana of any color."
+
+    keywords(Keyword.FIRST_STRIKE, Keyword.MENACE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "108"
+        artist = "Donato Giancola"
+        flavorText = "The staccato clatter of its metal claws on pavement is unmistakable."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c059e4b4-1542-4b5c-810a-9f0abac5792b.jpg?1783923118"
+        ruling("2022-04-29", "Even when it is on a creature, Treasure is an artifact type and not a creature type. Similarly, Dog is always a creature type and not an artifact type.")
+        ruling("2022-04-29", "Since Goldhound is a creature, its {T} ability can't be activated the turn that it enters the battlefield or the turn a player gains control of it unless it has haste.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/CombatProfessor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/stx/cards/CombatProfessor.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.stx.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Combat Professor
+ * {3}{W}
+ * Creature — Bird Cleric
+ * 2/3
+ * Flying
+ * At the beginning of combat on your turn, target creature you control gets +1/+0 and gains vigilance until end of turn.
+ */
+val CombatProfessor = card("Combat Professor") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird Cleric"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\nAt the beginning of combat on your turn, target creature you control gets +1/+0 and gains vigilance until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, t),
+            Effects.GrantKeyword(Keyword.VIGILANCE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Andrey Kuzinskiy"
+        flavorText = "\"Before Yovus was cut down at Pranticle Peak, she performed which maneuver? Anyone? From the reading?\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3f669ac4-98ed-4e23-91a9-281f8277ab04.jpg?1783927394"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ArchonOfSunsGrace.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ArchonOfSunsGrace.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Archon of Sun's Grace
+ * {2}{W}{W}
+ * Creature — Archon
+ * 3/4
+ * Flying
+ * Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+ * Pegasus creatures you control have lifelink.
+ * Constellation — Whenever an enchantment you control enters, create a 2/2 white Pegasus creature token with flying.
+ */
+val ArchonOfSunsGrace = card("Archon of Sun's Grace") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Archon"
+    power = 3
+    toughness = 4
+    oracleText = "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nPegasus creatures you control have lifelink.\nConstellation — Whenever an enchantment you control enters, create a 2/2 white Pegasus creature token with flying."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    // Pegasus creatures you control have lifelink.
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.LIFELINK,
+            GroupFilter(GameObjectFilter.Creature.withSubtype("Pegasus").youControl())
+        )
+    }
+
+    // Constellation — Whenever an enchantment you control enters, create a 2/2 white Pegasus
+    // creature token with flying. "Constellation" is an ability word: no rules meaning of its own.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Pegasus"),
+            keywords = setOf(Keyword.FLYING),
+        )
+        description = "Constellation — Whenever an enchantment you control enters, create a 2/2 " +
+            "white Pegasus creature token with flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "3"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/235e5999-e8e5-4093-adff-9d47aec70d10.jpg?1783931603"
+        ruling("2020-01-24", "Multiple instances of lifelink on the same creature are redundant.")
+        ruling("2020-01-24", "A constellation ability triggers whenever an enchantment enters the battlefield under your control for any reason. Enchantments with other card types, such as enchantment creatures, will also cause constellation abilities to trigger.")
+        ruling("2020-01-24", "An Aura spell that has an illegal target when it tries to resolve doesn't resolve and is instead put into its owner's graveyard. It doesn't enter the battlefield, so constellation abilities don't trigger.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/CaptivatingUnicorn.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/CaptivatingUnicorn.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Captivating Unicorn
+ * {4}{W}
+ * Creature — Unicorn
+ * 4/4
+ * Constellation — Whenever an enchantment you control enters, tap target creature an opponent controls.
+ *
+ * Constellation is an ability word (no rules meaning of its own): the trigger is
+ * `entersBattlefield(Enchantment.youControl(), ANY)` — the same atom Eerie uses — into
+ * [Effects.Tap] on a [Targets.CreatureOpponentControls]. ANY rather than OTHER because an
+ * enchantment *creature* entering is itself an enchantment you control, and the Unicorn is not
+ * an enchantment so it can never be the entering permanent anyway.
+ */
+val CaptivatingUnicorn = card("Captivating Unicorn") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Unicorn"
+    power = 4
+    toughness = 4
+    oracleText = "Constellation — Whenever an enchantment you control enters, tap target creature an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        val creature = target("creature", Targets.CreatureOpponentControls)
+        effect = Effects.Tap(creature)
+        description = "Constellation — Whenever an enchantment you control enters, tap target creature an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "6"
+        artist = "Emrah Elmasli"
+        flavorText = "\"Gazing at the unicorn, I felt closer to the majesty of Nyx than I ever had before.\" —Oineus, traveling merchant"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/13893599-0b87-4fc0-863d-f3e0ae51cc31.jpg?1783931602"
+        ruling("2020-01-24", "A constellation ability triggers whenever an enchantment enters the battlefield under your control for any reason. Enchantments with other card types, such as enchantment creatures, will also cause constellation abilities to trigger.")
+        ruling("2020-01-24", "An Aura spell that has an illegal target when it tries to resolve doesn't resolve and is instead put into its owner's graveyard. It doesn't enter the battlefield, so constellation abilities don't trigger.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/EliteInstructor.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/EliteInstructor.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Elite Instructor
+ * {2}{U}
+ * Creature — Human Wizard
+ * 2/2
+ * When this creature enters, draw a card, then discard a card.
+ */
+val EliteInstructor = card("Elite Instructor") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, draw a card, then discard a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Hand.loot()
+        description = "When this creature enters, draw a card, then discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "49"
+        artist = "Mike Sass"
+        flavorText = "The greatest minds in Meletis study under the masters at the Dekatia, a renowned school of magic and philosophy."
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/821cd2dd-aa03-4c55-b9e4-98e0284889d3.jpg?1783931585"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/FavoredOfIroas.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/FavoredOfIroas.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Favored of Iroas
+ * {2}{W}
+ * Creature — Human Soldier
+ * 2/2
+ * Constellation — Whenever an enchantment you control enters, this creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)
+ *
+ * Constellation is an ability word — it carries no rules meaning of its own, so the card is just a
+ * triggered ability on "an enchantment you control enters" (Cult Healer's Eerie shape).
+ */
+val FavoredOfIroas = card("Favored of Iroas") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Constellation — Whenever an enchantment you control enters, this creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)"
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, EffectTarget.Self)
+        description = "Constellation — Whenever an enchantment you control enters, this creature gains double strike until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "John Severin Brassell"
+        flavorText = "\"The promise of victory fills my heart. There is no room for fear.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f09e7aff-d873-4420-b0d5-1c63d686dd73.jpg?1783931598"
+        ruling("2020-01-24", "Multiple instances of double strike on the same creature are redundant.")
+        ruling(
+            "2020-01-24",
+            "A constellation ability triggers whenever an enchantment enters the battlefield under your control for any reason. Enchantments with other card types, such as enchantment creatures, will also cause constellation abilities to trigger."
+        )
+        ruling(
+            "2020-01-24",
+            "An Aura spell that has an illegal target when it tries to resolve doesn't resolve and is instead put into its owner's graveyard. It doesn't enter the battlefield, so constellation abilities don't trigger."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/IrreverentRevelers.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/IrreverentRevelers.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Irreverent Revelers
+ * {2}{R}
+ * Creature — Satyr
+ * 2/2
+ * When this creature enters, choose one —
+ * • Destroy target artifact.
+ * • This creature gains haste until end of turn.
+ *
+ * A modal ETB via [ModalEffect.chooseOne]. Only the first mode targets; the second grants haste to
+ * the source permanent itself ([EffectTarget.Self]) for the default end-of-turn duration.
+ */
+val IrreverentRevelers = card("Irreverent Revelers") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Satyr"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, choose one —\n• Destroy target artifact.\n• This creature gains haste until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                target = Targets.Artifact,
+                description = "Destroy target artifact."
+            ),
+            Mode.noTarget(
+                effect = Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self),
+                description = "This creature gains haste until end of turn."
+            )
+        )
+        description = "When this creature enters, choose one — Destroy target artifact. • This creature gains haste until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "Milivoj Ćeran"
+        flavorText = "To some satyrs, only blasphemy is sacred."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55405dca-3555-45ff-be1c-e276fe1a0c2e.jpg?1783931550"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/PiousWayfarer.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/PiousWayfarer.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Pious Wayfarer
+ * {W}
+ * Creature — Human Scout
+ * 1/2
+ * Constellation — Whenever an enchantment you control enters, target creature gets +1/+1 until end of turn.
+ *
+ * Constellation is an ability word — no rules meaning of its own. The trigger is a plain
+ * enters-the-battlefield watcher over enchantments you control, which is why an enchantment
+ * *creature* entering both triggers it and is a legal target for it.
+ */
+val PiousWayfarer = card("Pious Wayfarer") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    power = 1
+    toughness = 2
+    oracleText = "Constellation — Whenever an enchantment you control enters, target creature gets +1/+1 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        val t = target("target", Targets.Creature)
+        effect = Effects.ModifyStats(1, 1, t)
+        description = "Constellation — Whenever an enchantment you control enters, target creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Mark Zug"
+        flavorText = "Every footstep is a prayer, every road a temple."
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/10b1a2b5-5be2-43a2-bc35-95df6eb0984f.jpg?1783931591"
+
+        ruling(
+            "2020-01-24",
+            "If an enchantment creature enters the battlefield under your control, Pious Wayfarer's " +
+                "ability can target it."
+        )
+        ruling(
+            "2020-01-24",
+            "A constellation ability triggers whenever an enchantment enters the battlefield under " +
+                "your control for any reason. Enchantments with other card types, such as enchantment " +
+                "creatures, will also cause constellation abilities to trigger."
+        )
+        ruling(
+            "2020-01-24",
+            "An Aura spell that has an illegal target when it tries to resolve doesn't resolve and is " +
+                "instead put into its owner's graveyard. It doesn't enter the battlefield, so " +
+                "constellation abilities don't trigger."
+        )
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ThaumaturgesFamiliar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ThaumaturgesFamiliar.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thaumaturge's Familiar
+ * {3}
+ * Artifact Creature — Bird
+ * 1/3
+ * Flying
+ * When this creature enters, scry 1.
+ */
+val ThaumaturgesFamiliar = card("Thaumaturge's Familiar") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Bird"
+    power = 1
+    toughness = 3
+    oracleText = "Flying\nWhen this creature enters, scry 1."
+
+    keywords(Keyword.FLYING)
+
+    // When this creature enters, scry 1.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "238"
+        artist = "Andrea Radeck"
+        flavorText = "Meletian mages can't claim the title of thaumaturge until they have received a gift or omen from the gods. Ephara likes to give tangible tokens of her favor."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b497153-69a8-480e-b02f-88afec9d5053.jpg?1783931515"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/DivineArrow.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/DivineArrow.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Divine Arrow
+ * {1}{W}
+ * Instant
+ * Divine Arrow deals 4 damage to target attacking or blocking creature.
+ */
+val DivineArrow = card("Divine Arrow") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Divine Arrow deals 4 damage to target attacking or blocking creature."
+
+    spell {
+        val t = target(
+            "target attacking or blocking creature",
+            TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature)
+        )
+        effect = Effects.DealDamage(4, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "10"
+        artist = "Kieran Yanner"
+        flavorText = "Ravnica's defenders watched in horror as Oketra's shot pierced the body of the pegasus. Gideon tumbled through the air, Blackblade in hand."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73cbb58a-1b00-4883-9b45-da7ded7317e3.jpg?1783933485"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/IronBully.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/IronBully.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Iron Bully
+ * {3}
+ * Artifact Creature — Golem
+ * 1/1
+ * Menace (This creature can't be blocked except by two or more creatures.)
+ * When this creature enters, put a +1/+1 counter on target creature.
+ *
+ * The ETB targets any creature — including Iron Bully itself, per the ruling — so the target
+ * requirement is the unrestricted [Targets.Creature], not the "you control" variant.
+ */
+val IronBully = card("Iron Bully") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Golem"
+    power = 1
+    toughness = 1
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, put a +1/+1 counter on target creature."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+        description = "When this creature enters, put a +1/+1 counter on target creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "240"
+        artist = "Aaron Miller"
+        flavorText = "\"Why would someone have built ... wait, never mind. Send it to the front lines!\" —Commander Grozdan"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/ded2c66e-402c-4d5c-b987-402679aa914b.jpg?1783933373"
+        ruling("2020-08-07", "Iron Bully can be the target of its own ability.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/SparkReaper.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/war/cards/SparkReaper.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.war.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Spark Reaper
+ * {2}{B}
+ * Creature — Zombie
+ * 2/3
+ * {3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card.
+ */
+val SparkReaper = card("Spark Reaper") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 3
+    oracleText = "{3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}"),
+            Costs.Sacrifice(GameObjectFilter.CreatureOrPlaneswalker),
+        )
+        effect = Effects.Composite(
+            Effects.GainLife(1),
+            Effects.DrawCards(1),
+        )
+        description = "{3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Zoltan Boros"
+        flavorText = "\"I know they're unstoppable fighters created to harvest souls—it's just they're so rude about it.\" —Kaya"
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/922537f0-4caf-481c-b431-826f0c44e5c5.jpg?1783933437"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ColossalDreadmaw.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ColossalDreadmaw.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Colossal Dreadmaw
+ * {4}{G}{G}
+ * Creature — Dinosaur
+ * 6/6
+ * Trample
+ *
+ * French vanilla — a single evergreen keyword, no other text.
+ */
+val ColossalDreadmaw = card("Colossal Dreadmaw") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 6
+    toughness = 6
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "180"
+        artist = "Jesper Ejsing"
+        flavorText = "If you feel the ground quake, run. If you hear its bellow, flee. If you see its teeth, it's too late."
+        imageUri = "https://cards.scryfall.io/normal/front/7/6/76ac5b70-47db-4cdb-91e7-e5c18c42e516.jpg?1783935730"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/InspiringCleric.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/InspiringCleric.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Inspiring Cleric
+ * {2}{W}
+ * Creature — Vampire Cleric
+ * 3/2
+ * When this creature enters, you gain 4 life.
+ */
+val InspiringCleric = card("Inspiring Cleric") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Vampire Cleric"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, you gain 4 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(4)
+        description = "When this creature enters, you gain 4 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "16"
+        artist = "Randy Gallegos"
+        flavorText = "\"The Immortal Sun will bring us true eternal life to replace the everlasting shadow of undeath.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31b8f1da-c8ea-41d5-b1ad-b714c22d3683.jpg?1783935801"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/NestRobber.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/NestRobber.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Nest Robber
+ * {1}{R}
+ * Creature — Dinosaur
+ * 2/1
+ * Haste
+ */
+val NestRobber = card("Nest Robber") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur"
+    power = 2
+    toughness = 1
+    oracleText = "Haste"
+
+    keywords(Keyword.HASTE)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Jonathan Kuo"
+        flavorText = "\"These sailors on our shores are like the dinosaurs that plunder eggs from nests. They live on the labors of others.\" —Itzama the Crested"
+        imageUri = "https://cards.scryfall.io/normal/front/5/7/576d3845-f45a-4db0-9f7c-845cedb64c49.jpg?1783935742"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/OneWithTheWind.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/OneWithTheWind.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * One With the Wind
+ * {1}{U}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +2/+2 and has flying.
+ */
+val OneWithTheWind = card("One With the Wind") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\nEnchanted creature gets +2/+2 and has flying."
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "64"
+        artist = "Naomi Baker"
+        flavorText = "\"River and sea, jungle and sky. Water flows freely between the two halves of the world. We are creatures of the water.\" —Shaper Tuvasa"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c00f8bf-0088-44ad-b40b-26a2951a2428.jpg?1783935779"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RiverSneak.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RiverSneak.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlocked
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * River Sneak
+ * {1}{U}
+ * Creature — Merfolk Warrior
+ * 1/1
+ * This creature can't be blocked.
+ * Whenever another Merfolk you control enters, this creature gets +1/+1 until end of turn.
+ *
+ * The evasion is the source-scoped [CantBeBlocked] static. The bare tribal noun "Merfolk" names
+ * every *permanent* with the subtype (not just creatures), so the ETB trigger filters on
+ * [GameObjectFilter.Permanent]; [TriggerBinding.OTHER] excludes River Sneak itself.
+ */
+val RiverSneak = card("River Sneak") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Warrior"
+    power = 1
+    toughness = 1
+    oracleText = "This creature can't be blocked.\nWhenever another Merfolk you control enters, this creature gets +1/+1 until end of turn."
+
+    staticAbility {
+        ability = CantBeBlocked()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Permanent.withSubtype(Subtype.MERFOLK).youControl(),
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.ModifyStats(1, 1, EffectTarget.Self)
+        description = "Whenever another Merfolk you control enters, this creature gets +1/+1 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "70"
+        artist = "Slawomir Maniak"
+        flavorText = "No ripples, no splashes, no warning."
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2be32ffc-dc1d-4bb2-926f-51d110392b06.jpg?1783935775"
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/CanopyBaloth.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/CanopyBaloth.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Canopy Baloth
+ * {3}{G}
+ * Creature — Beast
+ * 4/3
+ * Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.
+ *
+ * Plain landfall pump: [Triggers.LandYouControlEnters] (ANY binding — no landfall ability prints
+ * "another") into [Effects.ModifyStats] on [EffectTarget.Self] with the default end-of-turn duration.
+ */
+val CanopyBaloth = card("Canopy Baloth") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 4
+    toughness = 3
+    oracleText = "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        description = "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "Filip Burburan"
+        flavorText = "\"You can almost see it calculating—are we a tasty enough treat to risk the jump?\" —Samila, Murasa Expeditionary House"
+        imageUri = "https://cards.scryfall.io/normal/front/6/b/6b04160c-89a7-4dcd-b05d-5dc846824d64.jpg?1783929341"
+        ruling("2024-11-08", "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control.")
+        ruling("2024-11-08", "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land.")
+        ruling("2024-11-08", "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.).")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/ChillingTrap.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/ChillingTrap.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Chilling Trap
+ * {U}
+ * Instant
+ * Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.
+ *
+ * The Wizard clause is a rider on resolution, not a cast condition: it is checked as the spell
+ * resolves ([ConditionalEffect]), and per the Scryfall ruling a fizzled spell (illegal target)
+ * never gets that far, so no card is drawn. "A Wizard" is a bare tribal noun — any *permanent*
+ * with the subtype counts ([Conditions.ControlPermanentOfType]).
+ */
+val ChillingTrap = card("Chilling Trap") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card."
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.ModifyStats(-4, 0, creature)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.ControlPermanentOfType(Subtype("Wizard")),
+                    effect = Effects.DrawCards(1),
+                )
+            )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Johann Bodin"
+        flavorText = "\"Serves you right for rushing ahead.\" —Kaliea, Sea Gate trapfinder"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60f9adfd-a940-4d62-894b-84f17c693a10.jpg?1783929401"
+        ruling("2020-09-25", "If the target creature is an illegal target by the time Chilling Trap tries to resolve, the spell doesn't resolve. You don't draw a card if you control a Wizard.")
+    }
+}

--- a/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/ProwlingFelidar.kt
+++ b/mtg-sets/2017-2022/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/ProwlingFelidar.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Prowling Felidar
+ * {3}{W}
+ * Creature — Cat Beast
+ * 2/3
+ * Vigilance
+ * Landfall — Whenever a land you control enters, put a +1/+1 counter on this creature.
+ */
+val ProwlingFelidar = card("Prowling Felidar") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Beast"
+    power = 2
+    toughness = 3
+    oracleText = "Vigilance\nLandfall — Whenever a land you control enters, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Landfall — Whenever a land you control enters, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "34"
+        artist = "Ilse Gort"
+        flavorText = "On occasion, felidars leave meaty \"gifts\" outside the tents of explorers they consider worthy."
+        imageUri = "https://cards.scryfall.io/normal/front/b/9/b9d1c11a-a32c-449c-95c6-450dce6c26d2.jpg?1783929408"
+
+        ruling(
+            "2024-11-08",
+            "A landfall ability triggers whenever a land you control enters for any reason. It " +
+                "triggers whenever you play a land, as well as whenever a spell or ability puts a " +
+                "land onto the battlefield under your control."
+        )
+        ruling(
+            "2024-11-08",
+            "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+        )
+        ruling(
+            "2024-11-08",
+            "Whenever a land you control enters, each landfall ability of the permanents you control " +
+                "will trigger. You can put them on the stack in any order. The last ability you put " +
+                "on the stack will be the first one to resolve (As a result, you can have those " +
+                "abilities resolve in the order of your choosing.)."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/AER.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AER.json
@@ -1,3 +1,27 @@
+// Alley Strangler
+{
+    "name": "Alley Strangler",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Aetherborn Rogue",
+    "oracleText": "Menace",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Enora Mercier",
+        "flavorText": "\"You never know what day might be your last.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a131d558-5f6b-448b-a378-1882e2d02bd2.jpg?1783936767"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Bastion Enforcer
 {
     "name": "Bastion Enforcer",

--- a/mtg-sets/src/test/resources/snapshots/cards/AFR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AFR.json
@@ -1,3 +1,48 @@
+// Improvised Weaponry
+{
+    "name": "Improvised Weaponry",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Improvised Weaponry deals 2 damage to any target. Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "artist": "Alix Branwyn",
+        "flavorText": "Anything can be a weapon if you swing it hard enough.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/29d5fd00-c616-4079-a91e-4da0bcaf9120.jpg?1783926476"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Vampire Spawn
 {
     "name": "Vampire Spawn",

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -83,6 +83,45 @@
     ]
 }
 
+// Electrify
+{
+    "name": "Electrify",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Electrify deals 4 damage to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Craig J Spearing",
+        "flavorText": "\"Some hid from the storm. I embraced it and learned its name.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/21c67128-2e5a-4c97-b265-6f3c73b4997a.jpg?1783936490"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Enigma Drake
 {
     "name": "Enigma Drake",
@@ -166,6 +205,38 @@
     ]
 }
 
+// Hieroglyphic Illumination
+{
+    "name": "Hieroglyphic Illumination",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Draw two cards.\nCycling {U} ({U}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "artist": "Raoul Vitale",
+        "flavorText": "\"The answers are here. This is the way through the trial.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c60a0e75-53bb-43e4-890f-0e1972a7e0b9.jpg?1783936520"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Hyena Pack
 {
     "name": "Hyena Pack",
@@ -183,6 +254,129 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Liliana's Mastery
+{
+    "name": "Liliana's Mastery",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Zombies you control get +1/+1.\nWhen this enchantment enters, create two 2/2 black Zombie creature tokens.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+                },
+                "descriptionOverride": "When this enchantment enters, create two 2/2 black Zombie creature tokens."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Zombie ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "RARE",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"There are so many of them. It seems they've just been waiting for someone to serve.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c57b3b8-71f1-479c-b7f7-508fee2b5b0f.jpg?1783936503"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Lord of the Accursed
+{
+    "name": "Lord of the Accursed",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Other Zombies you control get +1/+1.\n{1}{B}, {T}: All Zombies gain menace until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "permanent Zombie"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "MENACE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Zombie ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Grzegorz Rutkowski",
+        "flavorText": "The Curse of Wandering leaves only hatred.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/3941562d-3e39-4746-9a18-d3aa6d3468b0.jpg?1783936503"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -251,6 +251,67 @@
     ]
 }
 
+// Sanctum Gargoyle
+{
+    "name": "Sanctum Gargoyle",
+    "manaCost": "{3}{W}",
+    "typeLine": "Artifact Creature — Gargoyle",
+    "oracleText": "Flying\nWhen this creature enters, you may return target artifact card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Shelly Wan",
+        "flavorText": "As their supplies of etherium dwindled, mechanists sent gargoyles farther and farther afield in search of salvage.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1da1a2d5-d1fe-4aa2-aa83-64d6c269f7bc.jpg?1783942579",
+        "rulings": [
+            {
+                "date": "2008-10-01",
+                "text": "The only difference between a colored artifact and a colorless artifact is, obviously, its color. Unlike most artifacts, a colored artifact requires colored mana to cast. Also unlike most artifacts, a colored artifact has a color in all zones. It will interact with cards that care about color. Other than that, a colored artifact behaves just like any other artifact. It will interact as normal with any card that cares about artifacts, such as Shatter or Arcbound Ravager."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Woolly Thoctar
 {
     "name": "Woolly Thoctar",

--- a/mtg-sets/src/test/resources/snapshots/cards/AVR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AVR.json
@@ -1119,6 +1119,68 @@
     ]
 }
 
+// Goldnight Commander
+{
+    "name": "Goldnight Commander",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Cleric Soldier",
+    "oracleText": "Whenever another creature you control enters, creatures you control get +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rahn",
+        "flavorText": "\"One faith, but many hands in victory.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/6/c6ebec82-9d4a-4e78-b923-37c3a52133e7.jpg?1783940736",
+        "rulings": [
+            {
+                "date": "2012-05-01",
+                "text": "The creature that entered will also get +1/+1 until end of turn if it's still on the battlefield when the ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Goldnight Redeemer
 {
     "name": "Goldnight Redeemer",

--- a/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BFZ.json
@@ -145,6 +145,49 @@
     ]
 }
 
+// Demon's Grasp
+{
+    "name": "Demon's Grasp",
+    "manaCost": "{4}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature gets -5/-5 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -5
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "artist": "David Gaillet",
+        "flavorText": "\"Take what solace you can in the knowledge that you will not be here to witness Zendikar's demise.\" —Ob Nixilis",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff953948-db26-43af-9905-7d387769b4a9.jpg?1783938202"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Expedition Envoy
 {
     "name": "Expedition Envoy",
@@ -268,6 +311,237 @@
         "imageUri": "https://cards.scryfall.io/normal/front/2/5/2519149c-f8a3-413f-b7b2-cd596970be4c.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Lavastep Raider
+{
+    "name": "Lavastep Raider",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "{2}{R}: This creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Matt Stewart",
+        "flavorText": "Goblins were first to see the potential of hedrons in the fight against the Eldrazi, for the magical stones came ready-made with pointy bits.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/2428f13f-c445-4eb4-bab1-309f27cab208.jpg?1783938194"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Outnumber
+{
+    "name": "Outnumber",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Outnumber deals damage to target creature equal to the number of creatures you control.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "artist": "Tyler Jacobson",
+        "flavorText": "Everyone who could still lift a weapon had a part in retaking Sea Gate.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3373281-7319-4320-8afb-4546fb55ab4c.jpg?1783938193",
+        "rulings": [
+            {
+                "date": "2015-08-25",
+                "text": "Count the number of creatures you control as Outnumber resolves to determine how much damage Outnumber deals."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sandstone Bridge
+{
+    "name": "Sandstone Bridge",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, target creature gets +1/+1 and gains vigilance until end of turn.\n{T}: Add {W}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "artist": "Cliff Childs",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c781e932-4605-47aa-add1-4ee62f4e7ead.jpg?1783938173"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Snapping Gnarlid
+{
+    "name": "Snapping Gnarlid",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, this creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "artist": "Kev Walker",
+        "flavorText": "All of Zendikar's beings sense the upheaval that accompanies the Eldrazi.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/834409e3-134e-4a34-89cb-53e2a039e980.jpg?1783938185",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Stasis Snare
@@ -549,5 +823,46 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Windrider Patrol
+{
+    "name": "Windrider Patrol",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "Flying\nWhenever this creature deals combat damage to a player, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                },
+                "descriptionOverride": "Scry 2."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4ac7b904-7658-4248-a75c-b3a862bde196.jpg?1783938206"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/C16.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/C16.json
@@ -1,0 +1,42 @@
+// Ash Barrens
+{
+    "name": "Ash Barrens",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\nBasic landcycling {1} ({1}, Discard this card: Search your library for a basic land card, reveal it, put it into your hand, then shuffle.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}",
+            "searchFilter": {
+                "cardPredicates": [
+                    "IsBasicLand"
+                ]
+            },
+            "displayPrefix": "Basic landcycling"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d7ac112-bb20-4ea4-b797-5d21f6b7c121.jpg?1783937080"
+    },
+    "colorIdentityOverride": []
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/CON_.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CON_.json
@@ -290,6 +290,65 @@
     "colorIdentityOverride": []
 }
 
+// Sigil of the Empty Throne
+{
+    "name": "Sigil of the Empty Throne",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 4,
+                    "toughness": 4,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Angel"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "descriptionOverride": "Whenever you cast an enchantment spell, create a 4/4 white Angel creature token with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "RARE",
+        "artist": "Cyril Van Der Haegen",
+        "flavorText": "When Asha left Bant, she ensured that the world would have protection and order in her absence.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c451f63-2827-49fe-9d1d-87c87f7f5f8d.jpg?1783942490",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "An ability that triggers when a player casts a spell resolves before the spell that caused it to trigger, but after targets have been chosen for that spell. It resolves even if that spell is countered."
+            },
+            {
+                "date": "2021-03-19",
+                "text": "Because it's not on the battlefield yet, casting Sigil of the Empty Throne won't cause its own ability to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Valiant Guard
 {
     "name": "Valiant Guard",

--- a/mtg-sets/src/test/resources/snapshots/cards/CSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CSP.json
@@ -130,6 +130,53 @@
     ]
 }
 
+// Simian Brawler
+{
+    "name": "Simian Brawler",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Ape Warrior",
+    "oracleText": "Discard a land card: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomDiscard",
+                        "filter": "land"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Warren Mahy",
+        "flavorText": "\"It's odd to see the apes rip down trees to arm themselves in defense of their forests.\" —Taaveti of Kelsinko, elvish hunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df2ed9f3-50b1-493b-9c14-0f8ddb4d8c57.jpg?1783943326"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Zur the Enchanter
 {
     "name": "Zur the Enchanter",

--- a/mtg-sets/src/test/resources/snapshots/cards/DGM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DGM.json
@@ -39,6 +39,53 @@
     ]
 }
 
+// Kraul Warrior
+{
+    "name": "Kraul Warrior",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Insect Warrior",
+    "oracleText": "{5}{G}: This creature gets +3/+3 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "artist": "David Rapoza",
+        "flavorText": "The insectile kraul lurk in the tunnels below street level. Many are loyal to the Golgari Swarm, but others follow their own esoteric caste system.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f71da8cc-8773-4dcb-aca8-50a000142218.jpg?1783940036"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Maze's End
 {
     "name": "Maze's End",

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -1,3 +1,140 @@
+// Black Cat
+{
+    "name": "Black Cat",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Cat",
+    "oracleText": "When this creature dies, target opponent discards a card at random.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "Random",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "discarded"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "David Palumbo",
+        "flavorText": "Its last life is spent tormenting your dreams.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bb1c6379-69d5-48aa-8d06-257c0592794e.jpg?1783940835"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Briarpack Alpha
+{
+    "name": "Briarpack Alpha",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nWhen this creature enters, target creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "rarity": "UNCOMMON",
+        "artist": "Daarken",
+        "flavorText": "\"The wolves turned on us and a chill swept over me. The pack had a new leader.\" —Alena, trapper of Kessig",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a052e945-7535-4b0a-b580-cf76377633f3.jpg?1783940811"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Chalice of Life
 {
     "name": "Chalice of Life",
@@ -1084,6 +1221,46 @@
     "colorIdentityOverride": [
         "WHITE",
         "BLACK"
+    ]
+}
+
+// Midnight Guard
+{
+    "name": "Midnight Guard",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever another creature enters, untap this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "descriptionOverride": "Whenever another creature enters, untap this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"When you're on watch, no noise is harmless and no shadow can be ignored.\" —Olgard of the Skiltfolk",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/2264b760-c527-470d-bad0-d8baaf543631.jpg?1783940853"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/DTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DTK.json
@@ -772,6 +772,63 @@
     ]
 }
 
+// Vial of Dragonfire
+{
+    "name": "Vial of Dragonfire",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "{2}, {T}, Sacrifice this artifact: It deals 2 damage to target creature.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "It deals 2 damage to target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "artist": "Franz Vohwinkel",
+        "flavorText": "Designed by an ancient artificer, the vials are strong enough to hold the very breath of a dragon—until it's needed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e50e88fe-307a-4944-9233-14df4e0bb775.jpg?1783938567"
+    },
+    "colorIdentityOverride": []
+}
+
 // Wandering Tombshell
 {
     "name": "Wandering Tombshell",

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -135,6 +135,122 @@
     ]
 }
 
+// Faerie Formation
+{
+    "name": "Faerie Formation",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Faerie",
+    "oracleText": "Flying\n{3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Faerie"
+                            ],
+                            "keywords": [
+                                "FLYING"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg?1782727481"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{3}{U}: Create a 1/1 blue Faerie creature token with flying. Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "316",
+        "rarity": "RARE",
+        "artist": "Ryan Yee",
+        "flavorText": "The throng flitted from castle to castle, leaving a trail of star-crossed love, damaging rumors, and missing heirlooms in their wake.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/15709316-7382-46b9-9b70-53a5147e7051.jpg?1783932552"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Fierce Witchstalker
+{
+    "name": "Fierce Witchstalker",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhen this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "154",
+        "artist": "Nicholas Gregory",
+        "flavorText": "While the realm has laws, in the wilds there are other ways of balancing power.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d63a6be2-ae9a-4758-9d5c-0297ef9af57c.jpg?1783932611",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "Food is an artifact type. Even though it appears on some creatures, it's never a creature type."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "You can't sacrifice a Food to pay multiple costs. For example, you can't sacrifice a Food token to activate its own ability and also to activate Maraleaf Rider's ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Gingerbrute
 {
     "name": "Gingerbrute",
@@ -374,6 +490,67 @@
     ]
 }
 
+// Locthwain Gargoyle
+{
+    "name": "Locthwain Gargoyle",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Gargoyle",
+    "oracleText": "{4}: This creature gets +2/+0 and gains flying until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "artist": "Nils Hamm",
+        "flavorText": "\"As the traitor hurried across the courtyard, its eyes snapped open. It was time to pay the queen a visit.\" —*Beyond the Great Henge*",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02551bee-335c-4bf7-b38e-67dd71d1d567.jpg?1783932583",
+        "rulings": [
+            {
+                "date": "2019-10-04",
+                "text": "You can activate Locthwain Gargoyle's ability multiple times during one turn, even if it already has flying."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Raging Redcap
 {
     "name": "Raging Redcap",
@@ -511,6 +688,80 @@
     ]
 }
 
+// Shimmer Dragon
+{
+    "name": "Shimmer Dragon",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nAs long as you control four or more artifacts, this creature has hexproof. (It can't be the target of spells or abilities your opponents control.)\nTap two untapped artifacts you control: Draw a card.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "artifact"
+                    }
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Tap two untapped artifacts you control: Draw a card."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "317",
+        "rarity": "RARE",
+        "artist": "Lie Setiawan",
+        "flavorText": "The indigo dragon gladly traded a bit of its hoard for everlasting moonlight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5beffa4c-4188-48c1-8374-3ac3e8ea1900.jpg?1783932551"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Syr Alin, the Lion's Claw
 {
     "name": "Syr Alin, the Lion's Claw",
@@ -566,6 +817,126 @@
     ]
 }
 
+// The Circle of Loyalty
+{
+    "name": "The Circle of Loyalty",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Affinity for Knights (This spell costs {1} less to cast for each Knight you control.)\nCreatures you control get +1/+1.\nWhenever you cast a legendary spell, create a 2/2 white Knight creature token with vigilance.\n{3}{W}, {T}: Create a 2/2 white Knight creature token with vigilance.",
+    "keywords": [
+        "AFFINITY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "AffinityForSubtype",
+            "forSubtype": "Knight"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsLegendary"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "MYTHIC",
+        "artist": "Bastien L. Deharme",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/79093d00-362d-4d07-8a0a-cf5e1ccf9c0f.jpg?1783932677",
+        "rulings": [
+            {
+                "date": "2019-10-04",
+                "text": "The Circle of Loyalty's triggered ability resolves before the spell that caused it to trigger. It resolves even if that spell is countered."
+            },
+            {
+                "date": "2019-10-04",
+                "text": "The Circle of Loyalty's triggered ability won't trigger when you cast it because it's not on the battlefield yet."
+            },
+            {
+                "date": "2019-10-04",
+                "text": "To determine the total cost of a spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions. The mana value of the spell remains unchanged, no matter what the total cost to cast it was."
+            },
+            {
+                "date": "2019-10-04",
+                "text": "The cost reduction ability reduces only the generic mana in the relic's cost. The colored mana must still be paid."
+            },
+            {
+                "date": "2019-10-04",
+                "text": "Once you announce that you're casting a spell, no player may take actions until the spell has been paid for. Notably, opponents can't try to change by how much a relic's cost is reduced."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Thrill of Possibility
 {
     "name": "Thrill of Possibility",
@@ -592,6 +963,53 @@
         "artist": "Steve Argyle",
         "flavorText": "\"Remember all the great heroes who were careful and never did anything risky? Me neither.\"\n—Syr Carah, the Bold",
         "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9021f85-7ab4-4a78-a398-1611fe09cd14.jpg?1782707837"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Weaselback Redcap
+{
+    "name": "Weaselback Redcap",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Knight",
+    "oracleText": "{1}{R}: This creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "artist": "Grzegorz Rutkowski",
+        "flavorText": "\"I would rather cast myself into the abyss than let my blood stain the cap of those monsters.\" —Syr Alin, the Lion's Claw",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33a78207-fd76-4112-a257-54a25da6f818.jpg?1783932614"
     },
     "colorIdentityOverride": [
         "RED"

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -430,6 +430,47 @@
     ]
 }
 
+// Brazen Wolves
+{
+    "name": "Brazen Wolves",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Whenever this creature attacks, it gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Nils Hamm",
+        "flavorText": "With fewer patrols about, Kessig's roads have become prime hunting grounds.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab8e2ece-3c66-4f34-9042-fc02639c6a79.jpg?1783937466"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Brisela, Voice of Nightmares
 {
     "name": "Brisela, Voice of Nightmares",
@@ -2286,6 +2327,71 @@
     ]
 }
 
+// Graf Harvest
+{
+    "name": "Graf Harvest",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Zombies you control have menace. (They can't be blocked except by two or more creatures.)\n{3}{B}, Exile a creature card from your graveyard: Create a 2/2 black Zombie creature token.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bd6905-79be-4d2c-a343-f6e6a181b3e6.jpg?1783936411"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "MENACE",
+                "filter": {
+                    "baseFilter": "permanent Zombie ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Lake Hurwitz",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbc17697-9db9-41d4-aacf-b2f2e6ff80cf.jpg?1783937482"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Graf Rats
 {
     "name": "Graf Rats",
@@ -3663,6 +3769,59 @@
     ]
 }
 
+// Selfless Spirit
+{
+    "name": "Selfless Spirit",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Spirit Cleric",
+    "oracleText": "Flying\nSacrifice this creature: Creatures you control gain indestructible until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "INDESTRUCTIBLE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "RARE",
+        "artist": "Seb McKinnon",
+        "flavorText": "\"There is always more to give.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4624976-3773-4a1e-b725-5f6efce147a5.jpg?1783937510",
+        "rulings": [
+            {
+                "date": "2016-07-13",
+                "text": "The set of creatures affected by Selfless Spirit's last ability is determined as the ability resolves. Creatures you begin to control later in the turn won't gain indestructible."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Shrill Howler
 {
     "name": "Shrill Howler",
@@ -4765,6 +4924,68 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Wolfkin Bond
+{
+    "name": "Wolfkin Bond",
+    "manaCost": "{4}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, create a 2/2 green Wolf creature token.\nEnchanted creature gets +2/+2.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Wolf"
+                    ]
+                },
+                "descriptionOverride": "Create a 2/2 green Wolf creature token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "artist": "Lindsey Look",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/748f263e-efef-4033-8950-c58fd024a87f.jpg?1783937435",
+        "rulings": [
+            {
+                "date": "2019-07-12",
+                "text": "You need a creature for Wolfkin Bond to target as you cast it. It can't enter the battlefield attached to the Wolf token it will create."
+            },
+            {
+                "date": "2019-07-12",
+                "text": "If the target creature is an illegal target by the time Wolfkin Bond tries to resolve, the spell doesn't resolve. It won't enter the battlefield, so its ability won't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/EVE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EVE.json
@@ -1,0 +1,51 @@
+// Archon of Justice
+{
+    "name": "Archon of Justice",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Archon",
+    "oracleText": "Flying\nWhen this creature dies, exile target permanent.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "target permanent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "RARE",
+        "artist": "Jason Chan",
+        "flavorText": "In dark times, Truth bears a blade.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab707e7f-8ab5-43f1-9428-6a17c1b672fa.jpg?1783942696"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FEM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FEM.json
@@ -1,3 +1,62 @@
+// Goblin Grenade
+{
+    "name": "Goblin Grenade",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a Goblin.\nGoblin Grenade deals 5 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 5
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "any target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "permanent Goblin"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56a",
+        "artist": "Ron Spencer",
+        "flavorText": "\"According to accepted theory, the Grenade held some kind of flammable mixture and was carried to its target by a hapless Goblin.\" —*Sarpadian Empires, vol. IV*",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/8837eaba-9602-4f63-9897-85583fcdcf51.jpg?1783947894",
+        "rulings": [
+            {
+                "date": "2011-09-22",
+                "text": "Players can only respond once Goblin Grenade has been cast and all its costs have been paid. No one can try and destroy the Goblin to prevent you from casting Goblin Grenade."
+            },
+            {
+                "date": "2011-09-22",
+                "text": "The Goblin you sacrifice to cast Goblin Grenade doesn't have to be a creature. For example, you could sacrifice Boggart Shenanigans (a kindred enchantment with the subtype Goblin)."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "You can't sacrifice more than one Goblin to get a greater effect."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Icatian Priest
 {
     "name": "Icatian Priest",

--- a/mtg-sets/src/test/resources/snapshots/cards/HOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/HOU.json
@@ -132,6 +132,51 @@
     ]
 }
 
+// Desert of the Mindful
+{
+    "name": "Desert of the Mindful",
+    "manaCost": "",
+    "typeLine": "Land — Desert",
+    "oracleText": "This land enters tapped.\n{T}: Add {U}.\nCycling {1}{U} ({1}{U}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "artist": "Christine Choi",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/91b92d87-776c-490f-9ff1-234e47145df8.jpg?1783935997",
+        "rulings": [
+            {
+                "date": "2017-04-18",
+                "text": "Desert is a land subtype with no special meaning. It doesn't grant the land an intrinsic mana ability. Other cards may care about which lands are Deserts."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dutiful Servants
 {
     "name": "Dutiful Servants",
@@ -214,6 +259,124 @@
         "artist": "Filip Burburan",
         "flavorText": "She trusts that the potent poisons of her darts will reach the enemy before the enemy reaches her.",
         "imageUri": "https://cards.scryfall.io/normal/front/b/c/bcdc68c9-f5f3-4c5b-80df-85508cf15f84.jpg?1783936019"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Overcome
+{
+    "name": "Overcome",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Creatures you control get +2/+2 and gain trample until end of turn. (Each of those creatures can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    },
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                ]
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Craig J Spearing",
+        "flavorText": "\"Forward! Until the horizon is ours!\" —Khemses, charioteer",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1dc2427-685a-4739-8b92-e60f134d4adb.jpg?1783936018",
+        "rulings": [
+            {
+                "date": "2019-07-12",
+                "text": "Overcome affects only creatures you control at the time it resolves. Creatures you begin to control later in the turn won't get +2/+2 or gain trample."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Quarry Beetle
+{
+    "name": "Quarry Beetle",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "When this creature enters, you may return target land card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Battlefield",
+                        "fromZone": "Graveyard"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, you may return target land card from your graveyard to the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "UNCOMMON",
+        "artist": "Mike Burns",
+        "flavorText": "\"The ruin of the past is the topsoil of the future.\" —Sokar, former Nef-crop initiate",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/69e11478-bfc7-4bcc-b65c-dc2d4449e99f.jpg?1783936016",
+        "rulings": [
+            {
+                "date": "2017-07-14",
+                "text": "Quarry Beetle's ability doesn't count as playing a land. It can return a land card to the battlefield even if you've already played as many lands as able this turn."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/mtg-sets/src/test/resources/snapshots/cards/IKO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/IKO.json
@@ -38,6 +38,187 @@
     ]
 }
 
+// Lava Serpent
+{
+    "name": "Lava Serpent",
+    "manaCost": "{5}{R}",
+    "typeLine": "Creature — Elemental Serpent",
+    "oracleText": "Haste\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "124",
+        "artist": "Jason A. Engle",
+        "flavorText": "Lavabrink's boiling moat is a deterrent for most, and a relaxing bath for one.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/00ebd57f-7f7c-41b0-aa56-511c1816bc14.jpg?1783931047"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Light of Hope
+{
+    "name": "Light of Hope",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• You gain 4 life.\n• Destroy target enchantment.\n• Put a +1/+1 counter on target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "GainLife",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "description": "You gain 4 life."
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            }
+                        }
+                    ],
+                    "description": "Destroy target enchantment."
+                },
+                {
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Put a +1/+1 counter on target creature."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Kimonas Theodossiou",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bcb00599-e082-49b0-88f3-ef91b75595e4.jpg?1783931088"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Neutralize
+{
+    "name": "Neutralize",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "UNCOMMON",
+        "artist": "Yongjae Choi",
+        "flavorText": "On Ikoria, reactive magic can make the difference between barely grazed and really dead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/0430da3c-9460-4b62-ae28-2e7e6f4d06a4.jpg?1783931073"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Raking Claws
+{
+    "name": "Raking Claws",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gains double strike until end of turn.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "GrantKeyword",
+            "keyword": "DOUBLE_STRIKE",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Slawomir Maniak",
+        "flavorText": "\"How many claws does a monster have? Exactly one more than you've accounted for.\" —Alux, Skysail defender",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/e/6eb0d9a2-f9bb-4d8e-a1ca-896c42f8ad56.jpg?1783931044"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Savai Sabertooth
 {
     "name": "Savai Sabertooth",
@@ -55,6 +236,79 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Shredded Sails
+{
+    "name": "Shredded Sails",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target artifact.\n• Shredded Sails deals 4 damage to target creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target artifact"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature with flying"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature kw:flying"
+                            },
+                            "id": "target creature with flying"
+                        }
+                    ],
+                    "description": "Shredded Sails deals 4 damage to target creature with flying"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Titus Lunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b10219a-aa72-4431-9a6a-984109a605c8.jpg?1783931044"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/J22.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/J22.json
@@ -63,6 +63,83 @@
     ]
 }
 
+// Giant Ladybug
+{
+    "name": "Giant Ladybug",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Reach\nWhen this creature enters, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 1
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            "ShuffleLibrary",
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Library",
+                                    "placement": "Top"
+                                },
+                                "revealed": true
+                            },
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Marta Nael",
+        "flavorText": "It's bad luck to step on one, but worse luck to have one step on you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/7/67f55ef7-8479-4d56-9801-cb4fd5526e73.jpg?1783919180"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Ingenious Leonin
 {
     "name": "Ingenious Leonin",
@@ -201,6 +278,72 @@
         "rarity": "UNCOMMON",
         "artist": "Justyna Dura",
         "imageUri": "https://cards.scryfall.io/normal/front/3/e/3eee6f29-ef06-47f6-99af-fb0ff88f09d0.jpg?1782699338"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Spectral Hunt-Caller
+{
+    "name": "Spectral Hunt-Caller",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Wolf Spirit",
+    "oracleText": "{5}{G}: Creatures you control get +1/+1 and gain trample until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "TRAMPLE",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Uriah Voth",
+        "flavorText": "The nightsong begins with a lone howl, but soon swells to a deafening chorus.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/358fc99b-b2e5-4967-ba5a-ab2caee1751c.jpg?1783919178"
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/mtg-sets/src/test/resources/snapshots/cards/JOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JOU.json
@@ -378,3 +378,27 @@
         "GREEN"
     ]
 }
+
+// Triton Shorestalker
+{
+    "name": "Triton Shorestalker",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Merfolk Rogue",
+    "oracleText": "This creature can't be blocked.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "metadata": {
+        "collectorNumber": "56",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Who will miss you, drywalker? A wife? A child? Perhaps they will blame the sea for your fate, and teach future generations to stay far away from it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/881c554e-2324-41e2-89f1-db9f4017bc31.jpg?1783939440"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/KHM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KHM.json
@@ -351,6 +351,75 @@
     ]
 }
 
+// Mistwalker
+{
+    "name": "Mistwalker",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)\nFlying\n{1}{U}: This creature gets +1/-1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "keywords": [
+        "CHANGELING",
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Steve Prescott",
+        "flavorText": "\"To escape Littjara, follow a bird.\" —Tuskeri folklore",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/92f64b49-327c-473b-a492-f020a322aed7.jpg?1783928259",
+        "rulings": [
+            {
+                "date": "2021-02-05",
+                "text": "Changeling is a characteristic-defining ability. It functions in all zones, not only while a card that has it is on the battlefield."
+            },
+            {
+                "date": "2021-02-05",
+                "text": "The subtype Shapeshifter that appears on the type line is mostly there to reinforce the flavor. A creature card with changeling is just as much an Elf, a Dwarf, a Sliver, a Goat, a Coward, and a Zombie as it is a Shapeshifter."
+            },
+            {
+                "date": "2021-02-05",
+                "text": "If an effect causes a creature with changeling to become a new creature type, it will be only that new creature type. It will still have changeling; the effect making it all creature types will simply be overwritten."
+            },
+            {
+                "date": "2021-02-05",
+                "text": "If an effect causes a creature with changeling to lose all abilities, it will remain all creature types, even though it will no longer have changeling. This is because changeling applies before the effect that removes it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Seize the Spoils
 {
     "name": "Seize the Spoils",
@@ -439,6 +508,145 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Starnheim Aspirant
+{
+    "name": "Starnheim Aspirant",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Angel spells you cast cost {2} less to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "Angel"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "380",
+        "rarity": "UNCOMMON",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"I do not fear death. I know my soul will rise to Starnheim, where I will feast forever among valkyries and heroes. Can you say the same?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea007a18-b31a-4881-92c4-86120dc5729b.jpg?1783928123",
+        "rulings": [
+            {
+                "date": "2021-02-05",
+                "text": "To determine the total cost of a spell, start with the mana cost or alternative cost you're paying, add any cost increases, then apply any cost reductions (such as that of Starnheim Aspirant). The mana value of the spell is determined only by its mana cost, no matter what the total cost to cast the spell was."
+            },
+            {
+                "date": "2021-02-05",
+                "text": "The cost reduction applies only to generic mana in the costs of Angel spells you cast. It can't reduce requirements of specific colors of mana."
+            },
+            {
+                "date": "2021-02-05",
+                "text": "An Angel spell is a creature spell with the creature type Angel. Instant, sorcery, and enchantment cards that may create Angel tokens are not Angel spells."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Undersea Invader
+{
+    "name": "Undersea Invader",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Giant Rogue",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nThis creature enters tapped.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Lorenzo Mastroianni",
+        "flavorText": "\"The currents are strange today, and the fish are fearful. Something's stirring in the depths.\" —Rathstaf, Kannah fisherman",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/550c745b-64e8-4d20-9cf0-024248ddbd57.jpg?1783928254"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Vault Robber
+{
+    "name": "Vault Robber",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dwarf Rogue",
+    "oracleText": "{1}, {T}, Exile a creature card from your graveyard: Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Slawomir Maniak",
+        "flavorText": "The dwarves believe works of art should be passed down the generations, not buried with the dead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74f68014-489d-4f51-a959-0f335541cb4e.jpg?1783928220",
+        "rulings": [
+            {
+                "date": "2021-02-05",
+                "text": "Once you announce that you’re activating the activated ability, no player may take actions until the ability has been paid for. Notably, opponents can’t try to remove one of your creature cards to stop you from exiling it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/KLD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KLD.json
@@ -1,3 +1,67 @@
+// Aradara Express
+{
+    "name": "Aradara Express",
+    "manaCost": "{5}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Menace\nCrew 4 (Tap any number of creatures you control with total power 4 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 6
+    },
+    "keywords": [
+        "MENACE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 4
+        }
+    ],
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Adam Paquette",
+        "flavorText": "It glides around the city, a sublime combination of elegance and utility.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5fc0d1f7-c81c-4329-92b7-c4df227cc56c.jpg?1783937163",
+        "rulings": [
+            {
+                "date": "2017-09-29",
+                "text": "Each Vehicle is printed with a power and toughness, but it's not a creature. If it becomes a creature (most likely through its crew ability), it will have that power and toughness."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "If an effect causes a Vehicle to become an artifact creature with a specified power and toughness, that effect overwrites the Vehicle's printed power and toughness."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "Vehicle is an artifact type, not a creature type. A Vehicle that's crewed won't normally have any creature type."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "Once a player announces that they are activating a crew ability, no player may take other actions until the ability has been paid for. Notably, players can't try to stop the ability by changing a creature's power or by removing or tapping a creature."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "Any untapped creature you control can be tapped to pay a crew cost, even one that just came under your control."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "You may tap more creatures than necessary to activate a crew ability."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "Creatures that crew a Vehicle aren't attached to it or related in any other way. Effects that affect the Vehicle, such as by destroying it or giving it a +1/+1 counter, don't affect the creatures that crewed it."
+            },
+            {
+                "date": "2017-09-29",
+                "text": "Once a Vehicle becomes a creature, it behaves exactly like any other artifact creature. It can't attack unless you've controlled it continuously since your turn began, it can block if it's untapped, it can be tapped to pay a Vehicle's crew cost, and so on."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Armorcraft Judge
 {
     "name": "Armorcraft Judge",
@@ -621,6 +685,58 @@
     ]
 }
 
+// Impeccable Timing
+{
+    "name": "Impeccable Timing",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Impeccable Timing deals 3 damage to target attacking or blocking creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Chris Rallis",
+        "flavorText": "When Baral constructed his trap for Chandra, he did not account for the arrival of an enormous leonin wielding a twin-headed axe.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/9/2921c95e-bf2f-409b-a41d-86d873690562.jpg?1783937231"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Inspiring Vantage
 {
     "name": "Inspiring Vantage",
@@ -691,6 +807,60 @@
     ]
 }
 
+// Kujar Seedsculptor
+{
+    "name": "Kujar Seedsculptor",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Elf Druid",
+    "oracleText": "When this creature enters, put a +1/+1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "artist": "Anna Steinbauer",
+        "flavorText": "Every leaf, tree, and building in Kujar has been placed to achieve maximum harmony, in accordance with the elvish philosophy known as the Great Conduit.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a8664c65-77ca-4881-959a-e1923e1a6b98.jpg?1783937178",
+        "rulings": [
+            {
+                "date": "2016-09-20",
+                "text": "Kujar Seedsculptor can be the target of its own triggered ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Prakhata Club Security
 {
     "name": "Prakhata Club Security",
@@ -709,6 +879,83 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Self-Assembler
+{
+    "name": "Self-Assembler",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Assembly",
+    "oracleText": "When this creature enters, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "creature Assembly-Worker"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "artist": "Noah Bradley",
+        "flavorText": "It sees itself in all of its creations.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d05c6c2-4bb3-468a-b23c-b0425a9982f1.jpg?1783937148",
+        "rulings": [
+            {
+                "date": "2018-03-16",
+                "text": "Self-Assembler's ability can find any creature card with the Assembly-Worker subtype, not only creature cards named Assembly-Worker. Notably, it can't find Mishra's Factory."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
 }
 
 // Spirebluff Canal
@@ -838,6 +1085,87 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Weldfast Wingsmith
+{
+    "name": "Weldfast Wingsmith",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "Whenever an artifact you control enters, this creature gains flying until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "target": "Self"
+                },
+                "descriptionOverride": "This creature gains flying until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"Airships are too confining. If I'm in the sky, I want to feel the wind in my hair and taste the aether.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b115a65-e273-4264-9db7-317e1855f492.jpg?1783937211"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Wily Bandar
+{
+    "name": "Wily Bandar",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Cat Monkey",
+    "oracleText": "{2}{G}: This creature gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": "Self"
+                },
+                "descriptionOverride": "This creature gains indestructible until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "Part feline, part primate, all trouble.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/cac6ece3-9889-47fa-9140-420b4f31dd1b.jpg?1783937171"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LRW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LRW.json
@@ -406,6 +406,54 @@
     ]
 }
 
+// Mudbutton Torchrunner
+{
+    "name": "Mudbutton Torchrunner",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "When this creature dies, it deals 3 damage to any target.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Steve Ellis",
+        "flavorText": "The oil sloshes against his skull as he nears his destination: the Frogtosser Games and the lighting of the Flaming Boggart.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50575eab-6c23-4f63-9667-458416c5caa5.jpg?1783942871"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Nameless Inversion
 {
     "name": "Nameless Inversion",
@@ -519,6 +567,31 @@
         "artist": "Mark Tedin",
         "flavorText": "\"We see the same sky as you, just through a different lens.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba6b6fc5-5077-4812-b8e9-906783dbaf67.jpg?1783942899"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sentinels of Glen Elendra
+{
+    "name": "Sentinels of Glen Elendra",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Faerie Soldier",
+    "oracleText": "Flash\nFlying",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Howard Lyon",
+        "flavorText": "Some say the valley of Glen Elendra is mythical, and that rumors of its existence are nothing but a faerie prank. Others say it is the fae's most fiercely guarded secret.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f48daf7e-2f8e-4179-a145-a6b36dd11d44.jpg?1783942897"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/mtg-sets/src/test/resources/snapshots/cards/M10.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M10.json
@@ -18,6 +18,70 @@
     ]
 }
 
+// Divine Verdict
+{
+    "name": "Divine Verdict",
+    "manaCost": "{3}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target attacking or blocking creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "creature"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Kev Walker",
+        "flavorText": "Giants and pit spawn attempted to topple the cathedral's pillars. The fine grit of their remains still swirls in the breeze outside.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48444e14-c73b-47d1-9c55-0ff4dc3c6034.jpg?1783942404",
+        "rulings": [
+            {
+                "date": "2012-07-01",
+                "text": "Destroying a blocking creature won't cause any of the creatures it was blocking to become unblocked. They won't deal combat damage to the defending player or planeswalker (unless they have trample)."
+            },
+            {
+                "date": "2009-10-01",
+                "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+            },
+            {
+                "date": "2009-10-01",
+                "text": "A “blocking creature” is one that has been declared as a blocker this combat, or one that was put onto the battlefield blocking this combat. Unless that creature leaves combat, it continues to be a blocking creature through the end of combat step, even if the creature or creatures it was blocking are no longer on the battlefield or have otherwise left combat."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Elite Vanguard
 {
     "name": "Elite Vanguard",
@@ -115,6 +179,71 @@
         "artist": "Jon Foster",
         "flavorText": "Some wizards compete not to summon the most interesting creatures, but to create the most interesting aftereffects when a summons goes awry.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/2/c231101e-6620-46fc-a0ad-a53291d12dc2.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Merfolk Sovereign
+{
+    "name": "Merfolk Sovereign",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Creature — Merfolk Noble",
+    "oracleText": "Other Merfolk creatures you control get +1/+1.\n{T}: Target Merfolk creature can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Merfolk"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Target Merfolk creature can't be blocked this turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Merfolk ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "RARE",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"The sharks envy our ferocity. The eels envy our cunning.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9826a2e-361e-4701-9177-0907c0c6dc9f.jpg?1783942390",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "To have any effect, Merfolk Sovereign's activated ability must be activated before the declare blockers step begins. Once a Merfolk has become blocked, activating Merfolk Sovereign's ability won't change that."
+            }
+        ]
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -55,6 +55,44 @@
     ]
 }
 
+// Augury Owl
+{
+    "name": "Augury Owl",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying\nWhen this creature enters, scry 3. (Look at the top three cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 3
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Jim Nelson",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42b8b752-086c-4d7c-a0a2-e359819c550e.jpg?1783941827"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Barony Vampire
 {
     "name": "Barony Vampire",
@@ -365,6 +403,40 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Preordain
+{
+    "name": "Preordain",
+    "manaCost": "{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Scry",
+                    "count": 2
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3868c3d-4fcd-444b-866f-0f8e50ce7b67.jpg?1783941822"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -173,6 +173,113 @@
     ]
 }
 
+// Devouring Swarm
+{
+    "name": "Devouring Swarm",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "Flying\nSacrifice a creature: This creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "artist": "Wayne England",
+        "flavorText": "Their arrival is heralded by the deafening hum of ten thousand wings. Their departure is marked by the silence of the dead.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/735c2c79-9b4f-4f86-9dec-0749237fe9ce.jpg?1783941082"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Gideon's Lawkeeper
+{
+    "name": "Gideon's Lawkeeper",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{W}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "artist": "Steve Prescott",
+        "flavorText": "\"The essence of a lawful society is swift deterrence.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c71eb81-a077-4c85-a4ce-4ad664486bee.jpg?1783941103"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Grand Abolisher
 {
     "name": "Grand Abolisher",

--- a/mtg-sets/src/test/resources/snapshots/cards/M13.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M13.json
@@ -315,6 +315,93 @@
     ]
 }
 
+// Rummaging Goblin
+{
+    "name": "Rummaging Goblin",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "{T}, Discard a card: Draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Karl Kopinski",
+        "flavorText": "To a goblin, value is based on the four S's: shiny, stabby, smelly, and super smelly.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc5b622c-83a4-477e-a99c-2674e2bd6bb9.jpg?1783940480",
+        "rulings": [
+            {
+                "date": "2012-07-01",
+                "text": "Discarding a card is part of the cost to activate Rummaging Goblin's ability. If you don't have a card in your hand, you can't pay this part of the cost and you can't activate the ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Searing Spear
+{
+    "name": "Searing Spear",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Searing Spear deals 3 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Chris Rahn",
+        "flavorText": "Sometimes you die a glorious death with your sword held high. Sometimes you're just target practice.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11a94b7c-0216-473c-87a6-71e5a64d7799.jpg?1783940479"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Sentinel Spider
 {
     "name": "Sentinel Spider",

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -74,6 +74,83 @@
     "colorIdentityOverride": []
 }
 
+// Gnawing Zombie
+{
+    "name": "Gnawing Zombie",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "{1}{B}, Sacrifice a creature: Target player loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "player"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "player"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99",
+        "rarity": "UNCOMMON",
+        "artist": "Greg Staples",
+        "flavorText": "On still nights you can hear its rotted teeth grinding tirelessly on scavenged bones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56653d9e-0c29-440b-8724-cae746abb1a9.jpg?1783939924"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Kalonian Tusker
 {
     "name": "Kalonian Tusker",
@@ -444,5 +521,140 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Woodborn Behemoth
+{
+    "name": "Woodborn Behemoth",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "As long as you control eight or more lands, this creature gets +4/+4 and has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 4,
+                    "toughnessBonus": 4,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c73dbf3-e68e-4f21-b6ca-94302bf5574c.jpg?1783939898"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Young Pyromancer
+{
+    "name": "Young Pyromancer",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Elemental"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Cynthia Sheppard",
+        "flavorText": "Immolation is the sincerest form of flattery.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e349c204-3a93-4bf7-b79a-5f5f261ea2d3.jpg?1783939908",
+        "rulings": [
+            {
+                "date": "2021-03-19",
+                "text": "An ability that triggers when a player casts a spell resolves before the spell that caused it to trigger, but after targets have been chosen for that spell. It resolves even if that spell is countered."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/M15.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M15.json
@@ -1,3 +1,86 @@
+// Aeronaut Tinkerer
+{
+    "name": "Aeronaut Tinkerer",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "This creature has flying as long as you control an artifact. (It can't be blocked except by creatures with flying or reach.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Willian Murai",
+        "flavorText": "\"All tinkerers have their heads in the clouds. I don't intend to stop there.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/1/e145e85d-1eaa-4ec6-9208-ca6491577302.jpg?1783939196"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Borderland Marauder
+{
+    "name": "Borderland Marauder",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Whenever this creature attacks, it gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "artist": "Scott M. Fischer",
+        "flavorText": "Though she is rightly feared, there are relatively few tales of her deeds in battle, for few survive her raids.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/12e29b2b-5fe3-4dee-b247-10cd139fe2d0.jpg?1783939177"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Reclamation Sage
 {
     "name": "Reclamation Sage",
@@ -48,6 +131,134 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Triplicate Spirits
+{
+    "name": "Triplicate Spirits",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nCreate three 1/1 white Spirit creature tokens with flying.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "WHITE"
+            ],
+            "creatureTypes": [
+                "Spirit"
+            ],
+            "keywords": [
+                "FLYING"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d6498d3-bf1f-4bf1-a602-7c21fb44c106.jpg?1783939196",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "You can tap any untapped creature you control to convoke a spell, even one you haven't controlled continuously since the beginning of your most recent turn."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping an untapped creature that's attacking or blocking to convoke a spell won't cause that creature to stop attacking or blocking."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped before you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Ulcerate
+{
+    "name": "Ulcerate",
+    "manaCost": "{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -3/-3 until end of turn. You lose 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": "Controller"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "UNCOMMON",
+        "artist": "Johann Bodin",
+        "flavorText": "\"If it were merely lethal, that would be sufficient. The art, however, is in maximizing the suffering it causes.\" —Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e06e6c8-05c0-4d87-9961-605b888bc794.jpg?1783939179",
+        "rulings": [
+            {
+                "date": "2017-11-17",
+                "text": "The loss of life isn't a cost. If the target creature is an illegal target when Ulcerate tries to resolve, it won't resolve and none of its effects will happen. You won't lose any life."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -1,3 +1,72 @@
+// Aethershield Artificer
+{
+    "name": "Aethershield Artificer",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Dwarf Artificer",
+    "oracleText": "At the beginning of combat on your turn, target artifact creature you control gets +2/+2 and gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "artifact creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "artifact creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact creature ctrl:you"
+                    },
+                    "id": "artifact creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "Izzy",
+        "flavorText": "Most smiths shape metal, but some prefer more delicate materials.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/226f7c45-db9f-4d48-b575-4d2f1904c963.jpg?1783934613"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Aggressive Mammoth
 {
     "name": "Aggressive Mammoth",
@@ -121,6 +190,279 @@
     ]
 }
 
+// Bristling Boar
+{
+    "name": "Bristling Boar",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Boar",
+    "oracleText": "This creature can't be blocked by more than one creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByMoreThan",
+                "maxBlockers": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Nicol Bolas destroyed my world. I owe it to Skalla to celebrate all life, no matter how dangerous.\" —Vivien Reid",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/999030b2-2f91-4c45-981f-acdbbf9034af.jpg?1783934541",
+        "rulings": [
+            {
+                "date": "2020-04-17",
+                "text": "If Bristling Boar gains menace, it can't be blocked at all."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Catalyst Elemental
+{
+    "name": "Catalyst Elemental",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Sacrifice this creature: Add {R}{R}.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "As the hyperstormic generator crept past redline, a being emerged from the arc.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e83a678b-19d4-47a5-aa1c-c2437e5009c0.jpg?1783934556"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Cavalry Drillmaster
+{
+    "name": "Cavalry Drillmaster",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "When this creature enters, target creature gets +2/+0 and gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FIRST_STRIKE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "creature"
+                },
+                "descriptionOverride": "When this creature enters, target creature gets +2/+0 and gains first strike until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "artist": "Slawomir Maniak",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62d2e929-7ae3-4560-9cfa-53b89c8a6016.jpg?1783934610"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Colossal Majesty
+{
+    "name": "Colossal Majesty",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, if you control a creature with power 4 or greater, draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Vargas",
+        "flavorText": "\"Might doesn't just build empires. It protects them.\" —Inti, Sun Empire knight",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/93f99796-ddc5-4ccd-b925-35622a8648b8.jpg?1783934541",
+        "rulings": [
+            {
+                "date": "2018-07-13",
+                "text": "If you don't control a creature with power 4 or greater as your upkeep begins, Colossal Majesty's ability won't trigger. You can't take any actions during your turn before your upkeep begins."
+            },
+            {
+                "date": "2018-07-13",
+                "text": "If you don't control a creature with power 4 or greater as Colossal Majesty's ability resolves, you won't draw a card."
+            },
+            {
+                "date": "2018-07-13",
+                "text": "The creature with power 4 or greater that you control as Colossal Majesty's ability resolves doesn't have to be the same creature with power 4 or greater that was under your control as the ability triggered."
+            },
+            {
+                "date": "2018-07-13",
+                "text": "You draw only one card, no matter how many creatures with power 4 or greater you control."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Daybreak Chaplain
+{
+    "name": "Daybreak Chaplain",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Volkan Baǵa",
+        "flavorText": "\"May the light shine through me to guide the lost.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2f461b1-c801-4f0c-8fd7-fe68b6078ac6.jpg?1783934608"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Demon of Catastrophes
+{
+    "name": "Demon of Catastrophes",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature.\nFlying, trample",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING",
+        "TRAMPLE"
+    ],
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomSacrifice",
+                    "filter": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "91",
+        "rarity": "RARE",
+        "artist": "Sidharth Chaturvedi",
+        "flavorText": "A pit yawned open, a column of oily smoke arose, and a towering form hissed, \"I accept this offering.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d50f9563-7bf8-4c3c-ac82-327221e56551.jpg?1783934573",
+        "rulings": [
+            {
+                "date": "2018-07-13",
+                "text": "You must sacrifice exactly one creature to cast Demon of Catastrophes; you can't cast it without sacrificing a creature, and you can't sacrifice additional creatures."
+            },
+            {
+                "date": "2018-07-13",
+                "text": "Players can respond only after Demon of Catastrophes has been cast and all its costs have been paid. No one can try to destroy the creature you sacrificed to prevent you from casting this spell."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Diamond Mare
 {
     "name": "Diamond Mare",
@@ -170,6 +512,76 @@
     }
 }
 
+// Dragon's Hoard
+{
+    "name": "Dragon's Hoard",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever a Dragon you control enters, put a gold counter on this artifact.\n{T}, Remove a gold counter from this artifact: Draw a card.\n{T}: Add one mana of any color.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Dragon ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "gold",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever a Dragon you control enters, put a gold counter on this artifact."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomRemoveCounters",
+                                "counterType": "gold",
+                                "self": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{T}, Remove a gold counter from this artifact: Draw a card."
+            },
+            {
+                "id": "ability_3",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "RARE",
+        "artist": "Adam Paquette",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b441fc8-bc89-47d4-8745-2525aeb6d98d.jpg?1783934514"
+    },
+    "colorIdentityOverride": []
+}
+
 // Exclusion Mage
 {
     "name": "Exclusion Mage",
@@ -212,6 +624,139 @@
         "artist": "Chris Seaman",
         "flavorText": "Successful battles start with knowing who's worth fighting.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/c/ccad82f5-5c5c-42ad-b66e-942f0d9631ca.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Gallant Cavalry
+{
+    "name": "Gallant Cavalry",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, create a 2/2 white Knight creature token with vigilance.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Craig J Spearing",
+        "flavorText": "\"Our duty does not stop at our borders.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e388c433-3a37-45f6-825a-d13d2223b6f7.jpg?1783934607"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Gearsmith Guardian
+{
+    "name": "Gearsmith Guardian",
+    "manaCost": "{5}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "This creature gets +2/+0 as long as you control a blue creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature blue"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "Made in its creator's image, though slightly more clangy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d532b01-8bf7-4a27-a438-db03bcd00694.jpg?1783934512"
+    },
+    "colorIdentityOverride": []
+}
+
+// Gearsmith Prodigy
+{
+    "name": "Gearsmith Prodigy",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "This creature gets +1/+0 as long as you control an artifact.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "57",
+        "artist": "Deruchenko Alexander",
+        "flavorText": "Young artificers on Kaladesh let their imaginations run wild.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/77d9e666-d9c9-4ccd-89a5-83de79677fa6.jpg?1783934589"
     },
     "colorIdentityOverride": [
         "BLUE"
@@ -837,6 +1382,49 @@
         "artist": "Randy Vargas",
         "flavorText": "\"When it comes to killing with precision, a soul is but a hindrance.\"\n—Isareth the Awakener",
         "imageUri": "https://cards.scryfall.io/normal/front/8/f/8fee5cc4-a686-4ce6-aa6b-1b8a88e6dea3.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Strangling Spores
+{
+    "name": "Strangling Spores",
+    "manaCost": "{3}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -3/-3 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "Fixed",
+                "amount": -3
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": -3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Jason A. Engle",
+        "flavorText": "Imagine a thousand tiny mushrooms cropping up within your lungs.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/300468ab-fbae-42ae-97bc-b08f795efa5c.jpg?1783934561"
     },
     "colorIdentityOverride": [
         "BLACK"

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -175,6 +175,48 @@
     "colorIdentityOverride": []
 }
 
+// Dawning Angel
+{
+    "name": "Dawning Angel",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\nWhen this creature enters, you gain 4 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Yongjae Choi",
+        "flavorText": "\"As the sun rose behind the Bone Spire, an angel appeared over the charnel fields, bringing a surge of new hope.\" —Krinnea, *Siege of the Bone Spire*",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f3d90ef-6f70-4897-85c1-4e1beeb33363.jpg?1783933032"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Devout Decree
 {
     "name": "Devout Decree",
@@ -347,6 +389,51 @@
     ]
 }
 
+// Ferocious Pup
+{
+    "name": "Ferocious Pup",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "When this creature enters, create a 2/2 green Wolf creature token.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Wolf"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5f1e139-3054-4273-8a4d-faaaa9c383a8.jpg?1783924694"
+                },
+                "descriptionOverride": "When this creature enters, create a 2/2 green Wolf creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Rudy Siswanto",
+        "flavorText": "The strongest pack has the fiercest pups.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/2354cb24-5c70-4aaa-8636-46866f0950c1.jpg?1783932968"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Gnarlback Rhino
 {
     "name": "Gnarlback Rhino",
@@ -463,6 +550,42 @@
     ]
 }
 
+// Octoprophet
+{
+    "name": "Octoprophet",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Octopus",
+    "oracleText": "When this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Grzegorz Rutkowski",
+        "flavorText": "In every swirl of the tide, it sees the awakening of things yet to come.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13becea1-e745-4c96-bfc2-6a277fb60ee1.jpg?1783933006"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Rapacious Dragon
 {
     "name": "Rapacious Dragon",
@@ -501,6 +624,46 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Savannah Sage
+{
+    "name": "Savannah Sage",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Cleric",
+    "oracleText": "When this creature enters, you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "284",
+        "artist": "Bayard Wu",
+        "flavorText": "\"Now is not the time for your light to fade.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b5fa4bb-e061-456f-808e-8d98b2c8abf5.jpg?1783932921"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M21.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M21.json
@@ -1,3 +1,103 @@
+// Chandra's Magmutt
+{
+    "name": "Chandra's Magmutt",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Elemental Dog",
+    "oracleText": "{T}: This creature deals 1 damage to target player or planeswalker.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "player or planeswalker"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayerOrPlaneswalker",
+                        "id": "player or planeswalker"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Kimonas Theodossiou",
+        "flavorText": "\"Is it purebred? No, but it's pure fire.\" —Chandra Nalaar",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/91d3e366-4da5-42c8-bbd5-a0c178c0da28.jpg?1783930694"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Daybreak Charger
+{
+    "name": "Daybreak Charger",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Unicorn",
+    "oracleText": "When this creature enters, target creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "14",
+        "artist": "Forrest Imel",
+        "flavorText": "It's often mistaken for the coming dawn as it gallops across the horizon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff87a671-054f-4357-8a62-450d36559a1b.jpg?1783930743"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Garruk's Gorehorn
 {
     "name": "Garruk's Gorehorn",
@@ -191,6 +291,49 @@
     ]
 }
 
+// Library Larcenist
+{
+    "name": "Library Larcenist",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Merfolk Rogue",
+    "oracleText": "Whenever this creature attacks, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Mila Pesic",
+        "flavorText": "\"I specialize in missing manuscripts, pilfered poetry, and lifted letters.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/b/cb33529b-80bd-4f52-94cc-d8371c53ad75.jpg?1783930725",
+        "rulings": [
+            {
+                "date": "2020-06-23",
+                "text": "You may cast spells and activate abilities after the card has been drawn but before blockers are declared."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Mazemind Tome
 {
     "name": "Mazemind Tome",
@@ -310,6 +453,73 @@
     "colorIdentityOverride": []
 }
 
+// Ornery Dilophosaur
+{
+    "name": "Ornery Dilophosaur",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nWhenever this creature attacks, if you control a creature with power 4 or greater, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "interveningIf": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature pow>=4"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "artist": "Jonathan Kuo",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2c4a0e7-9ca4-4291-94de-165cc2ded822.jpg?1783930671",
+        "rulings": [
+            {
+                "date": "2020-06-23",
+                "text": "If you don't control a creature with power 4 or greater immediately after Ornery Dilophosaur attacks, its ability doesn't trigger. If you don't control one as the ability resolves, it has no effect. It doesn't have to be the same creature at both times, however."
+            },
+            {
+                "date": "2020-06-23",
+                "text": "If Ornery Dilophosaur's power is raised to 4 or greater, its ability triggers when it attacks."
+            },
+            {
+                "date": "2020-06-23",
+                "text": "Ornery Dilophosaur gets just +2/+2, no matter how many creatures you control with power 4 or greater."
+            },
+            {
+                "date": "2020-06-23",
+                "text": "Once Ornery Dilophosaur's ability has resolved, it keeps +2/+2 for the rest of the turn even if you no longer control a creature with power 4 or greater."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Primal Might
 {
     "name": "Primal Might",
@@ -369,6 +579,55 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Rambunctious Mutt
+{
+    "name": "Rambunctious Mutt",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "When this creature enters, destroy target artifact or enchantment an opponent controls.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact|enchantment ctrl:opponent"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "When this creature enters, destroy target artifact or enchantment an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Campbell White",
+        "flavorText": "Emphatic words with powerful gestures. Clearly this was playtime.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f602ecc-c264-4f3e-adeb-d0186668653e.jpg?1783930737"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -536,6 +795,149 @@
     ]
 }
 
+// Teferi's Protege
+{
+    "name": "Teferi's Protege",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "{1}{U}, {T}: Draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "artist": "Bram Sels",
+        "flavorText": "Teferi's legacy lives on in Tolaria through the study of time magic and a tradition of irrepressible mischief.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/5449d71c-5c1b-44c6-9407-0212aa3c3e3a.jpg?1783930718",
+        "rulings": [
+            {
+                "date": "2020-06-23",
+                "text": "You draw a card and discard a card all while the ability is resolving. Nothing can happen between the two, and no player may choose to take actions."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Valorous Steed
+{
+    "name": "Valorous Steed",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Unicorn",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen this creature enters, create a 2/2 white Knight creature token with vigilance.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "keywords": [
+                        "VIGILANCE"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "artist": "Donato Giancola",
+        "flavorText": "A unicorn chooses only the most virtuous and noble of knights to be its companion.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa01cb8c-f080-456b-a91a-f1d7943a70b2.jpg?1783930732"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Village Rites
 {
     "name": "Village Rites",
@@ -633,5 +1035,69 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Witch's Cauldron
+{
+    "name": "Witch's Cauldron",
+    "manaCost": "{B}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{B}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "UNCOMMON",
+        "artist": "Jason A. Engle",
+        "flavorText": "The best recipes start with reliable cookware.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d43a3eb7-3daf-4667-b824-1f5d801c9341.jpg?1783930697"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/MH1.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MH1.json
@@ -1,3 +1,43 @@
+// Faerie Seer
+{
+    "name": "Faerie Seer",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flying\nWhen this creature enters, scry 2. (Look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                },
+                "descriptionOverride": "When this creature enters, scry 2."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Colin Boyer",
+        "flavorText": "\"The patterns of crossing ripples reveal the future to those who know how to read them.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1fcfeb4-1818-4e08-be4c-27b8a9dc12e6.jpg?1783933144"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Goblin Oriflamme
 {
     "name": "Goblin Oriflamme",
@@ -70,6 +110,47 @@
     ]
 }
 
+// King of the Pride
+{
+    "name": "King of the Pride",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Other Cats you control get +2/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "permanent Cat ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "UNCOMMON",
+        "artist": "Jonathan Kuo",
+        "flavorText": "\"Glorious, to walk again across the savannah with my beloved.\" —\"Love Song of Night and Day\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/4/c4e83abd-6f15-491e-9253-90af9f6f1025.jpg?1783933160",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "Because damage remains marked on a creature until the damage is removed as the turn ends, nonlethal damage dealt to a Cat you control may become lethal if King of the Pride leaves the battlefield during that turn."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ravenous Giant
 {
     "name": "Ravenous Giant",
@@ -113,4 +194,124 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Sling-Gang Lieutenant
+{
+    "name": "Sling-Gang Lieutenant",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Goblin",
+    "oracleText": "When this creature enters, create two 1/1 red Goblin creature tokens.\nSacrifice a Goblin: Target player loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Goblin"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1782727474"
+                },
+                "descriptionOverride": "When this creature enters, create two 1/1 red Goblin creature tokens."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "permanent Goblin"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    }
+                ],
+                "descriptionOverride": "Sacrifice a Goblin: Target player loses 1 life and you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "rarity": "UNCOMMON",
+        "artist": "Craig J Spearing",
+        "flavorText": "Freshly promoted to \"first rock,\" Zaz was eager to make an impact.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f82aec21-441b-4fcd-b666-61723bd79531.jpg?1783933120",
+        "rulings": [
+            {
+                "date": "2019-06-14",
+                "text": "You can sacrifice any Goblin you control to activate Sling-Gang Lieutenant's activated ability, not just the ones its triggered ability creates. You can even sacrifice Sling-Gang Lieutenant itself."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Universal Automaton
+{
+    "name": "Universal Automaton",
+    "manaCost": "{1}",
+    "typeLine": "Artifact Creature — Shapeshifter",
+    "oracleText": "Changeling (This card is every creature type.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "CHANGELING"
+    ],
+    "metadata": {
+        "collectorNumber": "235",
+        "artist": "Ben Maier",
+        "flavorText": "\"Within minutes, the strange device was indistinguishable from the other upon my workbench.\" —Tocasia, journal entry",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53c682e2-c90f-4f4b-9010-00b099e85518.jpg?1783933069"
+    },
+    "colorIdentityOverride": []
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/MID.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MID.json
@@ -359,6 +359,31 @@
     ]
 }
 
+// Bounding Wolf
+{
+    "name": "Bounding Wolf",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "Flash\nReach",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "REACH"
+    ],
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Andrea Radeck",
+        "flavorText": "With their usual prey scared off by werewolves, the wolves of the Ulvenwald adopted inventive new hunting techniques.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/74e22ed6-9d39-4feb-8c64-64cdd8313816.jpg?1783925585"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Bramble Armor
 {
     "name": "Bramble Armor",
@@ -1216,6 +1241,52 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Electric Revelation
+{
+    "name": "Electric Revelation",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, discard a card.\nDraw two cards.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{3}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Liiga Smilshkalne",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20ff3289-00fb-4e91-b34f-6255e9de8e9e.jpg?1783925602",
+        "rulings": [
+            {
+                "date": "2021-09-24",
+                "text": "If you cast Electric Revelation using flashback, you must still pay its additional cost of discarding a card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -2131,6 +2202,118 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Pestilent Wolf
+{
+    "name": "Pestilent Wolf",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "{2}{G}: This creature gains deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Oriana Menendez",
+        "flavorText": "Wolves that feast on zombie flesh and survive carry the foul diseases of the dead wherever they roam.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2686431-8d9c-4b9c-998f-38b5ae113d4a.jpg?1783925575"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Raze the Effigy
+{
+    "name": "Raze the Effigy",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Destroy target artifact.\n• Target attacking creature gets +2/+2 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target artifact"
+                },
+                {
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature attacking"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target attacking creature gets +2/+2 until end of turn"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "artist": "Cristi Balanescu",
+        "flavorText": "The folk of Kessig build up their courage by burning effigies of the things they fear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0dd378c-5050-48c9-9a16-6d91afa62d21.jpg?1783925591"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MMQ.json
@@ -1,3 +1,77 @@
+// Arms Dealer
+{
+    "name": "Arms Dealer",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "{1}{R}, Sacrifice a Goblin: This creature deals 4 damage to target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "permanent Goblin"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "UNCOMMON",
+        "artist": "Luca Zontini",
+        "flavorText": "He has the weapons, he has the connections, and he knows the hangar's dark secret.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/dafea45d-be00-428d-a127-70e6a14efe3f.jpg?1783945943",
+        "rulings": [
+            {
+                "date": "2012-07-01",
+                "text": "You can sacrifice Arms Dealer to activate its own ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Arrest
 {
     "name": "Arrest",

--- a/mtg-sets/src/test/resources/snapshots/cards/MOR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOR.json
@@ -141,6 +141,51 @@
     ]
 }
 
+// Order of the Golden Cricket
+{
+    "name": "Order of the Golden Cricket",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kithkin Knight",
+    "oracleText": "Whenever this creature attacks, you may pay {W}. If you do, it gains flying until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{W}"
+                        }
+                    },
+                    "then": {
+                        "type": "GrantKeyword",
+                        "keyword": "FLYING",
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may pay {W}. If you do, it gains flying until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Mark Zug",
+        "flavorText": "\"Should you take it in mind to ride a springjack, remember: there are easier ways to fly, and harder ways to break your skull.\" —Lann of Cloverdell",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d1c2f16-5661-4c17-8265-f4b88ff1e833.jpg?1783942804"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Taurean Mauler
 {
     "name": "Taurean Mauler",

--- a/mtg-sets/src/test/resources/snapshots/cards/NEO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/NEO.json
@@ -1,3 +1,57 @@
+// Circuit Mender
+{
+    "name": "Circuit Mender",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Insect",
+    "oracleText": "When this creature enters, you gain 2 life.\nWhen this creature leaves the battlefield, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain 2 life."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "When this creature leaves the battlefield, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "UNCOMMON",
+        "artist": "Hector Ortiz",
+        "flavorText": "Inspired by industrious silkworms, its maker crafted it to restore the broken pieces of the world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/defaeb68-3f8a-4740-b13f-8c71c7e9c8b4.jpg?1783923827"
+    },
+    "colorIdentityOverride": []
+}
+
 // Secluded Courtyard
 {
     "name": "Secluded Courtyard",
@@ -41,6 +95,45 @@
         "imageUri": "https://cards.scryfall.io/normal/front/0/5/0539b1a5-8704-476f-ba1f-2fe01190e157.jpg?1783923815"
     },
     "colorIdentityOverride": []
+}
+
+// Spirited Companion
+{
+    "name": "Spirited Companion",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment Creature — Dog",
+    "oracleText": "When this creature enters, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "Ilse Gort",
+        "flavorText": "She formed a friendship with several playful spirits, and soon \"the pack\" was known as the source of much mischief in Eiganjo.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/a/5aa91a9e-2fe2-43bc-aa9c-cfb8a71829ff.jpg?1783923912"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Uncharted Haven

--- a/mtg-sets/src/test/resources/snapshots/cards/OGW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OGW.json
@@ -358,3 +358,43 @@
         "BLACK"
     ]
 }
+
+// Warden of Geometries
+{
+    "name": "Warden of Geometries",
+    "manaCost": "{4}",
+    "typeLine": "Creature — Eldrazi Drone",
+    "oracleText": "Vigilance\n{T}: Add {C}. ({C} represents colorless mana.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {C}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Jason Felix",
+        "flavorText": "The wastelands disorient even the most experienced scouts, making them easy prey for Kozilek's drones.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7f517b9-ac10-4710-8ef1-ced1253d5ecf.jpg?1783937928"
+    },
+    "colorIdentityOverride": []
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ORI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ORI.json
@@ -1,3 +1,49 @@
+// Anchor to the Aether
+{
+    "name": "Anchor to the Aether",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Put target creature on top of its owner's library. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "destination": "Library",
+                    "placement": "Top"
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/15058f91-d266-4804-96af-fc050b6c8436.jpg?1783938355"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Archangel of Tithes
 {
     "name": "Archangel of Tithes",
@@ -47,6 +93,118 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Blessed Spirits
+{
+    "name": "Blessed Spirits",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhenever you cast an enchantment spell, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Steinbauer",
+        "flavorText": "Not all heroes die in armor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/150dd602-5f61-4f1e-a422-e64c079de141.jpg?1783938364",
+        "rulings": [
+            {
+                "date": "2015-06-22",
+                "text": "Blessed Spirits's ability will resolve before the enchantment spell that caused it to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Caustic Caterpillar
+{
+    "name": "Caustic Caterpillar",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Insect",
+    "oracleText": "{1}{G}, Sacrifice this creature: Destroy target artifact or enchantment.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact or enchantment"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact|enchantment"
+                        },
+                        "id": "target artifact or enchantment"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "artist": "Jack Wang",
+        "flavorText": "\"The rare and beautiful butterflies inspire the design of our thopters. The larvae, however, are a different story entirely.\" —Kiran Nalaar, Ghirapur inventor",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f03d4e0d-bddd-4835-91b8-11c2f15e54c3.jpg?1783938324"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -412,6 +570,48 @@
     ]
 }
 
+// Fetid Imp
+{
+    "name": "Fetid Imp",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Imp",
+    "oracleText": "Flying\n{B}: This creature gains deathtouch until end of turn. (Any amount of damage it deals to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{B}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "artist": "Nils Hamm",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/891718e9-bef3-470a-80c5-514f7f43abe8.jpg?1783938342"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Gilt-Leaf Winnower
 {
     "name": "Gilt-Leaf Winnower",
@@ -577,6 +777,72 @@
     ]
 }
 
+// Priest of the Blood Rite
+{
+    "name": "Priest of the Blood Rite",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "When this creature enters, create a 5/5 black Demon creature token with flying.\nAt the beginning of your upkeep, you lose 2 life.At the beginning of your upkeep, you lose 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 5,
+                    "toughness": 5,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Demon"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/7/771ae1f8-70b3-40da-8352-421a36c7abb5.jpg?1783940883"
+                },
+                "descriptionOverride": "When this creature enters, create a 5/5 black Demon creature token with flying."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Controller"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, you lose 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "RARE",
+        "artist": "David Palumbo",
+        "flavorText": "Some will sacrifice everything for but a taste of power.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/118ba6f2-a2f0-4554-ad87-a932c951cdd4.jpg?1783938338"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Pyromancer's Goggles
 {
     "name": "Pyromancer's Goggles",
@@ -671,6 +937,69 @@
     ]
 }
 
+// Reave Soul
+{
+    "name": "Reave Soul",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature with power 3 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature with power 3 or less"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow<=3"
+                },
+                "id": "target creature with power 3 or less"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "David Palumbo",
+        "flavorText": "\"I was not convinced you had a soul until I saw it for myself.\" —Liliana Vess",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db3d5e9d-07e8-43e1-aaf0-1f9e4ed2834a.jpg?1783938337"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Shambling Ghoul
+{
+    "name": "Shambling Ghoul",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "This creature enters tapped.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "artist": "Joseph Meehan",
+        "flavorText": "Once he gets up and going, he will forever shamble on.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fd8061d2-84ce-4e4a-9911-ffc9833749da.jpg?1783938337"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Skyraker Giant
 {
     "name": "Skyraker Giant",
@@ -693,5 +1022,154 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Subterranean Scout
+{
+    "name": "Subterranean Scout",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Scout",
+    "oracleText": "When this creature enters, target creature with power 2 or less can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature with power 2 or less"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature pow<=2"
+                    },
+                    "id": "target creature with power 2 or less"
+                },
+                "descriptionOverride": "When this creature enters, target creature with power 2 or less can't be blocked this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Lucas Graciano",
+        "flavorText": "When things get ugly above ground, goblins resort to alternate routes of passage.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c9289dd-f1a3-4be5-8ed1-4b4dd4e97743.jpg?1783938325"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Valor in Akros
+{
+    "name": "Valor in Akros",
+    "manaCost": "{3}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a creature you control enters, creatures you control get +1/+1 until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Creatures you control get +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Kieryluk",
+        "flavorText": "They became a single entity, a phalanx in the Temple of Triumph standing against a host of enemies.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/22fa0acd-84c3-492e-adf7-e7438db47e0a.jpg?1783938356",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "Valor in Akros's ability affects only creatures you control at the time the ability resolves, including the creature that caused it to trigger. Creatures you begin to control later in the turn won't get +1/+1."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Zendikar's Roil
+{
+    "name": "Zendikar's Roil",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Landfall — Whenever a land you control enters, create a 2/2 green Elemental creature token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Elemental"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "rarity": "UNCOMMON",
+        "artist": "Sam Burley",
+        "flavorText": "\"I was wrong. Zendikar isn't after me. It isn't after any of us. It's not evil or vengeful. It's magnificent . . . but it's in pain.\" —Nissa Revane",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f75c0783-936d-4fa2-bdcb-01dae7a67fdb.jpg?1783938315"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1016,6 +1016,89 @@
     ]
 }
 
+// Devouring Light
+{
+    "name": "Devouring Light",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile target attacking or blocking creature.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target attacking or blocking creature"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target attacking or blocking creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "UNCOMMON",
+        "artist": "Pete Venters",
+        "flavorText": "Into the light the good are welcomed, and with the light the evil are banished.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53fcc46c-682c-4482-8422-811b951d96cf.jpg?1783943702",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "You can tap any untapped creature you control to convoke a spell, even one you haven't controlled continuously since the beginning of your most recent turn."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping an untapped creature that's attacking or blocking to convoke a spell won't cause that creature to stop attacking or blocking."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped before you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
+            },
+            {
+                "date": "2014-07-18",
+                "text": "The declare blockers step is the last chance to cast Devouring Light before creatures deal their combat damage. However, a creature remains an attacking or blocking creature during the combat damage step and end of combat step. Devouring Light may be cast targeting such a creature during those steps, after the creature has dealt combat damage."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Dimir Aqueduct
 {
     "name": "Dimir Aqueduct",
@@ -2320,6 +2403,77 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Hour of Reckoning
+{
+    "name": "Hour of Reckoning",
+    "manaCost": "{4}{W}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nDestroy all nontoken creatures.",
+    "keywords": [
+        "CONVOKE"
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature nontoken"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "RARE",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"Ravnica, like a hedge, must be pruned, leaving only leaves of verdant uniformity.\" —Niszka, Selesnya evangel",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/bec7a987-1ef2-40aa-a744-92d90b246df4.jpg?1783943699",
+        "rulings": [
+            {
+                "date": "2024-01-12",
+                "text": "You can tap any untapped creature you control to convoke a spell, even one you haven't controlled continuously since the beginning of your most recent turn."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping an untapped creature that's attacking or blocking to convoke a spell won't cause that creature to stop attacking or blocking."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "When calculating a spell's total cost, include any alternative costs, additional costs, or anything else that increases or reduces the cost to cast the spell. Convoke applies after the total cost is calculated. Convoke doesn't change a spell's mana cost or mana value."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "If a creature you control has a mana ability with {T} in the cost, activating that ability while casting a spell with convoke will result in the creature being tapped before you pay the spell's costs. You won't be able to tap it again for convoke. Similarly, if you sacrifice a creature to activate a mana ability while casting a spell with convoke, that creature won't be on the battlefield when you pay the spell's costs, so you won't be able to tap it for convoke."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Because convoke isn't an alternative cost, it can be used in conjunction with alternative costs."
+            },
+            {
+                "date": "2024-01-12",
+                "text": "Tapping a multicolored creature using convoke will pay for {1} or one mana of your choice of any of that creature's colors."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/RIX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RIX.json
@@ -1,3 +1,85 @@
+// Aquatic Incursion
+{
+    "name": "Aquatic Incursion",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, create two 1/1 blue Merfolk creature tokens with hexproof. (They can't be the targets of spells or abilities your opponents control.)\n{3}{U}: Target Merfolk can't be blocked this turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Merfolk"
+                    ],
+                    "keywords": [
+                        "HEXPROOF"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5d353ad-7160-41fa-809c-d76b36478a2a.jpg?1783913608"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "Merfolk"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent Merfolk"
+                        },
+                        "id": "Merfolk"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Rainville",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/56cb8fa2-337b-4596-9c31-01f0c0b171b7.jpg?1783935328",
+        "rulings": [
+            {
+                "date": "2018-01-19",
+                "text": "Activating the last ability of Aquatic Incursion after a Merfolk has become blocked won't cause it to become unblocked."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Brass's Bounty
 {
     "name": "Brass's Bounty",
@@ -428,6 +510,56 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Seafloor Oracle
+{
+    "name": "Seafloor Oracle",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Merfolk Wizard",
+    "oracleText": "Whenever a Merfolk you control deals combat damage to a player, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": "permanent Merfolk ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever a Merfolk you control deals combat damage to a player, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "RARE",
+        "artist": "Simon Dominic",
+        "flavorText": "Where the light falls dim and blue on broken ships, secrets lie unclaimed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/4316eacf-4b78-4b99-833c-53ecf49a0ae5.jpg?1783935319",
+        "rulings": [
+            {
+                "date": "2018-01-19",
+                "text": "If Seafloor Oracle is dealt lethal damage at the same time a Merfolk you control deals combat damage to a player, you'll draw a card."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/RNA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RNA.json
@@ -148,6 +148,82 @@
     ]
 }
 
+// Bring to Trial
+{
+    "name": "Bring to Trial",
+    "manaCost": "{2}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile target creature with power 4 or greater.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "creature with power 4 or greater"
+            },
+            "destination": "Exile"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature pow>=4"
+                },
+                "id": "creature with power 4 or greater"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "artist": "Victor Adame Minguez",
+        "flavorText": "\"In you go, big guy. Watch your head.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/63d566fc-0936-4035-96fd-f8b0c4eadbf5.jpg?1783933724"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Burn Bright
+{
+    "name": "Burn Bright",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Creatures you control get +2/+0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            "body": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 0
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "93",
+        "artist": "Scott Murphy",
+        "flavorText": "\"From a great bonfire at the dawn of time, the first Gruul kindled their rage. The same flame burns in you.\" —Kroshkar, Gruul shaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8574ffd-3e72-41de-90bf-69363189f047.jpg?1783933685"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Catacomb Crocodile
 {
     "name": "Catacomb Crocodile",
@@ -562,6 +638,43 @@
         "artist": "Magali Villeneuve",
         "flavorText": "\"Citizen! Your crime has been recorded. Cease movement and await arrest, or further penalties will be immediately imposed.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/1/1/11ee2c64-68f1-434b-8092-ae80d6575666.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sage's Row Savant
+{
+    "name": "Sage's Row Savant",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Vedalken Wizard",
+    "oracleText": "When this creature enters, scry 2.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                },
+                "descriptionOverride": "When this creature enters, scry 2."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Bastien L. Deharme",
+        "flavorText": "The streets of Ravnica are full of former guild members now using their institutional skills for personal gain.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d573626b-e7fa-4c31-a3d4-b853adfe787e.jpg?1783933705"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -227,6 +227,42 @@
     ]
 }
 
+// Goblin Rally
+{
+    "name": "Goblin Rally",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create four 1/1 red Goblin creature tokens.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateToken",
+            "count": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "power": 1,
+            "toughness": 1,
+            "colors": [
+                "RED"
+            ],
+            "creatureTypes": [
+                "Goblin"
+            ],
+            "imageUri": "https://cards.scryfall.io/normal/front/e/d/ed418a8b-f158-492d-a323-6265b3175292.jpg?1562640121"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "UNCOMMON",
+        "artist": "Nic Klein",
+        "flavorText": "You don't so much hire goblins as put ideas in their heads.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e4ec8ada-09a6-449a-ac4a-7d3acbd08014.jpg?1783940356"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Golgari Guildgate
 {
     "name": "Golgari Guildgate",
@@ -607,6 +643,77 @@
     "colorIdentityOverride": [
         "WHITE",
         "GREEN"
+    ]
+}
+
+// Seller of Songbirds
+{
+    "name": "Seller of Songbirds",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human",
+    "oracleText": "When this creature enters, create a 1/1 white Bird creature token with flying.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Bird"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b0c59f8-b407-47e7-8885-8c968f4ceecf.jpg?1783914993"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "artist": "Christopher Moeller",
+        "flavorText": "\"Lady Wren is the one merchant in Keyhole Downs who isn't running a scam.\" —Mirela, Azorius hussar",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2a41edbe-4c5a-4535-a082-235dc3ffe60a.jpg?1783940373"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Trained Caracal
+{
+    "name": "Trained Caracal",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "metadata": {
+        "collectorNumber": "27",
+        "artist": "James Ryman",
+        "flavorText": "Some Ravnicans consider carrying a sword to be beneath them, preferring instead a tooth-and-claw escort.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/797e45d1-d17d-40c0-bfdf-ec533784e676.jpg?1783940372"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/SNC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SNC.json
@@ -187,6 +187,58 @@
     ]
 }
 
+// Goldhound
+{
+    "name": "Goldhound",
+    "manaCost": "{R}",
+    "typeLine": "Artifact Creature — Treasure Dog",
+    "oracleText": "First strike\nMenace (This creature can't be blocked except by two or more creatures.)\n{T}, Sacrifice this creature: Add one mana of any color.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FIRST_STRIKE",
+        "MENACE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "artist": "Donato Giancola",
+        "flavorText": "The staccato clatter of its metal claws on pavement is unmistakable.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c059e4b4-1542-4b5c-810a-9f0abac5792b.jpg?1783923118",
+        "rulings": [
+            {
+                "date": "2022-04-29",
+                "text": "Even when it is on a creature, Treasure is an artifact type and not a creature type. Similarly, Dog is always a creature type and not an artifact type."
+            },
+            {
+                "date": "2022-04-29",
+                "text": "Since Goldhound is a creature, its {T} ability can't be activated the turn that it enters the battlefield or the turn a player gains control of it unless it has haste."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Inspiring Overseer
 {
     "name": "Inspiring Overseer",

--- a/mtg-sets/src/test/resources/snapshots/cards/SOI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOI.json
@@ -1796,6 +1796,67 @@
     ]
 }
 
+// Grotesque Mutation
+{
+    "name": "Grotesque Mutation",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+1 and gains lifelink until end of turn. (Damage dealt by the creature also causes its controller to gain that much life.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "artist": "Dan Murayama Scott",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce84d54c-ef63-4b90-a2b6-99a4aa21c02d.jpg?1783937773",
+        "rulings": [
+            {
+                "date": "2016-04-08",
+                "text": "Multiple instances of lifelink on the same creature are redundant."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Gryff's Boon
 {
     "name": "Gryff's Boon",
@@ -3272,6 +3333,62 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Rush of Adrenaline
+{
+    "name": "Rush of Adrenaline",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+1 and gains trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "artist": "Chris Rallis",
+        "flavorText": "Scarecrows only go so far in sending the message to stay away.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0def54b-9f0a-4ab1-9df9-25506a06350c.jpg?1783937744"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/SOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOM.json
@@ -18,6 +18,65 @@
     ]
 }
 
+// Barrage Ogre
+{
+    "name": "Barrage Ogre",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Ogre Warrior",
+    "oracleText": "{T}, Sacrifice an artifact: This creature deals 2 damage to any target.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "David Rapoza",
+        "flavorText": "The elves had devised countless strategies to combat Memnarch's war machines, but they had no idea what to do when one was *thrown* at them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e02c6f71-2448-47e1-9133-7af6a4d4577a.jpg?1783941726"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Blackcleave Cliffs
 {
     "name": "Blackcleave Cliffs",

--- a/mtg-sets/src/test/resources/snapshots/cards/STX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/STX.json
@@ -147,6 +147,77 @@
     "colorIdentityOverride": []
 }
 
+// Combat Professor
+{
+    "name": "Combat Professor",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Bird Cleric",
+    "oracleText": "Flying\nAt the beginning of combat on your turn, target creature you control gets +1/+0 and gains vigilance until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "VIGILANCE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Andrey Kuzinskiy",
+        "flavorText": "\"Before Yovus was cut down at Pranticle Peak, she performed which maneuver? Anyone? From the reading?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3f669ac4-98ed-4e23-91a9-281f8277ab04.jpg?1783927394"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Deadly Brew
 {
     "name": "Deadly Brew",

--- a/mtg-sets/src/test/resources/snapshots/cards/THB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THB.json
@@ -1,3 +1,339 @@
+// Archon of Sun's Grace
+{
+    "name": "Archon of Sun's Grace",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Creature — Archon",
+    "oracleText": "Flying\nLifelink (Damage dealt by this creature also causes you to gain that much life.)\nPegasus creatures you control have lifelink.\nConstellation — Whenever an enchantment you control enters, create a 2/2 white Pegasus creature token with flying.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Pegasus"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, create a 2/2 white Pegasus creature token with flying."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK",
+                "filter": {
+                    "baseFilter": "creature Pegasus ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "RARE",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/235e5999-e8e5-4093-adff-9d47aec70d10.jpg?1783931603",
+        "rulings": [
+            {
+                "date": "2020-01-24",
+                "text": "Multiple instances of lifelink on the same creature are redundant."
+            },
+            {
+                "date": "2020-01-24",
+                "text": "A constellation ability triggers whenever an enchantment enters the battlefield under your control for any reason. Enchantments with other card types, such as enchantment creatures, will also cause constellation abilities to trigger."
+            },
+            {
+                "date": "2020-01-24",
+                "text": "An Aura spell that has an illegal target when it tries to resolve doesn't resolve and is instead put into its owner's graveyard. It doesn't enter the battlefield, so constellation abilities don't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Captivating Unicorn
+{
+    "name": "Captivating Unicorn",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Unicorn",
+    "oracleText": "Constellation — Whenever an enchantment you control enters, tap target creature an opponent controls.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature"
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, tap target creature an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "artist": "Emrah Elmasli",
+        "flavorText": "\"Gazing at the unicorn, I felt closer to the majesty of Nyx than I ever had before.\" —Oineus, traveling merchant",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/13893599-0b87-4fc0-863d-f3e0ae51cc31.jpg?1783931602",
+        "rulings": [
+            {
+                "date": "2020-01-24",
+                "text": "A constellation ability triggers whenever an enchantment enters the battlefield under your control for any reason. Enchantments with other card types, such as enchantment creatures, will also cause constellation abilities to trigger."
+            },
+            {
+                "date": "2020-01-24",
+                "text": "An Aura spell that has an illegal target when it tries to resolve doesn't resolve and is instead put into its owner's graveyard. It doesn't enter the battlefield, so constellation abilities don't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Elite Instructor
+{
+    "name": "Elite Instructor",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "When this creature enters, draw a card, then discard a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, draw a card, then discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "artist": "Mike Sass",
+        "flavorText": "The greatest minds in Meletis study under the masters at the Dekatia, a renowned school of magic and philosophy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/821cd2dd-aa03-4c55-b9e4-98e0284889d3.jpg?1783931585"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Favored of Iroas
+{
+    "name": "Favored of Iroas",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Constellation — Whenever an enchantment you control enters, this creature gains double strike until end of turn. (It deals both first-strike and regular combat damage.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": "Self"
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, this creature gains double strike until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "UNCOMMON",
+        "artist": "John Severin Brassell",
+        "flavorText": "\"The promise of victory fills my heart. There is no room for fear.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f09e7aff-d873-4420-b0d5-1c63d686dd73.jpg?1783931598",
+        "rulings": [
+            {
+                "date": "2020-01-24",
+                "text": "Multiple instances of double strike on the same creature are redundant."
+            },
+            {
+                "date": "2020-01-24",
+                "text": "A constellation ability triggers whenever an enchantment enters the battlefield under your control for any reason. Enchantments with other card types, such as enchantment creatures, will also cause constellation abilities to trigger."
+            },
+            {
+                "date": "2020-01-24",
+                "text": "An Aura spell that has an illegal target when it tries to resolve doesn't resolve and is instead put into its owner's graveyard. It doesn't enter the battlefield, so constellation abilities don't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Irreverent Revelers
+{
+    "name": "Irreverent Revelers",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Satyr",
+    "oracleText": "When this creature enters, choose one —\n• Destroy target artifact.\n• This creature gains haste until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact"
+                                    }
+                                }
+                            ],
+                            "description": "Destroy target artifact."
+                        },
+                        {
+                            "effect": {
+                                "type": "GrantKeyword",
+                                "keyword": "HASTE",
+                                "target": "Self"
+                            },
+                            "description": "This creature gains haste until end of turn."
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, choose one — Destroy target artifact. • This creature gains haste until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "To some satyrs, only blasphemy is sacred.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55405dca-3555-45ff-be1c-e276fe1a0c2e.jpg?1783931550"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Nessian Hornbeetle
 {
     "name": "Nessian Hornbeetle",
@@ -144,6 +480,77 @@
     ]
 }
 
+// Pious Wayfarer
+{
+    "name": "Pious Wayfarer",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Constellation — Whenever an enchantment you control enters, target creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                },
+                "descriptionOverride": "Constellation — Whenever an enchantment you control enters, target creature gets +1/+1 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Mark Zug",
+        "flavorText": "Every footstep is a prayer, every road a temple.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/10b1a2b5-5be2-43a2-bc35-95df6eb0984f.jpg?1783931591",
+        "rulings": [
+            {
+                "date": "2020-01-24",
+                "text": "If an enchantment creature enters the battlefield under your control, Pious Wayfarer's ability can target it."
+            },
+            {
+                "date": "2020-01-24",
+                "text": "A constellation ability triggers whenever an enchantment enters the battlefield under your control for any reason. Enchantments with other card types, such as enchantment creatures, will also cause constellation abilities to trigger."
+            },
+            {
+                "date": "2020-01-24",
+                "text": "An Aura spell that has an illegal target when it tries to resolve doesn't resolve and is instead put into its owner's graveyard. It doesn't enter the battlefield, so constellation abilities don't trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Soul-Guide Lantern
 {
     "name": "Soul-Guide Lantern",
@@ -271,4 +678,41 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Thaumaturge's Familiar
+{
+    "name": "Thaumaturge's Familiar",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Bird",
+    "oracleText": "Flying\nWhen this creature enters, scry 1.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "artist": "Andrea Radeck",
+        "flavorText": "Meletian mages can't claim the title of thaumaturge until they have received a gift or omen from the gods. Ephara likes to give tangible tokens of her favor.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b497153-69a8-480e-b02f-88afec9d5053.jpg?1783931515"
+    },
+    "colorIdentityOverride": []
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -207,6 +207,56 @@
     ]
 }
 
+// Leonin Snarecaster
+{
+    "name": "Leonin Snarecaster",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Cat Soldier",
+    "oracleText": "When this creature enters, you may tap target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "artist": "Kev Walker",
+        "flavorText": "Formerly oppressed by the polis of Meletis, leonin occasionally \"mistake\" their old enemies for game.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ade9b739-122c-4659-b1b2-ea0510d96dbc.jpg?1783939812"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Lightning Strike
 {
     "name": "Lightning Strike",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -1376,6 +1376,42 @@
     ]
 }
 
+// Manakin
+{
+    "name": "Manakin",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "{T}: Add {C}.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "296",
+        "artist": "Scott Kirschner",
+        "flavorText": "Hanna regarded Squee sternly. \"Because it's *not* a toy, no matter how much it may look like one,\" she said, taking the manakin from him.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d33ce7f-f318-4161-843a-f5bb6d6e3d29.jpg?1783946602"
+    },
+    "colorIdentityOverride": []
+}
+
 // Manta Riders
 {
     "name": "Manta Riders",

--- a/mtg-sets/src/test/resources/snapshots/cards/TSP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TSP.json
@@ -216,6 +216,31 @@
     ]
 }
 
+// Havenwood Wurm
+{
+    "name": "Havenwood Wurm",
+    "manaCost": "{6}{G}",
+    "typeLine": "Creature — Wurm",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nTrample",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLASH",
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "199",
+        "artist": "Stuart Griffin",
+        "flavorText": "Time rifts bring tunneling beasts of old into the hard, dry earth of the present. Most die there, trapped, but the mightiest burst through the surface.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/6/561a4bb5-285a-4d52-b372-d165e442cff3.jpg?1783943212"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Lightning Axe
 {
     "name": "Lightning Axe",
@@ -516,6 +541,71 @@
         "artist": "Jim Nelson",
         "flavorText": "\"Great books are meant to be read, then read again backwards or upside down!\"\n—Ettovard, Tolarian archivist",
         "imageUri": "https://cards.scryfall.io/normal/front/3/5/352d99db-de6d-4405-90ec-b144abbaa5a4.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Tolarian Sentinel
+{
+    "name": "Tolarian Sentinel",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Spellshaper",
+    "oracleText": "Flying\n{U}, {T}, Discard a card: Return target permanent you control to its owner's hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent you control"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent ctrl:you"
+                        },
+                        "id": "target permanent you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Thomas M. Baxa",
+        "flavorText": "\"It is not just our people I try to rescue. It is our culture, and our hope that we can return to greatness.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e97ec8b-6163-41ff-9e6f-af091a7c529e.jpg?1783943238"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/mtg-sets/src/test/resources/snapshots/cards/VIS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VIS.json
@@ -163,6 +163,65 @@
     ]
 }
 
+// Infantry Veteran
+{
+    "name": "Infantry Veteran",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "{T}: Target attacking creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking creature"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        },
+                        "id": "target attacking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Christopher Rush",
+        "flavorText": "\"The true dishonor for a soldier is surviving the war.\" —Telim'Tor",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/0350470b-feea-4e15-bdf0-850b71dbeea6.jpg?1783947006",
+        "rulings": [
+            {
+                "date": "2010-08-15",
+                "text": "An “attacking creature” is one that has been declared as an attacker this combat, or one that was put onto the battlefield attacking this combat. Unless that creature leaves combat, it continues to be an attacking creature through the end of combat step, even if the player it was attacking has left the game, or the planeswalker it was attacking has left combat."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Inspiration
 {
     "name": "Inspiration",
@@ -242,6 +301,69 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Miraculous Recovery
+{
+    "name": "Miraculous Recovery",
+    "manaCost": "{4}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Return target creature card from your graveyard to the battlefield. Put a +1/+1 counter on it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Horton",
+        "flavorText": "\"You stop breathing for just a few minutes and everyone jumps to conclusions.\" —Zarkuu, necrosavant",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76fecb31-790a-4454-918e-5aeb253021f0.jpg?1783947006",
+        "rulings": [
+            {
+                "date": "2018-12-07",
+                "text": "The creature returns to the battlefield without a +1/+1 counter on it. Any abilities that trigger when a creature enters the battlefield will trigger or not as appropriate before it receives the +1/+1 counter and resolve after it has received that counter."
+            },
+            {
+                "date": "2018-12-07",
+                "text": "No player may take actions between the time the creature returns to the battlefield and the time you put a +1/+1 counter on it."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -683,6 +805,55 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Uktabi Orangutan
+{
+    "name": "Uktabi Orangutan",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Ape",
+    "oracleText": "When this creature enters, destroy target artifact.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target artifact"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact"
+                    },
+                    "id": "target artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "UNCOMMON",
+        "artist": "Una Fricker",
+        "flavorText": "\"Is it true that the apes wear furs of gold when they marry?\" —Rana, Suq'Ata market fool",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/101c7d58-43cc-4ebd-87f1-2016fbff56dd.jpg?1783946979"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/WAR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WAR.json
@@ -43,6 +43,58 @@
     ]
 }
 
+// Divine Arrow
+{
+    "name": "Divine Arrow",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Divine Arrow deals 4 damage to target attacking or blocking creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 4
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target attacking or blocking creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target attacking or blocking creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "artist": "Kieran Yanner",
+        "flavorText": "Ravnica's defenders watched in horror as Oketra's shot pierced the body of the pegasus. Gideon tumbled through the air, Blackblade in hand.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73cbb58a-1b00-4883-9b45-da7ded7317e3.jpg?1783933485"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Domri, Anarch of Bolas
 {
     "name": "Domri, Anarch of Bolas",
@@ -287,6 +339,62 @@
     ]
 }
 
+// Iron Bully
+{
+    "name": "Iron Bully",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this creature enters, put a +1/+1 counter on target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "artist": "Aaron Miller",
+        "flavorText": "\"Why would someone have built ... wait, never mind. Send it to the front lines!\" —Commander Grozdan",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/ded2c66e-402c-4d5c-b987-402679aa914b.jpg?1783933373",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "Iron Bully can be the target of its own ability."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // Ironclad Krovod
 {
     "name": "Ironclad Krovod",
@@ -522,6 +630,73 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Spark Reaper
+{
+    "name": "Spark Reaper",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "{3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|planeswalker"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{3}, Sacrifice a creature or planeswalker: You gain 1 life and draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"I know they're unstoppable fighters created to harvest souls—it's just they're so rude about it.\" —Kaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/922537f0-4caf-481c-b431-826f0c44e5c5.jpg?1783933437"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/WTH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WTH.json
@@ -95,6 +95,127 @@
     ]
 }
 
+// Festering Evil
+{
+    "name": "Festering Evil",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, this enchantment deals 1 damage to each creature and each player.\n{B}{B}, Sacrifice this enchantment: It deals 3 damage to each creature and each player.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature"
+                                }
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "Each"
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": "Controller"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature"
+                                }
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "Each"
+                            },
+                            "body": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": "Controller"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "rarity": "UNCOMMON",
+        "artist": "John Matson",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d688bda-fee2-496d-9793-794c2568b54e.jpg?1783946734"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Guided Strike
 {
     "name": "Guided Strike",

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -211,6 +211,65 @@
     ]
 }
 
+// Kitesail
+{
+    "name": "Kitesail",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+0 and has flying.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Cyril Van Der Haegen",
+        "flavorText": "Kitesailing is a way of life—and without practice, the end of it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/1/217a05a7-557f-4879-8fd1-d6c003f1751e.jpg?1783942039"
+    },
+    "colorIdentityOverride": []
+}
+
 // Leatherback Baloth
 {
     "name": "Leatherback Baloth",

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -131,6 +131,30 @@
     ]
 }
 
+// Colossal Dreadmaw
+{
+    "name": "Colossal Dreadmaw",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "metadata": {
+        "collectorNumber": "180",
+        "artist": "Jesper Ejsing",
+        "flavorText": "If you feel the ground quake, run. If you hear its bellow, flee. If you see its teeth, it's too late.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/6/76ac5b70-47db-4cdb-91e7-e5c18c42e516.jpg?1783935730"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Crushing Canopy
 {
     "name": "Crushing Canopy",
@@ -589,6 +613,47 @@
     ]
 }
 
+// Inspiring Cleric
+{
+    "name": "Inspiring Cleric",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Vampire Cleric",
+    "oracleText": "When this creature enters, you gain 4 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain 4 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "UNCOMMON",
+        "artist": "Randy Gallegos",
+        "flavorText": "\"The Immortal Sun will bring us true eternal life to replace the everlasting shadow of undeath.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31b8f1da-c8ea-41d5-b1ad-b714c22d3683.jpg?1783935801"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Looming Altisaur
 {
     "name": "Looming Altisaur",
@@ -670,6 +735,30 @@
     ]
 }
 
+// Nest Robber
+{
+    "name": "Nest Robber",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Haste",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Jonathan Kuo",
+        "flavorText": "\"These sailors on our shores are like the dinosaurs that plunder eggs from nests. They live on the labors of others.\" —Itzama the Crested",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/7/576d3845-f45a-4db0-9f7c-845cedb64c49.jpg?1783935742"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // New Horizons
 {
     "name": "New Horizons",
@@ -742,6 +831,42 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// One With the Wind
+{
+    "name": "One With the Wind",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2 and has flying.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "artist": "Naomi Baker",
+        "flavorText": "\"River and sea, jungle and sky. Water flows freely between the two halves of the world. We are creatures of the water.\" —Shaper Tuvasa",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c00f8bf-0088-44ad-b40b-26a2951a2428.jpg?1783935779"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -895,6 +1020,57 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// River Sneak
+{
+    "name": "River Sneak",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Warrior",
+    "oracleText": "This creature can't be blocked.\nWhenever another Merfolk you control enters, this creature gets +1/+1 until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "permanent Merfolk ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever another Merfolk you control enters, this creature gets +1/+1 until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            "CantBeBlocked"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "UNCOMMON",
+        "artist": "Slawomir Maniak",
+        "flavorText": "No ripples, no splashes, no warning.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2be32ffc-dc1d-4bb2-926f-51d110392b06.jpg?1783935775"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -142,6 +142,77 @@
     "colorIdentityOverride": []
 }
 
+// Baloth Woodcrasher
+{
+    "name": "Baloth Woodcrasher",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature gets +4/+4 and gains trample until end of turn. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "157",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros & Gabor Szikszai",
+        "flavorText": "Its insatiable hunger quickly depletes a region of prey. It must migrate from place to place to feed its massive bulk.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/8223dc6a-2bee-4be9-86d5-f0a17a24c33e.jpg?1783942137",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Blazing Torch
 {
     "name": "Blazing Torch",
@@ -492,6 +563,84 @@
     "colorIdentityOverride": []
 }
 
+// Feast of Blood
+{
+    "name": "Feast of Blood",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Cast this spell only if you control two or more Vampires.\nDestroy target creature. You gain 4 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ],
+        "castRestrictions": [
+            {
+                "type": "CastOnlyIfCondition",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "permanent Vampire"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "UNCOMMON",
+        "artist": "Jason Felix",
+        "flavorText": "\"The vampires of this world don't know the pleasures of hunger. They gorge themselves without savoring the kill.\" —Sorin Markov",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a7dd5e2-b2a5-46ab-a67c-499451706505.jpg?1783942154",
+        "rulings": [
+            {
+                "date": "2009-10-01",
+                "text": "Whether you control two or more Vampires is checked only as you try to move Feast of Blood to the stack as the first step of casting it. It doesn’t matter whether you still control two or more Vampires as you finish casting Feast of Blood (in case you somehow sacrifice one to produce mana) or as Feast of Blood resolves."
+            },
+            {
+                "date": "2009-10-01",
+                "text": "If the targeted creature is an illegal target by the time Feast of Blood resolves, the entire spell doesn’t resolve. You don’t gain life."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Into the Roil
 {
     "name": "Into the Roil",
@@ -809,6 +958,64 @@
     ]
 }
 
+// Piranha Marsh
+{
+    "name": "Piranha Marsh",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped.\nWhen this land enters, target player loses 1 life.\n{T}: Add {B}.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target player"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                },
+                "descriptionOverride": "When this land enters, target player loses 1 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "artist": "Nic Klein",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea077cff-b5c9-4a40-8e66-8810c37be5cb.jpg?1783942122"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Rampaging Baloths
 {
     "name": "Rampaging Baloths",
@@ -1101,6 +1308,67 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Steppe Lynx
+{
+    "name": "Steppe Lynx",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Cat",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "artist": "Nic Klein",
+        "flavorText": "Nothing quickens the predator's blood like the unfamiliar scents of new hunting grounds and the mewling cries of new prey.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0aaec1c-8084-4468-82e7-2e4cc5ebe244.jpg?1783942167",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -60,6 +60,140 @@
     ]
 }
 
+// Canopy Baloth
+{
+    "name": "Canopy Baloth",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, this creature gets +2/+2 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "Filip Burburan",
+        "flavorText": "\"You can almost see it calculating—are we a tasty enough treat to risk the jump?\" —Samila, Murasa Expeditionary House",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/b/6b04160c-89a7-4dcd-b05d-5dc846824d64.jpg?1783929341",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Chilling Trap
+{
+    "name": "Chilling Trap",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -4/-0 until end of turn. If you control a Wizard, draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -4
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "permanent Wizard"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Johann Bodin",
+        "flavorText": "\"Serves you right for rushing ahead.\" —Kaliea, Sea Gate trapfinder",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60f9adfd-a940-4d62-894b-84f17c693a10.jpg?1783929401",
+        "rulings": [
+            {
+                "date": "2020-09-25",
+                "text": "If the target creature is an illegal target by the time Chilling Trap tries to resolve, the spell doesn't resolve. You don't draw a card if you control a Wizard."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Cliffhaven Sell-Sword
 {
     "name": "Cliffhaven Sell-Sword",
@@ -450,6 +584,64 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Prowling Felidar
+{
+    "name": "Prowling Felidar",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Cat Beast",
+    "oracleText": "Vigilance\nLandfall — Whenever a land you control enters, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "artist": "Ilse Gort",
+        "flavorText": "On occasion, felidars leave meaty \"gifts\" outside the tents of explorers they consider worthy.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/9/b9d1c11a-a32c-449c-95c6-450dce6c26d2.jpg?1783929408",
+        "rulings": [
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability triggers whenever a land you control enters for any reason. It triggers whenever you play a land, as well as whenever a spell or ability puts a land onto the battlefield under your control."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "A landfall ability doesn't trigger if a permanent already on the battlefield becomes a land."
+            },
+            {
+                "date": "2024-11-08",
+                "text": "Whenever a land you control enters, each landfall ability of the permanents you control will trigger. You can put them on the stack in any order. The last ability you put on the stack will be the first one to resolve (As a result, you can have those abilities resolve in the order of your choosing.)."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Implements every **Assay-ready** card in Jumpstart 2022 — the cards the Set Completion view badges as
"Assay reads this card whole" that nobody had authored yet. That set is the cheapest work on the board
by construction: the grammar already reads the card, so no new SDK vocabulary is needed.

**J22 goes from 30/819 (4%) to 292/819 (36%).** All 262 Assay-ready cards, zero dropped.

## What's here

J22 is a reprint set, so most of the work landed outside it:

| | count |
|---|---|
| New canonical `CardDefinition`s, each in the card's **earliest real printing** | **166** across 58 sets |
| J22 `Printing(...)` rows for cards already implemented elsewhere | 90 |
| J22 basic lands (`basicLand(...)` variants, 3 arts each + Wastes) | 16 |
| New set scaffolds | 2 (EVE, C16) |

Eventide and Commander 2016 had no set module, so Archon of Justice and Ash Barrens had nowhere to put
a canonical — `check-card-printing` treats an unscaffolded earliest set as drift, so both are scaffolded
here.

Commits are one-per-card (card file + its J22 reprint row together), so any single card can be dropped
without unpicking the rest.

## No new SDK vocabulary

Every card composes existing `Effects.*` / `Patterns.*` / `Targets.*` / `Filters.*` / `Conditions.*`.
Nothing was added to the SDK, so `docs/card-sdk-language-reference.md` needs no update and no scenario
tests are required (the snapshot and lint nets cover pure compositions).

## Verification

- **`just build`** — green. `CardLintTest` and `FacadeBoundaryTest` pass.
- **`CardDefinitionSnapshotTest`** — re-blessed, 58 sets. The diff adds only the new cards; **zero
  existing card trees changed** (checked mechanically — no card name is removed or altered anywhere in
  the golden diff).
- **`just assay-differential`** — 2,990 compared (up from 2,854), **13 divergences — the same 13 that
  were there before**. The 136 newly-compared cards contribute none.
- **Metadata** — every card's mana cost, type line, P/T, oracle text, rarity, collector number, artist,
  flavour text and `imageUri` was diffed field-by-field against the Scryfall printing it claims. Zero
  mismatches. Image URLs sampled and verified HTTP 200.

### Six card bugs the differential caught, all fixed here

The differential compared Assay's reading of each new card against what was written, and disagreed six
times. Every one was a real defect in the new card, fixed in this branch:

- **Liliana's Mastery**, **Lord of the Accursed** (×2 clauses), **Dragon's Hoard**, **King of the Pride**
  — a bare tribal noun ("Zombies you control", "a Dragon you control", "Cats you control") is a
  *permanent* filter, not a creature filter. All four were written as `Creature.withSubtype(...)` and are
  now `Permanent.withSubtype(...)`.
- **Aeronaut Tinkerer** — `YouControlAtLeast(1, Artifact)` restates `Exists(You, Battlefield, Artifact)`;
  collapsed to the latter, which is what the rest of the corpus uses for "as long as you control an X".
- **Ferocious Pup** — an explicit `controller = EffectTarget.Controller` on a token that already defaults
  to it. Removed; same family as the known redundant-`damageSource` finding.

## Known drift this does *not* touch

`check-card-printing` over all 262: **165 fully clean**, and the rest split into two out-of-scope classes.

- **89 cards want `Printing(...)` rows in other scaffolded sets** — jmp (73), bfz (50), 8ed (40), zen
  (40), por (36)… Jumpstart 2020 reprints much of the same pool. For the 90 already-implemented cards
  those rows were equally absent before this branch; for the 166 new ones the gate previously exited
  "card not implemented" and could not see them at all. Filling them in is a separate change.
- **Basic lands** — the gate wants a `Printing(...)` row per basic per set, but the repo models basics as
  per-set `basicLand(...)` variants (DOM, VOW and FIN all flag identically). Pre-existing script
  limitation, not drift.

Two genuine pre-existing canonical misplacements surfaced and are deliberately left alone, since they
predate this work: **Big Score** (canonical in `blc`, earliest is `snc`) and **Flame Lash** (`blb`,
earliest `kld`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
